### PR TITLE
Update weekly plan generation to consume notes (Hytte-55sg)

### DIFF
--- a/changelog.d/Hytte-55sg.md
+++ b/changelog.d/Hytte-55sg.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Weekly plan generation now consumes notes** - Weekly plan generation fetches only unconsumed notes (instead of the 20 most recent) and marks them as consumed atomically within the same DB transaction as the plan upsert. Notes consumed by the nightly evaluation are excluded, and a failed plan insert rolls back note consumption. (Hytte-55sg)

--- a/internal/stride/generate.go
+++ b/internal/stride/generate.go
@@ -195,8 +195,8 @@ func GeneratePlan(ctx context.Context, db *sql.DB, userID int64, weekMode string
 		}
 	}
 
-	// Query stride notes (all, most recent first).
-	notes, err := listAllNotes(ctx, db, userID)
+	// Query unconsumed stride notes for plan context.
+	notes, err := listUnconsumedNotes(ctx, db, userID)
 	if err != nil {
 		return fmt.Errorf("list notes: %w", err)
 	}
@@ -295,8 +295,16 @@ func GeneratePlan(ctx context.Context, db *sql.DB, userID int64, weekMode string
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
+	// Use a transaction so that the plan upsert and note consumption are atomic —
+	// a failed plan insert does not silently eat notes.
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
 	// Upsert into stride_plans (unique on user_id + week_start).
-	_, err = db.ExecContext(ctx, `
+	_, err = tx.ExecContext(ctx, `
 		INSERT INTO stride_plans (user_id, week_start, week_end, phase, plan_json, prompt, response, model, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id, week_start) DO UPDATE SET
@@ -309,6 +317,21 @@ func GeneratePlan(ctx context.Context, db *sql.DB, userID int64, weekMode string
 	`, userID, weekStart, weekEnd, "", string(planBytes), encPrompt, encResponse, claudeCfg.Model, now)
 	if err != nil {
 		return fmt.Errorf("insert stride plan: %w", err)
+	}
+
+	// Mark consumed notes within the same transaction.
+	if len(notes) > 0 {
+		noteIDs := make([]int64, len(notes))
+		for i, n := range notes {
+			noteIDs[i] = n.ID
+		}
+		if err := MarkNotesConsumed(ctx, tx, userID, noteIDs, "weekly"); err != nil {
+			return fmt.Errorf("mark notes consumed: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit plan tx: %w", err)
 	}
 
 	return nil
@@ -336,14 +359,16 @@ func upcomingWeek() (weekStart, weekEnd string) {
 	return monday.Format(dateFmt), sunday.Format(dateFmt)
 }
 
-// listAllNotes returns all stride notes for a user, most recent first, limit 20.
-func listAllNotes(ctx context.Context, db *sql.DB, userID int64) ([]Note, error) {
+// listUnconsumedNotes returns stride notes for a user that have not yet been
+// consumed by any process (weekly plan generation, nightly evaluation, etc.).
+// Results are ordered most recent first with a safety limit of 200.
+func listUnconsumedNotes(ctx context.Context, db *sql.DB, userID int64) ([]Note, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT id, user_id, plan_id, content, target_date, created_at
 		FROM stride_notes
-		WHERE user_id = ?
+		WHERE user_id = ? AND consumed_at IS NULL
 		ORDER BY created_at DESC
-		LIMIT 20
+		LIMIT 200
 	`, userID)
 	if err != nil {
 		return nil, err

--- a/internal/stride/generate_test.go
+++ b/internal/stride/generate_test.go
@@ -528,12 +528,15 @@ func insertNote(t *testing.T, db *sql.DB, userID int64, content string) int64 {
 	if err != nil {
 		t.Fatalf("insert note: %v", err)
 	}
-	id, _ := res.LastInsertId()
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("insert note last insert id: %v", err)
+	}
 	return id
 }
 
 // mockClaude sets up runPromptFunc to return a valid 7-day plan for the given
-// weekStart. Returns a cleanup function.
+// weekStart and registers cleanup with t.Cleanup to restore the original function.
 func mockClaude(t *testing.T, weekStart string) {
 	t.Helper()
 	planDays := buildMinimalPlan(weekStart)

--- a/internal/stride/generate_test.go
+++ b/internal/stride/generate_test.go
@@ -517,3 +517,203 @@ func TestBuildGeneratePrompt_NoRaceHistoryWhenEmpty(t *testing.T) {
 	}
 }
 
+// insertNote is a test helper that inserts a stride note and returns its ID.
+func insertNote(t *testing.T, db *sql.DB, userID int64, content string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		"INSERT INTO stride_notes (user_id, content, target_date, created_at) VALUES (?, ?, '', ?)",
+		userID, content, now,
+	)
+	if err != nil {
+		t.Fatalf("insert note: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+// mockClaude sets up runPromptFunc to return a valid 7-day plan for the given
+// weekStart. Returns a cleanup function.
+func mockClaude(t *testing.T, weekStart string) {
+	t.Helper()
+	planDays := buildMinimalPlan(weekStart)
+	mockResponse, _ := json.Marshal(planDays)
+
+	origFn := runPromptFunc
+	runPromptFunc = func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return string(mockResponse), nil
+	}
+	t.Cleanup(func() { runPromptFunc = origFn })
+}
+
+// enableStride sets up user preferences to enable stride and Claude.
+func enableStride(t *testing.T, db *sql.DB, userID int64) {
+	t.Helper()
+	prefs := []struct{ k, v string }{
+		{"stride_enabled", "true"},
+		{"claude_enabled", "true"},
+		{"claude_model", "claude-opus-4-5"},
+	}
+	for _, p := range prefs {
+		if _, err := db.Exec("INSERT INTO user_preferences (user_id, key, value) VALUES (?, ?, ?)", userID, p.k, p.v); err != nil {
+			t.Fatalf("set pref %s: %v", p.k, err)
+		}
+	}
+}
+
+func TestListUnconsumedNotes_OnlyUnconsumed(t *testing.T) {
+	db := extendedTestDB(t)
+
+	// Insert two unconsumed notes.
+	insertNote(t, db, 1, "note-a")
+	insertNote(t, db, 1, "note-b")
+
+	// Insert a consumed note.
+	id3 := insertNote(t, db, 1, "note-consumed")
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec("UPDATE stride_notes SET consumed_at = ?, consumed_by = 'manual' WHERE id = ?", now, id3); err != nil {
+		t.Fatalf("mark consumed: %v", err)
+	}
+
+	notes, err := listUnconsumedNotes(context.Background(), db, 1)
+	if err != nil {
+		t.Fatalf("listUnconsumedNotes: %v", err)
+	}
+	if len(notes) != 2 {
+		t.Fatalf("expected 2 unconsumed notes, got %d", len(notes))
+	}
+	for _, n := range notes {
+		if n.Content == "note-consumed" {
+			t.Error("consumed note should not appear in unconsumed list")
+		}
+	}
+}
+
+func TestListUnconsumedNotes_ExcludesNightlyConsumed(t *testing.T) {
+	db := extendedTestDB(t)
+
+	insertNote(t, db, 1, "note-active")
+
+	// Simulate a note consumed by the nightly process.
+	idNightly := insertNote(t, db, 1, "note-nightly")
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec("UPDATE stride_notes SET consumed_at = ?, consumed_by = 'nightly' WHERE id = ?", now, idNightly); err != nil {
+		t.Fatalf("mark nightly consumed: %v", err)
+	}
+
+	notes, err := listUnconsumedNotes(context.Background(), db, 1)
+	if err != nil {
+		t.Fatalf("listUnconsumedNotes: %v", err)
+	}
+	if len(notes) != 1 {
+		t.Fatalf("expected 1 unconsumed note, got %d", len(notes))
+	}
+	if notes[0].Content != "note-active" {
+		t.Errorf("expected note-active, got %q", notes[0].Content)
+	}
+}
+
+func TestGeneratePlan_MarksNotesConsumed(t *testing.T) {
+	db := extendedTestDB(t)
+	enableStride(t, db, 1)
+
+	id1 := insertNote(t, db, 1, "plan-note-1")
+	id2 := insertNote(t, db, 1, "plan-note-2")
+
+	weekStart, _ := upcomingWeek()
+	mockClaude(t, weekStart)
+
+	if err := GeneratePlan(context.Background(), db, 1, "next"); err != nil {
+		t.Fatalf("GeneratePlan: %v", err)
+	}
+
+	// Both notes should now be consumed with consumed_by='weekly'.
+	for _, id := range []int64{id1, id2} {
+		var consumedAt sql.NullString
+		var consumedBy sql.NullString
+		if err := db.QueryRow("SELECT consumed_at, consumed_by FROM stride_notes WHERE id = ?", id).Scan(&consumedAt, &consumedBy); err != nil {
+			t.Fatalf("query note %d: %v", id, err)
+		}
+		if !consumedAt.Valid {
+			t.Errorf("note %d: consumed_at should be set", id)
+		}
+		if !consumedBy.Valid || consumedBy.String != "weekly" {
+			t.Errorf("note %d: consumed_by = %q, want %q", id, consumedBy.String, "weekly")
+		}
+	}
+}
+
+func TestGeneratePlan_FailedInsertRollsBackNoteConsumption(t *testing.T) {
+	db := extendedTestDB(t)
+	enableStride(t, db, 1)
+
+	id1 := insertNote(t, db, 1, "rollback-note")
+
+	weekStart, _ := upcomingWeek()
+	mockClaude(t, weekStart)
+
+	// Drop stride_plans to trigger a DB error on insert.
+	if _, err := db.Exec("DROP TABLE stride_plans"); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+
+	err := GeneratePlan(context.Background(), db, 1, "next")
+	if err == nil {
+		t.Fatal("expected error when stride_plans table is missing, got nil")
+	}
+
+	// Note should remain unconsumed because the transaction was rolled back.
+	var consumedAt sql.NullString
+	if err := db.QueryRow("SELECT consumed_at FROM stride_notes WHERE id = ?", id1).Scan(&consumedAt); err != nil {
+		t.Fatalf("query note: %v", err)
+	}
+	if consumedAt.Valid {
+		t.Error("note should remain unconsumed after failed plan insert")
+	}
+}
+
+func TestGeneratePlan_UnconsumedNotesSurviveAcrossRuns(t *testing.T) {
+	db := extendedTestDB(t)
+	enableStride(t, db, 1)
+
+	weekStart, _ := upcomingWeek()
+	mockClaude(t, weekStart)
+
+	// First run: one note gets consumed.
+	insertNote(t, db, 1, "first-run-note")
+
+	if err := GeneratePlan(context.Background(), db, 1, "next"); err != nil {
+		t.Fatalf("first GeneratePlan: %v", err)
+	}
+
+	// Add a new note after the first run.
+	id2 := insertNote(t, db, 1, "second-run-note")
+
+	// Second run: only the new note should be picked up.
+	if err := GeneratePlan(context.Background(), db, 1, "next"); err != nil {
+		t.Fatalf("second GeneratePlan: %v", err)
+	}
+
+	// The second note should now be consumed.
+	var consumedAt sql.NullString
+	var consumedBy sql.NullString
+	if err := db.QueryRow("SELECT consumed_at, consumed_by FROM stride_notes WHERE id = ?", id2).Scan(&consumedAt, &consumedBy); err != nil {
+		t.Fatalf("query note: %v", err)
+	}
+	if !consumedAt.Valid {
+		t.Error("second note should be consumed after second run")
+	}
+	if !consumedBy.Valid || consumedBy.String != "weekly" {
+		t.Errorf("consumed_by = %q, want %q", consumedBy.String, "weekly")
+	}
+
+	// Verify total: all notes should be consumed now.
+	var unconsumed int
+	if err := db.QueryRow("SELECT COUNT(*) FROM stride_notes WHERE user_id = 1 AND consumed_at IS NULL").Scan(&unconsumed); err != nil {
+		t.Fatalf("count unconsumed: %v", err)
+	}
+	if unconsumed != 0 {
+		t.Errorf("expected 0 unconsumed notes, got %d", unconsumed)
+	}
+}
+

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -488,7 +488,7 @@ func MarkNotesConsumed(ctx context.Context, tx *sql.Tx, userID int64, noteIDs []
 		args = append(args, id)
 	}
 
-	query := `UPDATE stride_notes SET consumed_at = ?, consumed_by = ? WHERE user_id = ? AND id IN (` + strings.Join(placeholders, ",") + `)`
+	query := `UPDATE stride_notes SET consumed_at = ?, consumed_by = ? WHERE user_id = ? AND consumed_at IS NULL AND id IN (` + strings.Join(placeholders, ",") + `)`
 	_, err := tx.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("mark notes consumed: %w", err)


### PR DESCRIPTION
## Changes

- **Weekly plan generation now consumes notes** - Weekly plan generation fetches only unconsumed notes (instead of the 20 most recent) and marks them as consumed atomically within the same DB transaction as the plan upsert. Notes consumed by the nightly evaluation are excluded, and a failed plan insert rolls back note consumption. (Hytte-55sg)

## Original Issue (task): Update weekly plan generation to consume notes

Modify `internal/stride/generate.go`: replace `listAllNotes` query from `LIMIT 20` to `WHERE user_id = ? AND consumed_at IS NULL` (with a generous safety limit like 200). After successful plan upsert, call `MarkNotesConsumed` with `consumed_by='weekly'` inside the same DB transaction so a failed plan insert doesn't silently eat notes. Update `internal/stride/generate_test.go`: test that (a) only unconsumed notes are fetched, (b) notes consumed by nightly are excluded, (c) notes are marked consumed after successful plan insert, (d) failed plan insert rolls back note consumption, (e) unconsumed notes survive across runs. Depends on sub-task 1 for schema and helpers.

---
Bead: Hytte-55sg | Branch: forge/Hytte-55sg
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)