### PR TITLE
Kiosk: 't is undefined' error on Android 5 Firefox after e8ei fix (Hytte-z5os)

### DIFF
--- a/changelog.d/Hytte-z5os.md
+++ b/changelog.d/Hytte-z5os.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Kiosk: fix 't is undefined' on Android 5 / old Firefox** - Added `whatwg-fetch` polyfill to the legacy bundle so that `i18next-http-backend` (which uses the `fetch` Web API to load locale JSON files) initialises correctly on browsers that lack native `fetch`. Without this, `useTranslation()` silently returned `t=undefined`, crashing the kiosk. (Hytte-z5os)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,7 +26,8 @@
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
-        "tailwindcss": "^4.2.2"
+        "tailwindcss": "^4.2.2",
+        "whatwg-fetch": "^3.6.20"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -7198,6 +7199,12 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "i18next": "^26.0.0",
+    "whatwg-fetch": "^3.6.20",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^3.0.2",
     "lucide-react": "^1.7.0",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,7 +14,11 @@ export default defineConfig({
       // core-js/regenerator-based polyfills for language features as configured here.
       // Web APIs (e.g. fetch, AbortController) require explicit polyfills if needed.
       targets: ['defaults', 'not IE 11', 'Firefox ESR', 'Chrome >= 37'],
-      additionalLegacyPolyfills: ['regenerator-runtime/runtime'],
+      // whatwg-fetch polyfills the fetch Web API for Android 5 / old Firefox
+      // which lack it. i18next-http-backend (v3) uses fetch to load locale
+      // JSON files; without this polyfill, i18n init fails silently and
+      // useTranslation() returns t=undefined, breaking the kiosk page.
+      additionalLegacyPolyfills: ['regenerator-runtime/runtime', 'whatwg-fetch'],
     }),
   ],
   server: {


### PR DESCRIPTION
## Changes

- **Kiosk: fix 't is undefined' on Android 5 / old Firefox** - Added `whatwg-fetch` polyfill to the legacy bundle so that `i18next-http-backend` (which uses the `fetch` Web API to load locale JSON files) initialises correctly on browsers that lack native `fetch`. Without this, `useTranslation()` silently returned `t=undefined`, crashing the kiosk. (Hytte-z5os)

## Original Issue (bug): Kiosk: 't is undefined' error on Android 5 Firefox after e8ei fix

Follow-up to Hytte-e8ei. The blank page was fixed (now shows an error message), but the kiosk still doesn't render on Android 5 Firefox. Error: 'Kiosk failed to load t is undefined'.

The 't' is the i18next translation function from useTranslation(). Either:
1. i18next fails to initialize on old browsers (missing Promise, fetch, or other polyfills)
2. The destructuring const { t } = useTranslation() results in undefined because the hook failed silently
3. The i18n bundle itself uses syntax the old browser can't parse

The e8ei fix likely added build.target or @vitejs/plugin-legacy but i18next or react-i18next still has code paths that need polyfilling. Check if the kiosk page needs a standalone i18n init that's simpler (hardcoded strings instead of async JSON loading) or if a polyfill for Promise/fetch is needed for the i18n HTTP backend loader.

---
Bead: Hytte-z5os | Branch: forge/Hytte-z5os
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)