### PR TITLE
forge: learn 5 warden rule(s) from PR #67 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -362,7 +362,8 @@ rules:
       category: testing
       pattern: Test inserts rows with SQLite datetime() functions (e.g., datetime('now')) for timestamp columns
       check: Verify that test timestamps use the same format as production code. If production stores RFC3339 strings via Go's time.Time, tests should use explicit RFC3339 literals or call the real Create helper — not SQLite datetime() — to avoid format mismatches in ordering and date functions.
-      source: copilot:PR#68      added: "2026-03-15"
+      source: copilot:PR#68
+      added: "2026-03-15"
     - id: min-interval-count-before-tagging
       category: other
       pattern: Auto-tag or pattern detection logic that checks group sizes before generating tags


### PR DESCRIPTION
## Warden Rule Learning

Learned **5** new review rule(s) from Copilot comments on PR #67.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*