### PR TITLE
CRUD handlers for Profile and Conversation listing (Hytte-bkcx)

### DIFF
--- a/changelog.d/Hytte-bkcx.md
+++ b/changelog.d/Hytte-bkcx.md
@@ -1,0 +1,2 @@
+category: Added
+- **Homework helper API** - CRUD handlers for homework profiles and conversation listing, gated by the new "homework" feature flag. Parents can manage their child's academic profile and start/view homework conversations. (Hytte-bkcx)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Robin831/Hytte/internal/family"
 	"github.com/Robin831/Hytte/internal/forge"
 	"github.com/Robin831/Hytte/internal/grocery"
+	"github.com/Robin831/Hytte/internal/homework"
 	"github.com/Robin831/Hytte/internal/infra"
 	"github.com/Robin831/Hytte/internal/kiosk"
 	"github.com/Robin831/Hytte/internal/lactate"
@@ -604,6 +605,16 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Put("/allowance/my/goals/{id}", allowance.UpdateMyGoalHandler(db))
 				// Photo serving (accessible to the child who uploaded and the parent).
 				r.Get("/allowance/photos/{completion_id}", allowance.ServePhotoHandler(db))
+			})
+
+			// Homework helper — gated by "homework" feature.
+			r.Group(func(r chi.Router) {
+				r.Use(auth.RequireFeature(db, "homework"))
+				r.Get("/homework/children/{childId}/profile", homework.HandleGetProfile(db))
+				r.Put("/homework/children/{childId}/profile", homework.HandleUpdateProfile(db))
+				r.Get("/homework/children/{childId}/conversations", homework.HandleListConversations(db))
+				r.Post("/homework/children/{childId}/conversations", homework.HandleNewConversation(db))
+				r.Get("/homework/children/{childId}/conversations/{id}", homework.HandleGetConversation(db))
 			})
 
 			// Transit departures — gated by "transit" feature.

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -32,6 +32,7 @@ var FeatureDefaults = map[string]bool{
 	"skywatch":          true,
 	"vault":            false,
 	"grocery":          false,
+	"homework":         false,
 }
 
 // FeatureKeys is a sorted list of all known feature keys, used for stable

--- a/internal/homework/handlers.go
+++ b/internal/homework/handlers.go
@@ -1,0 +1,249 @@
+package homework
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("writeJSON encode error: %v", err)
+	}
+}
+
+// verifyParentChild returns nil if a family_links row exists for parentID -> childID.
+func verifyParentChild(db *sql.DB, parentID, childID int64) error {
+	var id int64
+	return db.QueryRow(
+		`SELECT id FROM family_links WHERE parent_id = ? AND child_id = ?`,
+		parentID, childID,
+	).Scan(&id)
+}
+
+// parseChildID extracts the child ID from the URL and verifies the parent-child relationship.
+// Returns the child ID or writes an error response and returns 0.
+func parseChildID(w http.ResponseWriter, r *http.Request, db *sql.DB, userID int64) (int64, bool) {
+	childID, err := strconv.ParseInt(chi.URLParam(r, "childId"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid child ID"})
+		return 0, false
+	}
+
+	if err := verifyParentChild(db, userID, childID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "not authorized to access this child's data"})
+		} else {
+			log.Printf("homework: verify parent-child user %d child %d: %v", userID, childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		}
+		return 0, false
+	}
+	return childID, true
+}
+
+// HandleGetProfile returns the homework profile for a child.
+// GET /api/homework/children/{childId}/profile
+func HandleGetProfile(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		childID, ok := parseChildID(w, r, db, user.ID)
+		if !ok {
+			return
+		}
+
+		profile, err := GetProfileByKidID(db, childID)
+		if err != nil {
+			log.Printf("homework: get profile kid %d: %v", childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get profile"})
+			return
+		}
+		if profile == nil {
+			writeJSON(w, http.StatusOK, map[string]any{"profile": nil})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"profile": profile})
+	}
+}
+
+// HandleUpdateProfile creates or updates the homework profile for a child.
+// PUT /api/homework/children/{childId}/profile
+func HandleUpdateProfile(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		childID, ok := parseChildID(w, r, db, user.ID)
+		if !ok {
+			return
+		}
+
+		var body struct {
+			Age               int      `json:"age"`
+			GradeLevel        string   `json:"grade_level"`
+			Subjects          []string `json:"subjects"`
+			PreferredLanguage string   `json:"preferred_language"`
+			SchoolName        string   `json:"school_name"`
+			CurrentTopics     []string `json:"current_topics"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+
+		body.GradeLevel = strings.TrimSpace(body.GradeLevel)
+		body.PreferredLanguage = strings.TrimSpace(body.PreferredLanguage)
+		body.SchoolName = strings.TrimSpace(body.SchoolName)
+		if body.Subjects == nil {
+			body.Subjects = []string{}
+		}
+		if body.CurrentTopics == nil {
+			body.CurrentTopics = []string{}
+		}
+
+		if body.Age < 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "age must be non-negative"})
+			return
+		}
+
+		profile := HomeworkProfile{
+			KidID:             childID,
+			Age:               body.Age,
+			GradeLevel:        body.GradeLevel,
+			Subjects:          body.Subjects,
+			PreferredLanguage: body.PreferredLanguage,
+			SchoolName:        body.SchoolName,
+			CurrentTopics:     body.CurrentTopics,
+		}
+
+		// Try update first; if no row exists, create.
+		err := UpdateProfile(db, profile)
+		if errors.Is(err, sql.ErrNoRows) {
+			created, createErr := CreateProfile(db, profile)
+			if createErr != nil {
+				log.Printf("homework: create profile kid %d: %v", childID, createErr)
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create profile"})
+				return
+			}
+			writeJSON(w, http.StatusCreated, map[string]any{"profile": created})
+			return
+		}
+		if err != nil {
+			log.Printf("homework: update profile kid %d: %v", childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update profile"})
+			return
+		}
+
+		// Re-read the updated profile.
+		updated, err := GetProfileByKidID(db, childID)
+		if err != nil {
+			log.Printf("homework: re-read profile kid %d: %v", childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read updated profile"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"profile": updated})
+	}
+}
+
+// HandleListConversations returns all homework conversations for a child.
+// GET /api/homework/children/{childId}/conversations
+func HandleListConversations(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		childID, ok := parseChildID(w, r, db, user.ID)
+		if !ok {
+			return
+		}
+
+		convos, err := ListConversationsByKid(db, childID)
+		if err != nil {
+			log.Printf("homework: list conversations kid %d: %v", childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list conversations"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"conversations": convos})
+	}
+}
+
+// HandleGetConversation returns a single homework conversation with its messages.
+// GET /api/homework/children/{childId}/conversations/{id}
+func HandleGetConversation(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		childID, ok := parseChildID(w, r, db, user.ID)
+		if !ok {
+			return
+		}
+
+		convID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid conversation ID"})
+			return
+		}
+
+		conv, err := GetConversation(db, convID, childID)
+		if err != nil {
+			log.Printf("homework: get conversation %d kid %d: %v", convID, childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get conversation"})
+			return
+		}
+		if conv == nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "conversation not found"})
+			return
+		}
+
+		msgs, err := GetMessages(db, convID, childID)
+		if err != nil {
+			log.Printf("homework: get messages conv %d kid %d: %v", convID, childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get messages"})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"conversation": conv,
+			"messages":     msgs,
+		})
+	}
+}
+
+// HandleNewConversation starts a new homework conversation for a child.
+// Accepts an optional "subject" field; if absent, defaults to empty string.
+// POST /api/homework/children/{childId}/conversations
+func HandleNewConversation(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		childID, ok := parseChildID(w, r, db, user.ID)
+		if !ok {
+			return
+		}
+
+		var body struct {
+			Subject string `json:"subject"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+
+		body.Subject = strings.TrimSpace(body.Subject)
+
+		conv, err := CreateConversation(db, HomeworkConversation{
+			KidID:   childID,
+			Subject: body.Subject,
+		})
+		if err != nil {
+			log.Printf("homework: create conversation kid %d: %v", childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create conversation"})
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, map[string]any{"conversation": conv})
+	}
+}

--- a/internal/homework/handlers.go
+++ b/internal/homework/handlers.go
@@ -103,6 +103,11 @@ func HandleUpdateProfile(db *sql.DB) http.HandlerFunc {
 			CurrentTopics     []string `json:"current_topics"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+				return
+			}
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
 			return
 		}
@@ -238,12 +243,17 @@ func HandleNewConversation(db *sql.DB) http.HandlerFunc {
 		var body struct {
 			Subject string `json:"subject"`
 		}
-		// Subject is optional — tolerate an empty body.
+		// Subject is optional — tolerate an empty body, including whitespace-only bodies.
 		if data, err := io.ReadAll(r.Body); err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+				return
+			}
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
 			return
-		} else if len(data) > 0 {
-			if err := json.Unmarshal(data, &body); err != nil {
+		} else if trimmed := strings.TrimSpace(string(data)); trimmed != "" {
+			if err := json.Unmarshal([]byte(trimmed), &body); err != nil {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
 				return
 			}

--- a/internal/homework/handlers.go
+++ b/internal/homework/handlers.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -12,6 +13,12 @@ import (
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/go-chi/chi/v5"
 )
+
+// maxProfileBodySize is the maximum allowed request body size for profile updates (64 KB).
+const maxProfileBodySize = 64 << 10
+
+// maxConversationBodySize is the maximum allowed request body size for new conversations (8 KB).
+const maxConversationBodySize = 8 << 10
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
@@ -84,6 +91,8 @@ func HandleUpdateProfile(db *sql.DB) http.HandlerFunc {
 		if !ok {
 			return
 		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxProfileBodySize)
 
 		var body struct {
 			Age               int      `json:"age"`
@@ -224,12 +233,20 @@ func HandleNewConversation(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		r.Body = http.MaxBytesReader(w, r.Body, maxConversationBodySize)
+
 		var body struct {
 			Subject string `json:"subject"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		// Subject is optional — tolerate an empty body.
+		if data, err := io.ReadAll(r.Body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to read request body"})
 			return
+		} else if len(data) > 0 {
+			if err := json.Unmarshal(data, &body); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+				return
+			}
 		}
 
 		body.Subject = strings.TrimSpace(body.Subject)

--- a/internal/homework/handlers_test.go
+++ b/internal/homework/handlers_test.go
@@ -202,6 +202,23 @@ func TestHandleNewConversationNoSubject(t *testing.T) {
 	}
 }
 
+func TestHandleNewConversationEmptyBody(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	handler := HandleNewConversation(d)
+	r := withChiParams(withUser(httptest.NewRequest(http.MethodPost, "/api/homework/children/2/conversations", nil), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for empty body, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestHandleListConversations(t *testing.T) {
 	d := setupTestDB(t)
 	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)

--- a/internal/homework/handlers_test.go
+++ b/internal/homework/handlers_test.go
@@ -1,0 +1,308 @@
+package homework
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+func newRequest(method, path string, body any) *http.Request {
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			panic(err)
+		}
+	}
+	r := httptest.NewRequest(method, path, &buf)
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+func withUser(r *http.Request, user *auth.User) *http.Request {
+	return r.WithContext(auth.ContextWithUser(r.Context(), user))
+}
+
+func withChiParams(r *http.Request, params map[string]string) *http.Request {
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+func decode(t *testing.T, body []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(body, v); err != nil {
+		t.Fatalf("decode response: %v (body: %s)", err, body)
+	}
+}
+
+var testParent = &auth.User{ID: 1, Email: "parent@test.com", Name: "Parent"}
+
+func TestHandleGetProfileEmpty(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	handler := HandleGetProfile(d)
+	r := withChiParams(withUser(newRequest(http.MethodGet, "/api/homework/children/2/profile", nil), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	decode(t, w.Body.Bytes(), &resp)
+	if resp["profile"] != nil {
+		t.Errorf("expected null profile, got %v", resp["profile"])
+	}
+}
+
+func TestHandleGetProfileForbidden(t *testing.T) {
+	d := setupTestDB(t)
+	// No family link — parent 1 does not own kid 2.
+
+	handler := HandleGetProfile(d)
+	r := withChiParams(withUser(newRequest(http.MethodGet, "/api/homework/children/2/profile", nil), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpdateProfileCreateAndUpdate(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	handler := HandleUpdateProfile(d)
+
+	// Create profile (no existing row).
+	body := map[string]any{
+		"age":                10,
+		"grade_level":        "5th",
+		"subjects":           []string{"math"},
+		"preferred_language": "nb",
+		"school_name":        "Test School",
+		"current_topics":     []string{"fractions"},
+	}
+	r := withChiParams(withUser(newRequest(http.MethodPut, "/api/homework/children/2/profile", body), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Profile HomeworkProfile `json:"profile"`
+	}
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Profile.Age != 10 {
+		t.Errorf("expected age 10, got %d", resp.Profile.Age)
+	}
+	if resp.Profile.SchoolName != "Test School" {
+		t.Errorf("expected school 'Test School', got %q", resp.Profile.SchoolName)
+	}
+
+	// Update existing profile.
+	body["age"] = 11
+	body["school_name"] = "New School"
+	r = withChiParams(withUser(newRequest(http.MethodPut, "/api/homework/children/2/profile", body), testParent), map[string]string{"childId": "2"})
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on update, got %d: %s", w.Code, w.Body.String())
+	}
+
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Profile.Age != 11 {
+		t.Errorf("expected age 11, got %d", resp.Profile.Age)
+	}
+	if resp.Profile.SchoolName != "New School" {
+		t.Errorf("expected school 'New School', got %q", resp.Profile.SchoolName)
+	}
+}
+
+func TestHandleUpdateProfileInvalidJSON(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	handler := HandleUpdateProfile(d)
+	r := withChiParams(withUser(httptest.NewRequest(http.MethodPut, "/api/homework/children/2/profile", bytes.NewBufferString("not json")), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleNewConversation(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	handler := HandleNewConversation(d)
+	body := map[string]any{"subject": "Math homework"}
+	r := withChiParams(withUser(newRequest(http.MethodPost, "/api/homework/children/2/conversations", body), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Conversation HomeworkConversation `json:"conversation"`
+	}
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Conversation.Subject != "Math homework" {
+		t.Errorf("expected subject 'Math homework', got %q", resp.Conversation.Subject)
+	}
+	if resp.Conversation.KidID != 2 {
+		t.Errorf("expected kid_id 2, got %d", resp.Conversation.KidID)
+	}
+}
+
+func TestHandleNewConversationNoSubject(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	handler := HandleNewConversation(d)
+	r := withChiParams(withUser(newRequest(http.MethodPost, "/api/homework/children/2/conversations", map[string]any{}), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleListConversations(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	// Create two conversations.
+	if _, err := CreateConversation(d, HomeworkConversation{KidID: 2, Subject: "Math"}); err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	if _, err := CreateConversation(d, HomeworkConversation{KidID: 2, Subject: "Science"}); err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	handler := HandleListConversations(d)
+	r := withChiParams(withUser(newRequest(http.MethodGet, "/api/homework/children/2/conversations", nil), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Conversations []HomeworkConversation `json:"conversations"`
+	}
+	decode(t, w.Body.Bytes(), &resp)
+	if len(resp.Conversations) != 2 {
+		t.Fatalf("expected 2 conversations, got %d", len(resp.Conversations))
+	}
+}
+
+func TestHandleGetConversation(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	conv, err := CreateConversation(d, HomeworkConversation{KidID: 2, Subject: "Reading"})
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	// Add a message.
+	if _, err := AddMessage(d, HomeworkMessage{ConversationID: conv.ID, Role: "user", Content: "Help me", HelpLevel: HelpLevelHint}); err != nil {
+		t.Fatalf("add message: %v", err)
+	}
+
+	handler := HandleGetConversation(d)
+	r := withChiParams(withUser(newRequest(http.MethodGet, "/api/homework/children/2/conversations/1", nil), testParent), map[string]string{"childId": "2", "id": "1"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Conversation HomeworkConversation `json:"conversation"`
+		Messages     []HomeworkMessage    `json:"messages"`
+	}
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Conversation.Subject != "Reading" {
+		t.Errorf("expected subject 'Reading', got %q", resp.Conversation.Subject)
+	}
+	if len(resp.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(resp.Messages))
+	}
+	if resp.Messages[0].Content != "Help me" {
+		t.Errorf("expected content 'Help me', got %q", resp.Messages[0].Content)
+	}
+}
+
+func TestHandleGetConversationNotFound(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	handler := HandleGetConversation(d)
+	r := withChiParams(withUser(newRequest(http.MethodGet, "/api/homework/children/2/conversations/999", nil), testParent), map[string]string{"childId": "2", "id": "999"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleInvalidChildID(t *testing.T) {
+	d := setupTestDB(t)
+
+	handler := HandleGetProfile(d)
+	r := withChiParams(withUser(newRequest(http.MethodGet, "/api/homework/children/abc/profile", nil), testParent), map[string]string{"childId": "abc"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/homework/store.go
+++ b/internal/homework/store.go
@@ -35,12 +35,20 @@ func CreateProfile(db *sql.DB, p HomeworkProfile) (HomeworkProfile, error) {
 	if err != nil {
 		return HomeworkProfile{}, fmt.Errorf("encrypt current_topics: %w", err)
 	}
+	encGradeLevel, err := encryption.EncryptField(p.GradeLevel)
+	if err != nil {
+		return HomeworkProfile{}, fmt.Errorf("encrypt grade_level: %w", err)
+	}
+	encLang, err := encryption.EncryptField(p.PreferredLanguage)
+	if err != nil {
+		return HomeworkProfile{}, fmt.Errorf("encrypt preferred_language: %w", err)
+	}
 
 	now := time.Now().UTC().Format(timeFormat)
 	result, err := db.Exec(`
 		INSERT INTO kids_homework_profiles (kid_id, age, grade_level, subjects, preferred_language, school_name, current_topics, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		p.KidID, p.Age, p.GradeLevel, encSubjects, p.PreferredLanguage, encSchool, encTopics, now, now,
+		p.KidID, p.Age, encGradeLevel, encSubjects, encLang, encSchool, encTopics, now, now,
 	)
 	if err != nil {
 		return HomeworkProfile{}, fmt.Errorf("insert homework profile: %w", err)
@@ -80,13 +88,21 @@ func UpdateProfile(db *sql.DB, p HomeworkProfile) error {
 	if err != nil {
 		return fmt.Errorf("encrypt current_topics: %w", err)
 	}
+	encGradeLevel, err := encryption.EncryptField(p.GradeLevel)
+	if err != nil {
+		return fmt.Errorf("encrypt grade_level: %w", err)
+	}
+	encLang, err := encryption.EncryptField(p.PreferredLanguage)
+	if err != nil {
+		return fmt.Errorf("encrypt preferred_language: %w", err)
+	}
 
 	now := time.Now().UTC().Format(timeFormat)
 	result, err := db.Exec(`
 		UPDATE kids_homework_profiles
 		SET age = ?, grade_level = ?, subjects = ?, preferred_language = ?, school_name = ?, current_topics = ?, updated_at = ?
 		WHERE kid_id = ?`,
-		p.Age, p.GradeLevel, encSubjects, p.PreferredLanguage, encSchool, encTopics, now, p.KidID,
+		p.Age, encGradeLevel, encSubjects, encLang, encSchool, encTopics, now, p.KidID,
 	)
 	if err != nil {
 		return fmt.Errorf("update homework profile: %w", err)
@@ -105,19 +121,31 @@ func UpdateProfile(db *sql.DB, p HomeworkProfile) error {
 // GetProfileByKidID returns the homework profile for a given child.
 func GetProfileByKidID(db *sql.DB, kidID int64) (*HomeworkProfile, error) {
 	var p HomeworkProfile
-	var encSubjects, encSchool, encTopics string
+	var encSubjects, encSchool, encTopics, encGradeLevel, encLang string
 	err := db.QueryRow(`
 		SELECT id, kid_id, age, grade_level, subjects, preferred_language, school_name, current_topics, created_at, updated_at
 		FROM kids_homework_profiles
 		WHERE kid_id = ?`,
 		kidID,
-	).Scan(&p.ID, &p.KidID, &p.Age, &p.GradeLevel, &encSubjects, &p.PreferredLanguage, &encSchool, &encTopics, &p.CreatedAt, &p.UpdatedAt)
+	).Scan(&p.ID, &p.KidID, &p.Age, &encGradeLevel, &encSubjects, &encLang, &encSchool, &encTopics, &p.CreatedAt, &p.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get homework profile: %w", err)
 	}
+
+	gradeLevel, err := decryptField(encGradeLevel)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt grade_level: %w", err)
+	}
+	p.GradeLevel = gradeLevel
+
+	lang, err := decryptField(encLang)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt preferred_language: %w", err)
+	}
+	p.PreferredLanguage = lang
 
 	schoolName, err := decryptField(encSchool)
 	if err != nil {

--- a/internal/homework/store_test.go
+++ b/internal/homework/store_test.go
@@ -67,6 +67,9 @@ func TestProfileCRUD(t *testing.T) {
 	if got.Age != 10 || got.GradeLevel != "5th" {
 		t.Fatalf("unexpected profile values: age=%d grade=%s", got.Age, got.GradeLevel)
 	}
+	if got.PreferredLanguage != "nb" {
+		t.Fatalf("expected preferred_language 'nb', got %q", got.PreferredLanguage)
+	}
 	if got.SchoolName != "Test School" {
 		t.Fatalf("expected school 'Test School', got %q", got.SchoolName)
 	}
@@ -97,6 +100,9 @@ func TestProfileCRUD(t *testing.T) {
 	}
 	if got.Age != 11 || got.GradeLevel != "6th" {
 		t.Fatalf("profile not updated: age=%d grade=%s", got.Age, got.GradeLevel)
+	}
+	if got.PreferredLanguage != "en" {
+		t.Fatalf("expected preferred_language 'en' after update, got %q", got.PreferredLanguage)
 	}
 	if len(got.Subjects) != 3 {
 		t.Fatalf("expected 3 subjects, got %d", len(got.Subjects))


### PR DESCRIPTION
## Changes

- **Homework helper API** - CRUD handlers for homework profiles and conversation listing, gated by the new "homework" feature flag. Parents can manage their child's academic profile and start/view homework conversations. (Hytte-bkcx)

## Original Issue (task): CRUD handlers for Profile and Conversation listing

Create internal/homework/handlers.go with the simpler read/write handlers: HandleGetProfile(w, r), HandleUpdateProfile(w, r), HandleListConversations(w, r), HandleGetConversation(w, r), and HandleNewConversation(w, r). These handlers extract the authenticated user from request context, validate input, delegate to the data layer (from Hytte dependency), and return JSON responses. HandleNewConversation accepts an optional 'subject' field and initializes the conversation record. This sub-task establishes the file structure, common helpers (JSON response writing, error handling, auth extraction), and routing setup that the messaging handler will build on.

---
Bead: Hytte-bkcx | Branch: forge/Hytte-bkcx
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)