### PR TITLE
HandleParentReview with aggregated help-level stats (Hytte-99jq)

### DIFF
--- a/changelog.d/Hytte-99jq.md
+++ b/changelog.d/Hytte-99jq.md
@@ -1,0 +1,2 @@
+category: Added
+- **Parent review endpoint for homework** - Added GET /api/homework/children/{childId}/review endpoint that returns aggregated help-level statistics across all conversations for a child, letting parents monitor how much assistance is being used. (Hytte-99jq)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -616,6 +616,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/homework/children/{childId}/conversations", homework.HandleNewConversation(db))
 				r.Get("/homework/children/{childId}/conversations/{id}", homework.HandleGetConversation(db))
 				r.Post("/homework/children/{childId}/conversations/{id}/messages", homework.HandleSendMessage(db))
+				r.Get("/homework/children/{childId}/review", homework.HandleParentReview(db))
 			})
 
 			// Transit departures — gated by "transit" feature.

--- a/internal/homework/handlers.go
+++ b/internal/homework/handlers.go
@@ -545,6 +545,48 @@ func HandleSendMessage(db *sql.DB) http.HandlerFunc {
 	}
 }
 
+// ParentReviewResponse is the JSON shape returned by HandleParentReview.
+type ParentReviewResponse struct {
+	Conversations []ConversationSummary `json:"conversations"`
+	TotalMessages int                   `json:"total_messages"`
+	HelpLevelTotals map[string]int      `json:"help_level_totals"`
+}
+
+// HandleParentReview returns an aggregated summary of a child's homework conversations
+// with per-conversation and overall help-level statistics.
+// GET /api/homework/children/{childId}/review
+func HandleParentReview(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		childID, ok := parseChildID(w, r, db, user.ID)
+		if !ok {
+			return
+		}
+
+		summaries, err := GetConversationsForParentReview(db, childID)
+		if err != nil {
+			log.Printf("homework: parent review kid %d: %v", childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load review data"})
+			return
+		}
+
+		totalMessages := 0
+		helpTotals := map[string]int{}
+		for _, s := range summaries {
+			totalMessages += s.MessageCount
+			for level, count := range s.HelpLevels {
+				helpTotals[level] += count
+			}
+		}
+
+		writeJSON(w, http.StatusOK, ParentReviewResponse{
+			Conversations:   summaries,
+			TotalMessages:   totalMessages,
+			HelpLevelTotals: helpTotals,
+		})
+	}
+}
+
 // claudeStreamLine represents a line from Claude CLI's stream-json output.
 type claudeStreamLine struct {
 	Type      string `json:"type"`

--- a/internal/homework/handlers.go
+++ b/internal/homework/handlers.go
@@ -569,9 +569,12 @@ func HandleParentReview(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load review data"})
 			return
 		}
+		if summaries == nil {
+			summaries = []ConversationSummary{}
+		}
 
 		totalMessages := 0
-		helpTotals := map[string]int{}
+		helpTotals := make(map[string]int)
 		for _, s := range summaries {
 			totalMessages += s.MessageCount
 			for level, count := range s.HelpLevels {

--- a/internal/homework/handlers.go
+++ b/internal/homework/handlers.go
@@ -547,20 +547,35 @@ func HandleSendMessage(db *sql.DB) http.HandlerFunc {
 
 // ParentReviewResponse is the JSON shape returned by HandleParentReview.
 type ParentReviewResponse struct {
-	Conversations []ConversationSummary `json:"conversations"`
-	TotalMessages int                   `json:"total_messages"`
-	HelpLevelTotals map[string]int      `json:"help_level_totals"`
+	Conversations                  []ConversationSummary `json:"conversations"`
+	TotalMessages                  int                   `json:"total_messages"`
+	HelpLevelTotals                map[string]int        `json:"help_level_totals"`
+	HelpLevelAverages              map[string]float64    `json:"help_level_averages"`
+	AverageMessagesPerConversation float64               `json:"average_messages_per_conversation"`
 }
 
 // HandleParentReview returns an aggregated summary of a child's homework conversations
 // with per-conversation and overall help-level statistics.
 // GET /api/homework/children/{childId}/review
+// Admin users bypass the family_links check and may access any child's review.
 func HandleParentReview(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
-		childID, ok := parseChildID(w, r, db, user.ID)
-		if !ok {
-			return
+
+		var childID int64
+		if user.IsAdmin {
+			id, err := strconv.ParseInt(chi.URLParam(r, "childId"), 10, 64)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid child ID"})
+				return
+			}
+			childID = id
+		} else {
+			var ok bool
+			childID, ok = parseChildID(w, r, db, user.ID)
+			if !ok {
+				return
+			}
 		}
 
 		summaries, err := GetConversationsForParentReview(db, childID)
@@ -582,11 +597,22 @@ func HandleParentReview(db *sql.DB) http.HandlerFunc {
 			}
 		}
 
-		writeJSON(w, http.StatusOK, ParentReviewResponse{
-			Conversations:   summaries,
-			TotalMessages:   totalMessages,
-			HelpLevelTotals: helpTotals,
-		})
+		helpAverages := make(map[string]float64)
+		var avgMsgsPerConv float64
+		if len(summaries) > 0 {
+			avgMsgsPerConv = float64(totalMessages) / float64(len(summaries))
+			for level, count := range helpTotals {
+				helpAverages[level] = float64(count) / float64(len(summaries))
+			}
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"review": ParentReviewResponse{
+			Conversations:                  summaries,
+			TotalMessages:                  totalMessages,
+			HelpLevelTotals:                helpTotals,
+			HelpLevelAverages:              helpAverages,
+			AverageMessagesPerConversation: avgMsgsPerConv,
+		}})
 	}
 }
 

--- a/internal/homework/handlers_test.go
+++ b/internal/homework/handlers_test.go
@@ -646,15 +646,23 @@ func TestHandleParentReviewSuccess(t *testing.T) {
 		t.Fatalf("create conversation 2: %v", err)
 	}
 
-	// Conv1: 2 hints, 1 explain.
+	// Conv1: 2 hints, 1 explain — each turn has a user message and an assistant reply,
+	// matching the production pattern where HandleSendMessage stores help_level on both.
+	// Help-level totals count assistant messages only, so each pair contributes 1.
 	for _, hl := range []HelpLevel{HelpLevelHint, HelpLevelHint, HelpLevelExplain} {
 		if _, err := AddMessage(d, HomeworkMessage{ConversationID: conv1.ID, Role: "user", Content: "q", HelpLevel: hl}); err != nil {
 			t.Fatalf("add message: %v", err)
 		}
+		if _, err := AddMessage(d, HomeworkMessage{ConversationID: conv1.ID, Role: "assistant", Content: "a", HelpLevel: hl}); err != nil {
+			t.Fatalf("add assistant message: %v", err)
+		}
 	}
-	// Conv2: 1 walkthrough.
+	// Conv2: 1 walkthrough (user + assistant pair).
 	if _, err := AddMessage(d, HomeworkMessage{ConversationID: conv2.ID, Role: "user", Content: "q", HelpLevel: HelpLevelWalkthrough}); err != nil {
 		t.Fatalf("add message: %v", err)
+	}
+	if _, err := AddMessage(d, HomeworkMessage{ConversationID: conv2.ID, Role: "assistant", Content: "a", HelpLevel: HelpLevelWalkthrough}); err != nil {
+		t.Fatalf("add assistant message: %v", err)
 	}
 
 	handler := HandleParentReview(d)
@@ -666,15 +674,20 @@ func TestHandleParentReviewSuccess(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp ParentReviewResponse
-	decode(t, w.Body.Bytes(), &resp)
+	var envelope struct {
+		Review ParentReviewResponse `json:"review"`
+	}
+	decode(t, w.Body.Bytes(), &envelope)
+	resp := envelope.Review
 
 	if len(resp.Conversations) != 2 {
 		t.Fatalf("expected 2 conversations, got %d", len(resp.Conversations))
 	}
-	if resp.TotalMessages != 4 {
-		t.Errorf("expected 4 total messages, got %d", resp.TotalMessages)
+	// 3 user + 3 assistant in conv1, 1 user + 1 assistant in conv2 = 8 total messages.
+	if resp.TotalMessages != 8 {
+		t.Errorf("expected 8 total messages, got %d", resp.TotalMessages)
 	}
+	// Help-level totals count only assistant messages.
 	if resp.HelpLevelTotals["hint"] != 2 {
 		t.Errorf("expected 2 hints total, got %d", resp.HelpLevelTotals["hint"])
 	}
@@ -683,6 +696,14 @@ func TestHandleParentReviewSuccess(t *testing.T) {
 	}
 	if resp.HelpLevelTotals["walkthrough"] != 1 {
 		t.Errorf("expected 1 walkthrough total, got %d", resp.HelpLevelTotals["walkthrough"])
+	}
+	// Averages: 8 messages / 2 conversations = 4.0.
+	if resp.AverageMessagesPerConversation != 4.0 {
+		t.Errorf("expected 4.0 avg messages per conv, got %f", resp.AverageMessagesPerConversation)
+	}
+	// hint average: 2 / 2 conversations = 1.0.
+	if resp.HelpLevelAverages["hint"] != 1.0 {
+		t.Errorf("expected hint average 1.0, got %f", resp.HelpLevelAverages["hint"])
 	}
 }
 
@@ -702,8 +723,11 @@ func TestHandleParentReviewEmpty(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp ParentReviewResponse
-	decode(t, w.Body.Bytes(), &resp)
+	var envelope struct {
+		Review ParentReviewResponse `json:"review"`
+	}
+	decode(t, w.Body.Bytes(), &envelope)
+	resp := envelope.Review
 
 	if len(resp.Conversations) != 0 {
 		t.Errorf("expected 0 conversations, got %d", len(resp.Conversations))

--- a/internal/homework/handlers_test.go
+++ b/internal/homework/handlers_test.go
@@ -629,6 +629,104 @@ func TestHandleSendMessageSubjectAutoDetection(t *testing.T) {
 	}
 }
 
+func TestHandleParentReviewSuccess(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	// Create two conversations with messages at different help levels.
+	conv1, err := CreateConversation(d, HomeworkConversation{KidID: 2, Subject: "Math"})
+	if err != nil {
+		t.Fatalf("create conversation 1: %v", err)
+	}
+	conv2, err := CreateConversation(d, HomeworkConversation{KidID: 2, Subject: "Reading"})
+	if err != nil {
+		t.Fatalf("create conversation 2: %v", err)
+	}
+
+	// Conv1: 2 hints, 1 explain.
+	for _, hl := range []HelpLevel{HelpLevelHint, HelpLevelHint, HelpLevelExplain} {
+		if _, err := AddMessage(d, HomeworkMessage{ConversationID: conv1.ID, Role: "user", Content: "q", HelpLevel: hl}); err != nil {
+			t.Fatalf("add message: %v", err)
+		}
+	}
+	// Conv2: 1 walkthrough.
+	if _, err := AddMessage(d, HomeworkMessage{ConversationID: conv2.ID, Role: "user", Content: "q", HelpLevel: HelpLevelWalkthrough}); err != nil {
+		t.Fatalf("add message: %v", err)
+	}
+
+	handler := HandleParentReview(d)
+	r := withChiParams(withUser(newRequest(http.MethodGet, "/api/homework/children/2/review", nil), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ParentReviewResponse
+	decode(t, w.Body.Bytes(), &resp)
+
+	if len(resp.Conversations) != 2 {
+		t.Fatalf("expected 2 conversations, got %d", len(resp.Conversations))
+	}
+	if resp.TotalMessages != 4 {
+		t.Errorf("expected 4 total messages, got %d", resp.TotalMessages)
+	}
+	if resp.HelpLevelTotals["hint"] != 2 {
+		t.Errorf("expected 2 hints total, got %d", resp.HelpLevelTotals["hint"])
+	}
+	if resp.HelpLevelTotals["explain"] != 1 {
+		t.Errorf("expected 1 explain total, got %d", resp.HelpLevelTotals["explain"])
+	}
+	if resp.HelpLevelTotals["walkthrough"] != 1 {
+		t.Errorf("expected 1 walkthrough total, got %d", resp.HelpLevelTotals["walkthrough"])
+	}
+}
+
+func TestHandleParentReviewEmpty(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := d.Exec(`INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at) VALUES (1, 2, 'Kid', '📚', '2026-01-01T00:00:00.000Z')`)
+	if err != nil {
+		t.Fatalf("insert family link: %v", err)
+	}
+
+	handler := HandleParentReview(d)
+	r := withChiParams(withUser(newRequest(http.MethodGet, "/api/homework/children/2/review", nil), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ParentReviewResponse
+	decode(t, w.Body.Bytes(), &resp)
+
+	if len(resp.Conversations) != 0 {
+		t.Errorf("expected 0 conversations, got %d", len(resp.Conversations))
+	}
+	if resp.TotalMessages != 0 {
+		t.Errorf("expected 0 total messages, got %d", resp.TotalMessages)
+	}
+}
+
+func TestHandleParentReviewForbidden(t *testing.T) {
+	d := setupTestDB(t)
+	// No family link.
+
+	handler := HandleParentReview(d)
+	r := withChiParams(withUser(newRequest(http.MethodGet, "/api/homework/children/2/review", nil), testParent), map[string]string{"childId": "2"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestHandleSendMessageDefaultHelpLevel(t *testing.T) {
 	rec, handler, conv := setupSendMessageTest(t)
 

--- a/internal/homework/store.go
+++ b/internal/homework/store.go
@@ -471,7 +471,7 @@ func GetConversationsForParentReview(db *sql.DB, kidID int64) ([]ConversationSum
 			SELECT m.conversation_id, m.help_level, COUNT(*)
 			FROM homework_messages m
 			JOIN homework_conversations c ON c.id = m.conversation_id
-			WHERE c.kid_id = ? AND m.help_level != ''
+			WHERE c.kid_id = ? AND m.help_level != '' AND m.role = 'assistant'
 			GROUP BY m.conversation_id, m.help_level`, kidID)
 		if err != nil {
 			return nil, fmt.Errorf("count help levels: %w", err)


### PR DESCRIPTION
## Changes

- **Parent review endpoint for homework** - Added GET /api/homework/children/{childId}/review endpoint that returns aggregated help-level statistics across all conversations for a child, letting parents monitor how much assistance is being used. (Hytte-99jq)

## Original Issue (task): HandleParentReview with aggregated help-level stats

Add HandleParentReview(w, r) to internal/homework/handlers.go. This handler requires admin/parent access (check role from auth context), queries the data layer for a child's conversations, aggregates help-level statistics across conversations (e.g., count per help level, average), and returns a summary JSON response. Depends on sub-task 1 for the file scaffold, common helpers, and the data layer integration patterns established there.

---
Bead: Hytte-99jq | Branch: forge/Hytte-99jq
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)