### PR TITLE
Forge Dashboard: IPC status takes 5s (hits read timeout) — shows 'Daemon offline' (Hytte-e535)

### DIFF
--- a/changelog.d/Hytte-e535.md
+++ b/changelog.d/Hytte-e535.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Forge Dashboard no longer shows 'Daemon offline' when a smith is active** - The IPC health check now uses a dial-only connection test instead of a full ping/pong exchange. This avoids the 5s read timeout that fired when the daemon was busy processing workers and slow to respond, causing the dashboard to incorrectly report the daemon as offline. (Hytte-e535)

--- a/internal/forge/ipc.go
+++ b/internal/forge/ipc.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	ipcDialTimeout  = 3 * time.Second
-	ipcReadTimeout  = 5 * time.Second
-	ipcWriteTimeout = 5 * time.Second
-	ipcMaxResponse  = 1 << 20 // 1 MiB
+	ipcDialTimeout   = 3 * time.Second
+	ipcReadTimeout   = 5 * time.Second
+	ipcWriteTimeout  = 5 * time.Second
+	ipcMaxResponse   = 1 << 20 // 1 MiB
+	ipcHealthTimeout = 1 * time.Second
 )
 
 // Client is a Unix IPC client for communicating with the forge daemon.
@@ -76,12 +77,15 @@ func (c *Client) SendCommand(cmd string) ([]byte, error) {
 	return data, nil
 }
 
-// Health checks whether the forge daemon is reachable by sending a "ping"
-// command and expecting any response. Returns nil if the daemon is alive.
+// Health checks whether the forge daemon is reachable by attempting to connect
+// to its Unix socket. A successful dial means the daemon is alive; no command
+// or response exchange is needed, so this returns in well under a second
+// regardless of how busy the daemon is.
 func (c *Client) Health() error {
-	_, err := c.SendCommand("ping")
+	conn, err := net.DialTimeout("unix", c.socketPath, ipcHealthTimeout)
 	if err != nil {
 		return fmt.Errorf("forge: daemon not reachable: %w", err)
 	}
+	conn.Close()
 	return nil
 }


### PR DESCRIPTION
## Changes

- **Forge Dashboard no longer shows 'Daemon offline' when a smith is active** - The IPC health check now uses a dial-only connection test instead of a full ping/pong exchange. This avoids the 5s read timeout that fired when the daemon was busy processing workers and slow to respond, causing the dashboard to incorrectly report the daemon as offline. (Hytte-e535)

## Original Issue (bug): Forge Dashboard: IPC status takes 5s (hits read timeout) — shows 'Daemon offline'

The /api/forge/status endpoint takes exactly 5.003s on every request — hitting the ipcReadTimeout of 5 seconds in internal/forge/ipc.go:15. The response is 200 with 31KB of data, so the daemon IS responding, but the read times out before all data is received (or the daemon is slow to respond when a smith is active).

This causes the frontend to show 'Daemon offline' because it interprets the slow/partial response as a failure.

Possible fixes:
1. Increase ipcReadTimeout to 10-15s (quick fix but masks the real issue)
2. The status response is 31KB — that's huge for a status check. Trim it down (do we need all events/workers in the status response?)
3. Split the status endpoint: fast lightweight ping (just 'running: true') + separate detailed data endpoints
4. Read the status data directly from state.db instead of going through IPC (state.db is on the same box, read-only SQLite is instant)

Option 4 is best — the dashboard already reads state.db for workers/events/PRs. The IPC should only be used for actions (merge, kill, refresh), not data reads.

---
Bead: Hytte-e535 | Branch: forge/Hytte-e535
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)