### PR TITLE
Infra: forge_head version entry ignores dir field (Hytte-m7eh)

### DIFF
--- a/changelog.d/Hytte-m7eh.md
+++ b/changelog.d/Hytte-m7eh.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Fix forge_head version using wrong directory** - The forge_head git command now runs in FORGE_REPO_DIR instead of the service working directory. (Hytte-m7eh)

--- a/internal/infra/versions.go
+++ b/internal/infra/versions.go
@@ -33,7 +33,9 @@ type versionEntry struct {
 }
 
 // commandRunner abstracts exec.CommandContext so tests can inject stubs.
-type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+// The dir parameter sets the working directory for the command; empty means
+// the current process directory.
+type commandRunner func(ctx context.Context, dir string, name string, args ...string) ([]byte, error)
 
 // resolveCommand returns the full path to a command binary. If the command is
 // found via the normal PATH lookup, that path is returned. Otherwise, common
@@ -60,8 +62,12 @@ func resolveCommand(name string) string {
 	return name
 }
 
-func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, resolveCommand(name), args...).CombinedOutput()
+func defaultCommandRunner(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, resolveCommand(name), args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	return cmd.CombinedOutput()
 }
 
 // forgeRepoDir returns the Forge repository directory from the FORGE_REPO_DIR
@@ -96,7 +102,7 @@ func getVersions(runner commandRunner) map[string]string {
 	result := make(map[string]string, len(entries))
 	for _, e := range entries {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		out, err := runner(ctx, e.cmd, e.args...)
+		out, err := runner(ctx, e.dir, e.cmd, e.args...)
 		cancel()
 		if err != nil {
 			log.Printf("versions: command %q failed: %v; output: %s", e.cmd, err, strings.TrimSpace(string(out)))

--- a/internal/infra/versions_test.go
+++ b/internal/infra/versions_test.go
@@ -23,7 +23,7 @@ func resetVersionsCache() {
 // stubRunner returns a commandRunner that produces deterministic fake output
 // for each known tool command, without spawning any real processes.
 func stubRunner() commandRunner {
-	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return func(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
 		responses := map[string]string{
 			"claude": "claude 1.0.0",
 			"forge":  "forge 2.0.0",


### PR DESCRIPTION
## Changes

- **Fix forge_head version using wrong directory** - The forge_head git command now runs in FORGE_REPO_DIR instead of the service working directory. (Hytte-m7eh)

## Original Issue (bug): Infra: forge_head version entry ignores dir field

In internal/infra/versions.go, the versionEntry struct has a dir field that is set for forge_head to forgeRepoDir(), but getVersions() never passes dir to the command runner. The git rev-parse --short HEAD command runs in the service CWD instead of FORGE_REPO_DIR.

---
Bead: Hytte-m7eh | Branch: forge/Hytte-m7eh
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)