### PR TITLE
Wordfeud login failed (Hytte-t6r6)

### DIFF
--- a/changelog.d/Hytte-t6r6.md
+++ b/changelog.d/Hytte-t6r6.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Fix Wordfeud login failure** - Add trailing slash to the Wordfeud login API endpoint to prevent HTTP redirect from converting POST to GET and dropping the request body. (Hytte-t6r6)

--- a/internal/wordfeud/api.go
+++ b/internal/wordfeud/api.go
@@ -62,7 +62,7 @@ func (c *Client) Login(email, password string) (string, error) {
 		return "", fmt.Errorf("wordfeud: marshal login request: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/user/login/email", bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/user/login/email/", bytes.NewReader(payload))
 	if err != nil {
 		return "", fmt.Errorf("wordfeud: create login request: %w", err)
 	}

--- a/internal/wordfeud/api_test.go
+++ b/internal/wordfeud/api_test.go
@@ -23,7 +23,7 @@ func TestHashPassword(t *testing.T) {
 
 func TestLogin_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/wf/user/login/email" {
+		if r.URL.Path != "/wf/user/login/email/" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		if r.Method != http.MethodPost {


### PR DESCRIPTION
## Changes

- **Fix Wordfeud login failure** - Add trailing slash to the Wordfeud login API endpoint to prevent HTTP redirect from converting POST to GET and dropping the request body. (Hytte-t6r6)

## Original Issue (task): Wordfeud login failed

Still the same after the last fix

Source: https://github.com/Robin831/Hytte/issues/436

---
Bead: Hytte-t6r6 | Branch: forge/Hytte-t6r6
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)