### PR TITLE
Feed race results into Stride plan generation (Hytte-g23c)

### DIFF
--- a/changelog.d/Hytte-g23c.md
+++ b/changelog.d/Hytte-g23c.md
@@ -1,0 +1,2 @@
+category: Added
+- **Race history in Stride plan generation** - The AI coach now receives past race results (dates, distances, times, paces) when generating weekly training plans, enabling better calibration of training targets and recovery planning. (Hytte-g23c)

--- a/internal/stride/generate.go
+++ b/internal/stride/generate.go
@@ -391,17 +391,23 @@ type RaceResult struct {
 	Priority  string
 }
 
-// listRaceResults queries all workouts with non-null race_id, joined with
-// stride_races, returning completed race results for the user.
+// listRaceResults queries completed race results for the user that are linked
+// to at least one workout.
 func listRaceResults(ctx context.Context, db *sql.DB, userID int64) ([]RaceResult, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT sr.name, sr.date, sr.distance_m, sr.result_time, sr.priority
 		FROM stride_races sr
-		JOIN workouts w ON w.race_id = sr.id AND w.user_id = sr.user_id
 		WHERE sr.user_id = ?
 		  AND sr.result_time IS NOT NULL
 		  AND sr.result_time > 0
+		  AND EXISTS (
+			SELECT 1
+			FROM workouts w
+			WHERE w.race_id = sr.id
+			  AND w.user_id = sr.user_id
+		  )
 		ORDER BY sr.date DESC
+		LIMIT 20
 	`, userID)
 	if err != nil {
 		return nil, err

--- a/internal/stride/generate.go
+++ b/internal/stride/generate.go
@@ -201,6 +201,12 @@ func GeneratePlan(ctx context.Context, db *sql.DB, userID int64, weekMode string
 		return fmt.Errorf("list notes: %w", err)
 	}
 
+	// Query completed race results linked to workouts.
+	raceHistory, err := listRaceResults(ctx, db, userID)
+	if err != nil {
+		return fmt.Errorf("list race results: %w", err)
+	}
+
 	// Read optional custom prompt appended to the plan generation request.
 	// Decrypt it because the preference is stored encrypted at rest.
 	customPrompt := prefs["stride_custom_prompt"]
@@ -251,6 +257,7 @@ func GeneratePlan(ctx context.Context, db *sql.DB, userID int64, weekMode string
 		weekStart, weekEnd,
 		profileBlock,
 		races, notes,
+		raceHistory,
 		acr, acute, chronic,
 		recentSummaries,
 		prevPlanJSON, prevPlanModel, prevPlanCreatedAt,
@@ -375,12 +382,56 @@ func loadPreviousPlan(ctx context.Context, db *sql.DB, userID int64, weekStart s
 	return planJSON, model, createdAt, err
 }
 
+// RaceResult holds a completed race linked to a workout for prompt context.
+type RaceResult struct {
+	Name      string
+	Date      string
+	DistanceM float64
+	TimeSecs  int
+	Priority  string
+}
+
+// listRaceResults queries all workouts with non-null race_id, joined with
+// stride_races, returning completed race results for the user.
+func listRaceResults(ctx context.Context, db *sql.DB, userID int64) ([]RaceResult, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT sr.name, sr.date, sr.distance_m, sr.result_time, sr.priority
+		FROM stride_races sr
+		JOIN workouts w ON w.race_id = sr.id AND w.user_id = sr.user_id
+		WHERE sr.user_id = ?
+		  AND sr.result_time IS NOT NULL
+		  AND sr.result_time > 0
+		ORDER BY sr.date DESC
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []RaceResult
+	for rows.Next() {
+		var r RaceResult
+		var encName string
+		if err := rows.Scan(&encName, &r.Date, &r.DistanceM, &r.TimeSecs, &r.Priority); err != nil {
+			return nil, err
+		}
+		name, err := encryption.DecryptField(encName)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt race name: %w", err)
+		}
+		r.Name = name
+		results = append(results, r)
+	}
+	return results, rows.Err()
+}
+
 // buildGeneratePrompt assembles the full prompt string for Claude plan generation.
 func buildGeneratePrompt(
 	weekStart, weekEnd string,
 	profileBlock string,
 	races []Race,
 	notes []Note,
+	raceHistory []RaceResult,
 	acr *float64, acute, chronic float64,
 	summaries []training.WeeklySummary,
 	prevPlanJSON, prevPlanModel, prevPlanCreatedAt string,
@@ -477,6 +528,26 @@ func buildGeneratePrompt(
 			if r.Notes != "" {
 				fmt.Fprintf(&sb, "  Notes: %s\n", r.Notes)
 			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// Race history (completed races linked to workouts).
+	if len(raceHistory) > 0 {
+		sb.WriteString("## Race History\n")
+		for _, r := range raceHistory {
+			h, m, s := secondsToHMS(r.TimeSecs)
+			var timeStr string
+			if h > 0 {
+				timeStr = fmt.Sprintf("%dh%02dm%02ds", h, m, s)
+			} else {
+				timeStr = fmt.Sprintf("%dm%02ds", m, s)
+			}
+			paceSecPerKm := float64(r.TimeSecs) / (r.DistanceM / 1000)
+			paceMin := int(paceSecPerKm) / 60
+			paceSec := int(paceSecPerKm) % 60
+			fmt.Fprintf(&sb, "- %s on %s (%.1f km, %s, pace %d:%02d/km, priority %s)\n",
+				r.Name, r.Date, r.DistanceM/1000, timeStr, paceMin, paceSec, r.Priority)
 		}
 		sb.WriteString("\n")
 	}

--- a/internal/stride/generate.go
+++ b/internal/stride/generate.go
@@ -408,7 +408,7 @@ func listRaceResults(ctx context.Context, db *sql.DB, userID int64) ([]RaceResul
 	}
 	defer rows.Close()
 
-	var results []RaceResult
+	results := []RaceResult{}
 	for rows.Next() {
 		var r RaceResult
 		var encName string

--- a/internal/stride/generate_test.go
+++ b/internal/stride/generate_test.go
@@ -32,7 +32,8 @@ func extendedTestDB(t *testing.T) *sql.DB {
 			distance_meters  REAL NOT NULL DEFAULT 0,
 			avg_heart_rate   INTEGER NOT NULL DEFAULT 0,
 			sport            TEXT NOT NULL DEFAULT 'running',
-			training_load    REAL
+			training_load    REAL,
+			race_id          INTEGER
 		);
 	`)
 	if err != nil {

--- a/internal/stride/generate_test.go
+++ b/internal/stride/generate_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -387,5 +388,132 @@ func buildMinimalPlan(weekStart string) []DayPlan {
 		}
 	}
 	return days
+}
+
+func TestListRaceResults_Empty(t *testing.T) {
+	db := setupTestDB(t)
+
+	results, err := listRaceResults(context.Background(), db, 1)
+	if err != nil {
+		t.Fatalf("listRaceResults: %v", err)
+	}
+	if results == nil {
+		t.Error("expected non-nil empty slice, got nil")
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestListRaceResults_ReturnsLinkedRaces(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Insert a race with a result_time.
+	_, err := db.Exec(`INSERT INTO stride_races (id, user_id, name, date, distance_m, result_time, priority, created_at)
+		VALUES (1, 1, 'Test 10K', '2026-03-15', 10000, 2400, 'A', '2026-03-15')`)
+	if err != nil {
+		t.Fatalf("insert race: %v", err)
+	}
+
+	// Insert a workout linked to that race.
+	_, err = db.Exec(`INSERT INTO workouts (id, user_id, started_at, duration_seconds, distance_meters, sport, race_id)
+		VALUES (1, 1, '2026-03-15T08:00:00Z', 2400, 10000, 'running', 1)`)
+	if err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	// Insert a race without result_time (should not appear).
+	_, err = db.Exec(`INSERT INTO stride_races (id, user_id, name, date, distance_m, priority, created_at)
+		VALUES (2, 1, 'Future Race', '2026-06-01', 21097, 'A', '2026-03-01')`)
+	if err != nil {
+		t.Fatalf("insert future race: %v", err)
+	}
+
+	// Insert a workout linked to a race but for a different user (should not appear).
+	_, err = db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (2, 'other@test.com', 'Other', 'g2')`)
+	if err != nil {
+		t.Fatalf("insert user2: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO stride_races (id, user_id, name, date, distance_m, result_time, priority, created_at)
+		VALUES (3, 2, 'Other Race', '2026-03-10', 5000, 1200, 'B', '2026-03-10')`)
+	if err != nil {
+		t.Fatalf("insert other race: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO workouts (id, user_id, started_at, duration_seconds, distance_meters, sport, race_id)
+		VALUES (2, 2, '2026-03-10T08:00:00Z', 1200, 5000, 'running', 3)`)
+	if err != nil {
+		t.Fatalf("insert other workout: %v", err)
+	}
+
+	results, err := listRaceResults(context.Background(), db, 1)
+	if err != nil {
+		t.Fatalf("listRaceResults: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Name != "Test 10K" {
+		t.Errorf("name = %q, want %q", results[0].Name, "Test 10K")
+	}
+	if results[0].TimeSecs != 2400 {
+		t.Errorf("time = %d, want 2400", results[0].TimeSecs)
+	}
+	if results[0].DistanceM != 10000 {
+		t.Errorf("distance = %f, want 10000", results[0].DistanceM)
+	}
+	if results[0].Priority != "A" {
+		t.Errorf("priority = %q, want %q", results[0].Priority, "A")
+	}
+}
+
+func TestBuildGeneratePrompt_RaceHistorySection(t *testing.T) {
+	history := []RaceResult{
+		{Name: "Spring 10K", Date: "2026-03-15", DistanceM: 10000, TimeSecs: 2400, Priority: "A"},
+		{Name: "Park Run", Date: "2026-02-01", DistanceM: 5000, TimeSecs: 1185, Priority: "C"},
+	}
+
+	prompt := buildGeneratePrompt(
+		"2026-04-06", "2026-04-12",
+		"", nil, nil,
+		history,
+		nil, 0, 0,
+		nil,
+		"", "", "",
+		"", "",
+		"",
+	)
+
+	if !strings.Contains(prompt, "## Race History") {
+		t.Error("prompt missing Race History section")
+	}
+	if !strings.Contains(prompt, "Spring 10K") {
+		t.Error("prompt missing race name 'Spring 10K'")
+	}
+	if !strings.Contains(prompt, "40m00s") {
+		t.Error("prompt missing formatted time for 10K race")
+	}
+	if !strings.Contains(prompt, "4:00/km") {
+		t.Error("prompt missing pace for 10K race")
+	}
+	if !strings.Contains(prompt, "Park Run") {
+		t.Error("prompt missing race name 'Park Run'")
+	}
+}
+
+func TestBuildGeneratePrompt_NoRaceHistoryWhenEmpty(t *testing.T) {
+	prompt := buildGeneratePrompt(
+		"2026-04-06", "2026-04-12",
+		"", nil, nil,
+		[]RaceResult{},
+		nil, 0, 0,
+		nil,
+		"", "", "",
+		"", "",
+		"",
+	)
+
+	if strings.Contains(prompt, "## Race History") {
+		t.Error("prompt should not contain Race History when empty")
+	}
 }
 


### PR DESCRIPTION
## Changes

- **Race history in Stride plan generation** - The AI coach now receives past race results (dates, distances, times, paces) when generating weekly training plans, enabling better calibration of training targets and recovery planning. (Hytte-g23c)

## Original Issue (task): Feed race results into Stride plan generation

Modify buildGeneratePrompt in internal/stride/generate.go to include a 'Race History' section. Query all workouts with non-null race_id, join with stride_races, and format as a list of past race results with dates, distances, times, and paces. This context enables the AI coach to: compare actual performances vs predictions, adjust training targets based on proven fitness, calibrate threshold pace from race results, plan recovery blocks after races, and evaluate progress toward the A-goal. Depends on sub-task 1 for the race_id linkage being populated in the workouts table.

---
Bead: Hytte-g23c | Branch: forge/Hytte-g23c
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)