### PR TITLE
Mezzanine Needs Attention: Force Smith button missing (Hytte-4jbe)

### DIFF
--- a/changelog.d/Hytte-4jbe.md
+++ b/changelog.d/Hytte-4jbe.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Force Smith button now visible in Needs Attention panel** - The Force Smith action was only shown for beads needing clarification, but was missing for beads where the warden rejected the smith's changes (needs_human) or review was exhausted. (Hytte-4jbe)

--- a/web/src/hooks/useNeedsAttention.test.ts
+++ b/web/src/hooks/useNeedsAttention.test.ts
@@ -102,6 +102,14 @@ describe('isPRExhaustion', () => {
   it('is case-insensitive', () => {
     expect(isPRExhaustion(makeStuckBead({ last_error: 'CI_EXHAUSTED' }))).toBe(true)
   })
+
+  it('detects backend "CI fix attempts exhausted" wording', () => {
+    expect(isPRExhaustion(makeStuckBead({ last_error: 'CI fix attempts exhausted' }))).toBe(true)
+  })
+
+  it('detects backend "Review fix attempts exhausted" wording', () => {
+    expect(isPRExhaustion(makeStuckBead({ last_error: 'Review fix attempts exhausted' }))).toBe(true)
+  })
 })
 
 describe('classifyStatuses', () => {
@@ -175,6 +183,16 @@ describe('classifySource', () => {
 
   it('returns "pr" when last_error indicates max_retries', () => {
     expect(classifySource(makeStuckBead({ last_error: 'max_retries reached' }))).toBe('pr')
+  })
+
+  it('returns "pr" for backend "CI fix attempts exhausted" wording', () => {
+    expect(classifySource(makeStuckBead({ last_error: 'CI fix attempts exhausted' }))).toBe('pr')
+  })
+
+  it('returns "pr" for backend "Review fix attempts exhausted" wording', () => {
+    // Synthetic stuck-PR rows must not get source='retry' or Force Smith will 404
+    const bead = makeStuckBead({ needs_human: true, last_error: 'Review fix attempts exhausted' })
+    expect(classifySource(bead)).toBe('pr')
   })
 })
 

--- a/web/src/hooks/useNeedsAttention.test.ts
+++ b/web/src/hooks/useNeedsAttention.test.ts
@@ -213,8 +213,16 @@ describe('availableActions', () => {
     expect(availableActions('pr', ['clarification_needed'])).not.toContain('forceSmith')
   })
 
-  it('does NOT include forceSmith for retry source without clarification_needed', () => {
-    expect(availableActions('retry', ['needs_human'])).not.toContain('forceSmith')
+  it('includes forceSmith for retry source with needs_human', () => {
+    expect(availableActions('retry', ['needs_human'])).toContain('forceSmith')
+  })
+
+  it('includes forceSmith for retry source with review_exhausted', () => {
+    expect(availableActions('retry', ['review_exhausted'])).toContain('forceSmith')
+  })
+
+  it('does NOT include forceSmith for retry source without relevant status', () => {
+    expect(availableActions('retry', ['dispatch_failure'])).not.toContain('forceSmith')
   })
 
   it('includes wardenRerun for retry source with needs_human', () => {

--- a/web/src/hooks/useNeedsAttention.ts
+++ b/web/src/hooks/useNeedsAttention.ts
@@ -68,15 +68,17 @@ export function hasExhaustedReason(lastError: string | undefined, kind: 'ci' | '
 }
 
 export function isPRExhaustion(bead: StuckBead): boolean {
-  const lastError = bead.last_error?.toLowerCase() ?? ''
+  const lastError = bead.last_error
+  const normalized = lastError?.toLowerCase() ?? ''
 
+  // Delegate to hasExhaustedReason so backend strings like
+  // "Review fix attempts exhausted" / "CI fix attempts exhausted" are matched
+  // in addition to the short ci_exhausted / review_exhausted forms.
   return (
-    lastError.includes('ci_exhausted') ||
-    lastError.includes('ci exhausted') ||
-    lastError.includes('review_exhausted') ||
-    lastError.includes('review exhausted') ||
-    lastError.includes('max_retries') ||
-    lastError.includes('max retries')
+    hasExhaustedReason(lastError, 'ci') ||
+    hasExhaustedReason(lastError, 'review') ||
+    normalized.includes('max_retries') ||
+    normalized.includes('max retries')
   )
 }
 

--- a/web/src/hooks/useNeedsAttention.ts
+++ b/web/src/hooks/useNeedsAttention.ts
@@ -130,8 +130,12 @@ export function availableActions(source: NeedsAttentionSource, statuses: NeedsAt
   }
 
   // Force smith lets a human re-run with extra context, but only for items
-  // backed by a retries-table row.
-  if (hasRetryEntry && statuses.includes('clarification_needed')) {
+  // backed by a retries-table row. Available when the smith needs clarification
+  // or the warden rejected the smith's changes (needs_human / review_exhausted).
+  if (
+    hasRetryEntry &&
+    (statuses.includes('clarification_needed') || statuses.includes('needs_human') || statuses.includes('review_exhausted'))
+  ) {
     actions.push('forceSmith')
   }
 


### PR DESCRIPTION
## Changes

- **Force Smith button now visible in Needs Attention panel** - The Force Smith action was only shown for beads needing clarification, but was missing for beads where the warden rejected the smith's changes (needs_human) or review was exhausted. (Hytte-4jbe)

## Original Issue (bug): Mezzanine Needs Attention: Force Smith button missing

Hytte-ovus added action buttons to the Mezzanine Needs Attention panel — Approve, Retry, Dismiss, Rerun Warden are visible. But the Force Smith button is missing. The other actions work correctly.

Force Smith is needed when the smith made changes the warden didn't accept and the user wants to manually retry the smith with feedback (e.g. after appending warden concerns to the bead notes). It's available in Hearth.

## Fix

Check web/src/components/mezzanine/NeedsAttentionItem.tsx (or similar) — the action button list is missing the Force Smith case. The IPC command (force_smith) and Hytte API endpoint should already exist from Hytte-ovus.

If the API endpoint is missing, also add:
- POST /api/forge/beads/{id}/force-smith (or similar)
- Wire it through to the forge IPC force_smith command

## Files
- web/src/components/mezzanine/NeedsAttentionPanel.tsx or NeedsAttentionItem.tsx — add button
- internal/forge/handlers.go — verify ForceSmithHandler exists
- internal/api/router.go — verify route

---
Bead: Hytte-4jbe | Branch: forge/Hytte-4jbe
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)