### PR TITLE
forge: learn 8 warden rule(s) from PR #36 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -205,8 +205,8 @@ rules:
       added: "2026-03-10"
     - id: react-namespace-without-import
       category: style
-      pattern: TypeScript files using `React.` namespace types (e.g. `React.KeyboardEvent`, `React.ChangeEvent`, `React.FC`) without importing `React`
-      check: Verify that any file referencing the `React` namespace either imports `React` or imports the specific type directly from `react` (e.g. `import { KeyboardEvent } from 'react'`)
+      pattern: TypeScript files using `React.` namespace types (e.g. `React.KeyboardEvent`, `React.ChangeEvent`, `React.FC`) in a way that is inconsistent with the prevailing convention in this repo
+      check: In this codebase, many files rely on globally available React types and use `React.` namespace types without importing `React`. When reviewing changes, ensure each file (and related components) follows a single, consistent convention: either continue using the existing pattern (no explicit `React` import) or explicitly import `React` or the specific types from `react` and update usages accordingly, but avoid mixing conventions within the same area of the UI.
       source: copilot:PR#36
       added: "2026-03-11"
     - id: require-paired-query-params


### PR DESCRIPTION
## Warden Rule Learning

Learned **8** new review rule(s) from Copilot comments on PR #36.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*