### PR TITLE
npm: flatted vulnerable to DoS and prototype pollution (Hytte-vvb0)

### DIFF
--- a/changelog.d/Hytte-vvb0.md
+++ b/changelog.d/Hytte-vvb0.md
@@ -1,0 +1,2 @@
+category: Security
+- **Update flatted to 3.4.2** - Fixes two high-severity CVEs: unbounded recursion DoS in parse() (GHSA-25h7-pfq9-p65f) and prototype pollution (GHSA-rf6f-7fwh-wjgh). (Hytte-vvb0)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2406,9 +2406,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Changes

- **Update flatted to 3.4.2** - Fixes two high-severity CVEs: unbounded recursion DoS in parse() (GHSA-25h7-pfq9-p65f) and prototype pollution (GHSA-rf6f-7fwh-wjgh). (Hytte-vvb0)

## Original Issue (task): npm: flatted vulnerable to DoS and prototype pollution

npm audit reports high severity vulnerability in flatted <=3.4.1 (transitive dep). Two CVEs: unbounded recursion DoS in parse() (GHSA-25h7-pfq9-p65f) and prototype pollution (GHSA-rf6f-7fwh-wjgh). Fix available via npm audit fix. Found in web/node_modules/flatted.

---
Bead: Hytte-vvb0 | Branch: forge/Hytte-vvb0
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)