### PR TITLE
Deps(npm): update eslint-plugin-react-hooks to support eslint 10 natively (Hytte-r70)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,7 +21,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "eslint": "^10.0.3",
-        "eslint-plugin-react-hooks": "^7.1.0-canary-46103596-20260305",
+        "eslint-plugin-react-hooks": "7.1.0-canary-46103596-20260305",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "typescript": "~5.9.3",
@@ -2306,9 +2306,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.1.0-canary-fd524fe0-20251121",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.0-canary-fd524fe0-20251121.tgz",
-      "integrity": "sha512-G5we0+XjZTKpjkLL9AgdWxzmo4mqelVDIYzoR1dBlhhiN8Lf5PQ+l8frr+BmX02nU4g0AEez3eGSF/LNfHokEw==",
+      "version": "7.1.0-canary-46103596-20260305",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.0-canary-46103596-20260305.tgz",
+      "integrity": "sha512-np3UppCIrqafkINXLe2LX9pIla+HxQL1sN+6cfoBVws9UdA0RSs78zYv6lsaOb0Ps/0dIAxX4DeZ+xdpd3mkSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2322,7 +2322,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,16 +23,11 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "eslint": "^10.0.3",
-    "eslint-plugin-react-hooks": "^7.1.0-canary-46103596-20260305",
+    "eslint-plugin-react-hooks": "7.1.0-canary-46103596-20260305",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1"
-  },
-  "overrides": {
-    "eslint-plugin-react-hooks": {
-      "eslint": "$eslint"
-    }
   }
 }


### PR DESCRIPTION
## Automated PR by The Forge

**Bead**: Hytte-r70
**Branch**: forge/Hytte-r70

This PR was generated by The Forge autonomous pipeline.
A Smith agent implemented the changes, Temper verified the build,
and Warden approved the code review.

---
*Generated by [The Forge](https://github.com/Robin831/Forge)*