### PR TITLE
Infra: GitHub CLI update command wrong — gh has no 'upgrade' command (Hytte-ru66)

### DIFF
--- a/changelog.d/Hytte-ru66.md
+++ b/changelog.d/Hytte-ru66.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **GitHub CLI update command** - Fixed the gh update button to use apt-get instead of the non-existent `gh upgrade` command. (Hytte-ru66)

--- a/internal/infra/update.go
+++ b/internal/infra/update.go
@@ -41,7 +41,7 @@ func defaultToolRunners() map[string]toolRunner {
 		// resolveCommand handles restricted-PATH environments (e.g. systemd).
 		"npm":  makeSimpleRunner(resolveCommand("npm"), "install", "-g", "npm@latest"),
 		"git":  makeSimpleRunner("/bin/sh", "-c", "sudo apt-get update -qq && sudo apt-get install -y git"),
-		"gh":   makeSimpleRunner(resolveCommand("gh"), "upgrade", "--force"),
+		"gh":   makeSimpleRunner("/bin/sh", "-c", "sudo apt-get update -qq && sudo apt-get install -y gh"),
 		"dolt": defaultDoltRunner,
 	}
 }


### PR DESCRIPTION
## Changes

- **GitHub CLI update command** - Fixed the gh update button to use apt-get instead of the non-existent `gh upgrade` command. (Hytte-ru66)

## Original Issue (bug): Infra: GitHub CLI update command wrong — gh has no 'upgrade' command

The tool versions update button for GitHub CLI runs 'gh upgrade' which doesn't exist. gh is installed via apt on the Hetzner server and needs to be updated via the system package manager.

Fix the update command to:
```bash
sudo apt-get update && sudo apt-get install -y gh
```

Or if using the GitHub official apt repo:
```bash
type -p curl >/dev/null || sudo apt install curl -y
curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
echo 'deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
sudo apt update && sudo apt install gh -y
```

Check internal/infra/versions.go for the update command mapping and fix the gh entry.

---
Bead: Hytte-ru66 | Branch: forge/Hytte-ru66
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)