### PR TITLE
Handler status filter and frontend history UI (Hytte-fr17)

### DIFF
--- a/changelog.d/Hytte-fr17.md
+++ b/changelog.d/Hytte-fr17.md
@@ -1,0 +1,2 @@
+category: Added
+- **Coach notes history UI** - Stride notes are now split into Active and History sections. Consumed notes show a badge indicating which process used them (nightly/weekly) and when. The notes API defaults to returning active notes only, with `?status=consumed` or `?status=all` available for filtering. (Hytte-fr17)

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -360,8 +360,8 @@ func DeleteRace(db *sql.DB, id, userID int64) error {
 
 // ListNotes returns notes for a user, optionally filtered by plan_id and status.
 // When planID is nil, notes are not filtered by plan. The status parameter controls
-// consumption filtering: "active" returns only unconsumed notes (consumed_at IS NULL),
-// "consumed" returns only consumed notes, and "all" (or empty string) returns everything.
+// consumption filtering: "" or "active" returns only unconsumed notes (consumed_at IS NULL),
+// "consumed" returns only consumed notes, and "all" returns everything.
 func ListNotes(db *sql.DB, userID int64, planID *int64, status string) ([]Note, error) {
 	query := `
 		SELECT id, user_id, plan_id, content, target_date, consumed_at, consumed_by, created_at
@@ -383,7 +383,7 @@ func ListNotes(db *sql.DB, userID int64, planID *int64, status string) ([]Note, 
 	case "consumed":
 		query += ` AND consumed_at IS NOT NULL`
 	default:
-		return nil, fmt.Errorf("invalid status %q: must be active, consumed, all, or empty", status)
+		return nil, fmt.Errorf("invalid status %q: must be active, consumed, or all (empty defaults to active)", status)
 	}
 
 	query += ` ORDER BY created_at DESC`

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -376,9 +376,9 @@ func ListNotes(db *sql.DB, userID int64, planID *int64, status string) ([]Note, 
 
 	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
 	switch normalizedStatus {
-	case "", "all":
+	case "all":
 		// No additional filter.
-	case "active":
+	case "", "active":
 		query += ` AND consumed_at IS NULL`
 	case "consumed":
 		query += ` AND consumed_at IS NOT NULL`

--- a/web/public/locales/en/stride.json
+++ b/web/public/locales/en/stride.json
@@ -64,7 +64,10 @@
     "saving": "Saving...",
     "empty": "No notes yet. Add a note for your AI coach.",
     "delete": "Delete note",
-    "targetDate": "For date"
+    "targetDate": "For date",
+    "activeLabel": "Active",
+    "historyLabel": "History",
+    "consumedBy": "Used by {{process}} on {{date}}"
   },
   "history": {
     "title": "Plan History",

--- a/web/public/locales/en/stride.json
+++ b/web/public/locales/en/stride.json
@@ -67,7 +67,11 @@
     "targetDate": "For date",
     "activeLabel": "Active",
     "historyLabel": "History",
-    "consumedBy": "Used by {{process}} on {{date}}"
+    "consumedBy": "Used by {{process}} on {{date}}",
+    "consumedByProcess": {
+      "nightly": "Nightly",
+      "weekly": "Weekly"
+    }
   },
   "history": {
     "title": "Plan History",

--- a/web/public/locales/nb/stride.json
+++ b/web/public/locales/nb/stride.json
@@ -67,7 +67,11 @@
     "targetDate": "For dato",
     "activeLabel": "Aktive",
     "historyLabel": "Historikk",
-    "consumedBy": "Brukt av {{process}} den {{date}}"
+    "consumedBy": "Brukt av {{process}} den {{date}}",
+    "consumedByProcess": {
+      "nightly": "Nattlig",
+      "weekly": "Ukentlig"
+    }
   },
   "history": {
     "title": "Planhistorikk",

--- a/web/public/locales/nb/stride.json
+++ b/web/public/locales/nb/stride.json
@@ -64,7 +64,10 @@
     "saving": "Lagrer...",
     "empty": "Ingen notater ennå. Legg til et notat til AI-treneren din.",
     "delete": "Slett notat",
-    "targetDate": "For dato"
+    "targetDate": "For dato",
+    "activeLabel": "Aktive",
+    "historyLabel": "Historikk",
+    "consumedBy": "Brukt av {{process}} den {{date}}"
   },
   "history": {
     "title": "Planhistorikk",

--- a/web/public/locales/th/stride.json
+++ b/web/public/locales/th/stride.json
@@ -64,7 +64,10 @@
     "saving": "กำลังบันทึก...",
     "empty": "ยังไม่มีบันทึก เพิ่มบันทึกให้โค้ช AI ของคุณ",
     "delete": "ลบบันทึก",
-    "targetDate": "สำหรับวันที่"
+    "targetDate": "สำหรับวันที่",
+    "activeLabel": "ใช้งานอยู่",
+    "historyLabel": "ประวัติ",
+    "consumedBy": "ใช้โดย {{process}} เมื่อ {{date}}"
   },
   "history": {
     "title": "ประวัติแผนการฝึก",

--- a/web/public/locales/th/stride.json
+++ b/web/public/locales/th/stride.json
@@ -67,7 +67,11 @@
     "targetDate": "สำหรับวันที่",
     "activeLabel": "ใช้งานอยู่",
     "historyLabel": "ประวัติ",
-    "consumedBy": "ใช้โดย {{process}} เมื่อ {{date}}"
+    "consumedBy": "ใช้โดย {{process}} เมื่อ {{date}}",
+    "consumedByProcess": {
+      "nightly": "ทุกคืน",
+      "weekly": "ทุกสัปดาห์"
+    }
   },
   "history": {
     "title": "ประวัติแผนการฝึก",

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -25,6 +25,8 @@ interface Note {
   plan_id: number | null
   content: string
   target_date: string
+  consumed_at: string | null
+  consumed_by: string | null
   created_at: string
 }
 
@@ -471,6 +473,7 @@ export default function StridePage() {
 
   const [races, setRaces] = useState<Race[]>([])
   const [notes, setNotes] = useState<Note[]>([])
+  const [consumedNotes, setConsumedNotes] = useState<Note[]>([])
   const [currentPlan, setCurrentPlan] = useState<Plan | null>(null)
   const [hasAnyPlan, setHasAnyPlan] = useState(false)
   const [completedDates, setCompletedDates] = useState<Set<string>>(new Set())
@@ -524,13 +527,20 @@ export default function StridePage() {
 
   const loadNotes = useCallback(async (signal?: AbortSignal) => {
     try {
-      const res = await fetch('/api/stride/notes', { credentials: 'include', signal })
-      if (!res.ok) {
-        throw new Error(`Failed to load notes: ${res.status} ${res.statusText}`)
+      const [activeRes, consumedRes] = await Promise.all([
+        fetch('/api/stride/notes?status=active', { credentials: 'include', signal }),
+        fetch('/api/stride/notes?status=consumed', { credentials: 'include', signal }),
+      ])
+      if (!activeRes.ok) {
+        throw new Error(`Failed to load notes: ${activeRes.status} ${activeRes.statusText}`)
       }
-      const data = await res.json()
+      if (!consumedRes.ok) {
+        throw new Error(`Failed to load consumed notes: ${consumedRes.status} ${consumedRes.statusText}`)
+      }
+      const [activeData, consumedData] = await Promise.all([activeRes.json(), consumedRes.json()])
       if (!signal?.aborted) {
-        setNotes(data.notes ?? [])
+        setNotes(activeData.notes ?? [])
+        setConsumedNotes(consumedData.notes ?? [])
       }
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') return
@@ -790,6 +800,7 @@ export default function StridePage() {
         return
       }
       setNotes(prev => prev.filter(n => n.id !== id))
+      setConsumedNotes(prev => prev.filter(n => n.id !== id))
     } catch (error) {
       console.error('Failed to delete note', error)
     }
@@ -1120,30 +1131,72 @@ export default function StridePage() {
 
         {notesLoading ? (
           <p className="text-sm text-gray-400">{t('loading')}</p>
-        ) : notes.length === 0 ? (
+        ) : notes.length === 0 && consumedNotes.length === 0 ? (
           <p className="text-sm text-gray-500">{t('notes.empty')}</p>
         ) : (
-          <div className="space-y-2">
-            {notes.map(note => (
-              <div key={note.id} className="flex items-start gap-3 p-3 bg-gray-800 rounded-xl border border-gray-700 group">
-                <p className="flex-1 text-sm text-gray-200 whitespace-pre-wrap">{note.content}</p>
-                <div className="flex-shrink-0 flex flex-col items-end gap-1">
-                  <button
-                    type="button"
-                    onClick={() => handleDeleteNote(note.id)}
-                    className="sm:opacity-0 sm:group-hover:opacity-100 p-1.5 text-gray-500 hover:text-red-400 transition-all"
-                    aria-label={t('notes.delete')}
-                  >
-                    <Trash2 size={14} />
-                  </button>
-                  <span className="text-xs text-gray-500">
-                    {note.target_date && <span className="mr-1">{formatDate(`${note.target_date}T00:00:00`)}</span>}
-                    {formatDateTime(note.created_at, { dateStyle: 'short', timeStyle: 'short' })}
-                  </span>
+          <>
+            {notes.length > 0 && (
+              <>
+                <h3 className="text-sm font-medium text-gray-400 mb-2">{t('notes.activeLabel')}</h3>
+                <div className="space-y-2 mb-4">
+                  {notes.map(note => (
+                    <div key={note.id} className="flex items-start gap-3 p-3 bg-gray-800 rounded-xl border border-gray-700 group">
+                      <p className="flex-1 text-sm text-gray-200 whitespace-pre-wrap">{note.content}</p>
+                      <div className="flex-shrink-0 flex flex-col items-end gap-1">
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteNote(note.id)}
+                          className="sm:opacity-0 sm:group-hover:opacity-100 p-1.5 text-gray-500 hover:text-red-400 transition-all"
+                          aria-label={t('notes.delete')}
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                        <span className="text-xs text-gray-500">
+                          {note.target_date && <span className="mr-1">{formatDate(`${note.target_date}T00:00:00`)}</span>}
+                          {formatDateTime(note.created_at, { dateStyle: 'short', timeStyle: 'short' })}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
                 </div>
-              </div>
-            ))}
-          </div>
+              </>
+            )}
+
+            {consumedNotes.length > 0 && (
+              <>
+                <h3 className="text-sm font-medium text-gray-400 mb-2">{t('notes.historyLabel')}</h3>
+                <div className="space-y-2">
+                  {consumedNotes.map(note => (
+                    <div key={note.id} className="flex items-start gap-3 p-3 bg-gray-800/60 rounded-xl border border-gray-700/50 group">
+                      <p className="flex-1 text-sm text-gray-400 whitespace-pre-wrap">{note.content}</p>
+                      <div className="flex-shrink-0 flex flex-col items-end gap-1">
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteNote(note.id)}
+                          className="sm:opacity-0 sm:group-hover:opacity-100 p-1.5 text-gray-500 hover:text-red-400 transition-all"
+                          aria-label={t('notes.delete')}
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                        <div className="flex flex-col items-end gap-0.5">
+                          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-gray-700/50 text-gray-400">
+                            {t('notes.consumedBy', {
+                              process: note.consumed_by ?? '',
+                              date: note.consumed_at ? formatDate(note.consumed_at) : '',
+                            })}
+                          </span>
+                          <span className="text-xs text-gray-500">
+                            {note.target_date && <span className="mr-1">{formatDate(`${note.target_date}T00:00:00`)}</span>}
+                            {formatDateTime(note.created_at, { dateStyle: 'short', timeStyle: 'short' })}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </>
         )}
       </section>
 

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -527,20 +527,15 @@ export default function StridePage() {
 
   const loadNotes = useCallback(async (signal?: AbortSignal) => {
     try {
-      const [activeRes, consumedRes] = await Promise.all([
-        fetch('/api/stride/notes?status=active', { credentials: 'include', signal }),
-        fetch('/api/stride/notes?status=consumed', { credentials: 'include', signal }),
-      ])
-      if (!activeRes.ok) {
-        throw new Error(`Failed to load notes: ${activeRes.status} ${activeRes.statusText}`)
+      const res = await fetch('/api/stride/notes?status=all', { credentials: 'include', signal })
+      if (!res.ok) {
+        throw new Error(`Failed to load notes: ${res.status} ${res.statusText}`)
       }
-      if (!consumedRes.ok) {
-        throw new Error(`Failed to load consumed notes: ${consumedRes.status} ${consumedRes.statusText}`)
-      }
-      const [activeData, consumedData] = await Promise.all([activeRes.json(), consumedRes.json()])
+      const data = await res.json()
       if (!signal?.aborted) {
-        setNotes(activeData.notes ?? [])
-        setConsumedNotes(consumedData.notes ?? [])
+        const allNotes = data.notes ?? []
+        setNotes(allNotes.filter((n: { consumed_at: string | null }) => !n.consumed_at))
+        setConsumedNotes(allNotes.filter((n: { consumed_at: string | null }) => !!n.consumed_at))
       }
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') return
@@ -1179,12 +1174,20 @@ export default function StridePage() {
                           <Trash2 size={14} />
                         </button>
                         <div className="flex flex-col items-end gap-0.5">
-                          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-gray-700/50 text-gray-400">
-                            {t('notes.consumedBy', {
-                              process: note.consumed_by ?? '',
-                              date: note.consumed_at ? formatDate(note.consumed_at) : '',
-                            })}
-                          </span>
+                          {(() => {
+                            const consumedByLabel = note.consumed_by === 'nightly'
+                              ? t('notes.consumedByProcess.nightly')
+                              : note.consumed_by === 'weekly'
+                                ? t('notes.consumedByProcess.weekly')
+                                : null
+                            const consumedDate = note.consumed_at ? formatDate(note.consumed_at) : null
+                            if (!consumedByLabel || !consumedDate) return null
+                            return (
+                              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-gray-700/50 text-gray-400">
+                                {t('notes.consumedBy', { process: consumedByLabel, date: consumedDate })}
+                              </span>
+                            )
+                          })()}
                           <span className="text-xs text-gray-500">
                             {note.target_date && <span className="mr-1">{formatDate(`${note.target_date}T00:00:00`)}</span>}
                             {formatDateTime(note.created_at, { dateStyle: 'short', timeStyle: 'short' })}


### PR DESCRIPTION
## Changes

- **Coach notes history UI** - Stride notes are now split into Active and History sections. Consumed notes show a badge indicating which process used them (nightly/weekly) and when. The notes API defaults to returning active notes only, with `?status=consumed` or `?status=all` available for filtering. (Hytte-fr17)

## Original Issue (task): Handler status filter and frontend history UI

Backend: update `ListNotesHandler` in `internal/stride/handlers.go` to accept `?status=active|consumed|all` query param (default 'active' for backwards-compat). Ensure `DeleteNoteHandler` works on both active and consumed notes. Frontend: modify `web/src/pages/StridePage.tsx` and components under `web/src/components/stride/` to split the notes list into 'Active' (unconsumed) and 'History' (consumed) sections. History items show a badge with consumed_by ('nightly'/'weekly') and consumed_at date. Ensure 375px mobile layout works. Add i18n keys to `web/public/locales/{en,nb,th}/stride.json` for History header, active/consumed labels, and 'consumed by X on DATE' text. Add changelog fragment `changelog.d/Hytte-7404.md`. Depends on sub-tasks 1-3 being complete so the API returns consumed metadata.

---
Bead: Hytte-fr17 | Branch: forge/Hytte-fr17
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)