### PR TITLE
Infra: tool versions 'unavailable' — Hytte service PATH missing user bins (Hytte-24zl)

### DIFF
--- a/changelog.d/Hytte-24zl.md
+++ b/changelog.d/Hytte-24zl.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Tool versions no longer show 'unavailable' under systemd** - The versions handler now checks ~/.local/bin and ~/bin as fallback paths when commands are not found in PATH, fixing the issue where the Hytte systemd service couldn't locate user-installed tools like forge, bd, and claude. (Hytte-24zl)

--- a/internal/infra/versions.go
+++ b/internal/infra/versions.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -34,8 +35,33 @@ type versionEntry struct {
 // commandRunner abstracts exec.CommandContext so tests can inject stubs.
 type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
 
+// resolveCommand returns the full path to a command binary. If the command is
+// found via the normal PATH lookup, that path is returned. Otherwise, common
+// user binary directories (~/.local/bin, ~/bin) are checked as a fallback.
+// This ensures commands are found even when running as a systemd service whose
+// PATH does not include user-specific directories.
+func resolveCommand(name string) string {
+	if p, err := exec.LookPath(name); err == nil {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return name
+	}
+	for _, dir := range []string{
+		filepath.Join(home, ".local", "bin"),
+		filepath.Join(home, "bin"),
+	} {
+		candidate := filepath.Join(dir, name)
+		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return name
+}
+
 func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+	return exec.CommandContext(ctx, resolveCommand(name), args...).CombinedOutput()
 }
 
 // forgeRepoDir returns the Forge repository directory from the FORGE_REPO_DIR

--- a/internal/infra/versions_test.go
+++ b/internal/infra/versions_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -132,6 +134,45 @@ func TestVersionsHandler_CachesResult(t *testing.T) {
 		if !ok || v1 != v2 {
 			t.Errorf("cache inconsistency for key %q: first=%q, second=%q", k, v1, v2)
 		}
+	}
+}
+
+func TestResolveCommand_FallsBackToUserBinDirs(t *testing.T) {
+	// Create a temp directory to act as a fake home with .local/bin
+	tmpHome := t.TempDir()
+	localBin := filepath.Join(tmpHome, ".local", "bin")
+	if err := os.MkdirAll(localBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake executable in .local/bin
+	fakeBin := filepath.Join(localBin, "my-test-tool")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Override HOME so resolveCommand looks in our temp dir
+	t.Setenv("HOME", tmpHome)
+
+	// "my-test-tool" won't be in PATH, so resolveCommand should find it in ~/.local/bin
+	resolved := resolveCommand("my-test-tool")
+	if resolved != fakeBin {
+		t.Errorf("expected %q, got %q", fakeBin, resolved)
+	}
+}
+
+func TestResolveCommand_PrefersPathLookup(t *testing.T) {
+	// "ls" is a standard command that should always be in PATH
+	resolved := resolveCommand("ls")
+	if resolved == "ls" {
+		t.Error("expected resolveCommand to return a full path for 'ls'")
+	}
+}
+
+func TestResolveCommand_ReturnsNameWhenNotFound(t *testing.T) {
+	resolved := resolveCommand("definitely-not-a-real-command-xyz")
+	if resolved != "definitely-not-a-real-command-xyz" {
+		t.Errorf("expected unresolved name, got %q", resolved)
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Tool versions no longer show 'unavailable' under systemd** - The versions handler now checks ~/.local/bin and ~/bin as fallback paths when commands are not found in PATH, fixing the issue where the Hytte systemd service couldn't locate user-installed tools like forge, bd, and claude. (Hytte-24zl)

## Original Issue (bug): Infra: tool versions 'unavailable' — Hytte service PATH missing user bins

The Hytte systemd service PATH doesn't include /home/robin/bin or /home/robin/.local/bin where forge, bd, and claude are installed. The versions endpoint runs these commands but they're not found.

Quick fix: add PATH to ~/Hytte/.env. But the proper fix: the versions handler should check common user bin paths as fallback, or resolve the full path using a config/env var rather than relying on PATH alone. This avoids the issue recurring if the service is reinstalled.

---
Bead: Hytte-24zl | Branch: forge/Hytte-24zl
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)