### PR TITLE
PWA manifest icon missing — vite.svg download error (Hytte-d2st)

### DIFF
--- a/changelog.d/Hytte-d2st.md
+++ b/changelog.d/Hytte-d2st.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Replace missing vite.svg PWA icon with Hytte cabin icon** - The PWA manifest and favicon referenced `/vite.svg` which did not exist, causing a browser download error. Replaced with a proper `/hytte-icon.svg` cabin icon matching the app's dark theme. (Hytte-d2st)

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/hytte-icon.svg" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#030712" />

--- a/web/public/hytte-icon.svg
+++ b/web/public/hytte-icon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="80" fill="#030712"/>
+  <!-- Roof -->
+  <polygon points="80,260 256,100 432,260" fill="#3b82f6"/>
+  <!-- Chimney -->
+  <rect x="310" y="130" width="36" height="80" fill="#1d4ed8"/>
+  <!-- House body -->
+  <rect x="120" y="256" width="272" height="180" fill="#1e40af"/>
+  <!-- Door -->
+  <rect x="216" y="330" width="80" height="106" rx="6" fill="#030712"/>
+  <!-- Window left -->
+  <rect x="148" y="288" width="60" height="55" rx="5" fill="#93c5fd"/>
+  <!-- Window right -->
+  <rect x="304" y="288" width="60" height="55" rx="5" fill="#93c5fd"/>
+</svg>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -7,7 +7,7 @@
   "theme_color": "#030712",
   "icons": [
     {
-      "src": "/vite.svg",
+      "src": "/hytte-icon.svg",
       "sizes": "any",
       "type": "image/svg+xml"
     }


### PR DESCRIPTION
## Changes

- **Replace missing vite.svg PWA icon with Hytte cabin icon** - The PWA manifest and favicon referenced `/vite.svg` which did not exist, causing a browser download error. Replaced with a proper `/hytte-icon.svg` cabin icon matching the app's dark theme. (Hytte-d2st)

## Original Issue (bug): PWA manifest icon missing — vite.svg download error

Browser console shows: 'Error while trying to use the following icon from the Manifest: https://robinedvardsmith.com/vite.svg (Download error or resource isn't a valid image)'. The PWA manifest references vite.svg as an icon but it's either missing from the build output, not served correctly, or is the default Vite placeholder that was never replaced with a proper app icon. Replace with a proper Hytte icon (PNG/SVG) and update the manifest accordingly.

---
Bead: Hytte-d2st | Branch: forge/Hytte-d2st
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)