### PR TITLE
Backend: Tests for Reward & Claim Logic (Hytte-muv9)

### DIFF
--- a/changelog.d/Hytte-muv9.md
+++ b/changelog.d/Hytte-muv9.md
@@ -1,2 +1,5 @@
 category: Added
 - **Backend tests for reward & claim logic** - Added unit tests for ClaimReward happy path, insufficient balance with no side effects verification, max claims enforcement, concurrent claim race condition prevention, ResolveClaim approve/deny paths, authorization checks, and encryption of all sensitive fields (title, description, parent_note, resolution note). (Hytte-muv9)
+
+category: Changed
+- **ClaimReward retry on database busy** - ClaimReward now retries up to 10 times on SQLITE_BUSY/SQLITE_LOCKED errors instead of surfacing a raw lock error to callers. Exhausted retries return a typed `ErrDatabaseBusy` sentinel (suitable for HTTP 503). (Hytte-muv9)

--- a/internal/family/rewards_storage.go
+++ b/internal/family/rewards_storage.go
@@ -3,21 +3,29 @@ package family
 import (
 	"database/sql"
 	"errors"
-	"strings"
+	"fmt"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
+	sqlite "modernc.org/sqlite"
+	sqlite3lib "modernc.org/sqlite/lib"
 )
 
-// isSQLiteBusy returns true when err is a SQLite SQLITE_BUSY / "database is
-// locked" error. These can occur under concurrent write load and are safe to
-// retry.
+// isSQLiteBusy returns true when err is a SQLite SQLITE_BUSY or SQLITE_LOCKED
+// error. These can occur under concurrent write load and are safe to retry.
+// It uses errors.As to inspect the driver error code rather than string
+// matching, which is more robust against message changes and wrapped errors.
 func isSQLiteBusy(err error) bool {
-	if err == nil {
+	var e *sqlite.Error
+	if !errors.As(err, &e) {
 		return false
 	}
-	s := err.Error()
-	return strings.Contains(s, "SQLITE_BUSY") || strings.Contains(s, "database is locked")
+	c := e.Code()
+	return c == sqlite3lib.SQLITE_BUSY ||
+		c == sqlite3lib.SQLITE_BUSY_RECOVERY ||
+		c == sqlite3lib.SQLITE_BUSY_SNAPSHOT ||
+		c == sqlite3lib.SQLITE_LOCKED ||
+		c == sqlite3lib.SQLITE_LOCKED_SHAREDCACHE
 }
 
 // Sentinel errors for reward and claim operations.
@@ -28,6 +36,9 @@ var (
 	ErrMaxClaimsReached  = errors.New("reward has reached max claims limit")
 	ErrClaimNotFound     = errors.New("claim not found")
 	ErrClaimNotPending   = errors.New("claim is not in pending status")
+	// ErrDatabaseBusy is returned when ClaimReward exhausts all retries due to
+	// SQLite lock contention. Callers can map this to an HTTP 503 response.
+	ErrDatabaseBusy = errors.New("database busy")
 )
 
 // boolToInt converts a bool to 0/1 for SQLite storage.
@@ -247,18 +258,20 @@ func DeleteReward(db *sql.DB, id, parentID int64) error {
 // surfacing a raw lock error to the caller.
 func ClaimReward(db *sql.DB, childID, rewardID int64) (*RewardClaim, error) {
 	const maxAttempts = 10
+	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		claim, err := claimRewardOnce(db, childID, rewardID)
 		if err == nil {
 			return claim, nil
 		}
 		if isSQLiteBusy(err) {
+			lastErr = err
 			time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
 			continue
 		}
 		return nil, err
 	}
-	return nil, errors.New("reward claim failed: database busy after retries")
+	return nil, fmt.Errorf("%w after %d retries: %v", ErrDatabaseBusy, maxAttempts, lastErr)
 }
 
 func claimRewardOnce(db *sql.DB, childID, rewardID int64) (*RewardClaim, error) {

--- a/internal/family/rewards_storage_test.go
+++ b/internal/family/rewards_storage_test.go
@@ -3,6 +3,7 @@ package family
 import (
 	"database/sql"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -72,7 +73,8 @@ func setupConcurrentRewardsTestDB(t *testing.T) *sql.DB {
 	t.Cleanup(func() { encryption.ResetEncryptionKey() })
 
 	dir := t.TempDir()
-	dsn := fmt.Sprintf("file:%s/rewards_concurrent.db?_pragma=foreign_keys(ON)&_pragma=journal_mode(WAL)", dir)
+	dbPath := filepath.Join(dir, "rewards_concurrent.db")
+	dsn := fmt.Sprintf("file:%s?_pragma=foreign_keys(ON)&_pragma=journal_mode(WAL)", dbPath)
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		t.Fatalf("open concurrent db: %v", err)
@@ -782,12 +784,14 @@ func TestClaimRewardRaceCondition(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Count successes and failures.
+	// Count successes and failures. ErrInsufficientStars must NOT appear: the
+	// child has 600 stars and the reward costs 5, so the balance can never be
+	// insufficient given a single successful claim.
 	successes := 0
 	for _, e := range errs {
 		if e == nil {
 			successes++
-		} else if !isErr(e, ErrMaxClaimsReached) && !isErr(e, ErrInsufficientStars) {
+		} else if !isErr(e, ErrMaxClaimsReached) {
 			t.Errorf("unexpected error from concurrent claim: %v", e)
 		}
 	}
@@ -802,6 +806,24 @@ func TestClaimRewardRaceCondition(t *testing.T) {
 	}
 	if claimCount != 1 {
 		t.Errorf("expected 1 claim row in DB, got %d", claimCount)
+	}
+
+	// Exactly 1 star transaction should have been recorded.
+	var txCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM star_transactions WHERE user_id = 2`).Scan(&txCount); err != nil {
+		t.Fatalf("count star transactions: %v", err)
+	}
+	if txCount != 1 {
+		t.Errorf("expected exactly 1 star transaction, got %d", txCount)
+	}
+
+	// Balance should have decreased by exactly star_cost (5): 600 → 595.
+	var balance int
+	if err := db.QueryRow(`SELECT current_balance FROM star_balances WHERE user_id = 2`).Scan(&balance); err != nil {
+		t.Fatalf("scan balance: %v", err)
+	}
+	if balance != 595 {
+		t.Errorf("expected balance 595 after 1 claim (cost=5), got %d", balance)
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Backend tests for reward & claim logic** - Added unit tests for ClaimReward happy path, insufficient balance with no side effects verification, max claims enforcement, concurrent claim race condition prevention, ResolveClaim approve/deny paths, authorization checks, and encryption of all sensitive fields (title, description, parent_note, resolution note). (Hytte-muv9)

## Original Issue (task): Backend: Tests for Reward & Claim Logic

Write Go tests covering: ClaimReward happy path (stars deducted, claim inserted, balance updated), insufficient balance (no side effects), max claims exceeded, double-claim race condition prevention via transaction, ResolveClaim approve (no refund), ResolveClaim deny (refund + balance correction), authorization checks (parent owns reward, parent owns child's claim), and encryption of title/description/parent_note. Tests live alongside the storage file (internal/family/rewards_storage_test.go or similar). Depends on sub-task 1 being complete.

---
Bead: Hytte-muv9 | Branch: forge/Hytte-muv9
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)