### PR TITLE
Add GitHub CLI (gh) update button to Tool Versions panel (Hytte-1wj4)

### DIFF
--- a/changelog.d/Hytte-1wj4.md
+++ b/changelog.d/Hytte-1wj4.md
@@ -1,0 +1,2 @@
+category: Added
+- **GitHub CLI update button** - Added an Update button for gh (GitHub CLI) in the Tool Versions panel, using `gh upgrade --force`. (Hytte-1wj4)

--- a/internal/infra/update.go
+++ b/internal/infra/update.go
@@ -41,13 +41,14 @@ func defaultToolRunners() map[string]toolRunner {
 		// resolveCommand handles restricted-PATH environments (e.g. systemd).
 		"npm":  makeSimpleRunner(resolveCommand("npm"), "install", "-g", "npm@latest"),
 		"git":  makeSimpleRunner("/bin/sh", "-c", "sudo apt-get update -qq && sudo apt-get install -y git"),
+		"gh":   makeSimpleRunner(resolveCommand("gh"), "upgrade", "--force"),
 		"dolt": defaultDoltRunner,
 	}
 }
 
 // UpdateToolHandler runs the update/install script for a given tool.
 // Supported tools: "forge", "beads", "claude", "go", "node", "npm", "git",
-// "dolt". Auth is enforced by RequireAdmin middleware in the router.
+// "gh", "dolt". Auth is enforced by RequireAdmin middleware in the router.
 func UpdateToolHandler() http.HandlerFunc {
 	return updateToolHandlerWithRunners(defaultToolRunners())
 }

--- a/internal/infra/update_test.go
+++ b/internal/infra/update_test.go
@@ -162,7 +162,7 @@ func TestUpdateToolHandler_BeadsExecutionError(t *testing.T) {
 // TestUpdateToolHandler_ToolSuccess verifies that each new tool returns
 // success:true when its runner succeeds.
 func TestUpdateToolHandler_ToolSuccess(t *testing.T) {
-	tools := []string{"claude", "go", "node", "npm", "git", "dolt"}
+	tools := []string{"claude", "go", "node", "npm", "git", "gh", "dolt"}
 
 	for _, tool := range tools {
 		t.Run(tool, func(t *testing.T) {
@@ -190,7 +190,7 @@ func TestUpdateToolHandler_ToolSuccess(t *testing.T) {
 // TestUpdateToolHandler_ToolFailure verifies that each new tool returns
 // success:false with stdout/stderr when its runner fails.
 func TestUpdateToolHandler_ToolFailure(t *testing.T) {
-	tools := []string{"claude", "go", "node", "npm", "git", "dolt"}
+	tools := []string{"claude", "go", "node", "npm", "git", "gh", "dolt"}
 
 	for _, tool := range tools {
 		t.Run(tool, func(t *testing.T) {

--- a/web/src/pages/Infra.tsx
+++ b/web/src/pages/Infra.tsx
@@ -392,7 +392,7 @@ function parseVersion(raw: string): string {
   return m ? m[1] : raw
 }
 
-const UPDATABLE_TOOLS = new Set(['forge', 'bd', 'claude', 'go', 'node', 'npm', 'git', 'dolt'])
+const UPDATABLE_TOOLS = new Set(['forge', 'bd', 'claude', 'go', 'node', 'npm', 'git', 'gh', 'dolt'])
 
 function ToolVersionsPanel() {
   const { t } = useTranslation('infra')


### PR DESCRIPTION
## Changes

- **GitHub CLI update button** - Added an Update button for gh (GitHub CLI) in the Tool Versions panel, using `gh upgrade --force`. (Hytte-1wj4)

## Original Issue (task): Add GitHub CLI (gh) update button to Tool Versions panel

Small, focused change to add an Update button for the gh tool, matching the pattern used by all other tools in the Tool Versions panel. Find the file rendering the tool versions table/panel (likely a React/Vue component or server-rendered template). Locate where update buttons are defined for each tool and add an entry for gh. The update action should run 'gh upgrade' (or fall back to downloading from GitHub releases). Follow the exact same pattern (button component, click handler, status feedback) used by the existing update buttons for other tools. This sub-task is independent of the Latest Version column work but touches the same UI component.

---
Bead: Hytte-1wj4 | Branch: forge/Hytte-1wj4
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)