### PR TITLE
forge: learn 1 warden rule(s) from PR #117 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -749,3 +749,9 @@ rules:
       check: When displaying tags that may contain prefixes (e.g. `ai:`, `category:`), verify they are rendered through the existing display helpers (such as `displayTag` or `TagBadge`) rather than raw, to ensure consistent prefix-stripping across all UI surfaces
       source: copilot:PR#105
       added: "2026-03-19"
+    - id: fetch-credentials-include
+      category: security
+      pattern: Frontend fetch() calls to /api/* endpoints
+      check: "Verify that all fetch() calls to API endpoints include `credentials: 'include'` in the options to ensure session cookies are sent correctly across all deployment topologies"
+      source: copilot:PR#117
+      added: "2026-03-20"


### PR DESCRIPTION
## Warden Rule Learning

Learned **1** new review rule(s) from Copilot comments on PR #117.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*