### PR TITLE
Frontend: LevelBadge component + Stars.tsx enhancements (Hytte-pl64)

### DIFF
--- a/changelog.d/Hytte-pl64.md
+++ b/changelog.d/Hytte-pl64.md
@@ -1,0 +1,3 @@
+category: Added
+- **LevelBadge component** - Reusable `LevelBadge` component that renders level number, emoji, and title together; used in the Stars dashboard and Family child detail view. (Hytte-pl64)
+- **XP progress display** - Stars dashboard now shows exact XP progress as `current / total XP` next to the progress bar, and displays the level emoji alongside the level badge. (Hytte-pl64)

--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -186,7 +186,8 @@
     },
     "xp": {
       "progress": "XP Progress",
-      "toNext": "{{xp}} XP to next level"
+      "toNext": "{{xp}} XP to next level",
+      "currentOfNext": "{{current}} / {{total}} XP"
     },
     "quickStats": {
       "title": "Quick Stats",

--- a/web/public/locales/nb/common.json
+++ b/web/public/locales/nb/common.json
@@ -186,7 +186,8 @@
     },
     "xp": {
       "progress": "XP-fremgang",
-      "toNext": "{{xp}} XP til neste nivå"
+      "toNext": "{{xp}} XP til neste nivå",
+      "currentOfNext": "{{current}} / {{total}} XP"
     },
     "quickStats": {
       "title": "Raske statistikker",

--- a/web/public/locales/th/common.json
+++ b/web/public/locales/th/common.json
@@ -186,7 +186,8 @@
     },
     "xp": {
       "progress": "ความคืบหน้า XP",
-      "toNext": "อีก {{xp}} XP สู่ระดับถัดไป"
+      "toNext": "อีก {{xp}} XP สู่ระดับถัดไป",
+      "currentOfNext": "{{current}} / {{total}} XP"
     },
     "quickStats": {
       "title": "สถิติด่วน",

--- a/web/src/components/LevelBadge.tsx
+++ b/web/src/components/LevelBadge.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next'
+
+interface LevelBadgeProps {
+  level: number
+  emoji?: string
+  title: string
+}
+
+export default function LevelBadge({ level, emoji, title }: LevelBadgeProps) {
+  const { t } = useTranslation('common')
+  return (
+    <div className="inline-flex items-center gap-1.5 bg-yellow-500/10 border border-yellow-500/20 rounded-full px-4 py-1">
+      {emoji && (
+        <span className="text-sm" role="img" aria-hidden="true">{emoji}</span>
+      )}
+      <span className="text-yellow-300 text-sm font-medium">
+        {t('stars.level', { level })} · {title}
+      </span>
+    </div>
+  )
+}

--- a/web/src/pages/FamilyChildDetail.tsx
+++ b/web/src/pages/FamilyChildDetail.tsx
@@ -8,6 +8,7 @@ import {
 } from 'recharts'
 import { formatDate, formatNumber } from '../utils/formatDate'
 import { xpProgressPercent } from '../utils/stars'
+import LevelBadge from '../components/LevelBadge'
 
 interface ChildStats {
   current_balance: number
@@ -16,6 +17,7 @@ interface ChildStats {
   level: number
   xp: number
   title: string
+  emoji?: string
   current_streak: number
   longest_streak: number
   this_week_stars: number
@@ -287,9 +289,7 @@ export default function FamilyChildDetail() {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap mb-1">
             <h1 className="text-xl font-bold text-white truncate">{nickname}</h1>
-            <span className="text-xs bg-yellow-500/20 text-yellow-300 border border-yellow-500/30 rounded-full px-2 py-0.5 flex-shrink-0">
-              {t('stars.level', { level: stats.level })} · {stats.title}
-            </span>
+            <LevelBadge level={stats.level} emoji={stats.emoji} title={stats.title} />
           </div>
           <div className="flex items-center gap-1.5 mb-2">
             <Star size={14} className="text-yellow-400" aria-hidden="true" />

--- a/web/src/pages/Stars.tsx
+++ b/web/src/pages/Stars.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Activity, Clock, MapPin, Star } from 'lucide-react'
 import { xpForLevel, xpProgressPercent, getFlameVariant } from '../utils/stars'
+import LevelBadge from '../components/LevelBadge'
 import '../stars.css'
 
 interface Balance {
@@ -12,6 +13,7 @@ interface Balance {
   level: number
   xp: number
   title: string
+  emoji?: string
 }
 
 interface Transaction {
@@ -157,7 +159,6 @@ export default function Stars() {
   const dailyStreak = streaks?.daily_workout ?? { current_count: 0, longest_count: 0, last_activity: '' }
   const weeklyStreak = streaks?.weekly_workout ?? { current_count: 0, longest_count: 0, last_activity: '' }
   const xpPercent = balance ? xpProgressPercent(balance.level, balance.xp) : 0
-  const xpToNext = balance ? Math.max(0, xpForLevel(balance.level) - balance.xp) : 0
 
   return (
     <div className="p-6 max-w-2xl mx-auto space-y-6">
@@ -183,17 +184,15 @@ export default function Stars() {
         {/* Level badge */}
         {balance && (
           <div className="mt-5">
-            <div className="inline-block bg-yellow-500/10 border border-yellow-500/20 rounded-full px-4 py-1 mb-4">
-              <span className="text-yellow-300 text-sm font-medium">
-                {t('stars.level', { level: balance.level })} · {balance.title}
-              </span>
+            <div className="mb-4">
+              <LevelBadge level={balance.level} emoji={balance.emoji} title={balance.title} />
             </div>
 
             {/* XP Progress bar */}
             <div className="px-2">
               <div className="flex justify-between text-xs text-gray-400 mb-1">
                 <span>{t('stars.xp.progress')}</span>
-                <span>{t('stars.xp.toNext', { xp: xpToNext })}</span>
+                <span>{t('stars.xp.currentOfNext', { current: balance.xp, total: xpForLevel(balance.level) })}</span>
               </div>
               <div className="h-3 rounded-full bg-gray-700/60 overflow-hidden">
                 <div


### PR DESCRIPTION
## Changes

- **LevelBadge component** - Reusable `LevelBadge` component that renders level number, emoji, and title together; used in the Stars dashboard and Family child detail view. (Hytte-pl64)
- **XP progress display** - Stars dashboard now shows exact XP progress as `current / total XP` next to the progress bar, and displays the level emoji alongside the level badge. (Hytte-pl64)

## Original Issue (task): Frontend: LevelBadge component + Stars.tsx enhancements

Create a reusable LevelBadge component (e.g., components/LevelBadge.tsx) that accepts level, emoji, title props and renders them together. Update Stars.tsx level-progress section to: display current level emoji next to level number, show exact XP progress string '{current_xp} / {xp_for_next_level} XP', and use LevelBadge. Update parent's FamilyChildDetail.tsx to also use LevelBadge. Consumes the new fields added to GET /api/stars/balance in the backend integration sub-task.

---
Bead: Hytte-pl64 | Branch: forge/Hytte-pl64
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)