### PR TITLE
Add cleanup/repair for orphaned workout_laps rows blocking reimport (Hytte-ccf)

### DIFF
--- a/changelog.d/Hytte-ccf.md
+++ b/changelog.d/Hytte-ccf.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Auto-cleanup orphaned workout child rows on startup** - Databases with orphaned rows in workout_laps, workout_samples, or workout_tags (left behind by deletes before the cascade fix) are now automatically cleaned up when the app starts, unblocking .fit file reimports. (Hytte-ccf)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -309,5 +309,18 @@ func createSchema(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_infra_module_preferences_user_module ON infra_module_preferences(user_id, module);`
 
 	_, err := db.Exec(schema)
+	if err != nil {
+		return err
+	}
+
+	// Clean up orphaned workout child rows left behind by deletes that
+	// occurred before ON DELETE CASCADE was properly enforced (Hytte-c93).
+	// These statements are no-ops on databases without orphans.
+	orphanCleanup := `
+	DELETE FROM workout_laps WHERE workout_id NOT IN (SELECT id FROM workouts);
+	DELETE FROM workout_samples WHERE workout_id NOT IN (SELECT id FROM workouts);
+	DELETE FROM workout_tags WHERE workout_id NOT IN (SELECT id FROM workouts);`
+
+	_, err = db.Exec(orphanCleanup)
 	return err
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,118 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestOrphanCleanup(t *testing.T) {
+	database, err := Init(":memory:")
+	if err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	defer database.Close()
+
+	// Insert a user and a workout.
+	_, err = database.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g1')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	_, err = database.Exec(`INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (100, 1, 'running', '2025-01-01T00:00:00Z', 'hash1', '2025-01-01T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	// Insert valid child rows (parent workout_id=100 exists).
+	_, err = database.Exec(`INSERT INTO workout_laps (workout_id, lap_number) VALUES (100, 1)`)
+	if err != nil {
+		t.Fatalf("insert valid lap: %v", err)
+	}
+	_, err = database.Exec(`INSERT INTO workout_samples (workout_id, data) VALUES (100, '[]')`)
+	if err != nil {
+		t.Fatalf("insert valid sample: %v", err)
+	}
+	_, err = database.Exec(`INSERT INTO workout_tags (workout_id, tag) VALUES (100, 'easy')`)
+	if err != nil {
+		t.Fatalf("insert valid tag: %v", err)
+	}
+
+	// Simulate orphaned rows by disabling foreign keys temporarily.
+	_, err = database.Exec(`PRAGMA foreign_keys = OFF`)
+	if err != nil {
+		t.Fatalf("disable FK: %v", err)
+	}
+	_, err = database.Exec(`INSERT INTO workout_laps (workout_id, lap_number) VALUES (999, 1)`)
+	if err != nil {
+		t.Fatalf("insert orphan lap: %v", err)
+	}
+	_, err = database.Exec(`INSERT INTO workout_samples (workout_id, data) VALUES (999, '[]')`)
+	if err != nil {
+		t.Fatalf("insert orphan sample: %v", err)
+	}
+	_, err = database.Exec(`INSERT INTO workout_tags (workout_id, tag) VALUES (999, 'orphan')`)
+	if err != nil {
+		t.Fatalf("insert orphan tag: %v", err)
+	}
+	_, err = database.Exec(`PRAGMA foreign_keys = ON`)
+	if err != nil {
+		t.Fatalf("enable FK: %v", err)
+	}
+
+	// Run createSchema again — orphan cleanup should remove the bad rows.
+	if err := createSchema(database); err != nil {
+		t.Fatalf("createSchema: %v", err)
+	}
+
+	// Verify orphaned rows are gone.
+	for _, q := range []struct {
+		table string
+		query string
+	}{
+		{"workout_laps", "SELECT COUNT(*) FROM workout_laps WHERE workout_id = 999"},
+		{"workout_samples", "SELECT COUNT(*) FROM workout_samples WHERE workout_id = 999"},
+		{"workout_tags", "SELECT COUNT(*) FROM workout_tags WHERE workout_id = 999"},
+	} {
+		var count int
+		if err := database.QueryRow(q.query).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", q.table, err)
+		}
+		if count != 0 {
+			t.Errorf("expected 0 orphaned rows in %s, got %d", q.table, count)
+		}
+	}
+
+	// Verify valid rows are still present.
+	for _, q := range []struct {
+		table string
+		query string
+	}{
+		{"workout_laps", "SELECT COUNT(*) FROM workout_laps WHERE workout_id = 100"},
+		{"workout_samples", "SELECT COUNT(*) FROM workout_samples WHERE workout_id = 100"},
+		{"workout_tags", "SELECT COUNT(*) FROM workout_tags WHERE workout_id = 100"},
+	} {
+		var count int
+		if err := database.QueryRow(q.query).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", q.table, err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 valid row in %s, got %d", q.table, count)
+		}
+	}
+}
+
+func TestOrphanCleanupIdempotent(t *testing.T) {
+	database, err := Init(":memory:")
+	if err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	defer database.Close()
+
+	// Running createSchema on a clean DB should succeed without errors.
+	if err := createSchema(database); err != nil {
+		t.Fatalf("second createSchema should be idempotent: %v", err)
+	}
+}


### PR DESCRIPTION
## Changes

- **Auto-cleanup orphaned workout child rows on startup** - Databases with orphaned rows in workout_laps, workout_samples, or workout_tags (left behind by deletes before the cascade fix) are now automatically cleaned up when the app starts, unblocking .fit file reimports. (Hytte-ccf)

## Original Issue (bug): Add cleanup/repair for orphaned workout_laps rows blocking reimport

## Bug

Hytte-c93 fixed the delete logic to cascade properly going forward, but existing databases still have orphaned rows in `workout_laps` (and possibly other child tables) from before the fix. Reimporting still fails:

```
476070571738693837.fit: insert lap 1: constraint failed: UNIQUE constraint failed: workout_laps.workout_id, workout_laps.lap_number (2067)
```

### What needs to happen
Add a DB migration or repair step that cleans up orphaned child rows — rows in `workout_laps` (and any other workout child tables) where the parent `workout_id` no longer exists in `workouts`.

### Approach options (pick simplest)
1. **Migration**: Add a migration that runs `DELETE FROM workout_laps WHERE workout_id NOT IN (SELECT id FROM workouts)` (and same for other child tables)
2. **Startup repair**: Run orphan cleanup on app startup or DB open
3. **Manual endpoint**: Add a repair/cleanup API endpoint or CLI command

Option 1 (migration) is preferred — it's a one-time fix that runs automatically on deploy.

### Related
- Hytte-c93: Fixed cascade delete (root cause prevention)

---
Bead: Hytte-ccf | Branch: forge/Hytte-ccf
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)