### PR TITLE
Stars: Challenges page missing — card links to nowhere (Hytte-3trn)

### DIFF
--- a/changelog.d/Hytte-3trn.md
+++ b/changelog.d/Hytte-3trn.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Stars Challenges card now navigates correctly** - The Challenges navigation card on the Stars page was linking to `/stars` (itself) instead of `/stars/challenges`, making it appear broken. (Hytte-3trn)

--- a/web/src/pages/Stars.tsx
+++ b/web/src/pages/Stars.tsx
@@ -93,7 +93,7 @@ interface JourneyResponse {
 const NAV_CARDS = [
   { to: '/stars/badges', emoji: '🏅', key: 'nav.badges' },
   { to: '/stars/rewards', emoji: '🎁', key: 'nav.rewards' },
-  { to: '/stars', emoji: '🎯', key: 'nav.challenges' },
+  { to: '/stars/challenges', emoji: '🎯', key: 'nav.challenges' },
   { to: '/stars/leaderboard', emoji: '🏆', key: 'nav.leaderboard' },
 ] as const
 


### PR DESCRIPTION
## Changes

- **Stars Challenges card now navigates correctly** - The Challenges navigation card on the Stars page was linking to `/stars` (itself) instead of `/stars/challenges`, making it appear broken. (Hytte-3trn)

## Original Issue (bug): Stars: Challenges page missing — card links to nowhere

The Stars page has a Challenges navigation card (🎯 Challenges - Active challenges and goals) but it links to a page that doesn't exist. Either the StarChallenges.tsx page isn't routed, or the route isn't registered in App.tsx. Verify the route exists at /stars/challenges and that StarChallenges.tsx is properly imported and accessible to child users.

---
Bead: Hytte-3trn | Branch: forge/Hytte-3trn
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)