### PR TITLE
Schema migration and core consume logic (Hytte-4xnx)

### DIFF
--- a/changelog.d/Hytte-4xnx.md
+++ b/changelog.d/Hytte-4xnx.md
@@ -1,0 +1,2 @@
+category: Added
+- **Note consumption tracking** - Added consumed_at and consumed_by columns to stride notes, enabling tracking of which notes have been processed by plan generation or nightly evaluation. ListNotes now supports a status filter (active/consumed/all). (Hytte-4xnx)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1335,6 +1335,8 @@ func createSchema(db *sql.DB) error {
 		plan_id     INTEGER REFERENCES stride_plans(id) ON DELETE SET NULL,
 		content     TEXT NOT NULL,
 		target_date TEXT NOT NULL DEFAULT '',
+		consumed_at TEXT,
+		consumed_by TEXT,
 		created_at  TEXT NOT NULL DEFAULT ''
 	);
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2072,6 +2072,27 @@ func createSchema(db *sql.DB) error {
 		}
 	}
 
+	// Add consumed_at and consumed_by columns to stride_notes table (Hytte-4xnx).
+	// Tracks when and by what process a note was consumed (e.g. weekly plan generation).
+	var hasConsumedAt int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('stride_notes') WHERE name = 'consumed_at'`).Scan(&hasConsumedAt); err != nil {
+		return fmt.Errorf("check stride_notes consumed_at column: %w", err)
+	}
+	if hasConsumedAt == 0 {
+		if _, err := db.Exec(`ALTER TABLE stride_notes ADD COLUMN consumed_at TEXT`); err != nil {
+			return fmt.Errorf("add stride_notes consumed_at column: %w", err)
+		}
+	}
+	var hasConsumedBy int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('stride_notes') WHERE name = 'consumed_by'`).Scan(&hasConsumedBy); err != nil {
+		return fmt.Errorf("check stride_notes consumed_by column: %w", err)
+	}
+	if hasConsumedBy == 0 {
+		if _, err := db.Exec(`ALTER TABLE stride_notes ADD COLUMN consumed_by TEXT`); err != nil {
+			return fmt.Errorf("add stride_notes consumed_by column: %w", err)
+		}
+	}
+
 	// Add race_id FK column to workouts table (Hytte-im9y).
 	// Links a workout to a stride_races entry when the workout is a race result.
 	var hasRaceID int

--- a/internal/stride/handlers.go
+++ b/internal/stride/handlers.go
@@ -376,7 +376,7 @@ func DeleteRaceHandler(db *sql.DB) http.HandlerFunc {
 }
 
 // ListNotesHandler returns notes for the authenticated user.
-// Optional query param: plan_id (integer).
+// Optional query params: plan_id (integer), status ("active", "consumed", "all").
 func ListNotesHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
@@ -391,7 +391,9 @@ func ListNotesHandler(db *sql.DB) http.HandlerFunc {
 			planID = &pid
 		}
 
-		notes, err := ListNotes(db, user.ID, planID)
+		status := r.URL.Query().Get("status")
+
+		notes, err := ListNotes(db, user.ID, planID, status)
 		if err != nil {
 			log.Printf("stride: list notes: %v", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list notes"})

--- a/internal/stride/handlers.go
+++ b/internal/stride/handlers.go
@@ -391,7 +391,13 @@ func ListNotesHandler(db *sql.DB) http.HandlerFunc {
 			planID = &pid
 		}
 
-		status := r.URL.Query().Get("status")
+		status := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("status")))
+		switch status {
+		case "", "active", "consumed", "all":
+		default:
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid status"})
+			return
+		}
 
 		notes, err := ListNotes(db, user.ID, planID, status)
 		if err != nil {

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -374,11 +374,16 @@ func ListNotes(db *sql.DB, userID int64, planID *int64, status string) ([]Note, 
 		args = append(args, *planID)
 	}
 
-	switch status {
+	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
+	switch normalizedStatus {
+	case "", "all":
+		// No additional filter.
 	case "active":
 		query += ` AND consumed_at IS NULL`
 	case "consumed":
 		query += ` AND consumed_at IS NOT NULL`
+	default:
+		return nil, fmt.Errorf("invalid status %q: must be active, consumed, all, or empty", status)
 	}
 
 	query += ` ORDER BY created_at DESC`

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -468,7 +468,7 @@ func DeleteNote(db *sql.DB, id, userID int64) error {
 // MarkNotesConsumed sets consumed_at and consumed_by for the given note IDs
 // within the provided transaction. This marks notes as having been processed
 // by a consuming process (e.g. weekly plan generation, nightly evaluation).
-func MarkNotesConsumed(ctx context.Context, tx *sql.Tx, noteIDs []int64, consumedBy string) error {
+func MarkNotesConsumed(ctx context.Context, tx *sql.Tx, userID int64, noteIDs []int64, consumedBy string) error {
 	if len(noteIDs) == 0 {
 		return nil
 	}
@@ -476,14 +476,14 @@ func MarkNotesConsumed(ctx context.Context, tx *sql.Tx, noteIDs []int64, consume
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	placeholders := make([]string, len(noteIDs))
-	args := make([]any, 0, len(noteIDs)+2)
-	args = append(args, now, consumedBy)
+	args := make([]any, 0, len(noteIDs)+3)
+	args = append(args, now, consumedBy, userID)
 	for i, id := range noteIDs {
 		placeholders[i] = "?"
 		args = append(args, id)
 	}
 
-	query := `UPDATE stride_notes SET consumed_at = ?, consumed_by = ? WHERE id IN (` + strings.Join(placeholders, ",") + `)`
+	query := `UPDATE stride_notes SET consumed_at = ?, consumed_by = ? WHERE user_id = ? AND id IN (` + strings.Join(placeholders, ",") + `)`
 	_, err := tx.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("mark notes consumed: %w", err)

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -1,10 +1,12 @@
 package stride
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
@@ -27,12 +29,14 @@ type Race struct {
 // Note represents a short free-text note from the user that feeds into the
 // next Stride plan generation.
 type Note struct {
-	ID         int64  `json:"id"`
-	UserID     int64  `json:"user_id"`
-	PlanID     *int64 `json:"plan_id"`     // nullable — linked to plan when created during a plan week
-	Content    string `json:"content"`     // encrypted at rest
-	TargetDate string `json:"target_date"` // YYYY-MM-DD — which date this note applies to
-	CreatedAt  string `json:"created_at"`
+	ID         int64      `json:"id"`
+	UserID     int64      `json:"user_id"`
+	PlanID     *int64     `json:"plan_id"`      // nullable — linked to plan when created during a plan week
+	Content    string     `json:"content"`      // encrypted at rest
+	TargetDate string     `json:"target_date"`  // YYYY-MM-DD — which date this note applies to
+	ConsumedAt *time.Time `json:"consumed_at"`  // nullable — set when consumed by a process (e.g. plan generation)
+	ConsumedBy *string    `json:"consumed_by"`  // nullable — identifier of the consuming process
+	CreatedAt  string     `json:"created_at"`
 }
 
 // NextStrideRun returns the next time the weekly Stride cron should fire
@@ -52,6 +56,31 @@ func NextStrideRun(now time.Time, loc *time.Location) time.Time {
 		return todayRun.AddDate(0, 0, 7)
 	}
 	return time.Date(now.Year(), now.Month(), now.Day()+daysUntilSunday, 18, 0, 0, 0, loc)
+}
+
+// scanNote scans a note row into a Note struct, handling nullable consumed_at/consumed_by
+// columns and decrypting the content field.
+func scanNote(scanner interface{ Scan(...any) error }, n *Note) error {
+	var consumedAt sql.NullString
+	var consumedBy sql.NullString
+	if err := scanner.Scan(&n.ID, &n.UserID, &n.PlanID, &n.Content, &n.TargetDate, &consumedAt, &consumedBy, &n.CreatedAt); err != nil {
+		return err
+	}
+	if consumedAt.Valid {
+		t, err := time.Parse(time.RFC3339, consumedAt.String)
+		if err != nil {
+			return fmt.Errorf("parse consumed_at: %w", err)
+		}
+		n.ConsumedAt = &t
+	}
+	if consumedBy.Valid {
+		n.ConsumedBy = &consumedBy.String
+	}
+	var err error
+	if n.Content, err = encryption.DecryptField(n.Content); err != nil {
+		return fmt.Errorf("decrypt note content: %w", err)
+	}
+	return nil
 }
 
 // ListRaces returns all races for a user ordered by date ascending.
@@ -329,11 +358,13 @@ func DeleteRace(db *sql.DB, id, userID int64) error {
 	return nil
 }
 
-// ListNotes returns notes for a user, optionally filtered by plan_id.
-// When planID is nil, all notes for the user are returned.
-func ListNotes(db *sql.DB, userID int64, planID *int64) ([]Note, error) {
+// ListNotes returns notes for a user, optionally filtered by plan_id and status.
+// When planID is nil, notes are not filtered by plan. The status parameter controls
+// consumption filtering: "active" returns only unconsumed notes (consumed_at IS NULL),
+// "consumed" returns only consumed notes, and "all" (or empty string) returns everything.
+func ListNotes(db *sql.DB, userID int64, planID *int64, status string) ([]Note, error) {
 	query := `
-		SELECT id, user_id, plan_id, content, target_date, created_at
+		SELECT id, user_id, plan_id, content, target_date, consumed_at, consumed_by, created_at
 		FROM stride_notes
 		WHERE user_id = ?`
 	args := []any{userID}
@@ -342,6 +373,14 @@ func ListNotes(db *sql.DB, userID int64, planID *int64) ([]Note, error) {
 		query += ` AND plan_id = ?`
 		args = append(args, *planID)
 	}
+
+	switch status {
+	case "active":
+		query += ` AND consumed_at IS NULL`
+	case "consumed":
+		query += ` AND consumed_at IS NOT NULL`
+	}
+
 	query += ` ORDER BY created_at DESC`
 
 	rows, err := db.Query(query, args...)
@@ -353,11 +392,8 @@ func ListNotes(db *sql.DB, userID int64, planID *int64) ([]Note, error) {
 	var notes []Note
 	for rows.Next() {
 		var n Note
-		if err := rows.Scan(&n.ID, &n.UserID, &n.PlanID, &n.Content, &n.TargetDate, &n.CreatedAt); err != nil {
+		if err := scanNote(rows, &n); err != nil {
 			return nil, err
-		}
-		if n.Content, err = encryption.DecryptField(n.Content); err != nil {
-			return nil, fmt.Errorf("decrypt note content: %w", err)
 		}
 		notes = append(notes, n)
 	}
@@ -402,16 +438,13 @@ func CreateNote(db *sql.DB, userID int64, planID *int64, content, targetDate str
 // getNoteByID returns a single note by ID, scoped to the given user.
 func getNoteByID(db *sql.DB, id, userID int64) (*Note, error) {
 	var n Note
-	err := db.QueryRow(`
-		SELECT id, user_id, plan_id, content, target_date, created_at
+	row := db.QueryRow(`
+		SELECT id, user_id, plan_id, content, target_date, consumed_at, consumed_by, created_at
 		FROM stride_notes
 		WHERE id = ? AND user_id = ?
-	`, id, userID).Scan(&n.ID, &n.UserID, &n.PlanID, &n.Content, &n.TargetDate, &n.CreatedAt)
-	if err != nil {
+	`, id, userID)
+	if err := scanNote(row, &n); err != nil {
 		return nil, err
-	}
-	if n.Content, err = encryption.DecryptField(n.Content); err != nil {
-		return nil, fmt.Errorf("decrypt note content: %w", err)
 	}
 	return &n, nil
 }
@@ -432,10 +465,36 @@ func DeleteNote(db *sql.DB, id, userID int64) error {
 	return nil
 }
 
+// MarkNotesConsumed sets consumed_at and consumed_by for the given note IDs
+// within the provided transaction. This marks notes as having been processed
+// by a consuming process (e.g. weekly plan generation, nightly evaluation).
+func MarkNotesConsumed(ctx context.Context, tx *sql.Tx, noteIDs []int64, consumedBy string) error {
+	if len(noteIDs) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	placeholders := make([]string, len(noteIDs))
+	args := make([]any, 0, len(noteIDs)+2)
+	args = append(args, now, consumedBy)
+	for i, id := range noteIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+
+	query := `UPDATE stride_notes SET consumed_at = ?, consumed_by = ? WHERE id IN (` + strings.Join(placeholders, ",") + `)`
+	_, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("mark notes consumed: %w", err)
+	}
+	return nil
+}
+
 // GetNotesByTargetDate returns all notes for a user targeting a specific date.
 func GetNotesByTargetDate(db *sql.DB, userID int64, date string) ([]Note, error) {
 	rows, err := db.Query(`
-		SELECT id, user_id, plan_id, content, target_date, created_at
+		SELECT id, user_id, plan_id, content, target_date, consumed_at, consumed_by, created_at
 		FROM stride_notes
 		WHERE user_id = ? AND target_date = ?
 		ORDER BY created_at ASC
@@ -448,11 +507,8 @@ func GetNotesByTargetDate(db *sql.DB, userID int64, date string) ([]Note, error)
 	var notes []Note
 	for rows.Next() {
 		var n Note
-		if err := rows.Scan(&n.ID, &n.UserID, &n.PlanID, &n.Content, &n.TargetDate, &n.CreatedAt); err != nil {
+		if err := scanNote(rows, &n); err != nil {
 			return nil, err
-		}
-		if n.Content, err = encryption.DecryptField(n.Content); err != nil {
-			return nil, fmt.Errorf("decrypt note content: %w", err)
 		}
 		notes = append(notes, n)
 	}

--- a/internal/stride/stride_test.go
+++ b/internal/stride/stride_test.go
@@ -69,6 +69,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 			plan_id     INTEGER REFERENCES stride_plans(id) ON DELETE SET NULL,
 			content     TEXT NOT NULL,
 			target_date TEXT NOT NULL DEFAULT '',
+			consumed_at TEXT,
+			consumed_by TEXT,
 			created_at  TEXT NOT NULL DEFAULT ''
 		);
 		CREATE TABLE workouts (
@@ -294,7 +296,7 @@ func TestCreateAndListNotes(t *testing.T) {
 		t.Errorf("target_date = %q, want %q", note2.TargetDate, explicitDate)
 	}
 
-	notes, err := ListNotes(db, 1, nil)
+	notes, err := ListNotes(db, 1, nil, "")
 	if err != nil {
 		t.Fatalf("list notes: %v", err)
 	}
@@ -318,7 +320,7 @@ func TestDeleteNote(t *testing.T) {
 		t.Fatalf("delete: %v", err)
 	}
 
-	notes, err := ListNotes(db, 1, nil)
+	notes, err := ListNotes(db, 1, nil, "")
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -1172,5 +1174,92 @@ func TestTryMatchRaceForWorkout_CrossUserIsolation(t *testing.T) {
 	}
 	if result.Status != "no_match" {
 		t.Errorf("expected no_match for cross-user, got %q", result.Status)
+	}
+}
+
+func TestMarkNotesConsumed(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Create a few notes.
+	n1, err := CreateNote(db, 1, nil, "Note one", "2026-04-10")
+	if err != nil {
+		t.Fatalf("create note 1: %v", err)
+	}
+	n2, err := CreateNote(db, 1, nil, "Note two", "2026-04-10")
+	if err != nil {
+		t.Fatalf("create note 2: %v", err)
+	}
+	n3, err := CreateNote(db, 1, nil, "Note three", "2026-04-11")
+	if err != nil {
+		t.Fatalf("create note 3: %v", err)
+	}
+
+	// Mark first two as consumed.
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if err := MarkNotesConsumed(context.Background(), tx, []int64{n1.ID, n2.ID}, "weekly-plan"); err != nil {
+		t.Fatalf("MarkNotesConsumed: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Verify consumed notes have consumed_at and consumed_by set.
+	allNotes, err := ListNotes(db, 1, nil, "all")
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(allNotes) != 3 {
+		t.Fatalf("expected 3 notes, got %d", len(allNotes))
+	}
+
+	// Active filter should return only the unconsumed note.
+	active, err := ListNotes(db, 1, nil, "active")
+	if err != nil {
+		t.Fatalf("list active: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("expected 1 active note, got %d", len(active))
+	}
+	if active[0].ID != n3.ID {
+		t.Errorf("active note ID = %d, want %d", active[0].ID, n3.ID)
+	}
+	if active[0].ConsumedAt != nil {
+		t.Errorf("active note should have nil ConsumedAt")
+	}
+
+	// Consumed filter should return the two consumed notes.
+	consumed, err := ListNotes(db, 1, nil, "consumed")
+	if err != nil {
+		t.Fatalf("list consumed: %v", err)
+	}
+	if len(consumed) != 2 {
+		t.Fatalf("expected 2 consumed notes, got %d", len(consumed))
+	}
+	for _, cn := range consumed {
+		if cn.ConsumedAt == nil {
+			t.Errorf("consumed note %d should have ConsumedAt set", cn.ID)
+		}
+		if cn.ConsumedBy == nil || *cn.ConsumedBy != "weekly-plan" {
+			t.Errorf("consumed note %d ConsumedBy = %v, want 'weekly-plan'", cn.ID, cn.ConsumedBy)
+		}
+	}
+}
+
+func TestMarkNotesConsumedEmpty(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Marking an empty slice should be a no-op.
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if err := MarkNotesConsumed(context.Background(), tx, nil, "test"); err != nil {
+		t.Fatalf("MarkNotesConsumed with empty slice: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
 	}
 }

--- a/internal/stride/stride_test.go
+++ b/internal/stride/stride_test.go
@@ -1180,16 +1180,19 @@ func TestTryMatchRaceForWorkout_CrossUserIsolation(t *testing.T) {
 func TestMarkNotesConsumed(t *testing.T) {
 	db := setupTestDB(t)
 
+	today := time.Now().Format("2006-01-02")
+	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+
 	// Create a few notes.
-	n1, err := CreateNote(db, 1, nil, "Note one", "2026-04-10")
+	n1, err := CreateNote(db, 1, nil, "Note one", today)
 	if err != nil {
 		t.Fatalf("create note 1: %v", err)
 	}
-	n2, err := CreateNote(db, 1, nil, "Note two", "2026-04-10")
+	n2, err := CreateNote(db, 1, nil, "Note two", today)
 	if err != nil {
 		t.Fatalf("create note 2: %v", err)
 	}
-	n3, err := CreateNote(db, 1, nil, "Note three", "2026-04-11")
+	n3, err := CreateNote(db, 1, nil, "Note three", tomorrow)
 	if err != nil {
 		t.Fatalf("create note 3: %v", err)
 	}
@@ -1199,7 +1202,7 @@ func TestMarkNotesConsumed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("begin tx: %v", err)
 	}
-	if err := MarkNotesConsumed(context.Background(), tx, []int64{n1.ID, n2.ID}, "weekly-plan"); err != nil {
+	if err := MarkNotesConsumed(context.Background(), tx, 1, []int64{n1.ID, n2.ID}, "weekly-plan"); err != nil {
 		t.Fatalf("MarkNotesConsumed: %v", err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -1256,7 +1259,7 @@ func TestMarkNotesConsumedEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("begin tx: %v", err)
 	}
-	if err := MarkNotesConsumed(context.Background(), tx, nil, "test"); err != nil {
+	if err := MarkNotesConsumed(context.Background(), tx, 1, nil, "test"); err != nil {
 		t.Fatalf("MarkNotesConsumed with empty slice: %v", err)
 	}
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
## Changes

- **Note consumption tracking** - Added consumed_at and consumed_by columns to stride notes, enabling tracking of which notes have been processed by plan generation or nightly evaluation. ListNotes now supports a status filter (active/consumed/all). (Hytte-4xnx)

## Original Issue (task): Schema migration and core consume logic

Add `consumed_at` (nullable TIMESTAMP) and `consumed_by` (nullable TEXT) columns to `stride_notes` table in `internal/db/db.go` using ALTER TABLE with existence checks. Update the `Note` struct in `internal/stride/stride.go` to include the new fields. Implement a `MarkNotesConsumed(ctx, tx, noteIDs []int64, consumedBy string) error` helper that sets `consumed_at=NOW()` and `consumed_by` for the given IDs within a transaction. Update `ListNotes` in `internal/stride/stride.go` to accept an optional status filter ('active'=unconsumed, 'consumed', 'all') and adjust the SQL WHERE clause accordingly (active: `consumed_at IS NULL`, consumed: `consumed_at IS NOT NULL`). This sub-task is a prerequisite for all others — the schema and helpers must exist before nightly/weekly/handler/frontend work can proceed.

---
Bead: Hytte-4xnx | Branch: forge/Hytte-4xnx
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)