### PR TITLE
Training compare: show tags in workout dropdown selector (Hytte-k4to)

### DIFF
--- a/changelog.d/Hytte-k4to.md
+++ b/changelog.d/Hytte-k4to.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Training compare: show tags in workout dropdown** - Auto-generated and AI tags (e.g. "10x1km", "6x6min") are now shown in the workout selector dropdowns on the compare page, making it easier to distinguish between multiple sessions with the same title. (Hytte-k4to)

--- a/web/src/pages/TrainingCompare.tsx
+++ b/web/src/pages/TrainingCompare.tsx
@@ -14,8 +14,19 @@ import {
 import { useAuth } from '../auth'
 import { useTranslation } from 'react-i18next'
 import { formatDate } from '../utils/formatDate'
+import { isAutoTag, isAITag, displayTag } from '../tags'
 import type { TFunction } from 'i18next'
 import type { Workout, Lap, ComparisonResult, CachedComparisonAnalysis, ComparisonAnalysisSummary } from '../types/training'
+
+function workoutOptionLabel(w: Workout): string {
+  const tagPart = w.tags
+    ?.filter((t) => isAutoTag(t) || isAITag(t))
+    .map(displayTag)
+    .join(', ')
+  return tagPart
+    ? `${w.title} — ${tagPart} — ${formatDate(w.started_at)}`
+    : `${w.title} — ${formatDate(w.started_at)}`
+}
 
 function formatPace(secPerKm: number, t: TFunction<'training'>): string {
   if (secPerKm <= 0) return '--:--'
@@ -484,7 +495,7 @@ export default function TrainingCompare() {
             <option value="">{t('compare.selectWorkout')}</option>
             {workouts.map((w) => (
               <option key={w.id} value={w.id}>
-                {w.title} — {formatDate(w.started_at)}
+                {workoutOptionLabel(w)}
               </option>
             ))}
           </select>
@@ -499,7 +510,7 @@ export default function TrainingCompare() {
             <option value="">{t('compare.selectWorkout')}</option>
             {workouts.map((w) => (
               <option key={w.id} value={w.id}>
-                {w.title} — {formatDate(w.started_at)}
+                {workoutOptionLabel(w)}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Changes

- **Training compare: show tags in workout dropdown** - Auto-generated and AI tags (e.g. "10x1km", "6x6min") are now shown in the workout selector dropdowns on the compare page, making it easier to distinguish between multiple sessions with the same title. (Hytte-k4to)

## Original Issue (feature): Training compare: show tags in workout dropdown selector

The workout comparison dropdown shows title and date for each workout, but when you have multiple workouts of the same type (e.g. several 'Threshold Intervals' sessions) it's hard to tell them apart. Add the auto-generated tags to the dropdown entries — e.g. 'Threshold Intervals — 10x1km — Mar 25' or show tags as small badges next to the title. Tags are already available from the workout data (auto-tags like '10x1km', '6x6min', sport type, etc.).

---
Bead: Hytte-k4to | Branch: forge/Hytte-k4to
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)