### PR TITLE
HR chart Y-axis shows raw floats and X-axis has duplicate minute labels (Hytte-5w6)

### DIFF
--- a/changelog.d/Hytte-5w6.md
+++ b/changelog.d/Hytte-5w6.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **HR chart Y-axis and X-axis display cleanup** - Y-axis now shows rounded integers instead of raw floats, and X-axis no longer shows duplicate minute labels. (Hytte-5w6)

--- a/web/src/components/charts/WorkoutHRChart.tsx
+++ b/web/src/components/charts/WorkoutHRChart.tsx
@@ -23,7 +23,7 @@ export default function WorkoutHRChart({ samples, avgHeartRate, height = 250 }: 
   const rawData = samples
     .filter((s) => s.hr && s.hr > 0)
     .map((s) => ({
-      time: Math.round(s.t / 60000),
+      time: s.t / 60000,
       hr: s.hr as number,
     }))
 
@@ -48,11 +48,13 @@ export default function WorkoutHRChart({ samples, avgHeartRate, height = 250 }: 
           <XAxis
             dataKey="time"
             tick={{ fill: '#9ca3af', fontSize: 11 }}
+            tickFormatter={(v: number) => Math.round(v).toString()}
             label={{ value: 'Minutes', position: 'insideBottom', offset: -3, fill: '#9ca3af', fontSize: 11 }}
           />
           <YAxis
-            domain={['dataMin - 10', 'dataMax + 10']}
+            domain={[(min: number) => Math.floor(min) - 10, (max: number) => Math.ceil(max) + 10]}
             tick={{ fill: '#9ca3af', fontSize: 11 }}
+            tickFormatter={(v: number) => Math.round(v).toString()}
             label={{ value: 'BPM', angle: -90, position: 'insideLeft', fill: '#9ca3af', fontSize: 11 }}
           />
           <Tooltip
@@ -63,7 +65,7 @@ export default function WorkoutHRChart({ samples, avgHeartRate, height = 250 }: 
               color: '#e5e7eb',
             }}
             formatter={(value) => [`${Math.round(Number(value))} bpm`, 'Heart Rate']}
-            labelFormatter={(label) => `${String(label)} min`}
+            labelFormatter={(label) => `${Math.round(Number(label))} min`}
           />
           {avgHR > 0 && (
             <ReferenceLine


### PR DESCRIPTION
## Changes

- **HR chart Y-axis and X-axis display cleanup** - Y-axis now shows rounded integers instead of raw floats, and X-axis no longer shows duplicate minute labels. (Hytte-5w6)

## Original Issue (bug): HR chart Y-axis shows raw floats and X-axis has duplicate minute labels

## Bug

The workout HR chart has two display issues:

### Y-axis shows unrounded floats
Values like `85.08333333333333`, `110.08333333333333` appear on the Y-axis instead of clean integers like `85`, `110`. This is because the smoothed HR values (from `rollingAvg`) are fractional, and the YAxis domain strings `'dataMin - 10'` / `'dataMax + 10'` produce float results.

### X-axis has duplicate labels
Labels show `0, 1, 1, 1, 2, 2, 3, 3, 3...` because `Math.round(s.t / 60000)` maps multiple samples to the same whole-minute integer.

### Fix

In `web/src/components/charts/WorkoutHRChart.tsx`:

1. **Y-axis**: Add `tickFormatter={(v: number) => Math.round(v).toString()}` to the YAxis component. Also change domain to use functions: `domain={[(min: number) => Math.floor(min) - 10, (max: number) => Math.ceil(max) + 10]}`

2. **X-axis**: Keep fractional minutes for the data (`s.t / 60000` without rounding) so each sample has a unique position, but format the tick labels: `tickFormatter={(v: number) => Math.round(v).toString()}`

### File
- `web/src/components/charts/WorkoutHRChart.tsx` — lines 26, 53-56, 48-51

---
Bead: Hytte-5w6 | Branch: forge/Hytte-5w6
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)