### PR TITLE
Settings: AI prompt save fails with 500 when saving multiple prompts simultaneously (Hytte-7iu4)

### DIFF
--- a/changelog.d/Hytte-7iu4.md
+++ b/changelog.d/Hytte-7iu4.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **AI prompt save no longer fails with 500 errors** - Saving multiple AI prompts now fires requests sequentially instead of in parallel, avoiding SQLite write lock contention. (Hytte-7iu4)

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -346,18 +346,15 @@ function Settings() {
       const dirtyKeys = aiPrompts
         .filter((p) => aiPromptDrafts[p.key] !== p.body)
         .map((p) => p.key)
-      await Promise.all(
-        dirtyKeys.map((key) =>
-          fetch(`/api/settings/ai-prompts/${key}`, {
-            method: 'PUT',
-            credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ body: aiPromptDrafts[key] }),
-          }).then((res) => {
-            if (!res.ok) throw new Error(`Failed to save prompt "${key}"`)
-          })
-        )
-      )
+      for (const key of dirtyKeys) {
+        const res = await fetch(`/api/settings/ai-prompts/${key}`, {
+          method: 'PUT',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ body: aiPromptDrafts[key] }),
+        })
+        if (!res.ok) throw new Error(`Failed to save prompt "${key}"`)
+      }
       await reloadAiPrompts()
       setAiPromptsFeedback({ ok: true, message: t('aiPrompts.saveSuccess') })
     } catch (err) {


### PR DESCRIPTION
## Changes

- **AI prompt save no longer fails with 500 errors** - Saving multiple AI prompts now fires requests sequentially instead of in parallel, avoiding SQLite write lock contention. (Hytte-7iu4)

## Original Issue (bug): Settings: AI prompt save fails with 500 when saving multiple prompts simultaneously

The frontend fires all 4 PUT /api/settings/ai-prompts/{key} requests in parallel. SQLite can only handle one concurrent writer, so 2 of 4 requests typically fail with 500 (database is locked). The success/failure pattern is random — different keys fail each time.

Fix options (pick one):
1. Frontend: save prompts sequentially (await each PUT before firing the next)
2. Backend: batch all prompts into a single PUT /api/settings/ai-prompts endpoint that updates all keys in one transaction
3. Backend: add retry-on-busy logic to the SQLite write (retry after short delay on SQLITE_BUSY)

Option 1 is simplest. Option 2 is cleanest. The frontend currently does Promise.all() on all 4 PUTs — change to sequential awaits or a single batch endpoint.

---
Bead: Hytte-7iu4 | Branch: forge/Hytte-7iu4
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)