### PR TITLE
Database schema and homework profiles backend (Hytte-bn5m)

### DIFF
--- a/changelog.d/Hytte-bn5m.md
+++ b/changelog.d/Hytte-bn5m.md
@@ -1,0 +1,2 @@
+category: Added
+- **Homework helper database schema and backend** - Added database tables and Go store layer for kids homework profiles, conversations, and messages with per-message help level tracking for parent review. (Hytte-bn5m)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1432,6 +1432,43 @@ func createSchema(db *sql.DB) error {
 
 	CREATE INDEX IF NOT EXISTS idx_grocery_items_household ON grocery_items(household_id);
 
+	-- Homework helper tables (Hytte-bn5m).
+	CREATE TABLE IF NOT EXISTS kids_homework_profiles (
+		id                 INTEGER PRIMARY KEY,
+		kid_id             INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		age                INTEGER NOT NULL DEFAULT 0,
+		grade_level        TEXT NOT NULL DEFAULT '',
+		subjects           TEXT NOT NULL DEFAULT '[]',
+		preferred_language TEXT NOT NULL DEFAULT '',
+		school_name        TEXT NOT NULL DEFAULT '',
+		current_topics     TEXT NOT NULL DEFAULT '[]',
+		created_at         TEXT NOT NULL DEFAULT '',
+		updated_at         TEXT NOT NULL DEFAULT '',
+		UNIQUE(kid_id)
+	);
+
+	CREATE TABLE IF NOT EXISTS homework_conversations (
+		id         INTEGER PRIMARY KEY,
+		kid_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		subject    TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL DEFAULT '',
+		updated_at TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_homework_conversations_kid ON homework_conversations(kid_id);
+
+	CREATE TABLE IF NOT EXISTS homework_messages (
+		id              INTEGER PRIMARY KEY,
+		conversation_id INTEGER NOT NULL REFERENCES homework_conversations(id) ON DELETE CASCADE,
+		role            TEXT NOT NULL DEFAULT '',
+		content         TEXT NOT NULL DEFAULT '',
+		help_level      TEXT NOT NULL DEFAULT '',
+		image_path      TEXT NOT NULL DEFAULT '',
+		created_at      TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_homework_messages_conversation ON homework_messages(conversation_id);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1462,7 +1462,7 @@ func createSchema(db *sql.DB) error {
 		conversation_id INTEGER NOT NULL REFERENCES homework_conversations(id) ON DELETE CASCADE,
 		role            TEXT NOT NULL DEFAULT '',
 		content         TEXT NOT NULL DEFAULT '',
-		help_level      TEXT NOT NULL DEFAULT '',
+		help_level      TEXT NOT NULL DEFAULT '' CHECK (help_level IN ('', 'hint', 'explain', 'walkthrough', 'answer')),
 		image_path      TEXT NOT NULL DEFAULT '',
 		created_at      TEXT NOT NULL DEFAULT ''
 	);

--- a/internal/homework/models.go
+++ b/internal/homework/models.go
@@ -1,0 +1,60 @@
+package homework
+
+// HelpLevel describes how much assistance a message provides.
+type HelpLevel string
+
+const (
+	HelpLevelHint        HelpLevel = "hint"
+	HelpLevelExplain     HelpLevel = "explain"
+	HelpLevelWalkthrough HelpLevel = "walkthrough"
+	HelpLevelAnswer      HelpLevel = "answer"
+)
+
+// ValidHelpLevels is the set of allowed help level values.
+var ValidHelpLevels = map[HelpLevel]bool{
+	HelpLevelHint:        true,
+	HelpLevelExplain:     true,
+	HelpLevelWalkthrough: true,
+	HelpLevelAnswer:      true,
+}
+
+// HomeworkProfile stores a child's academic context for personalised help.
+type HomeworkProfile struct {
+	ID                int64    `json:"id"`
+	KidID             int64    `json:"kid_id"`
+	Age               int      `json:"age"`
+	GradeLevel        string   `json:"grade_level"`
+	Subjects          []string `json:"subjects"`
+	PreferredLanguage string   `json:"preferred_language"`
+	SchoolName        string   `json:"school_name"`
+	CurrentTopics     []string `json:"current_topics"`
+	CreatedAt         string   `json:"created_at"`
+	UpdatedAt         string   `json:"updated_at"`
+}
+
+// HomeworkConversation groups messages about a single homework topic.
+type HomeworkConversation struct {
+	ID        int64  `json:"id"`
+	KidID     int64  `json:"kid_id"`
+	Subject   string `json:"subject"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// HomeworkMessage is a single turn in a homework conversation.
+type HomeworkMessage struct {
+	ID             int64     `json:"id"`
+	ConversationID int64     `json:"conversation_id"`
+	Role           string    `json:"role"`
+	Content        string    `json:"content"`
+	HelpLevel      HelpLevel `json:"help_level,omitempty"`
+	ImagePath      string    `json:"image_path,omitempty"`
+	CreatedAt      string    `json:"created_at"`
+}
+
+// ConversationSummary extends HomeworkConversation with review info for parents.
+type ConversationSummary struct {
+	HomeworkConversation
+	MessageCount int            `json:"message_count"`
+	HelpLevels   map[string]int `json:"help_levels"`
+}

--- a/internal/homework/store.go
+++ b/internal/homework/store.go
@@ -242,6 +242,10 @@ func ListConversationsByKid(db *sql.DB, kidID int64) ([]HomeworkConversation, er
 
 // AddMessage inserts a new message into a homework conversation and updates the conversation timestamp.
 func AddMessage(db *sql.DB, msg HomeworkMessage) (HomeworkMessage, error) {
+	if msg.HelpLevel != "" && !ValidHelpLevels[msg.HelpLevel] {
+		return HomeworkMessage{}, fmt.Errorf("invalid help_level %q: must be one of hint, explain, walkthrough, answer", msg.HelpLevel)
+	}
+
 	encContent, err := encryption.EncryptField(msg.Content)
 	if err != nil {
 		return HomeworkMessage{}, fmt.Errorf("encrypt content: %w", err)
@@ -251,8 +255,14 @@ func AddMessage(db *sql.DB, msg HomeworkMessage) (HomeworkMessage, error) {
 		return HomeworkMessage{}, fmt.Errorf("encrypt image_path: %w", err)
 	}
 
+	tx, err := db.Begin()
+	if err != nil {
+		return HomeworkMessage{}, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
 	now := time.Now().UTC().Format(timeFormat)
-	result, err := db.Exec(`
+	result, err := tx.Exec(`
 		INSERT INTO homework_messages (conversation_id, role, content, help_level, image_path, created_at)
 		VALUES (?, ?, ?, ?, ?, ?)`,
 		msg.ConversationID, msg.Role, encContent, string(msg.HelpLevel), encImagePath, now,
@@ -267,9 +277,13 @@ func AddMessage(db *sql.DB, msg HomeworkMessage) (HomeworkMessage, error) {
 	}
 
 	// Update the conversation's updated_at timestamp.
-	_, err = db.Exec(`UPDATE homework_conversations SET updated_at = ? WHERE id = ?`, now, msg.ConversationID)
+	_, err = tx.Exec(`UPDATE homework_conversations SET updated_at = ? WHERE id = ?`, now, msg.ConversationID)
 	if err != nil {
 		return HomeworkMessage{}, fmt.Errorf("update conversation timestamp: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return HomeworkMessage{}, fmt.Errorf("commit transaction: %w", err)
 	}
 
 	msg.ID = id

--- a/internal/homework/store.go
+++ b/internal/homework/store.go
@@ -119,14 +119,24 @@ func GetProfileByKidID(db *sql.DB, kidID int64) (*HomeworkProfile, error) {
 		return nil, fmt.Errorf("get homework profile: %w", err)
 	}
 
-	p.SchoolName = decryptOrPlaintext(encSchool)
+	schoolName, err := decryptField(encSchool)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt school_name: %w", err)
+	}
+	p.SchoolName = schoolName
 
-	subjectsStr := decryptOrPlaintext(encSubjects)
+	subjectsStr, err := decryptField(encSubjects)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt subjects: %w", err)
+	}
 	if err := json.Unmarshal([]byte(subjectsStr), &p.Subjects); err != nil {
 		return nil, fmt.Errorf("unmarshal subjects: %w", err)
 	}
 
-	topicsStr := decryptOrPlaintext(encTopics)
+	topicsStr, err := decryptField(encTopics)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt current_topics: %w", err)
+	}
 	if err := json.Unmarshal([]byte(topicsStr), &p.CurrentTopics); err != nil {
 		return nil, fmt.Errorf("unmarshal current_topics: %w", err)
 	}
@@ -169,15 +179,15 @@ func CreateConversation(db *sql.DB, conv HomeworkConversation) (HomeworkConversa
 	return conv, nil
 }
 
-// GetConversation returns a single homework conversation by ID.
-func GetConversation(db *sql.DB, id int64) (*HomeworkConversation, error) {
+// GetConversation returns a single homework conversation by ID, scoped to a specific kid.
+func GetConversation(db *sql.DB, id, kidID int64) (*HomeworkConversation, error) {
 	var c HomeworkConversation
 	var encSubject string
 	err := db.QueryRow(`
 		SELECT id, kid_id, subject, created_at, updated_at
 		FROM homework_conversations
-		WHERE id = ?`,
-		id,
+		WHERE id = ? AND kid_id = ?`,
+		id, kidID,
 	).Scan(&c.ID, &c.KidID, &encSubject, &c.CreatedAt, &c.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -185,7 +195,11 @@ func GetConversation(db *sql.DB, id int64) (*HomeworkConversation, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get homework conversation: %w", err)
 	}
-	c.Subject = decryptOrPlaintext(encSubject)
+	subject, err := decryptField(encSubject)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt conversation subject: %w", err)
+	}
+	c.Subject = subject
 	return &c, nil
 }
 
@@ -210,7 +224,11 @@ func ListConversationsByKid(db *sql.DB, kidID int64) ([]HomeworkConversation, er
 		if err := rows.Scan(&c.ID, &c.KidID, &encSubject, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
-		c.Subject = decryptOrPlaintext(encSubject)
+		subject, err := decryptField(encSubject)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt conversation subject: %w", err)
+		}
+		c.Subject = subject
 		convos = append(convos, c)
 	}
 	if err := rows.Err(); err != nil {
@@ -259,14 +277,15 @@ func AddMessage(db *sql.DB, msg HomeworkMessage) (HomeworkMessage, error) {
 	return msg, nil
 }
 
-// GetMessages returns all messages for a conversation, ordered chronologically.
-func GetMessages(db *sql.DB, conversationID int64) ([]HomeworkMessage, error) {
+// GetMessages returns all messages for a conversation, scoped to a specific kid.
+func GetMessages(db *sql.DB, conversationID, kidID int64) ([]HomeworkMessage, error) {
 	rows, err := db.Query(`
-		SELECT id, conversation_id, role, content, help_level, image_path, created_at
-		FROM homework_messages
-		WHERE conversation_id = ?
-		ORDER BY created_at ASC, id ASC`,
-		conversationID,
+		SELECT m.id, m.conversation_id, m.role, m.content, m.help_level, m.image_path, m.created_at
+		FROM homework_messages m
+		JOIN homework_conversations c ON c.id = m.conversation_id
+		WHERE m.conversation_id = ? AND c.kid_id = ?
+		ORDER BY m.created_at ASC, m.id ASC`,
+		conversationID, kidID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list homework messages: %w", err)
@@ -281,8 +300,16 @@ func GetMessages(db *sql.DB, conversationID int64) ([]HomeworkMessage, error) {
 		if err := rows.Scan(&m.ID, &m.ConversationID, &m.Role, &encContent, &helpLevel, &encImagePath, &m.CreatedAt); err != nil {
 			return nil, err
 		}
-		m.Content = decryptOrPlaintext(encContent)
-		m.ImagePath = decryptOrPlaintext(encImagePath)
+		content, err := decryptField(encContent)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt message content: %w", err)
+		}
+		m.Content = content
+		imgPath, err := decryptField(encImagePath)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt message image_path: %w", err)
+		}
+		m.ImagePath = imgPath
 		m.HelpLevel = HelpLevel(helpLevel)
 		msgs = append(msgs, m)
 	}
@@ -314,50 +341,52 @@ func GetConversationsForParentReview(db *sql.DB, kidID int64) ([]ConversationSum
 	defer rows.Close()
 
 	var summaries []ConversationSummary
-	var convIDs []int64
+	idIndex := map[int64]int{}
 	for rows.Next() {
 		var s ConversationSummary
 		var encSubject string
 		if err := rows.Scan(&s.ID, &s.KidID, &encSubject, &s.CreatedAt, &s.UpdatedAt, &s.MessageCount); err != nil {
 			return nil, err
 		}
-		s.Subject = decryptOrPlaintext(encSubject)
+		subject, err := decryptField(encSubject)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt conversation subject: %w", err)
+		}
+		s.Subject = subject
 		s.HelpLevels = map[string]int{}
+		idIndex[s.ID] = len(summaries)
 		summaries = append(summaries, s)
-		convIDs = append(convIDs, s.ID)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
-	// Fetch help-level counts per conversation.
-	if len(convIDs) > 0 {
-		idIndex := make(map[int64]int, len(summaries))
-		for i, s := range summaries {
-			idIndex[s.ID] = i
+	// Fetch help-level counts for all conversations in a single query.
+	if len(summaries) > 0 {
+		hlRows, err := db.Query(`
+			SELECT m.conversation_id, m.help_level, COUNT(*)
+			FROM homework_messages m
+			JOIN homework_conversations c ON c.id = m.conversation_id
+			WHERE c.kid_id = ? AND m.help_level != ''
+			GROUP BY m.conversation_id, m.help_level`, kidID)
+		if err != nil {
+			return nil, fmt.Errorf("count help levels: %w", err)
 		}
+		defer hlRows.Close()
 
-		for _, cid := range convIDs {
-			hlRows, err := db.Query(`
-				SELECT help_level, COUNT(*) FROM homework_messages
-				WHERE conversation_id = ? AND help_level != ''
-				GROUP BY help_level`, cid)
-			if err != nil {
-				return nil, fmt.Errorf("count help levels: %w", err)
-			}
-			for hlRows.Next() {
-				var level string
-				var count int
-				if err := hlRows.Scan(&level, &count); err != nil {
-					hlRows.Close()
-					return nil, err
-				}
-				summaries[idIndex[cid]].HelpLevels[level] = count
-			}
-			hlRows.Close()
-			if err := hlRows.Err(); err != nil {
+		for hlRows.Next() {
+			var convID int64
+			var level string
+			var count int
+			if err := hlRows.Scan(&convID, &level, &count); err != nil {
 				return nil, err
 			}
+			if idx, ok := idIndex[convID]; ok {
+				summaries[idx].HelpLevels[level] = count
+			}
+		}
+		if err := hlRows.Err(); err != nil {
+			return nil, err
 		}
 	}
 
@@ -367,21 +396,20 @@ func GetConversationsForParentReview(db *sql.DB, kidID int64) ([]ConversationSum
 	return summaries, nil
 }
 
-// decryptOrPlaintext decrypts a field value. If the value has the "enc:" prefix but
-// decryption fails, it returns an empty string to avoid leaking ciphertext.
+// decryptField decrypts a field value. If the value has the "enc:" prefix but
+// decryption fails, the error is propagated to avoid silently losing data.
 // For legacy plaintext values (no "enc:" prefix), the value is returned as-is.
-func decryptOrPlaintext(val string) string {
+func decryptField(val string) (string, error) {
 	if val == "" {
-		return val
+		return val, nil
 	}
 	decrypted, err := encryption.DecryptField(val)
 	if err != nil {
 		if len(val) >= 4 && val[:4] == "enc:" {
-			log.Printf("homework: decrypt field failed for enc:-prefixed value: %v", err)
-			return ""
+			return "", fmt.Errorf("decrypt encrypted field: %w", err)
 		}
 		log.Printf("homework: decrypt field warning (legacy plaintext): %v", err)
-		return val
+		return val, nil
 	}
-	return decrypted
+	return decrypted, nil
 }

--- a/internal/homework/store.go
+++ b/internal/homework/store.go
@@ -1,0 +1,387 @@
+package homework
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+const timeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+// CreateProfile inserts a new homework profile for a child.
+func CreateProfile(db *sql.DB, p HomeworkProfile) (HomeworkProfile, error) {
+	subjectsJSON, err := json.Marshal(p.Subjects)
+	if err != nil {
+		return HomeworkProfile{}, fmt.Errorf("marshal subjects: %w", err)
+	}
+	topicsJSON, err := json.Marshal(p.CurrentTopics)
+	if err != nil {
+		return HomeworkProfile{}, fmt.Errorf("marshal current_topics: %w", err)
+	}
+
+	encSchool, err := encryption.EncryptField(p.SchoolName)
+	if err != nil {
+		return HomeworkProfile{}, fmt.Errorf("encrypt school_name: %w", err)
+	}
+	encSubjects, err := encryption.EncryptField(string(subjectsJSON))
+	if err != nil {
+		return HomeworkProfile{}, fmt.Errorf("encrypt subjects: %w", err)
+	}
+	encTopics, err := encryption.EncryptField(string(topicsJSON))
+	if err != nil {
+		return HomeworkProfile{}, fmt.Errorf("encrypt current_topics: %w", err)
+	}
+
+	now := time.Now().UTC().Format(timeFormat)
+	result, err := db.Exec(`
+		INSERT INTO kids_homework_profiles (kid_id, age, grade_level, subjects, preferred_language, school_name, current_topics, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		p.KidID, p.Age, p.GradeLevel, encSubjects, p.PreferredLanguage, encSchool, encTopics, now, now,
+	)
+	if err != nil {
+		return HomeworkProfile{}, fmt.Errorf("insert homework profile: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return HomeworkProfile{}, err
+	}
+
+	p.ID = id
+	p.CreatedAt = now
+	p.UpdatedAt = now
+	return p, nil
+}
+
+// UpdateProfile updates an existing homework profile.
+func UpdateProfile(db *sql.DB, p HomeworkProfile) error {
+	subjectsJSON, err := json.Marshal(p.Subjects)
+	if err != nil {
+		return fmt.Errorf("marshal subjects: %w", err)
+	}
+	topicsJSON, err := json.Marshal(p.CurrentTopics)
+	if err != nil {
+		return fmt.Errorf("marshal current_topics: %w", err)
+	}
+
+	encSchool, err := encryption.EncryptField(p.SchoolName)
+	if err != nil {
+		return fmt.Errorf("encrypt school_name: %w", err)
+	}
+	encSubjects, err := encryption.EncryptField(string(subjectsJSON))
+	if err != nil {
+		return fmt.Errorf("encrypt subjects: %w", err)
+	}
+	encTopics, err := encryption.EncryptField(string(topicsJSON))
+	if err != nil {
+		return fmt.Errorf("encrypt current_topics: %w", err)
+	}
+
+	now := time.Now().UTC().Format(timeFormat)
+	result, err := db.Exec(`
+		UPDATE kids_homework_profiles
+		SET age = ?, grade_level = ?, subjects = ?, preferred_language = ?, school_name = ?, current_topics = ?, updated_at = ?
+		WHERE kid_id = ?`,
+		p.Age, p.GradeLevel, encSubjects, p.PreferredLanguage, encSchool, encTopics, now, p.KidID,
+	)
+	if err != nil {
+		return fmt.Errorf("update homework profile: %w", err)
+	}
+
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// GetProfileByKidID returns the homework profile for a given child.
+func GetProfileByKidID(db *sql.DB, kidID int64) (*HomeworkProfile, error) {
+	var p HomeworkProfile
+	var encSubjects, encSchool, encTopics string
+	err := db.QueryRow(`
+		SELECT id, kid_id, age, grade_level, subjects, preferred_language, school_name, current_topics, created_at, updated_at
+		FROM kids_homework_profiles
+		WHERE kid_id = ?`,
+		kidID,
+	).Scan(&p.ID, &p.KidID, &p.Age, &p.GradeLevel, &encSubjects, &p.PreferredLanguage, &encSchool, &encTopics, &p.CreatedAt, &p.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get homework profile: %w", err)
+	}
+
+	p.SchoolName = decryptOrPlaintext(encSchool)
+
+	subjectsStr := decryptOrPlaintext(encSubjects)
+	if err := json.Unmarshal([]byte(subjectsStr), &p.Subjects); err != nil {
+		return nil, fmt.Errorf("unmarshal subjects: %w", err)
+	}
+
+	topicsStr := decryptOrPlaintext(encTopics)
+	if err := json.Unmarshal([]byte(topicsStr), &p.CurrentTopics); err != nil {
+		return nil, fmt.Errorf("unmarshal current_topics: %w", err)
+	}
+
+	if p.Subjects == nil {
+		p.Subjects = []string{}
+	}
+	if p.CurrentTopics == nil {
+		p.CurrentTopics = []string{}
+	}
+
+	return &p, nil
+}
+
+// CreateConversation starts a new homework conversation for a child.
+func CreateConversation(db *sql.DB, conv HomeworkConversation) (HomeworkConversation, error) {
+	encSubject, err := encryption.EncryptField(conv.Subject)
+	if err != nil {
+		return HomeworkConversation{}, fmt.Errorf("encrypt subject: %w", err)
+	}
+
+	now := time.Now().UTC().Format(timeFormat)
+	result, err := db.Exec(`
+		INSERT INTO homework_conversations (kid_id, subject, created_at, updated_at)
+		VALUES (?, ?, ?, ?)`,
+		conv.KidID, encSubject, now, now,
+	)
+	if err != nil {
+		return HomeworkConversation{}, fmt.Errorf("insert homework conversation: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return HomeworkConversation{}, err
+	}
+
+	conv.ID = id
+	conv.CreatedAt = now
+	conv.UpdatedAt = now
+	return conv, nil
+}
+
+// GetConversation returns a single homework conversation by ID.
+func GetConversation(db *sql.DB, id int64) (*HomeworkConversation, error) {
+	var c HomeworkConversation
+	var encSubject string
+	err := db.QueryRow(`
+		SELECT id, kid_id, subject, created_at, updated_at
+		FROM homework_conversations
+		WHERE id = ?`,
+		id,
+	).Scan(&c.ID, &c.KidID, &encSubject, &c.CreatedAt, &c.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get homework conversation: %w", err)
+	}
+	c.Subject = decryptOrPlaintext(encSubject)
+	return &c, nil
+}
+
+// ListConversationsByKid returns all homework conversations for a child, newest first.
+func ListConversationsByKid(db *sql.DB, kidID int64) ([]HomeworkConversation, error) {
+	rows, err := db.Query(`
+		SELECT id, kid_id, subject, created_at, updated_at
+		FROM homework_conversations
+		WHERE kid_id = ?
+		ORDER BY updated_at DESC, id DESC`,
+		kidID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list homework conversations: %w", err)
+	}
+	defer rows.Close()
+
+	var convos []HomeworkConversation
+	for rows.Next() {
+		var c HomeworkConversation
+		var encSubject string
+		if err := rows.Scan(&c.ID, &c.KidID, &encSubject, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			return nil, err
+		}
+		c.Subject = decryptOrPlaintext(encSubject)
+		convos = append(convos, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if convos == nil {
+		convos = []HomeworkConversation{}
+	}
+	return convos, nil
+}
+
+// AddMessage inserts a new message into a homework conversation and updates the conversation timestamp.
+func AddMessage(db *sql.DB, msg HomeworkMessage) (HomeworkMessage, error) {
+	encContent, err := encryption.EncryptField(msg.Content)
+	if err != nil {
+		return HomeworkMessage{}, fmt.Errorf("encrypt content: %w", err)
+	}
+	encImagePath, err := encryption.EncryptField(msg.ImagePath)
+	if err != nil {
+		return HomeworkMessage{}, fmt.Errorf("encrypt image_path: %w", err)
+	}
+
+	now := time.Now().UTC().Format(timeFormat)
+	result, err := db.Exec(`
+		INSERT INTO homework_messages (conversation_id, role, content, help_level, image_path, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		msg.ConversationID, msg.Role, encContent, string(msg.HelpLevel), encImagePath, now,
+	)
+	if err != nil {
+		return HomeworkMessage{}, fmt.Errorf("insert homework message: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return HomeworkMessage{}, err
+	}
+
+	// Update the conversation's updated_at timestamp.
+	_, err = db.Exec(`UPDATE homework_conversations SET updated_at = ? WHERE id = ?`, now, msg.ConversationID)
+	if err != nil {
+		return HomeworkMessage{}, fmt.Errorf("update conversation timestamp: %w", err)
+	}
+
+	msg.ID = id
+	msg.CreatedAt = now
+	return msg, nil
+}
+
+// GetMessages returns all messages for a conversation, ordered chronologically.
+func GetMessages(db *sql.DB, conversationID int64) ([]HomeworkMessage, error) {
+	rows, err := db.Query(`
+		SELECT id, conversation_id, role, content, help_level, image_path, created_at
+		FROM homework_messages
+		WHERE conversation_id = ?
+		ORDER BY created_at ASC, id ASC`,
+		conversationID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list homework messages: %w", err)
+	}
+	defer rows.Close()
+
+	var msgs []HomeworkMessage
+	for rows.Next() {
+		var m HomeworkMessage
+		var encContent, encImagePath string
+		var helpLevel string
+		if err := rows.Scan(&m.ID, &m.ConversationID, &m.Role, &encContent, &helpLevel, &encImagePath, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		m.Content = decryptOrPlaintext(encContent)
+		m.ImagePath = decryptOrPlaintext(encImagePath)
+		m.HelpLevel = HelpLevel(helpLevel)
+		msgs = append(msgs, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if msgs == nil {
+		msgs = []HomeworkMessage{}
+	}
+	return msgs, nil
+}
+
+// GetConversationsForParentReview returns conversations for a child with message counts
+// and help-level breakdowns so parents can review how much assistance was used.
+func GetConversationsForParentReview(db *sql.DB, kidID int64) ([]ConversationSummary, error) {
+	rows, err := db.Query(`
+		SELECT c.id, c.kid_id, c.subject, c.created_at, c.updated_at,
+		       COUNT(m.id) AS message_count
+		FROM homework_conversations c
+		LEFT JOIN homework_messages m ON m.conversation_id = c.id
+		WHERE c.kid_id = ?
+		GROUP BY c.id
+		ORDER BY c.updated_at DESC, c.id DESC`,
+		kidID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list conversations for review: %w", err)
+	}
+	defer rows.Close()
+
+	var summaries []ConversationSummary
+	var convIDs []int64
+	for rows.Next() {
+		var s ConversationSummary
+		var encSubject string
+		if err := rows.Scan(&s.ID, &s.KidID, &encSubject, &s.CreatedAt, &s.UpdatedAt, &s.MessageCount); err != nil {
+			return nil, err
+		}
+		s.Subject = decryptOrPlaintext(encSubject)
+		s.HelpLevels = map[string]int{}
+		summaries = append(summaries, s)
+		convIDs = append(convIDs, s.ID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Fetch help-level counts per conversation.
+	if len(convIDs) > 0 {
+		idIndex := make(map[int64]int, len(summaries))
+		for i, s := range summaries {
+			idIndex[s.ID] = i
+		}
+
+		for _, cid := range convIDs {
+			hlRows, err := db.Query(`
+				SELECT help_level, COUNT(*) FROM homework_messages
+				WHERE conversation_id = ? AND help_level != ''
+				GROUP BY help_level`, cid)
+			if err != nil {
+				return nil, fmt.Errorf("count help levels: %w", err)
+			}
+			for hlRows.Next() {
+				var level string
+				var count int
+				if err := hlRows.Scan(&level, &count); err != nil {
+					hlRows.Close()
+					return nil, err
+				}
+				summaries[idIndex[cid]].HelpLevels[level] = count
+			}
+			hlRows.Close()
+			if err := hlRows.Err(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if summaries == nil {
+		summaries = []ConversationSummary{}
+	}
+	return summaries, nil
+}
+
+// decryptOrPlaintext decrypts a field value. If the value has the "enc:" prefix but
+// decryption fails, it returns an empty string to avoid leaking ciphertext.
+// For legacy plaintext values (no "enc:" prefix), the value is returned as-is.
+func decryptOrPlaintext(val string) string {
+	if val == "" {
+		return val
+	}
+	decrypted, err := encryption.DecryptField(val)
+	if err != nil {
+		if len(val) >= 4 && val[:4] == "enc:" {
+			log.Printf("homework: decrypt field failed for enc:-prefixed value: %v", err)
+			return ""
+		}
+		log.Printf("homework: decrypt field warning (legacy plaintext): %v", err)
+		return val
+	}
+	return decrypted
+}

--- a/internal/homework/store_test.go
+++ b/internal/homework/store_test.go
@@ -169,7 +169,7 @@ func TestConversationCRUD(t *testing.T) {
 	}
 
 	// Get conversation.
-	got, err := GetConversation(d, conv.ID)
+	got, err := GetConversation(d, conv.ID, 2)
 	if err != nil {
 		t.Fatalf("get conversation: %v", err)
 	}
@@ -181,12 +181,21 @@ func TestConversationCRUD(t *testing.T) {
 	}
 
 	// Get non-existent conversation.
-	none, err := GetConversation(d, 999)
+	none, err := GetConversation(d, 999, 2)
 	if err != nil {
 		t.Fatalf("get missing conversation: %v", err)
 	}
 	if none != nil {
 		t.Fatal("expected nil for missing conversation")
+	}
+
+	// Get conversation with wrong kid_id returns nil (access control).
+	wrongKid, err := GetConversation(d, conv.ID, 1)
+	if err != nil {
+		t.Fatalf("get conversation wrong kid: %v", err)
+	}
+	if wrongKid != nil {
+		t.Fatal("expected nil when accessing conversation with wrong kid_id")
 	}
 
 	// List conversations.
@@ -266,7 +275,7 @@ func TestMessageCRUD(t *testing.T) {
 	}
 
 	// Get messages.
-	msgs, err := GetMessages(d, conv.ID)
+	msgs, err := GetMessages(d, conv.ID, 2)
 	if err != nil {
 		t.Fatalf("get messages: %v", err)
 	}
@@ -284,12 +293,21 @@ func TestMessageCRUD(t *testing.T) {
 	}
 
 	// Empty messages for non-existent conversation.
-	empty, err := GetMessages(d, 999)
+	empty, err := GetMessages(d, 999, 2)
 	if err != nil {
 		t.Fatalf("get empty messages: %v", err)
 	}
 	if len(empty) != 0 {
 		t.Fatalf("expected 0 messages, got %d", len(empty))
+	}
+
+	// Messages with wrong kid_id returns empty (access control).
+	wrongKid, err := GetMessages(d, conv.ID, 1)
+	if err != nil {
+		t.Fatalf("get messages wrong kid: %v", err)
+	}
+	if len(wrongKid) != 0 {
+		t.Fatalf("expected 0 messages for wrong kid, got %d", len(wrongKid))
 	}
 }
 
@@ -317,7 +335,7 @@ func TestConversationUpdatedAtOnMessage(t *testing.T) {
 		t.Fatalf("add message: %v", err)
 	}
 
-	got, err := GetConversation(d, conv.ID)
+	got, err := GetConversation(d, conv.ID, 2)
 	if err != nil {
 		t.Fatalf("get conversation: %v", err)
 	}
@@ -403,7 +421,7 @@ func TestMessageWithImage(t *testing.T) {
 		t.Fatalf("add message with image: %v", err)
 	}
 
-	msgs, err := GetMessages(d, conv.ID)
+	msgs, err := GetMessages(d, conv.ID, 2)
 	if err != nil {
 		t.Fatalf("get messages: %v", err)
 	}

--- a/internal/homework/store_test.go
+++ b/internal/homework/store_test.go
@@ -1,0 +1,415 @@
+package homework
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/db"
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-key-for-homework-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+
+	d, err := db.Init(":memory:")
+	if err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	d.SetMaxOpenConns(1)
+	t.Cleanup(func() { d.Close() })
+
+	_, err = d.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'parent@example.com', 'Parent', 'g1')`)
+	if err != nil {
+		t.Fatalf("insert parent user: %v", err)
+	}
+	_, err = d.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (2, 'kid@example.com', 'Kid', 'g2')`)
+	if err != nil {
+		t.Fatalf("insert kid user: %v", err)
+	}
+	return d
+}
+
+func TestProfileCRUD(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Create profile.
+	p, err := CreateProfile(d, HomeworkProfile{
+		KidID:             2,
+		Age:               10,
+		GradeLevel:        "5th",
+		Subjects:          []string{"math", "science"},
+		PreferredLanguage: "nb",
+		SchoolName:        "Test School",
+		CurrentTopics:     []string{"fractions", "plants"},
+	})
+	if err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	if p.ID == 0 {
+		t.Fatal("expected non-zero profile ID")
+	}
+	if p.CreatedAt == "" || p.UpdatedAt == "" {
+		t.Fatal("expected timestamps to be set")
+	}
+
+	// Get profile.
+	got, err := GetProfileByKidID(d, 2)
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected profile, got nil")
+	}
+	if got.Age != 10 || got.GradeLevel != "5th" {
+		t.Fatalf("unexpected profile values: age=%d grade=%s", got.Age, got.GradeLevel)
+	}
+	if got.SchoolName != "Test School" {
+		t.Fatalf("expected school 'Test School', got %q", got.SchoolName)
+	}
+	if len(got.Subjects) != 2 || got.Subjects[0] != "math" {
+		t.Fatalf("unexpected subjects: %v", got.Subjects)
+	}
+	if len(got.CurrentTopics) != 2 || got.CurrentTopics[0] != "fractions" {
+		t.Fatalf("unexpected topics: %v", got.CurrentTopics)
+	}
+
+	// Update profile.
+	err = UpdateProfile(d, HomeworkProfile{
+		KidID:             2,
+		Age:               11,
+		GradeLevel:        "6th",
+		Subjects:          []string{"math", "science", "english"},
+		PreferredLanguage: "en",
+		SchoolName:        "New School",
+		CurrentTopics:     []string{"decimals"},
+	})
+	if err != nil {
+		t.Fatalf("update profile: %v", err)
+	}
+
+	got, err = GetProfileByKidID(d, 2)
+	if err != nil {
+		t.Fatalf("get updated profile: %v", err)
+	}
+	if got.Age != 11 || got.GradeLevel != "6th" {
+		t.Fatalf("profile not updated: age=%d grade=%s", got.Age, got.GradeLevel)
+	}
+	if len(got.Subjects) != 3 {
+		t.Fatalf("expected 3 subjects, got %d", len(got.Subjects))
+	}
+
+	// Get non-existent profile.
+	none, err := GetProfileByKidID(d, 999)
+	if err != nil {
+		t.Fatalf("get missing profile: %v", err)
+	}
+	if none != nil {
+		t.Fatal("expected nil for missing profile")
+	}
+}
+
+func TestProfileUniqueKid(t *testing.T) {
+	d := setupTestDB(t)
+
+	_, err := CreateProfile(d, HomeworkProfile{
+		KidID:         2,
+		Age:           10,
+		GradeLevel:    "5th",
+		Subjects:      []string{},
+		CurrentTopics: []string{},
+	})
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	_, err = CreateProfile(d, HomeworkProfile{
+		KidID:         2,
+		Age:           11,
+		GradeLevel:    "6th",
+		Subjects:      []string{},
+		CurrentTopics: []string{},
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate kid_id profile")
+	}
+}
+
+func TestUpdateProfileNotFound(t *testing.T) {
+	d := setupTestDB(t)
+
+	err := UpdateProfile(d, HomeworkProfile{
+		KidID:         999,
+		Age:           10,
+		GradeLevel:    "5th",
+		Subjects:      []string{},
+		CurrentTopics: []string{},
+	})
+	if err != sql.ErrNoRows {
+		t.Fatalf("expected ErrNoRows, got: %v", err)
+	}
+}
+
+func TestConversationCRUD(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Create conversation.
+	conv, err := CreateConversation(d, HomeworkConversation{
+		KidID:   2,
+		Subject: "Math homework chapter 5",
+	})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	if conv.ID == 0 {
+		t.Fatal("expected non-zero conversation ID")
+	}
+
+	// Get conversation.
+	got, err := GetConversation(d, conv.ID)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected conversation, got nil")
+	}
+	if got.Subject != "Math homework chapter 5" {
+		t.Fatalf("expected subject 'Math homework chapter 5', got %q", got.Subject)
+	}
+
+	// Get non-existent conversation.
+	none, err := GetConversation(d, 999)
+	if err != nil {
+		t.Fatalf("get missing conversation: %v", err)
+	}
+	if none != nil {
+		t.Fatal("expected nil for missing conversation")
+	}
+
+	// List conversations.
+	conv2, err := CreateConversation(d, HomeworkConversation{
+		KidID:   2,
+		Subject: "Science project",
+	})
+	if err != nil {
+		t.Fatalf("create second conversation: %v", err)
+	}
+
+	list, err := ListConversationsByKid(d, 2)
+	if err != nil {
+		t.Fatalf("list conversations: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 conversations, got %d", len(list))
+	}
+	// Newest first.
+	if list[0].ID != conv2.ID {
+		t.Fatalf("expected newest conversation first, got id=%d", list[0].ID)
+	}
+
+	// Empty list for user with no conversations.
+	empty, err := ListConversationsByKid(d, 1)
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected 0 conversations, got %d", len(empty))
+	}
+}
+
+func TestMessageCRUD(t *testing.T) {
+	d := setupTestDB(t)
+
+	conv, err := CreateConversation(d, HomeworkConversation{
+		KidID:   2,
+		Subject: "Math",
+	})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	// Add messages.
+	msg1, err := AddMessage(d, HomeworkMessage{
+		ConversationID: conv.ID,
+		Role:           "user",
+		Content:        "How do I solve 3/4 + 1/2?",
+		HelpLevel:      "",
+	})
+	if err != nil {
+		t.Fatalf("add message 1: %v", err)
+	}
+	if msg1.ID == 0 {
+		t.Fatal("expected non-zero message ID")
+	}
+
+	msg2, err := AddMessage(d, HomeworkMessage{
+		ConversationID: conv.ID,
+		Role:           "assistant",
+		Content:        "First, find a common denominator...",
+		HelpLevel:      HelpLevelHint,
+	})
+	if err != nil {
+		t.Fatalf("add message 2: %v", err)
+	}
+
+	_, err = AddMessage(d, HomeworkMessage{
+		ConversationID: conv.ID,
+		Role:           "assistant",
+		Content:        "The common denominator of 4 and 2 is 4...",
+		HelpLevel:      HelpLevelExplain,
+	})
+	if err != nil {
+		t.Fatalf("add message 3: %v", err)
+	}
+
+	// Get messages.
+	msgs, err := GetMessages(d, conv.ID)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+	if msgs[0].Content != "How do I solve 3/4 + 1/2?" {
+		t.Fatalf("unexpected first message content: %q", msgs[0].Content)
+	}
+	if msgs[1].HelpLevel != HelpLevelHint {
+		t.Fatalf("expected hint help level, got %q", msgs[1].HelpLevel)
+	}
+	if msgs[1].ID != msg2.ID {
+		t.Fatalf("expected message ID %d, got %d", msg2.ID, msgs[1].ID)
+	}
+
+	// Empty messages for non-existent conversation.
+	empty, err := GetMessages(d, 999)
+	if err != nil {
+		t.Fatalf("get empty messages: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected 0 messages, got %d", len(empty))
+	}
+}
+
+func TestConversationUpdatedAtOnMessage(t *testing.T) {
+	d := setupTestDB(t)
+
+	conv, err := CreateConversation(d, HomeworkConversation{
+		KidID:   2,
+		Subject: "Math",
+	})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	originalUpdatedAt := conv.UpdatedAt
+
+	_, err = AddMessage(d, HomeworkMessage{
+		ConversationID: conv.ID,
+		Role:           "user",
+		Content:        "Help me",
+	})
+	if err != nil {
+		t.Fatalf("add message: %v", err)
+	}
+
+	got, err := GetConversation(d, conv.ID)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if got.UpdatedAt == originalUpdatedAt {
+		t.Fatal("expected updated_at to change after adding a message")
+	}
+}
+
+func TestParentReview(t *testing.T) {
+	d := setupTestDB(t)
+
+	conv, err := CreateConversation(d, HomeworkConversation{
+		KidID:   2,
+		Subject: "Math",
+	})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	_, err = AddMessage(d, HomeworkMessage{ConversationID: conv.ID, Role: "user", Content: "Q1"})
+	if err != nil {
+		t.Fatalf("add msg: %v", err)
+	}
+	_, err = AddMessage(d, HomeworkMessage{ConversationID: conv.ID, Role: "assistant", Content: "A1", HelpLevel: HelpLevelHint})
+	if err != nil {
+		t.Fatalf("add msg: %v", err)
+	}
+	_, err = AddMessage(d, HomeworkMessage{ConversationID: conv.ID, Role: "assistant", Content: "A2", HelpLevel: HelpLevelHint})
+	if err != nil {
+		t.Fatalf("add msg: %v", err)
+	}
+	_, err = AddMessage(d, HomeworkMessage{ConversationID: conv.ID, Role: "assistant", Content: "A3", HelpLevel: HelpLevelExplain})
+	if err != nil {
+		t.Fatalf("add msg: %v", err)
+	}
+
+	summaries, err := GetConversationsForParentReview(d, 2)
+	if err != nil {
+		t.Fatalf("parent review: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	s := summaries[0]
+	if s.MessageCount != 4 {
+		t.Fatalf("expected 4 messages, got %d", s.MessageCount)
+	}
+	if s.HelpLevels["hint"] != 2 {
+		t.Fatalf("expected 2 hints, got %d", s.HelpLevels["hint"])
+	}
+	if s.HelpLevels["explain"] != 1 {
+		t.Fatalf("expected 1 explain, got %d", s.HelpLevels["explain"])
+	}
+
+	// Empty review for user with no conversations.
+	empty, err := GetConversationsForParentReview(d, 1)
+	if err != nil {
+		t.Fatalf("empty review: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected 0 summaries, got %d", len(empty))
+	}
+}
+
+func TestMessageWithImage(t *testing.T) {
+	d := setupTestDB(t)
+
+	conv, err := CreateConversation(d, HomeworkConversation{
+		KidID:   2,
+		Subject: "Science",
+	})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	msg, err := AddMessage(d, HomeworkMessage{
+		ConversationID: conv.ID,
+		Role:           "user",
+		Content:        "What is this diagram?",
+		ImagePath:      "/uploads/homework/diagram.png",
+	})
+	if err != nil {
+		t.Fatalf("add message with image: %v", err)
+	}
+
+	msgs, err := GetMessages(d, conv.ID)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].ImagePath != "/uploads/homework/diagram.png" {
+		t.Fatalf("expected image path, got %q", msgs[0].ImagePath)
+	}
+	if msgs[0].ID != msg.ID {
+		t.Fatalf("expected message ID %d, got %d", msg.ID, msgs[0].ID)
+	}
+}

--- a/internal/homework/store_test.go
+++ b/internal/homework/store_test.go
@@ -3,6 +3,7 @@ package homework
 import (
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/db"
 	"github.com/Robin831/Hytte/internal/encryption"
@@ -303,6 +304,9 @@ func TestConversationUpdatedAtOnMessage(t *testing.T) {
 		t.Fatalf("create conversation: %v", err)
 	}
 	originalUpdatedAt := conv.UpdatedAt
+
+	// Ensure a distinct timestamp for the next operation.
+	time.Sleep(2 * time.Millisecond)
 
 	_, err = AddMessage(d, HomeworkMessage{
 		ConversationID: conv.ID,

--- a/internal/homework/store_test.go
+++ b/internal/homework/store_test.go
@@ -323,8 +323,9 @@ func TestConversationUpdatedAtOnMessage(t *testing.T) {
 	}
 	originalUpdatedAt := conv.UpdatedAt
 
-	// Ensure a distinct timestamp for the next operation.
-	time.Sleep(2 * time.Millisecond)
+	// Ensure a distinct timestamp for the next operation even when the
+	// underlying clock or stored timestamp format has coarse resolution.
+	time.Sleep(1100 * time.Millisecond)
 
 	_, err = AddMessage(d, HomeworkMessage{
 		ConversationID: conv.ID,


### PR DESCRIPTION
## Changes

- **Homework helper database schema and backend** - Added database tables and Go store layer for kids homework profiles, conversations, and messages with per-message help level tracking for parent review. (Hytte-bn5m)

## Original Issue (task): Database schema and homework profiles backend

Create the foundational data layer for the homework helper.

Files to create/modify:
- internal/db/db.go — Add three new tables: kids_homework_profiles (kid_id FK to users, age, grade_level, subjects JSON, preferred_language, school_name, current_topics), homework_conversations (id, kid_id, subject, created_at, updated_at), homework_messages (id, conversation_id, role, content, help_level enum, image_path, created_at). Add migration logic.
- internal/homework/models.go — Define Go structs: HomeworkProfile, HomeworkConversation, HomeworkMessage, HelpLevel enum (hint/explain/walkthrough/answer).
- internal/homework/store.go — CRUD operations: CreateProfile, UpdateProfile, GetProfileByKidID, CreateConversation, GetConversation, ListConversationsByKid, AddMessage, GetMessages, GetConversationsForParentReview.

Approach: Follow existing DB patterns in db.go. HelpLevel is stored per-message so parent review can track which levels were used. This sub-task is a dependency for all other sub-tasks — no UI or API work depends on anything except this being done first.

---
Bead: Hytte-bn5m | Branch: forge/Hytte-bn5m
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)