### PR TITLE
Infra: npm update needs sudo — EACCES permission denied (Hytte-fnto)

### DIFF
--- a/changelog.d/Hytte-fnto.md
+++ b/changelog.d/Hytte-fnto.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **npm update no longer fails with EACCES** - Added sudo to the npm global update command so it can write to system-owned directories. (Hytte-fnto)

--- a/internal/infra/update.go
+++ b/internal/infra/update.go
@@ -38,8 +38,9 @@ func defaultToolRunners() map[string]toolRunner {
 		// provide the latest upstream Node version if the NodeSource PPA is
 		// not configured on the host.
 		"node": makeSimpleRunner("/bin/sh", "-c", "sudo apt-get update -qq && sudo apt-get install -y nodejs"),
-		// resolveCommand handles restricted-PATH environments (e.g. systemd).
-		"npm":  makeSimpleRunner(resolveCommand("npm"), "install", "-g", "npm@latest"),
+		// npm is installed globally via the system package manager and needs
+		// sudo to write to /usr/lib/node_modules.
+		"npm":  makeSimpleRunner("sudo", resolveCommand("npm"), "install", "-g", "npm@latest"),
 		"git":  makeSimpleRunner("/bin/sh", "-c", "sudo apt-get update -qq && sudo apt-get install -y git"),
 		"gh":   makeSimpleRunner("/bin/sh", "-c", "sudo apt-get update -qq && sudo apt-get install -y gh"),
 		"dolt": defaultDoltRunner,


### PR DESCRIPTION
## Changes

- **npm update no longer fails with EACCES** - Added sudo to the npm global update command so it can write to system-owned directories. (Hytte-fnto)

## Original Issue (bug): Infra: npm update needs sudo — EACCES permission denied

The npm update button fails with EACCES permission denied when trying to rename /usr/lib/node_modules/npm. npm is installed globally and needs sudo to update itself.

Fix: change the npm update command from 'npm install -g npm@latest' to 'sudo npm install -g npm@latest'.

Check `internal/infra/update.go` for the update command mapping (in `defaultToolRunners()`). All global npm operations need sudo on Linux when installed via the system package manager.

---
Bead: Hytte-fnto | Branch: forge/Hytte-fnto
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)