### PR TITLE
Wire notes into nightly evaluation and mark consumed (Hytte-nu5w)

### DIFF
--- a/changelog.d/Hytte-nu5w.md
+++ b/changelog.d/Hytte-nu5w.md
@@ -1,0 +1,2 @@
+category: Added
+- **Nightly evaluation considers user notes** - Stride nightly evaluation now fetches unconsumed user notes and passes them to Claude for context about sickness, fatigue, or skipped workouts. Notes are marked as consumed after a successful evaluation run. (Hytte-nu5w)

--- a/internal/stride/evaluate.go
+++ b/internal/stride/evaluate.go
@@ -58,6 +58,7 @@ func NextNightlyEvaluationRun(now time.Time, loc *time.Location) time.Time {
 // matchedSession may be nil for bonus (unplanned) workouts or when no plan exists.
 // plan is used for weekly context; an empty Plan (ID == 0) is acceptable.
 // profile carries the athlete's HR zones and training context.
+// notes are unconsumed user notes providing context about sickness, fatigue, etc.
 func EvaluateWorkout(
 	ctx context.Context,
 	cfg *training.ClaudeConfig,
@@ -65,8 +66,9 @@ func EvaluateWorkout(
 	matchedSession *PlannedSession,
 	plan Plan,
 	profile training.UserTrainingProfile,
+	notes []Note,
 ) (*Evaluation, error) {
-	prompt := buildEvalPrompt(workout, matchedSession, plan, profile)
+	prompt := buildEvalPrompt(workout, matchedSession, plan, profile, notes)
 
 	response, err := runPromptFunc(ctx, cfg, prompt)
 	if err != nil {
@@ -142,7 +144,7 @@ func RunUserEvaluation(ctx context.Context, db *sql.DB, httpClient *http.Client,
 	evaluated := 0
 	for _, workout := range workouts {
 		evalCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
-		if err := evaluateSingleWorkout(evalCtx, db, httpClient, userID, workout, claudeCfg, profile); err != nil {
+		if err := evaluateSingleWorkout(evalCtx, db, httpClient, userID, workout, claudeCfg, profile, nil); err != nil {
 			log.Printf("stride eval: workout %d for user %d: %v", workout.ID, userID, err)
 		} else {
 			evaluated++
@@ -168,15 +170,45 @@ func evaluateUserWorkouts(ctx context.Context, db *sql.DB, httpClient *http.Clie
 		return fmt.Errorf("query unevaluated workouts: %w", err)
 	}
 
+	// Fetch unconsumed notes for this user to provide context to Claude.
+	userNotes, err := ListNotes(db, userID, nil, "active")
+	if err != nil {
+		log.Printf("stride eval: fetch notes for user %d: %v", userID, err)
+		// Non-fatal — continue without notes.
+	}
+
 	if len(workouts) > 0 {
 		profile := training.BuildUserTrainingProfile(db, userID)
 
+		anySuccess := false
 		for _, workout := range workouts {
 			evalCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
-			if err := evaluateSingleWorkout(evalCtx, db, httpClient, userID, workout, claudeCfg, profile); err != nil {
+			if err := evaluateSingleWorkout(evalCtx, db, httpClient, userID, workout, claudeCfg, profile, userNotes); err != nil {
 				log.Printf("stride eval: workout %d for user %d: %v", workout.ID, userID, err)
+			} else {
+				anySuccess = true
 			}
 			cancel()
+		}
+
+		// Mark notes consumed once per user per nightly run, only when notes were
+		// actually sent to Claude (workouts existed and at least one succeeded).
+		if anySuccess && len(userNotes) > 0 {
+			noteIDs := make([]int64, len(userNotes))
+			for i, n := range userNotes {
+				noteIDs[i] = n.ID
+			}
+			tx, err := db.BeginTx(ctx, nil)
+			if err != nil {
+				log.Printf("stride eval: begin tx to mark notes consumed for user %d: %v", userID, err)
+			} else {
+				if err := MarkNotesConsumed(ctx, tx, userID, noteIDs, "nightly"); err != nil {
+					log.Printf("stride eval: mark notes consumed for user %d: %v", userID, err)
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
 		}
 	}
 
@@ -251,6 +283,7 @@ func queryUnevaluatedWorkouts(ctx context.Context, db *sql.DB, userID int64, sin
 
 // evaluateSingleWorkout finds the matching plan+session for a workout, evaluates it via
 // Claude, stores the result, and sends a push notification for critical flags.
+// notes are unconsumed user notes providing context about sickness, fatigue, etc.
 func evaluateSingleWorkout(
 	ctx context.Context,
 	db *sql.DB,
@@ -259,6 +292,7 @@ func evaluateSingleWorkout(
 	workout training.Workout,
 	cfg *training.ClaudeConfig,
 	profile training.UserTrainingProfile,
+	notes []Note,
 ) error {
 	workoutDate := extractDate(workout.StartedAt)
 	if workoutDate == "" {
@@ -278,7 +312,7 @@ func evaluateSingleWorkout(
 		matchedSession = MatchWorkoutToSession(workout, sessions)
 	}
 
-	eval, err := EvaluateWorkout(ctx, cfg, workout, matchedSession, planForEval, profile)
+	eval, err := EvaluateWorkout(ctx, cfg, workout, matchedSession, planForEval, profile, notes)
 	if err != nil {
 		return fmt.Errorf("evaluate workout: %w", err)
 	}
@@ -609,11 +643,13 @@ func buildCriticalNotifBody(eval *Evaluation) string {
 }
 
 // buildEvalPrompt assembles the Claude prompt for evaluating a single workout.
+// notes are unconsumed user notes providing context about sickness, fatigue, etc.
 func buildEvalPrompt(
 	workout training.Workout,
 	matchedSession *PlannedSession,
 	plan Plan,
 	profile training.UserTrainingProfile,
+	notes []Note,
 ) string {
 	var sb strings.Builder
 
@@ -697,6 +733,15 @@ func buildEvalPrompt(
 					fmt.Fprintf(&sb, "- %s: %s\n", dp.Date, dp.Session.Description)
 				}
 			}
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(notes) > 0 {
+		sb.WriteString("## User Notes\n")
+		sb.WriteString("The athlete left the following notes. Consider these for context about sickness, fatigue, skipped workouts, or other factors:\n")
+		for _, n := range notes {
+			fmt.Fprintf(&sb, "- [%s] %s\n", n.TargetDate, n.Content)
 		}
 		sb.WriteString("\n")
 	}

--- a/internal/stride/evaluate.go
+++ b/internal/stride/evaluate.go
@@ -202,9 +202,9 @@ func evaluateUserWorkouts(ctx context.Context, db *sql.DB, httpClient *http.Clie
 			if err != nil {
 				log.Printf("stride eval: begin tx to mark notes consumed for user %d: %v", userID, err)
 			} else {
+				defer tx.Rollback()
 				if err := MarkNotesConsumed(ctx, tx, userID, noteIDs, "nightly"); err != nil {
 					log.Printf("stride eval: mark notes consumed for user %d: %v", userID, err)
-					tx.Rollback()
 				} else if err := tx.Commit(); err != nil {
 					log.Printf("stride eval: commit notes consumed for user %d: %v", userID, err)
 				}

--- a/internal/stride/evaluate.go
+++ b/internal/stride/evaluate.go
@@ -205,8 +205,8 @@ func evaluateUserWorkouts(ctx context.Context, db *sql.DB, httpClient *http.Clie
 				if err := MarkNotesConsumed(ctx, tx, userID, noteIDs, "nightly"); err != nil {
 					log.Printf("stride eval: mark notes consumed for user %d: %v", userID, err)
 					tx.Rollback()
-				} else {
-					tx.Commit()
+				} else if err := tx.Commit(); err != nil {
+					log.Printf("stride eval: commit notes consumed for user %d: %v", userID, err)
 				}
 			}
 		}

--- a/internal/stride/evaluate_test.go
+++ b/internal/stride/evaluate_test.go
@@ -219,6 +219,41 @@ func TestBuildEvalPrompt_OmitsEmptyTitle(t *testing.T) {
 	}
 }
 
+func TestBuildEvalPrompt_WithNotes(t *testing.T) {
+	workout := training.Workout{
+		Sport:     "running",
+		StartedAt: "2026-04-06T07:00:00Z",
+	}
+	notes := []Note{
+		{ID: 1, TargetDate: "2026-04-05", Content: "Felt sick with a cold"},
+		{ID: 2, TargetDate: "2026-04-06", Content: "Still recovering, took it easy"},
+	}
+	prompt := buildEvalPrompt(workout, nil, Plan{}, training.UserTrainingProfile{}, notes)
+	if !strings.Contains(prompt, "User Notes") {
+		t.Error("expected prompt to contain User Notes section header")
+	}
+	if !strings.Contains(prompt, "Felt sick with a cold") {
+		t.Error("expected prompt to contain first note content")
+	}
+	if !strings.Contains(prompt, "Still recovering, took it easy") {
+		t.Error("expected prompt to contain second note content")
+	}
+	if !strings.Contains(prompt, "2026-04-05") {
+		t.Error("expected prompt to contain first note date")
+	}
+}
+
+func TestBuildEvalPrompt_WithoutNotes(t *testing.T) {
+	workout := training.Workout{
+		Sport:     "running",
+		StartedAt: "2026-04-06T07:00:00Z",
+	}
+	prompt := buildEvalPrompt(workout, nil, Plan{}, training.UserTrainingProfile{}, nil)
+	if strings.Contains(prompt, "User Notes") {
+		t.Error("prompt should not contain User Notes section when no notes provided")
+	}
+}
+
 // --- storeEvaluation and queryUnevaluatedWorkouts ---
 
 func TestStoreEvaluation_RoundTrip(t *testing.T) {

--- a/internal/stride/evaluate_test.go
+++ b/internal/stride/evaluate_test.go
@@ -2,7 +2,9 @@ package stride
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -163,7 +165,7 @@ func TestBuildEvalPrompt_NoSession(t *testing.T) {
 		AvgHeartRate:    145,
 		Title:           "Morning Run",
 	}
-	prompt := buildEvalPrompt(workout, nil, Plan{}, training.UserTrainingProfile{})
+	prompt := buildEvalPrompt(workout, nil, Plan{}, training.UserTrainingProfile{}, nil)
 	if !strings.Contains(prompt, "bonus/unplanned") {
 		t.Error("expected prompt to mention bonus/unplanned when no session")
 	}
@@ -196,7 +198,7 @@ func TestBuildEvalPrompt_WithSession(t *testing.T) {
 		WeekEnd:   "2026-04-13",
 		Plan:      json.RawMessage(`[]`),
 	}
-	prompt := buildEvalPrompt(workout, session, plan, training.UserTrainingProfile{})
+	prompt := buildEvalPrompt(workout, session, plan, training.UserTrainingProfile{}, nil)
 	if !strings.Contains(prompt, "4x10min threshold") {
 		t.Error("expected prompt to include session main set")
 	}
@@ -211,7 +213,7 @@ func TestBuildEvalPrompt_OmitsEmptyTitle(t *testing.T) {
 		StartedAt: "2026-04-06T07:00:00Z",
 		Title:     "",
 	}
-	prompt := buildEvalPrompt(workout, nil, Plan{}, training.UserTrainingProfile{})
+	prompt := buildEvalPrompt(workout, nil, Plan{}, training.UserTrainingProfile{}, nil)
 	if strings.Contains(prompt, "Title:") {
 		t.Error("prompt should not include Title line when title is empty")
 	}
@@ -436,7 +438,7 @@ func TestEvaluateWorkout_Success(t *testing.T) {
 	cfg := &training.ClaudeConfig{Enabled: true, Model: "claude-test"}
 	workout := training.Workout{Sport: "running", StartedAt: "2026-04-06T07:00:00Z"}
 
-	eval, err := EvaluateWorkout(context.Background(), cfg, workout, nil, Plan{}, training.UserTrainingProfile{})
+	eval, err := EvaluateWorkout(context.Background(), cfg, workout, nil, Plan{}, training.UserTrainingProfile{}, nil)
 	if err != nil {
 		t.Fatalf("EvaluateWorkout: %v", err)
 	}
@@ -453,7 +455,7 @@ func TestEvaluateWorkout_PromptError(t *testing.T) {
 	t.Cleanup(func() { runPromptFunc = origFn })
 
 	cfg := &training.ClaudeConfig{Enabled: true}
-	_, err := EvaluateWorkout(context.Background(), cfg, training.Workout{}, nil, Plan{}, training.UserTrainingProfile{})
+	_, err := EvaluateWorkout(context.Background(), cfg, training.Workout{}, nil, Plan{}, training.UserTrainingProfile{}, nil)
 	if err == nil {
 		t.Error("expected error from failed prompt, got nil")
 	}
@@ -467,7 +469,7 @@ func TestEvaluateWorkout_InvalidJSON(t *testing.T) {
 	t.Cleanup(func() { runPromptFunc = origFn })
 
 	cfg := &training.ClaudeConfig{Enabled: true}
-	_, err := EvaluateWorkout(context.Background(), cfg, training.Workout{}, nil, Plan{}, training.UserTrainingProfile{})
+	_, err := EvaluateWorkout(context.Background(), cfg, training.Workout{}, nil, Plan{}, training.UserTrainingProfile{}, nil)
 	if err == nil {
 		t.Error("expected error for invalid JSON response, got nil")
 	}
@@ -646,5 +648,193 @@ func TestEvaluateRestDaysAndMissedSessions_Idempotent(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected 1 evaluation after two runs (idempotent), got %d", count)
+	}
+}
+
+// --- Notes in nightly evaluation ---
+
+func TestBuildEvalPrompt_IncludesNotes(t *testing.T) {
+	workout := training.Workout{
+		Sport:     "running",
+		StartedAt: "2026-04-08T07:00:00Z",
+	}
+	notes := []Note{
+		{ID: 1, Content: "Feeling sick, sore throat", TargetDate: "2026-04-08"},
+		{ID: 2, Content: "Slept poorly last night", TargetDate: "2026-04-07"},
+	}
+	prompt := buildEvalPrompt(workout, nil, Plan{}, training.UserTrainingProfile{}, notes)
+	if !strings.Contains(prompt, "User Notes") {
+		t.Error("expected prompt to contain User Notes section")
+	}
+	if !strings.Contains(prompt, "Feeling sick, sore throat") {
+		t.Error("expected prompt to contain first note content")
+	}
+	if !strings.Contains(prompt, "Slept poorly last night") {
+		t.Error("expected prompt to contain second note content")
+	}
+}
+
+func TestEvaluateUserWorkouts_NotesConsumedAfterSuccess(t *testing.T) {
+	db := setupTestDB(t)
+
+	origFn := runPromptFunc
+	runPromptFunc = func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return `{"planned_type":"easy","actual_type":"easy","compliance":"compliant","notes":"Good.","flags":[],"adjustments":"None."}`, nil
+	}
+	t.Cleanup(func() { runPromptFunc = origFn })
+
+	// Set up Claude config.
+	_, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'stride_enabled', 'true')`)
+	if err != nil {
+		t.Fatalf("insert pref: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'claude_enabled', 'true')`)
+	if err != nil {
+		t.Fatalf("insert pref: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'claude_cli_path', '/usr/bin/claude')`)
+	if err != nil {
+		t.Fatalf("insert pref: %v", err)
+	}
+
+	yesterday := time.Now().UTC().AddDate(0, 0, -1)
+	weekStart := yesterday.AddDate(0, 0, -3).Format("2006-01-02")
+	weekEnd := yesterday.AddDate(0, 0, 3).Format("2006-01-02")
+	insertTestPlan(t, db, 1, weekStart, weekEnd, `[]`)
+
+	// Insert a workout from yesterday.
+	workoutStarted := yesterday.Format("2006-01-02") + "T12:00:00Z"
+	_, err = db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (100, 1, 'running', ?, 'hash-notes-test', ?)
+	`, workoutStarted, workoutStarted)
+	if err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	// Insert unconsumed notes.
+	note1, err := CreateNote(db, 1, nil, "Feeling fatigued", yesterday.Format("2006-01-02"))
+	if err != nil {
+		t.Fatalf("create note 1: %v", err)
+	}
+	note2, err := CreateNote(db, 1, nil, "Sore knee after last run", yesterday.Format("2006-01-02"))
+	if err != nil {
+		t.Fatalf("create note 2: %v", err)
+	}
+
+	ctx := context.Background()
+	since := yesterday.Format("2006-01-02") + "T00:00:00Z"
+	targetDate := yesterday.Format("2006-01-02")
+	if err := evaluateUserWorkouts(ctx, db, nil, 1, since, targetDate); err != nil {
+		t.Fatalf("evaluateUserWorkouts: %v", err)
+	}
+
+	// Verify notes are consumed.
+	for _, noteID := range []int64{note1.ID, note2.ID} {
+		var consumedBy sql.NullString
+		if err := db.QueryRow(`SELECT consumed_by FROM stride_notes WHERE id = ?`, noteID).Scan(&consumedBy); err != nil {
+			t.Fatalf("query note %d: %v", noteID, err)
+		}
+		if !consumedBy.Valid || consumedBy.String != "nightly" {
+			t.Errorf("note %d consumed_by = %v, want 'nightly'", noteID, consumedBy)
+		}
+	}
+}
+
+func TestEvaluateUserWorkouts_NotesNotConsumedOnClaudeFailure(t *testing.T) {
+	db := setupTestDB(t)
+
+	origFn := runPromptFunc
+	runPromptFunc = func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return "", errors.New("claude call failed")
+	}
+	t.Cleanup(func() { runPromptFunc = origFn })
+
+	_, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'stride_enabled', 'true')`)
+	if err != nil {
+		t.Fatalf("insert pref: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'claude_enabled', 'true')`)
+	if err != nil {
+		t.Fatalf("insert pref: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'claude_cli_path', '/usr/bin/claude')`)
+	if err != nil {
+		t.Fatalf("insert pref: %v", err)
+	}
+
+	yesterday := time.Now().UTC().AddDate(0, 0, -1)
+	weekStart := yesterday.AddDate(0, 0, -3).Format("2006-01-02")
+	weekEnd := yesterday.AddDate(0, 0, 3).Format("2006-01-02")
+	insertTestPlan(t, db, 1, weekStart, weekEnd, `[]`)
+
+	workoutStarted := yesterday.Format("2006-01-02") + "T12:00:00Z"
+	_, err = db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (101, 1, 'running', ?, 'hash-notes-fail', ?)
+	`, workoutStarted, workoutStarted)
+	if err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	note, err := CreateNote(db, 1, nil, "Feeling tired", yesterday.Format("2006-01-02"))
+	if err != nil {
+		t.Fatalf("create note: %v", err)
+	}
+
+	ctx := context.Background()
+	since := yesterday.Format("2006-01-02") + "T00:00:00Z"
+	targetDate := yesterday.Format("2006-01-02")
+	// evaluateUserWorkouts logs errors but doesn't return them for individual workouts.
+	evaluateUserWorkouts(ctx, db, nil, 1, since, targetDate)
+
+	// Notes should NOT be consumed because Claude call failed.
+	var consumedAt sql.NullString
+	if err := db.QueryRow(`SELECT consumed_at FROM stride_notes WHERE id = ?`, note.ID).Scan(&consumedAt); err != nil {
+		t.Fatalf("query note: %v", err)
+	}
+	if consumedAt.Valid {
+		t.Errorf("note should not be consumed when Claude call fails, but consumed_at = %v", consumedAt.String)
+	}
+}
+
+func TestEvaluateUserWorkouts_NotesNotConsumedWhenNoWorkouts(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'stride_enabled', 'true')`)
+	if err != nil {
+		t.Fatalf("insert pref: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'claude_enabled', 'true')`)
+	if err != nil {
+		t.Fatalf("insert pref: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'claude_cli_path', '/usr/bin/claude')`)
+	if err != nil {
+		t.Fatalf("insert pref: %v", err)
+	}
+
+	yesterday := time.Now().UTC().AddDate(0, 0, -1)
+
+	// Insert unconsumed notes but NO workouts.
+	note, err := CreateNote(db, 1, nil, "Skipped today, feeling unwell", yesterday.Format("2006-01-02"))
+	if err != nil {
+		t.Fatalf("create note: %v", err)
+	}
+
+	ctx := context.Background()
+	since := yesterday.Format("2006-01-02") + "T00:00:00Z"
+	targetDate := yesterday.Format("2006-01-02")
+	if err := evaluateUserWorkouts(ctx, db, nil, 1, since, targetDate); err != nil {
+		t.Fatalf("evaluateUserWorkouts: %v", err)
+	}
+
+	// Notes should NOT be consumed because no workouts exist.
+	var consumedAt sql.NullString
+	if err := db.QueryRow(`SELECT consumed_at FROM stride_notes WHERE id = ?`, note.ID).Scan(&consumedAt); err != nil {
+		t.Fatalf("query note: %v", err)
+	}
+	if consumedAt.Valid {
+		t.Errorf("note should not be consumed when no workouts exist, but consumed_at = %v", consumedAt.String)
 	}
 }

--- a/internal/stride/evaluate_test.go
+++ b/internal/stride/evaluate_test.go
@@ -688,32 +688,13 @@ func TestEvaluateRestDaysAndMissedSessions_Idempotent(t *testing.T) {
 
 // --- Notes in nightly evaluation ---
 
-func TestBuildEvalPrompt_IncludesNotes(t *testing.T) {
-	workout := training.Workout{
-		Sport:     "running",
-		StartedAt: "2026-04-08T07:00:00Z",
-	}
-	notes := []Note{
-		{ID: 1, Content: "Feeling sick, sore throat", TargetDate: "2026-04-08"},
-		{ID: 2, Content: "Slept poorly last night", TargetDate: "2026-04-07"},
-	}
-	prompt := buildEvalPrompt(workout, nil, Plan{}, training.UserTrainingProfile{}, notes)
-	if !strings.Contains(prompt, "User Notes") {
-		t.Error("expected prompt to contain User Notes section")
-	}
-	if !strings.Contains(prompt, "Feeling sick, sore throat") {
-		t.Error("expected prompt to contain first note content")
-	}
-	if !strings.Contains(prompt, "Slept poorly last night") {
-		t.Error("expected prompt to contain second note content")
-	}
-}
-
 func TestEvaluateUserWorkouts_NotesConsumedAfterSuccess(t *testing.T) {
 	db := setupTestDB(t)
 
 	origFn := runPromptFunc
-	runPromptFunc = func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+	var capturedPrompt string
+	runPromptFunc = func(_ context.Context, _ *training.ClaudeConfig, prompt string) (string, error) {
+		capturedPrompt = prompt
 		return `{"planned_type":"easy","actual_type":"easy","compliance":"compliant","notes":"Good.","flags":[],"adjustments":"None."}`, nil
 	}
 	t.Cleanup(func() { runPromptFunc = origFn })
@@ -762,6 +743,17 @@ func TestEvaluateUserWorkouts_NotesConsumedAfterSuccess(t *testing.T) {
 	targetDate := yesterday.Format("2006-01-02")
 	if err := evaluateUserWorkouts(ctx, db, nil, 1, since, targetDate); err != nil {
 		t.Fatalf("evaluateUserWorkouts: %v", err)
+	}
+
+	// Verify notes were included in the prompt sent to Claude.
+	if !strings.Contains(capturedPrompt, "Feeling fatigued") {
+		t.Error("expected prompt to contain first note content")
+	}
+	if !strings.Contains(capturedPrompt, "Sore knee after last run") {
+		t.Error("expected prompt to contain second note content")
+	}
+	if !strings.Contains(capturedPrompt, yesterday.Format("2006-01-02")) {
+		t.Error("expected prompt to contain note target date")
 	}
 
 	// Verify notes are consumed.


### PR DESCRIPTION
## Changes

- **Nightly evaluation considers user notes** - Stride nightly evaluation now fetches unconsumed user notes and passes them to Claude for context about sickness, fatigue, or skipped workouts. Notes are marked as consumed after a successful evaluation run. (Hytte-nu5w)

## Original Issue (task): Wire notes into nightly evaluation and mark consumed

Modify `internal/stride/evaluate.go` (`RunNightlyEvaluation` / `evaluateUserWorkouts`): fetch unconsumed notes for each user via the updated `ListNotes` with status='active'. Pass them into the `EvaluateWorkout` prompt builder so Claude can consider sickness, fatigue, skipped workouts, etc. After a successful Claude call, call `MarkNotesConsumed` with `consumed_by='nightly'`. Per the edge-case requirement, only consume notes when they were actually sent to Claude (i.e., skip marking if no workouts exist for that user that night). Ensure notes are marked consumed once per nightly run per user, not once per workout. Update `internal/stride/evaluate_test.go`: test that (a) notes are passed to the prompt, (b) notes are marked consumed after success, (c) notes are NOT marked consumed on Claude call failure, (d) notes are NOT consumed when no workouts exist. Depends on sub-task 1 for schema and MarkNotesConsumed helper.

---
Bead: Hytte-nu5w | Branch: forge/Hytte-nu5w
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)