### PR TITLE
Forge Dashboard: anvils in queue should be collapsed by default + stop auto-scroll to bottom (Hytte-nnc9)

### DIFF
--- a/changelog.d/Hytte-nnc9.md
+++ b/changelog.d/Hytte-nnc9.md
@@ -1,0 +1,3 @@
+category: Fixed
+- **Forge Dashboard queue collapsed by default** - Anvil groups in the queue are now collapsed by default so the queue doesn't dominate the page. (Hytte-nnc9)
+- **Forge Dashboard auto-scroll contained to event log** - Auto-scroll now stays within the event log and worker output containers instead of pulling the whole page to the bottom. (Hytte-nnc9)

--- a/web/src/components/FullQueueCard.tsx
+++ b/web/src/components/FullQueueCard.tsx
@@ -189,7 +189,7 @@ interface AnvilSectionProps {
 
 function AnvilSection({ anvilGroup, onLabelAction, pendingLabels }: AnvilSectionProps) {
   const { t } = useTranslation('forge')
-  const [open, setOpen] = useState(true)
+  const [open, setOpen] = useState(false)
 
   return (
     <div className="border-b border-gray-700/40 last:border-0">

--- a/web/src/components/LiveActivity.tsx
+++ b/web/src/components/LiveActivity.tsx
@@ -160,8 +160,6 @@ export default function LiveActivity({ selectedWorker }: LiveActivityProps) {
   const [logUserScrolledUp, setLogUserScrolledUp] = useState(false)
   const [showPolls, setShowPolls] = useState(false)
 
-  const eventBottomRef = useRef<HTMLDivElement>(null)
-  const logBottomRef = useRef<HTMLDivElement>(null)
   const eventContainerRef = useRef<HTMLDivElement>(null)
   const logContainerRef = useRef<HTMLDivElement>(null)
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined)
@@ -323,14 +321,16 @@ export default function LiveActivity({ selectedWorker }: LiveActivityProps) {
   // Auto-scroll event log unless user scrolled up
   useEffect(() => {
     if (!eventUserScrolledUp) {
-      eventBottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+      const el = eventContainerRef.current
+      if (el) el.scrollTop = el.scrollHeight
     }
   }, [visibleEvents, eventUserScrolledUp])
 
   // Auto-scroll log output unless user scrolled up
   useEffect(() => {
     if (!logUserScrolledUp) {
-      logBottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+      const el = logContainerRef.current
+      if (el) el.scrollTop = el.scrollHeight
     }
   }, [logEntries, logUserScrolledUp])
 
@@ -350,12 +350,14 @@ export default function LiveActivity({ selectedWorker }: LiveActivityProps) {
 
   function scrollEventToBottom() {
     setEventUserScrolledUp(false)
-    eventBottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    const el = eventContainerRef.current
+    if (el) el.scrollTop = el.scrollHeight
   }
 
   function scrollLogToBottom() {
     setLogUserScrolledUp(false)
-    logBottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    const el = logContainerRef.current
+    if (el) el.scrollTop = el.scrollHeight
   }
 
   return (
@@ -422,7 +424,6 @@ export default function LiveActivity({ selectedWorker }: LiveActivityProps) {
                 <LogEntryRow key={entry.seq} entry={entry} t={t} />
               ))
             )}
-            <div ref={logBottomRef} />
           </div>
         </div>
       )}
@@ -505,7 +506,6 @@ export default function LiveActivity({ selectedWorker }: LiveActivityProps) {
               </div>
             )
           })}
-          <div ref={eventBottomRef} />
         </div>
       )}
       </div>


### PR DESCRIPTION
## Changes

- **Forge Dashboard queue collapsed by default** - Anvil groups in the queue are now collapsed by default so the queue doesn't dominate the page. (Hytte-nnc9)
- **Forge Dashboard auto-scroll contained to event log** - Auto-scroll now stays within the event log and worker output containers instead of pulling the whole page to the bottom. (Hytte-nnc9)

## Original Issue (bug): Forge Dashboard: anvils in queue should be collapsed by default + stop auto-scroll to bottom

Two issues:
1. Anvil groups in the queue are expanded by default — should be collapsed so the queue doesn't take up the entire page
2. The page auto-scrolls to the bottom on load/refresh — likely the event log auto-scroll is pulling the whole page down. The auto-scroll should only apply within the event log container, not the page itself.

---
Bead: Hytte-nnc9 | Branch: forge/Hytte-nnc9
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)