### PR TITLE
Forge Dashboard: make bead IDs clickable everywhere — open detail modal (Hytte-pl8c)

### DIFF
--- a/changelog.d/Hytte-pl8c.md
+++ b/changelog.d/Hytte-pl8c.md
@@ -1,0 +1,2 @@
+category: Added
+- **Clickable bead IDs on Ready to Merge cards** - Bead IDs on Ready to Merge PR cards are now clickable links that open the bead detail modal, consistent with all other dashboard sections. Also added hover underline style to Recently Closed PRs bead links for visual consistency. (Hytte-pl8c)

--- a/web/src/components/ReadyToMergeCard.tsx
+++ b/web/src/components/ReadyToMergeCard.tsx
@@ -10,13 +10,14 @@ interface ReadyToMergeCardProps {
   prs: OpenPR[]
   onMerged?: (id: number) => void
   showToast: (message: string, type: 'success' | 'error') => void
+  onBeadClick?: (beadId: string) => void
 }
 
 function isMergeReady(pr: OpenPR): boolean {
   return pr.ci_passing && pr.has_approval && !pr.is_conflicting && !pr.has_unresolved_threads
 }
 
-export default function ReadyToMergeCard({ prs, onMerged, showToast }: ReadyToMergeCardProps) {
+export default function ReadyToMergeCard({ prs, onMerged, showToast, onBeadClick }: ReadyToMergeCardProps) {
   const { t } = useTranslation('forge')
   const [merging, setMerging] = useState<Partial<Record<number, boolean>>>({})
   const [bellowing, setBellowing] = useState<Partial<Record<number, boolean>>>({})
@@ -131,6 +132,15 @@ export default function ReadyToMergeCard({ prs, onMerged, showToast }: ReadyToMe
                     <span className="text-sm text-white truncate">{pr.title}</span>
                     <div className="flex items-center gap-2 flex-wrap">
                       <span className="text-xs text-gray-500">#{pr.number}</span>
+                      {pr.bead_id && (
+                        <button
+                          type="button"
+                          onClick={() => onBeadClick?.(pr.bead_id)}
+                          className="text-xs font-mono text-cyan-400 hover:text-cyan-300 hover:underline transition-colors"
+                        >
+                          {pr.bead_id}
+                        </button>
+                      )}
                       {pr.ci_passing ? (
                         <span className="text-xs text-green-500">CI ✓</span>
                       ) : (

--- a/web/src/components/RecentlyClosedPRsCard.tsx
+++ b/web/src/components/RecentlyClosedPRsCard.tsx
@@ -151,7 +151,7 @@ export default function RecentlyClosedPRsCard({ onBeadClick }: RecentlyClosedPRs
                                   <button
                                     type="button"
                                     onClick={() => onBeadClick?.(pr.bead_id)}
-                                    className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+                                    className="text-xs font-mono text-blue-400 hover:text-blue-300 hover:underline transition-colors"
                                   >
                                     {pr.bead_id}
                                   </button>

--- a/web/src/pages/ForgeDashboardPage.tsx
+++ b/web/src/pages/ForgeDashboardPage.tsx
@@ -414,7 +414,7 @@ export default function ForgeDashboardPage() {
             <div id="lower-panels">
               <div className="flex flex-col gap-6">
                 <NeedsAttentionCard stuck={status?.stuck ?? []} showToast={showToast} onBeadClick={handleBeadClick} />
-                <ReadyToMergeCard prs={status?.open_prs ?? []} showToast={showToast} />
+                <ReadyToMergeCard prs={status?.open_prs ?? []} showToast={showToast} onBeadClick={handleBeadClick} />
                 <RecentlyClosedPRsCard onBeadClick={handleBeadClick} />
                 <FullQueueCard showToast={showToast} onBeadClick={handleBeadClick} />
                 {status?.today_stats && <TodayStatsCard stats={status.today_stats} />}


### PR DESCRIPTION
## Changes

- **Clickable bead IDs on Ready to Merge cards** - Bead IDs on Ready to Merge PR cards are now clickable links that open the bead detail modal, consistent with all other dashboard sections. Also added hover underline style to Recently Closed PRs bead links for visual consistency. (Hytte-pl8c)

## Original Issue (feature): Forge Dashboard: make bead IDs clickable everywhere — open detail modal

Every bead ID displayed anywhere on the dashboard should be a clickable link that opens the bead detail modal (Hytte-2klo). Locations to update:

- Active Workers (bead_id column)
- Needs Attention (bead ID in the card)
- Event Log (bead_id in event entries)
- Full Queue (bead IDs in the list)
- Ready to Merge (bead_id on PR cards)
- Recently Closed PRs (bead_id)
- Live Activity (bead ID in the header)

Style as a subtle link (underline on hover, cursor pointer). Clicking opens the modal without navigating away from the dashboard.

---
Bead: Hytte-pl8c | Branch: forge/Hytte-pl8c
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)