### PR TITLE
Kiosk: 404 page not found after latest PR merge (Hytte-2fat)

### DIFF
--- a/changelog.d/Hytte-2fat.md
+++ b/changelog.d/Hytte-2fat.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Kiosk 404 after legacy polyfill change** - Moving `whatwg-fetch` from `additionalLegacyPolyfills` to a direct top-level import in `main.tsx` fixes the build failure introduced by PR #354. The polyfill sub-build run by `@vitejs/plugin-legacy` could not bundle the package correctly, causing `web/dist/index.html` to not be generated and all SPA routes (including `/kiosk`) to return 404. Importing it directly in `main.tsx` ensures the polyfill is bundled reliably and still runs before `i18next-http-backend` calls `fetch()`. (Hytte-2fat)

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,3 +1,7 @@
+// whatwg-fetch polyfills the fetch Web API for Android 5 / old Firefox.
+// Must be the first import so the polyfill runs before i18next-http-backend
+// attempts its first fetch() call to load locale JSON files.
+import 'whatwg-fetch'
 import { StrictMode, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,11 +14,7 @@ export default defineConfig({
       // core-js/regenerator-based polyfills for language features as configured here.
       // Web APIs (e.g. fetch, AbortController) require explicit polyfills if needed.
       targets: ['defaults', 'not IE 11', 'Firefox ESR', 'Chrome >= 37'],
-      // whatwg-fetch polyfills the fetch Web API for Android 5 / old Firefox
-      // which lack it. i18next-http-backend (v3) uses fetch to load locale
-      // JSON files; without this polyfill, i18n init fails silently and
-      // useTranslation() returns t=undefined, breaking the kiosk page.
-      additionalLegacyPolyfills: ['regenerator-runtime/runtime', 'whatwg-fetch'],
+      additionalLegacyPolyfills: ['regenerator-runtime/runtime'],
     }),
   ],
   server: {


### PR DESCRIPTION
## Changes

- **Kiosk 404 after legacy polyfill change** - Moving `whatwg-fetch` from `additionalLegacyPolyfills` to a direct top-level import in `main.tsx` fixes the build failure introduced by PR #354. The polyfill sub-build run by `@vitejs/plugin-legacy` could not bundle the package correctly, causing `web/dist/index.html` to not be generated and all SPA routes (including `/kiosk`) to return 404. Importing it directly in `main.tsx` ensures the polyfill is bundled reliably and still runs before `i18next-http-backend` calls `fetch()`. (Hytte-2fat)

## Original Issue (bug): Kiosk: 404 page not found after latest PR merge

PR #354 (Hytte-z5os) added whatwg-fetch to the @vitejs/plugin-legacy polyfills. The kiosk page worked before this PR. After merge, /kiosk returns 404 on both deployed server and locally.

The @vitejs/plugin-legacy generates legacy + modern bundles with a different output structure. This may have changed the built file paths or the index.html structure in a way that breaks the SPA fallback routing.

Check:
1. Does web/dist/index.html still exist after npm run build? Has its structure changed?
2. Does the legacy plugin add a separate entry point that confuses the SPA handler?
3. Try reverting just the vite.config.ts change and see if /kiosk works again
4. The Go SPA handler (router.go:502) serves index.html as fallback — verify the built index.html loads the correct JS bundle

The fix in PR #354 was small (one line: adding whatwg-fetch to polyfills) but the legacy plugin may have side effects on the build output.

---
Bead: Hytte-2fat | Branch: forge/Hytte-2fat
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)