### PR TITLE
Homework: Claude CLI invocation missing --verbose flag breaks every send (Hytte-g8fq)

### DIFF
--- a/changelog.d/Hytte-g8fq.md
+++ b/changelog.d/Hytte-g8fq.md
@@ -1,0 +1,3 @@
+category: Fixed
+- **Homework chat sends now work** - Added missing `--verbose` flag to Claude CLI invocation required by `--output-format stream-json`, which caused every homework message to fail. (Hytte-g8fq)
+- **Better error diagnostics for Claude CLI failures** - Captured stderr from the Claude CLI subprocess so failures include actionable error messages instead of just "exit status 1". (Hytte-g8fq)

--- a/internal/homework/handlers.go
+++ b/internal/homework/handlers.go
@@ -542,8 +542,7 @@ func sendMessage(db *sql.DB, w http.ResponseWriter, r *http.Request, kidID, conf
 
 	if err != nil {
 		log.Printf("homework: claude error conv %d: %v", conv.ID, err)
-		errMsg := "Claude failed to respond: " + err.Error()
-		errJSON, _ := json.Marshal(map[string]string{"error": errMsg})
+		errJSON, _ := json.Marshal(map[string]string{"error": "Claude failed to respond. Please try again."})
 		fmt.Fprintf(w, "event: error\ndata: %s\n\n", errJSON)
 		flusher.Flush()
 		return
@@ -750,6 +749,10 @@ func streamClaude(ctx context.Context, cfg *training.ClaudeConfig, systemPrompt,
 		case "result":
 			if ev.IsError {
 				cmd.Wait()
+				stderr := strings.TrimSpace(stderrBuf.String())
+				if stderr != "" {
+					return "", "", fmt.Errorf("claude returned error: %s: %s", ev.Result, stderr)
+				}
 				return "", "", fmt.Errorf("claude returned error: %s", ev.Result)
 			}
 			if ev.Result != "" {
@@ -763,11 +766,17 @@ func streamClaude(ctx context.Context, cfg *training.ClaudeConfig, systemPrompt,
 
 	if err := scanner.Err(); err != nil {
 		cmd.Wait()
-		return "", "", fmt.Errorf("scan claude output: %w: %s", err, strings.TrimSpace(stderrBuf.String()))
+		if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
+			return "", "", fmt.Errorf("scan claude output: %w: %s", err, stderr)
+		}
+		return "", "", fmt.Errorf("scan claude output: %w", err)
 	}
 
 	if err := cmd.Wait(); err != nil {
-		return "", "", fmt.Errorf("claude exit: %w: %s", err, strings.TrimSpace(stderrBuf.String()))
+		if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
+			return "", "", fmt.Errorf("claude exit: %w: %s", err, stderr)
+		}
+		return "", "", fmt.Errorf("claude exit: %w", err)
 	}
 
 	return strings.TrimSpace(fullText.String()), resultSessionID, nil

--- a/internal/homework/handlers.go
+++ b/internal/homework/handlers.go
@@ -2,6 +2,7 @@ package homework
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -672,7 +673,7 @@ type claudeStreamLine struct {
 // using the @path syntax so Claude can analyse it. Returns the full response text
 // and session ID.
 func streamClaude(ctx context.Context, cfg *training.ClaudeConfig, systemPrompt, prompt, imagePath, sessionID string, w http.ResponseWriter, flusher http.Flusher) (string, string, error) {
-	args := []string{"--model", cfg.Model, "-p", "-", "--output-format", "stream-json", "--system-prompt", systemPrompt}
+	args := []string{"--model", cfg.Model, "-p", "-", "--output-format", "stream-json", "--verbose", "--system-prompt", systemPrompt}
 	if sessionID != "" {
 		args = append(args, "--resume", sessionID)
 	}
@@ -689,6 +690,9 @@ func streamClaude(ctx context.Context, cfg *training.ClaudeConfig, systemPrompt,
 
 	cmd := execCommand(ctx, cfg.CLIPath, args...)
 	cmd.Stdin = strings.NewReader(fullPrompt)
+
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -757,11 +761,11 @@ func streamClaude(ctx context.Context, cfg *training.ClaudeConfig, systemPrompt,
 
 	if err := scanner.Err(); err != nil {
 		cmd.Wait()
-		return "", "", fmt.Errorf("scan claude output: %w", err)
+		return "", "", fmt.Errorf("scan claude output: %w: %s", err, strings.TrimSpace(stderrBuf.String()))
 	}
 
 	if err := cmd.Wait(); err != nil {
-		return "", "", fmt.Errorf("claude exit: %w", err)
+		return "", "", fmt.Errorf("claude exit: %w: %s", err, strings.TrimSpace(stderrBuf.String()))
 	}
 
 	return strings.TrimSpace(fullText.String()), resultSessionID, nil

--- a/internal/homework/handlers.go
+++ b/internal/homework/handlers.go
@@ -542,7 +542,9 @@ func sendMessage(db *sql.DB, w http.ResponseWriter, r *http.Request, kidID, conf
 
 	if err != nil {
 		log.Printf("homework: claude error conv %d: %v", conv.ID, err)
-		fmt.Fprintf(w, "event: error\ndata: {\"error\":\"Claude failed to respond\"}\n\n")
+		errMsg := "Claude failed to respond: " + err.Error()
+		errJSON, _ := json.Marshal(map[string]string{"error": errMsg})
+		fmt.Fprintf(w, "event: error\ndata: %s\n\n", errJSON)
 		flusher.Flush()
 		return
 	}

--- a/internal/homework/handlers_test.go
+++ b/internal/homework/handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -1178,13 +1179,26 @@ func TestStreamClaudeArgsIncludeVerbose(t *testing.T) {
 	}
 }
 
+// TestHelperProcess is not a real test — it's a subprocess re-entry point used
+// by tests that need a fake CLI command writing to stderr and exiting non-zero,
+// without depending on a POSIX shell.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Error: --verbose required")
+	os.Exit(1)
+}
+
 func TestStreamClaudeStderrCapturedOnError(t *testing.T) {
 	rec, handler, conv := setupSendMessageTest(t)
 
 	origExec := execCommand
 	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		// Use sh -c to write to stderr and exit 1.
-		cmd := exec.CommandContext(ctx, "sh", "-c", "echo 'Error: --verbose required' >&2; exit 1")
+		// Re-invoke this test binary as a helper subprocess that writes to stderr
+		// and exits non-zero — no POSIX shell required.
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestHelperProcess$")
+		cmd.Env = append(os.Environ(), "GO_TEST_HELPER_PROCESS=1")
 		return cmd
 	}
 	t.Cleanup(func() { execCommand = origExec })
@@ -1201,11 +1215,11 @@ func TestStreamClaudeStderrCapturedOnError(t *testing.T) {
 	handler.ServeHTTP(rec, r)
 
 	respBody := rec.Body.String()
-	// The error event should contain the stderr output.
+	// An error event must be emitted; the message must be generic (no internal detail exposed).
 	if !strings.Contains(respBody, "event: error") {
 		t.Errorf("expected error event, got: %s", respBody)
 	}
-	if !strings.Contains(respBody, "--verbose required") {
-		t.Errorf("expected stderr content in error event, got: %s", respBody)
+	if !strings.Contains(respBody, "Please try again") {
+		t.Errorf("expected generic error message, got: %s", respBody)
 	}
 }

--- a/internal/homework/handlers_test.go
+++ b/internal/homework/handlers_test.go
@@ -397,6 +397,17 @@ func fakeExecCommand(lines []string) func(ctx context.Context, name string, args
 	}
 }
 
+// fakeExecCommandCapture is like fakeExecCommand but also records the args
+// passed to each invocation into the provided slice.
+func fakeExecCommandCapture(lines []string, captured *[][]string) func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		*captured = append(*captured, args)
+		output := strings.Join(lines, "\n") + "\n"
+		cmd := exec.CommandContext(ctx, "echo", "-n", output)
+		return cmd
+	}
+}
+
 func TestHandleSendMessageSuccess(t *testing.T) {
 	rec, handler, conv := setupSendMessageTest(t)
 
@@ -1116,5 +1127,85 @@ func TestHandleSendMessageDefaultHelpLevel(t *testing.T) {
 	respBody := rec.Body.String()
 	if !strings.Contains(respBody, "event: done") {
 		t.Errorf("expected done event in response")
+	}
+}
+
+func TestStreamClaudeArgsIncludeVerbose(t *testing.T) {
+	rec, handler, conv := setupSendMessageTest(t)
+
+	var captured [][]string
+	origExec := execCommand
+	execCommand = fakeExecCommandCapture([]string{
+		`{"type":"result","result":"ok","session_id":"sess-v","is_error":false}`,
+	}, &captured)
+	t.Cleanup(func() { execCommand = origExec })
+
+	body, contentType := multipartBody(t, map[string]string{
+		"message":    "test verbose flag",
+		"help_level": "hint",
+	}, nil)
+
+	r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/homework/children/2/conversations/%d/messages", conv.ID), body)
+	r.Header.Set("Content-Type", contentType)
+	r = withChiParams(withUser(r, testParent), map[string]string{"childId": "2", "id": fmt.Sprintf("%d", conv.ID)})
+
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if len(captured) == 0 {
+		t.Fatal("execCommand was never called")
+	}
+
+	args := captured[0]
+	hasVerbose := false
+	hasStreamJSON := false
+	for i, a := range args {
+		if a == "--verbose" {
+			hasVerbose = true
+		}
+		if a == "--output-format" && i+1 < len(args) && args[i+1] == "stream-json" {
+			hasStreamJSON = true
+		}
+	}
+	if !hasStreamJSON {
+		t.Error("expected --output-format stream-json in args")
+	}
+	if !hasVerbose {
+		t.Error("expected --verbose in args alongside --output-format stream-json")
+	}
+}
+
+func TestStreamClaudeStderrCapturedOnError(t *testing.T) {
+	rec, handler, conv := setupSendMessageTest(t)
+
+	origExec := execCommand
+	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		// Use sh -c to write to stderr and exit 1.
+		cmd := exec.CommandContext(ctx, "sh", "-c", "echo 'Error: --verbose required' >&2; exit 1")
+		return cmd
+	}
+	t.Cleanup(func() { execCommand = origExec })
+
+	body, contentType := multipartBody(t, map[string]string{
+		"message":    "test stderr",
+		"help_level": "hint",
+	}, nil)
+
+	r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/homework/children/2/conversations/%d/messages", conv.ID), body)
+	r.Header.Set("Content-Type", contentType)
+	r = withChiParams(withUser(r, testParent), map[string]string{"childId": "2", "id": fmt.Sprintf("%d", conv.ID)})
+
+	handler.ServeHTTP(rec, r)
+
+	respBody := rec.Body.String()
+	// The error event should contain the stderr output.
+	if !strings.Contains(respBody, "event: error") {
+		t.Errorf("expected error event, got: %s", respBody)
+	}
+	if !strings.Contains(respBody, "--verbose required") {
+		t.Errorf("expected stderr content in error event, got: %s", respBody)
 	}
 }


### PR DESCRIPTION
## Changes

- **Homework chat sends now work** - Added missing `--verbose` flag to Claude CLI invocation required by `--output-format stream-json`, which caused every homework message to fail. (Hytte-g8fq)
- **Better error diagnostics for Claude CLI failures** - Captured stderr from the Claude CLI subprocess so failures include actionable error messages instead of just "exit status 1". (Hytte-g8fq)

## Original Issue (bug): Homework: Claude CLI invocation missing --verbose flag breaks every send

## Summary

Every homework send-message request fails with 'Claude failed to respond'. The Claude CLI is invoked with `--print -p - --output-format stream-json` but **without** `--verbose`, which Claude CLI 2.1.100 requires for that combination. The CLI exits immediately with status 1 before writing anything to stdout.

## Reproduction

James (user 2) sent a homework message at 2026-04-10 13:07:19 and again at 13:07:34. Both attempts: `POST /api/homework/conversations/1/messages` returned 200 (SSE stream) but the stream contained only an `error` event. Logs:

```
2026/04/10 13:07:19 homework: claude error conv 1: claude exit: exit status 1
2026/04/10 13:07:34 homework: claude error conv 1: claude exit: exit status 1
```

The conversation row exists (`homework_conversations.id=1, kid_id=2, session_id=''`) and both user messages are persisted encrypted (`homework_messages` ids 1 and 2, both with non-empty encrypted image_path). The saved images are on disk at `data/homework-uploads/1/hw-1-*.jpg` (3.3 MB JPEGs, readable by the hytte service).

Manual reproduction on the server reproduces the exact failure:

```bash
printf 'hello' | /home/robin/.local/bin/claude --model claude-opus-4-6 -p - \
  --output-format stream-json --system-prompt 'test'
# → Error: When using --print, --output-format=stream-json requires --verbose
# → exit status 1
```

Adding `--verbose` makes the same command succeed end-to-end with the exact image the kid uploaded (Claude successfully reads and describes the Norwegian homework sheet).

## Root cause

`internal/homework/handlers.go:675`:

```go
args := []string{"--model", cfg.Model, "-p", "-", "--output-format", "stream-json", "--system-prompt", systemPrompt}
```

Claude CLI 2.1.100 rejects `--print + --output-format stream-json` without `--verbose`. This is the ONLY place in Hytte that uses `stream-json` output — `internal/training/claude.go` uses `text` and `json` formats, which don't need `--verbose`. Homework is the first streaming caller and missed the flag requirement.

## Fix

1. **Add `--verbose` to the args slice** in `streamClaude` at `internal/homework/handlers.go:675`:

   ```go
   args := []string{"--model", cfg.Model, "-p", "-", "--output-format", "stream-json", "--verbose", "--system-prompt", systemPrompt}
   ```

2. **Capture stderr in `streamClaude`.** Currently only `StdoutPipe` is wired up (`handlers.go:693`), so when the CLI prints a startup error to stderr — like this one — neither the user nor the logs see it. The handler just logs `claude exit: exit status 1`, which is useless for diagnosis. Attach a `bytes.Buffer` as `cmd.Stderr` (or use `StderrPipe` + a goroutine that appends to a buffer) and include the captured output in the wrapped error returned at `handlers.go:760` and `:764`. Example:

   ```go
   var stderrBuf bytes.Buffer
   cmd.Stderr = &stderrBuf
   // ...
   if err := cmd.Wait(); err != nil {
       return "", "", fmt.Errorf("claude exit: %w: %s", err, strings.TrimSpace(stderrBuf.String()))
   }
   ```

   This would have turned a silent 'claude failed to respond' into an actionable 'claude exit: exit status 1: Error: When using --print, --output-format=stream-json requires --verbose' on the first report.

3. **Add a test that asserts `--verbose` is in the args.** `handlers_test.go` overrides `execCommand` so the real CLI is never invoked, which is why this bug slipped CI. A unit test that captures the args passed to `execCommand` and asserts `--verbose` is present (alongside `--output-format stream-json`) would pin this down. Optional but nice: also assert stderr is captured on failure paths.

## Cleanup

- The two broken user messages for `kid_id=2, conv_id=1` are still sitting in `homework_messages` (ids 1 and 2). The kid may want to retry from a clean slate — consider whether the frontend should allow deleting a conversation, or if we should just leave them and let him send a new message in the same conversation (which will work once --verbose is in place).

## Files to touch

- `internal/homework/handlers.go` — add `--verbose`, capture stderr
- `internal/homework/handlers_test.go` — assert args include `--verbose`, cover stderr-on-error path
- `changelog.d/Hytte-<id>.md` — `Fixed` category fragment

---
Bead: Hytte-g8fq | Branch: forge/Hytte-g8fq
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)