### PR TITLE
Prompt engine and subject detection (Hytte-naqi)

### DIFF
--- a/changelog.d/Hytte-naqi.md
+++ b/changelog.d/Hytte-naqi.md
@@ -1,0 +1,2 @@
+category: Added
+- **Homework prompt engine and subject detection** - Added keyword-based subject classifier and system prompt builder for the homework tutoring feature, supporting math, writing, reading, and general subjects with age-appropriate language calibration and help-level enforcement. (Hytte-naqi)

--- a/internal/homework/prompts.go
+++ b/internal/homework/prompts.go
@@ -1,0 +1,171 @@
+package homework
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Subject keywords for classification.
+var (
+	mathKeywords = []string{
+		"equation", "solve", "calculate", "algebra", "geometry", "fraction",
+		"multiply", "divide", "subtract", "add", "derivative", "integral",
+		"graph", "number", "math", "arithmetic", "trigonometry", "percentage",
+		"ratio", "exponent",
+	}
+	writingKeywords = []string{
+		"essay", "write", "paragraph", "thesis", "draft", "composition",
+		"grammar", "punctuation", "narrative", "persuasive", "argument",
+		"outline", "topic sentence", "writing",
+	}
+	readingKeywords = []string{
+		"read", "book", "chapter", "character", "plot", "theme",
+		"literature", "story", "author", "comprehension", "vocabulary",
+		"passage", "novel", "poem",
+	}
+)
+
+// DetectSubject scans message text for subject indicators and returns the
+// best-matching subject: "math", "writing", "reading", or "general".
+func DetectSubject(messageText string) string {
+	lower := strings.ToLower(messageText)
+
+	mathCount := countKeywords(lower, mathKeywords)
+	writingCount := countKeywords(lower, writingKeywords)
+	readingCount := countKeywords(lower, readingKeywords)
+
+	if mathCount == 0 && writingCount == 0 && readingCount == 0 {
+		return "general"
+	}
+
+	best := "general"
+	bestCount := 0
+
+	if mathCount > bestCount {
+		best = "math"
+		bestCount = mathCount
+	}
+	if writingCount > bestCount {
+		best = "writing"
+		bestCount = writingCount
+	}
+	if readingCount > bestCount {
+		best = "reading"
+	}
+
+	return best
+}
+
+func countKeywords(text string, keywords []string) int {
+	count := 0
+	for _, kw := range keywords {
+		if strings.Contains(text, kw) {
+			count++
+		}
+	}
+	return count
+}
+
+// BuildSystemPrompt assembles the full system prompt for a homework tutoring
+// session. It composes tutor framing, age calibration, subject-specific rules,
+// anti-cheating guardrails, and help-level enforcement.
+func BuildSystemPrompt(profile HomeworkProfile, helpLevel HelpLevel, detectedSubject string) string {
+	var b strings.Builder
+
+	// Section 1: Tutor framing preamble
+	b.WriteString("You are a friendly, patient homework tutor. Your goal is to help the student understand concepts and develop problem-solving skills, not to give them answers. Encourage curiosity and celebrate effort.\n\n")
+
+	// Section 2: Age/grade calibration
+	b.WriteString(ageCalibration(profile))
+
+	// Section 3: Subject-specific pedagogical rules
+	b.WriteString(subjectRules(detectedSubject))
+
+	// Section 4: Anti-cheating guardrails
+	b.WriteString("IMPORTANT RULES:\n")
+	b.WriteString("- Never provide complete answers directly.\n")
+	b.WriteString("- Do not do the student's work for them.\n")
+	b.WriteString("- If the student asks you to just give the answer, gently redirect them to think through the problem.\n")
+	b.WriteString("- Do not generate entire essays, solutions, or assignments.\n\n")
+
+	// Section 5: Help-level enforcement
+	b.WriteString(helpLevelRules(helpLevel))
+
+	return b.String()
+}
+
+func ageCalibration(profile HomeworkProfile) string {
+	age := profile.Age
+	grade := parseGrade(profile.GradeLevel)
+
+	if age <= 8 || grade <= 3 {
+		return "Use simple, clear language appropriate for a young child. Keep sentences short. Use everyday examples and be very encouraging.\n\n"
+	}
+	if age <= 13 || grade <= 8 {
+		return "Use moderate vocabulary appropriate for a middle-school student. You can introduce subject-specific terms but explain them when first used.\n\n"
+	}
+	return "Use advanced vocabulary appropriate for a high-school student. You can use subject-specific terminology and expect more independent reasoning.\n\n"
+}
+
+// parseGrade extracts a numeric grade from strings like "3", "5th", "grade 7".
+func parseGrade(gradeLevel string) int {
+	cleaned := strings.ToLower(gradeLevel)
+	cleaned = strings.TrimPrefix(cleaned, "grade ")
+	cleaned = strings.TrimPrefix(cleaned, "grade")
+	cleaned = strings.TrimSuffix(cleaned, "th")
+	cleaned = strings.TrimSuffix(cleaned, "st")
+	cleaned = strings.TrimSuffix(cleaned, "nd")
+	cleaned = strings.TrimSuffix(cleaned, "rd")
+	cleaned = strings.TrimSpace(cleaned)
+
+	n, err := strconv.Atoi(cleaned)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func subjectRules(subject string) string {
+	switch subject {
+	case "math":
+		return "MATH TUTORING RULES:\n" +
+			"- Always enforce step-by-step reasoning. Do not skip steps.\n" +
+			"- Ask the student to show their work before offering help.\n" +
+			"- When correcting errors, point to the specific step where the mistake occurred.\n" +
+			"- Use visual representations (number lines, diagrams) when helpful.\n\n"
+	case "writing":
+		return "WRITING TUTORING RULES:\n" +
+			"- Never write essays or full paragraphs for the student.\n" +
+			"- Redirect to brainstorming, outlining, and revision techniques.\n" +
+			"- Ask guiding questions to help the student develop their own ideas.\n" +
+			"- Focus on structure, clarity, and the writing process.\n\n"
+	case "reading":
+		return "READING TUTORING RULES:\n" +
+			"- Generate discussion questions to deepen comprehension.\n" +
+			"- Encourage the student to support answers with text evidence.\n" +
+			"- Help with vocabulary by providing context clues before definitions.\n" +
+			"- Ask the student to make predictions and connections.\n\n"
+	default:
+		return ""
+	}
+}
+
+func helpLevelRules(level HelpLevel) string {
+	switch level {
+	case HelpLevelHint:
+		return "HELP LEVEL - HINTS ONLY:\n" +
+			"Provide hints only. Do not reveal the answer. Give just enough direction for the student to take the next step on their own.\n"
+	case HelpLevelExplain:
+		return "HELP LEVEL - EXPLAIN:\n" +
+			"Explain the relevant concepts and principles. Help the student understand the 'why' behind the problem, but let them apply it themselves.\n"
+	case HelpLevelWalkthrough:
+		return "HELP LEVEL - GUIDED WALKTHROUGH:\n" +
+			"Provide a guided walkthrough, explaining each step but letting the student attempt each part before moving on.\n"
+	case HelpLevelAnswer:
+		return "HELP LEVEL - EXPLAIN SOLUTION:\n" +
+			"Explain the full solution step-by-step so the student can learn from it. Still focus on teaching, not just giving the answer.\n"
+	default:
+		return "HELP LEVEL - HINTS ONLY:\n" +
+			"Provide hints only. Do not reveal the answer. Give just enough direction for the student to take the next step on their own.\n"
+	}
+}

--- a/internal/homework/prompts.go
+++ b/internal/homework/prompts.go
@@ -98,10 +98,13 @@ func ageCalibration(profile HomeworkProfile) string {
 	age := profile.Age
 	grade := parseGrade(profile.GradeLevel)
 
-	if age <= 8 || grade <= 3 {
+	isYoung := (age > 0 && age <= 8) || (grade > 0 && grade <= 3)
+	isMiddle := (age > 0 && age <= 13) || (grade > 0 && grade <= 8)
+
+	if isYoung {
 		return "Use simple, clear language appropriate for a young child. Keep sentences short. Use everyday examples and be very encouraging.\n\n"
 	}
-	if age <= 13 || grade <= 8 {
+	if isMiddle {
 		return "Use moderate vocabulary appropriate for a middle-school student. You can introduce subject-specific terms but explain them when first used.\n\n"
 	}
 	return "Use advanced vocabulary appropriate for a high-school student. You can use subject-specific terminology and expect more independent reasoning.\n\n"

--- a/internal/homework/prompts.go
+++ b/internal/homework/prompts.go
@@ -1,11 +1,18 @@
 package homework
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 )
 
-// Subject keywords for classification.
+// Subject keyword patterns with word-boundary matching.
+var (
+	mathPatterns    []*regexp.Regexp
+	writingPatterns []*regexp.Regexp
+	readingPatterns []*regexp.Regexp
+)
+
 var (
 	mathKeywords = []string{
 		"equation", "solve", "calculate", "algebra", "geometry", "fraction",
@@ -25,14 +32,29 @@ var (
 	}
 )
 
+func init() {
+	mathPatterns = compileKeywords(mathKeywords)
+	writingPatterns = compileKeywords(writingKeywords)
+	readingPatterns = compileKeywords(readingKeywords)
+}
+
+func compileKeywords(keywords []string) []*regexp.Regexp {
+	patterns := make([]*regexp.Regexp, len(keywords))
+	for i, kw := range keywords {
+		escaped := regexp.QuoteMeta(kw)
+		patterns[i] = regexp.MustCompile(`\b` + escaped + `\b`)
+	}
+	return patterns
+}
+
 // DetectSubject scans message text for subject indicators and returns the
 // best-matching subject: "math", "writing", "reading", or "general".
 func DetectSubject(messageText string) string {
 	lower := strings.ToLower(messageText)
 
-	mathCount := countKeywords(lower, mathKeywords)
-	writingCount := countKeywords(lower, writingKeywords)
-	readingCount := countKeywords(lower, readingKeywords)
+	mathCount := countPatterns(lower, mathPatterns)
+	writingCount := countPatterns(lower, writingPatterns)
+	readingCount := countPatterns(lower, readingPatterns)
 
 	if mathCount == 0 && writingCount == 0 && readingCount == 0 {
 		return "general"
@@ -56,10 +78,10 @@ func DetectSubject(messageText string) string {
 	return best
 }
 
-func countKeywords(text string, keywords []string) int {
+func countPatterns(text string, patterns []*regexp.Regexp) int {
 	count := 0
-	for _, kw := range keywords {
-		if strings.Contains(text, kw) {
+	for _, p := range patterns {
+		if p.MatchString(text) {
 			count++
 		}
 	}
@@ -78,15 +100,21 @@ func BuildSystemPrompt(profile HomeworkProfile, helpLevel HelpLevel, detectedSub
 	// Section 2: Age/grade calibration
 	b.WriteString(ageCalibration(profile))
 
-	// Section 3: Subject-specific pedagogical rules
-	b.WriteString(subjectRules(detectedSubject))
+	// Section 3: Subject-specific pedagogical rules (normalize case for robustness)
+	b.WriteString(subjectRules(strings.ToLower(detectedSubject)))
 
-	// Section 4: Anti-cheating guardrails
+	// Section 4: Anti-cheating guardrails, adapted to the selected help level
 	b.WriteString("IMPORTANT RULES:\n")
-	b.WriteString("- Never provide complete answers directly.\n")
-	b.WriteString("- Do not do the student's work for them.\n")
-	b.WriteString("- If the student asks you to just give the answer, gently redirect them to think through the problem.\n")
-	b.WriteString("- Do not generate entire essays, solutions, or assignments.\n\n")
+	if helpLevel == HelpLevelAnswer {
+		b.WriteString("- You may explain the full solution step-by-step to help the student learn.\n")
+		b.WriteString("- Focus on teaching understanding, not just providing answers to copy.\n")
+		b.WriteString("- Encourage the student to explain back what they learned.\n\n")
+	} else {
+		b.WriteString("- Never provide complete answers directly.\n")
+		b.WriteString("- Do not do the student's work for them.\n")
+		b.WriteString("- If the student asks you to just give the answer, gently redirect them to think through the problem.\n")
+		b.WriteString("- Do not generate entire essays, solutions, or assignments.\n\n")
+	}
 
 	// Section 5: Help-level enforcement
 	b.WriteString(helpLevelRules(helpLevel))
@@ -97,6 +125,12 @@ func BuildSystemPrompt(profile HomeworkProfile, helpLevel HelpLevel, detectedSub
 func ageCalibration(profile HomeworkProfile) string {
 	age := profile.Age
 	grade := parseGrade(profile.GradeLevel)
+
+	// When no calibration data is available, use a neutral middle-school default
+	// rather than assuming an advanced student.
+	if age == 0 && grade == 0 {
+		return "Use moderate vocabulary appropriate for a middle-school student. You can introduce subject-specific terms but explain them when first used.\n\n"
+	}
 
 	isYoung := (age > 0 && age <= 8) || (grade > 0 && grade <= 3)
 	isMiddle := (age > 0 && age <= 13) || (grade > 0 && grade <= 8)
@@ -112,7 +146,8 @@ func ageCalibration(profile HomeworkProfile) string {
 
 // parseGrade extracts a numeric grade from strings like "3", "5th", "grade 7".
 func parseGrade(gradeLevel string) int {
-	cleaned := strings.ToLower(gradeLevel)
+	// TrimSpace first so trailing whitespace doesn't prevent suffix removal.
+	cleaned := strings.TrimSpace(strings.ToLower(gradeLevel))
 	cleaned = strings.TrimPrefix(cleaned, "grade ")
 	cleaned = strings.TrimPrefix(cleaned, "grade")
 	cleaned = strings.TrimSuffix(cleaned, "th")

--- a/internal/homework/prompts_test.go
+++ b/internal/homework/prompts_test.go
@@ -1,0 +1,169 @@
+package homework
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectSubject(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+	}{
+		{"math keywords", "I need help to solve this equation", "math"},
+		{"writing keywords", "Help me write an essay with a good thesis", "writing"},
+		{"reading keywords", "Tell me about the character in this book chapter", "reading"},
+		{"no keywords", "hello can you help me", "general"},
+		{"empty string", "", "general"},
+		{"case insensitive", "SOLVE the EQUATION please", "math"},
+		{"math wins by count", "solve the equation and calculate the fraction for my math homework", "math"},
+		{"writing wins by count", "write an essay with a thesis paragraph and good grammar", "writing"},
+		{"reading wins by count", "I read a book about a character in a novel and the plot was great", "reading"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectSubject(tt.input)
+			if got != tt.want {
+				t.Errorf("DetectSubject(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSystemPrompt_Preamble(t *testing.T) {
+	profile := HomeworkProfile{Age: 10, GradeLevel: "5"}
+	prompt := BuildSystemPrompt(profile, HelpLevelHint, "general")
+
+	if !strings.Contains(prompt, "friendly, patient homework tutor") {
+		t.Error("prompt missing tutor framing preamble")
+	}
+}
+
+func TestBuildSystemPrompt_AntiCheating(t *testing.T) {
+	profile := HomeworkProfile{Age: 10, GradeLevel: "5"}
+	prompt := BuildSystemPrompt(profile, HelpLevelHint, "general")
+
+	if !strings.Contains(prompt, "Never provide complete answers directly") {
+		t.Error("prompt missing anti-cheating guardrails")
+	}
+}
+
+func TestBuildSystemPrompt_AgeCalibration(t *testing.T) {
+	young := HomeworkProfile{Age: 7, GradeLevel: "2"}
+	middle := HomeworkProfile{Age: 12, GradeLevel: "7"}
+	older := HomeworkProfile{Age: 16, GradeLevel: "10"}
+
+	youngPrompt := BuildSystemPrompt(young, HelpLevelHint, "general")
+	middlePrompt := BuildSystemPrompt(middle, HelpLevelHint, "general")
+	olderPrompt := BuildSystemPrompt(older, HelpLevelHint, "general")
+
+	if !strings.Contains(youngPrompt, "simple, clear language") {
+		t.Error("young profile should use simple language")
+	}
+	if !strings.Contains(middlePrompt, "moderate vocabulary") {
+		t.Error("middle profile should use moderate vocabulary")
+	}
+	if !strings.Contains(olderPrompt, "advanced vocabulary") {
+		t.Error("older profile should use advanced vocabulary")
+	}
+}
+
+func TestBuildSystemPrompt_GradeSuffixes(t *testing.T) {
+	tests := []struct {
+		grade string
+		want  string
+	}{
+		{"1st", "simple"},
+		{"2nd", "simple"},
+		{"3rd", "simple"},
+		{"5th", "moderate"},
+		{"grade 7", "moderate"},
+		{"12th", "advanced"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.grade, func(t *testing.T) {
+			profile := HomeworkProfile{Age: 0, GradeLevel: tt.grade}
+			prompt := BuildSystemPrompt(profile, HelpLevelHint, "general")
+			if !strings.Contains(strings.ToLower(prompt), tt.want) {
+				t.Errorf("grade %q: expected prompt to contain %q", tt.grade, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSystemPrompt_SubjectRules(t *testing.T) {
+	profile := HomeworkProfile{Age: 12, GradeLevel: "7"}
+
+	mathPrompt := BuildSystemPrompt(profile, HelpLevelHint, "math")
+	if !strings.Contains(mathPrompt, "step-by-step reasoning") {
+		t.Error("math prompt missing step-by-step enforcement")
+	}
+
+	writingPrompt := BuildSystemPrompt(profile, HelpLevelHint, "writing")
+	if !strings.Contains(writingPrompt, "Never write essays") {
+		t.Error("writing prompt missing essay prohibition")
+	}
+
+	readingPrompt := BuildSystemPrompt(profile, HelpLevelHint, "reading")
+	if !strings.Contains(readingPrompt, "discussion questions") {
+		t.Error("reading prompt missing discussion questions rule")
+	}
+
+	generalPrompt := BuildSystemPrompt(profile, HelpLevelHint, "general")
+	if strings.Contains(generalPrompt, "MATH TUTORING") || strings.Contains(generalPrompt, "WRITING TUTORING") || strings.Contains(generalPrompt, "READING TUTORING") {
+		t.Error("general prompt should not contain subject-specific rules")
+	}
+}
+
+func TestBuildSystemPrompt_HelpLevels(t *testing.T) {
+	profile := HomeworkProfile{Age: 12, GradeLevel: "7"}
+
+	tests := []struct {
+		level HelpLevel
+		want  string
+	}{
+		{HelpLevelHint, "hints only"},
+		{HelpLevelExplain, "concepts and principles"},
+		{HelpLevelWalkthrough, "guided walkthrough"},
+		{HelpLevelAnswer, "full solution step-by-step"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.level), func(t *testing.T) {
+			prompt := BuildSystemPrompt(profile, tt.level, "general")
+			if !strings.Contains(strings.ToLower(prompt), strings.ToLower(tt.want)) {
+				t.Errorf("help level %q: expected prompt to contain %q", tt.level, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGrade(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"3", 3},
+		{"5th", 5},
+		{"1st", 1},
+		{"2nd", 2},
+		{"3rd", 3},
+		{"grade 7", 7},
+		{"grade7", 7},
+		{"12th", 12},
+		{"invalid", 0},
+		{"", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseGrade(tt.input)
+			if got != tt.want {
+				t.Errorf("parseGrade(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/homework/prompts_test.go
+++ b/internal/homework/prompts_test.go
@@ -20,6 +20,9 @@ func TestDetectSubject(t *testing.T) {
 		{"math wins by count", "solve the equation and calculate the fraction for my math homework", "math"},
 		{"writing wins by count", "write an essay with a thesis paragraph and good grammar", "writing"},
 		{"reading wins by count", "I read a book about a character in a novel and the plot was great", "reading"},
+		// Word-boundary checks: short keywords must not match inside longer words.
+		{"add inside address", "my home address is on the form", "general"},
+		{"read inside already", "I have already finished the assignment", "general"},
 	}
 
 	for _, tt := range tests {
@@ -50,14 +53,30 @@ func TestBuildSystemPrompt_AntiCheating(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPrompt_AntiCheatingAnswerLevel(t *testing.T) {
+	profile := HomeworkProfile{Age: 10, GradeLevel: "5"}
+	prompt := BuildSystemPrompt(profile, HelpLevelAnswer, "general")
+
+	// At HelpLevelAnswer the restrictive anti-cheating rule should not appear,
+	// but the prompt should still guide toward teaching rather than copying.
+	if strings.Contains(prompt, "Never provide complete answers directly") {
+		t.Error("HelpLevelAnswer prompt should not include restrictive anti-cheating rule")
+	}
+	if !strings.Contains(prompt, "teaching understanding") {
+		t.Error("HelpLevelAnswer prompt should encourage teaching understanding")
+	}
+}
+
 func TestBuildSystemPrompt_AgeCalibration(t *testing.T) {
 	young := HomeworkProfile{Age: 7, GradeLevel: "2"}
 	middle := HomeworkProfile{Age: 12, GradeLevel: "7"}
 	older := HomeworkProfile{Age: 16, GradeLevel: "10"}
+	unknown := HomeworkProfile{Age: 0, GradeLevel: ""}
 
 	youngPrompt := BuildSystemPrompt(young, HelpLevelHint, "general")
 	middlePrompt := BuildSystemPrompt(middle, HelpLevelHint, "general")
 	olderPrompt := BuildSystemPrompt(older, HelpLevelHint, "general")
+	unknownPrompt := BuildSystemPrompt(unknown, HelpLevelHint, "general")
 
 	if !strings.Contains(youngPrompt, "simple, clear language") {
 		t.Error("young profile should use simple language")
@@ -67,6 +86,10 @@ func TestBuildSystemPrompt_AgeCalibration(t *testing.T) {
 	}
 	if !strings.Contains(olderPrompt, "advanced vocabulary") {
 		t.Error("older profile should use advanced vocabulary")
+	}
+	// Unknown profile should default to neutral middle-school, not advanced.
+	if !strings.Contains(unknownPrompt, "moderate vocabulary") {
+		t.Error("unknown profile should default to moderate vocabulary, not advanced")
 	}
 }
 
@@ -100,6 +123,12 @@ func TestBuildSystemPrompt_SubjectRules(t *testing.T) {
 	mathPrompt := BuildSystemPrompt(profile, HelpLevelHint, "math")
 	if !strings.Contains(mathPrompt, "step-by-step reasoning") {
 		t.Error("math prompt missing step-by-step enforcement")
+	}
+
+	// Subject matching should be case-insensitive.
+	mathPromptUpper := BuildSystemPrompt(profile, HelpLevelHint, "Math")
+	if !strings.Contains(mathPromptUpper, "step-by-step reasoning") {
+		t.Error("math prompt missing step-by-step enforcement when subject is 'Math'")
 	}
 
 	writingPrompt := BuildSystemPrompt(profile, HelpLevelHint, "writing")
@@ -154,6 +183,8 @@ func TestParseGrade(t *testing.T) {
 		{"grade 7", 7},
 		{"grade7", 7},
 		{"12th", 12},
+		{"5th ", 5},  // trailing whitespace must not break suffix removal
+		{" 3rd", 3},  // leading whitespace must not break suffix removal
 		{"invalid", 0},
 		{"", 0},
 	}


### PR DESCRIPTION
## Changes

- **Homework prompt engine and subject detection** - Added keyword-based subject classifier and system prompt builder for the homework tutoring feature, supporting math, writing, reading, and general subjects with age-appropriate language calibration and help-level enforcement. (Hytte-naqi)

## Original Issue (task): Prompt engine and subject detection

Create internal/homework/prompts.go with two functions:

- `DetectSubject(messageText string) string` — keyword-based classifier that scans message text for subject indicators (math terms, writing/essay terms, reading/literature terms) and returns a subject string like "math", "writing", "reading", or "general".

- `BuildSystemPrompt(profile HomeworkProfile, helpLevel HelpLevel, detectedSubject string) string` — assembles the full system prompt by composing: (1) tutor framing preamble, (2) age-appropriate language calibration based on profile age/grade, (3) subject-specific pedagogical rules (math: enforce step-by-step reasoning; writing: never write essays, redirect to brainstorming; reading: generate discussion questions), (4) anti-cheating guardrails, (5) help-level enforcement (e.g. level 1 = hints only, level 2 = guided walkthrough, level 3 = explain solution). This is a pure-logic module with no HTTP or DB dependencies. Unit-testable in isolation. Sibling sub-tasks depend on this for prompt generation but not vice versa.

---
Bead: Hytte-naqi | Branch: forge/Hytte-naqi
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)