### PR TITLE
Cache-bust locale JSON files on deploy (Hytte-6l67)

### DIFF
--- a/changelog.d/Hytte-6l67.md
+++ b/changelog.d/Hytte-6l67.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Cache-bust locale JSON files on deploy** - Added a build-time hash to i18next loadPath so browsers fetch fresh locale files after each deploy instead of serving stale cached versions. (Hytte-6l67)

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -15,7 +15,7 @@ i18n
       escapeValue: false,
     },
     backend: {
-      loadPath: '/locales/{{lng}}/{{ns}}.json',
+      loadPath: '/locales/{{lng}}/{{ns}}.json?v=' + __BUILD_HASH__,
     },
     detection: {
       order: ['localStorage', 'navigator'],

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __BUILD_HASH__: string;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     tailwindcss(),
     react(),
   ],
+  define: {
+    __BUILD_HASH__: JSON.stringify(Date.now().toString(36)),
+  },
   server: {
     proxy: {
       '/api': 'http://localhost:8080'


### PR DESCRIPTION
## Changes

- **Cache-bust locale JSON files on deploy** - Added a build-time hash to i18next loadPath so browsers fetch fresh locale files after each deploy instead of serving stale cached versions. (Hytte-6l67)

## Original Issue (bug): Cache-bust locale JSON files on deploy

i18next loads locale files via HTTP (e.g. /locales/en/common.json). After deploys, browsers serve stale cached versions causing raw i18n keys to display. This has happened multiple times.

Fix: add a cache-busting query param to the locale loadPath in i18n.ts. Options:
1. Use the Vite build hash: loadPath: '/locales/{{lng}}/{{ns}}.json?v=' + __BUILD_HASH__  (define via Vite's define config)
2. Use a timestamp injected at build time
3. Set proper Cache-Control headers on the server for /locales/ paths (short max-age or must-revalidate)

Option 1 is cleanest — locale files get a new URL on every build, browser fetches fresh. Old cached versions are harmless since they have a different query param.

---
Bead: Hytte-6l67 | Branch: forge/Hytte-6l67
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)