### PR TITLE
Ignore .forge-logs/ in root .gitignore (Hytte-dys)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ web/dist/
 
 # Dolt database files (added by bd init)
 .dolt/
+
+# Forge smith logs
+.forge-logs/


### PR DESCRIPTION
## Changes

Minimal, correct .gitignore entry — no issues found.

## Original Issue (task): Ignore .forge-logs/ in root .gitignore

.forge-logs/ directory in the root is untracked. It contains smith logs and should be ignored by git.

---
Bead: Hytte-dys | Branch: forge/Hytte-dys
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)