### PR TITLE
Implement interval pattern detection and tag generation logic (autotag.go) (Hytte-d7q)

### DIFF
--- a/changelog.d/Hytte-d7q.md
+++ b/changelog.d/Hytte-d7q.md
@@ -1,2 +1,2 @@
 category: Added
-- **Auto-tag workouts based on interval structure** - Analyzes lap data after import to detect alternating work/rest patterns and uniform repeats, generating compact tags like "6x6m (r1m)" or "8x400m". Supports distance-based formatting for running, cycling, and other distance sports. (Hytte-d7q)
+- **Auto-tag workouts based on interval structure** - Adds `GenerateAutoTags` to analyze lap data and detect alternating work/rest patterns and uniform repeats, generating compact tags like `auto:6x6m (r1m)` or `auto:8x400m`. Supports distance-based formatting for running, cycling, and other distance sports. (Hytte-d7q)

--- a/internal/training/autotag.go
+++ b/internal/training/autotag.go
@@ -6,7 +6,7 @@ import (
 )
 
 // GenerateAutoTags analyzes a parsed workout's lap structure and returns
-// auto-generated tags describing the interval pattern (e.g. "6x6m (r1m)").
+// auto-generated tags describing the interval pattern (e.g. "auto:6x6m (r1m)").
 // Returns nil if no recognizable interval pattern is detected.
 func GenerateAutoTags(pw *ParsedWorkout) []string {
 	if len(pw.Laps) < 3 {
@@ -46,8 +46,8 @@ func detectAlternatingPattern(pw *ParsedWorkout) string {
 		}
 	}
 
-	// Need at least 2 in the larger group, at least 1 in the smaller.
-	if len(group1) < 2 || len(group2) == 0 {
+	// Need at least 2 in each group to avoid low-signal "1x…" tags.
+	if len(group1) < 2 || len(group2) < 2 {
 		return ""
 	}
 
@@ -85,6 +85,22 @@ func detectAlternatingPattern(pw *ParsedWorkout) string {
 			workLaps, restLaps = group1, group2
 		} else {
 			workLaps, restLaps = group2, group1
+		}
+		// For true non-distance sports (e.g. strength) we have no pace signal to
+		// validate which group is work vs rest. Guard against inverted patterns
+		// (e.g. 30s hard / 2m easy tagged as "Nx2m (r30s)"):
+		if !isDistanceSport(pw.Sport) {
+			avgRestDur := avgDuration(restLaps)
+			avgWorkDur := avgDuration(workLaps)
+			// Bail if rest somehow exceeds work (defensive; guards future logic changes).
+			if avgRestDur > avgWorkDur {
+				return ""
+			}
+			// Bail when work is >3× rest and rest is a real interval (>=30s) —
+			// signals a likely inverted pattern.
+			if avgWorkDur/avgRestDur > 3.0 && avgRestDur >= 30 {
+				return ""
+			}
 		}
 	}
 

--- a/internal/training/autotag_test.go
+++ b/internal/training/autotag_test.go
@@ -152,6 +152,38 @@ func TestGenerateAutoTags_NonDistanceSport(t *testing.T) {
 	}
 }
 
+func TestGenerateAutoTags_ThreeLaps_WorkRestWork(t *testing.T) {
+	// 3-lap workout: [work, rest, work] produces group1=2, group2=1 — should return nil
+	// to avoid a low-signal "1x…" tag from the single-rest group.
+	laps := []ParsedLap{
+		{DurationSeconds: 360},
+		{DurationSeconds: 60},
+		{DurationSeconds: 360},
+	}
+	pw := &ParsedWorkout{Sport: "running", Laps: laps}
+	tags := GenerateAutoTags(pw)
+	if tags != nil {
+		t.Errorf("expected nil for 3-lap work/rest/work (would yield 1x tag), got %v", tags)
+	}
+}
+
+func TestGenerateAutoTags_RestLongerThanWork(t *testing.T) {
+	// 30s hard / 2m easy — rest > work for a non-distance sport.
+	// The algorithm must not invert work/rest and emit "Nx2m (r30s)".
+	var laps []ParsedLap
+	for i := range 4 {
+		laps = append(laps, ParsedLap{DurationSeconds: 30})
+		if i < 3 {
+			laps = append(laps, ParsedLap{DurationSeconds: 120})
+		}
+	}
+	pw := &ParsedWorkout{Sport: "strength", Laps: laps}
+	tags := GenerateAutoTags(pw)
+	if tags != nil {
+		t.Errorf("expected nil for rest-longer-than-work pattern, got %v", tags)
+	}
+}
+
 func TestFormatDuration(t *testing.T) {
 	tests := []struct {
 		seconds float64


### PR DESCRIPTION
## Changes

- **Auto-tag workouts based on interval structure** - Analyzes lap data after import to detect alternating work/rest patterns and uniform repeats, generating compact tags like "6x6m (r1m)" or "8x400m". Supports distance-based formatting for running, cycling, and other distance sports. (Hytte-d7q)

## Original Issue (task): Implement interval pattern detection and tag generation logic (autotag.go)

Sub-task decomposed from Hytte-hp0: Training: auto-tag workouts based on interval structure

---
Bead: Hytte-d7q | Branch: forge/Hytte-d7q
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)