### PR TITLE
forge: learn 1 warden rule(s) from PR #79 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -565,7 +565,7 @@ rules:
       added: "2026-03-16"
     - id: yaml-date-field-consistency
       category: style
-      pattern: YAML config entries with a date field (e.g. `added`) where some entries have ISO dates and others have empty strings
-      check: All date fields must be populated with a valid ISO date (YYYY-MM-DD); no entry should have an empty string where sibling entries use a date value
+      pattern: YAML config entries with a date field (e.g. `added`) where the field is missing, null, an empty string, or a non-ISO format (e.g. `2026/03/16`) instead of a valid ISO date
+      check: All date fields must be present and populated with a valid ISO date (YYYY-MM-DD); flag entries where the field is absent, null, empty, or uses a non-ISO format such as slashes or locale-specific ordering
       source: copilot:PR#79
       added: "2026-03-16"


### PR DESCRIPTION
## Warden Rule Learning

Learned **1** new review rule(s) from Copilot comments on PR #79.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*