### PR TITLE
Stride Chat: schema, store helpers, and session management (Hytte-78qv)

### DIFF
--- a/changelog.d/Hytte-78qv.md
+++ b/changelog.d/Hytte-78qv.md
@@ -1,0 +1,2 @@
+category: Added
+- **Stride Chat data layer** - Schema, store helpers, and session management for per-plan coaching chat conversations. (Hytte-78qv)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2147,11 +2147,11 @@ func createSchema(db *sql.DB) error {
 
 	// Add chat_session_id column to stride_plans table (Hytte-78qv).
 	// Stores the Claude CLI session ID for --resume continuity within a plan week's chat.
-	var hasChatSessionID int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('stride_plans') WHERE name = 'chat_session_id'`).Scan(&hasChatSessionID); err != nil {
+	var hasStrideChatSessionID int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('stride_plans') WHERE name = 'chat_session_id'`).Scan(&hasStrideChatSessionID); err != nil {
 		return fmt.Errorf("check stride_plans chat_session_id column: %w", err)
 	}
-	if hasChatSessionID == 0 {
+	if hasStrideChatSessionID == 0 {
 		if _, err := db.Exec(`ALTER TABLE stride_plans ADD COLUMN chat_session_id TEXT NOT NULL DEFAULT ''`); err != nil {
 			return fmt.Errorf("add stride_plans chat_session_id column: %w", err)
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1354,6 +1354,19 @@ func createSchema(db *sql.DB) error {
 
 	CREATE INDEX IF NOT EXISTS idx_stride_evaluations_plan ON stride_evaluations(plan_id);
 
+	-- Stride chat: per-plan coaching conversation messages (Hytte-78qv)
+	CREATE TABLE IF NOT EXISTS stride_chat_messages (
+		id            INTEGER PRIMARY KEY,
+		plan_id       INTEGER NOT NULL REFERENCES stride_plans(id) ON DELETE CASCADE,
+		user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		role          TEXT NOT NULL DEFAULT '',
+		content       TEXT NOT NULL DEFAULT '',
+		plan_modified INTEGER NOT NULL DEFAULT 0,
+		created_at    TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_stride_chat_messages_plan ON stride_chat_messages(plan_id);
+
 	-- Vault: encrypted personal file storage (Hytte-r43)
 	CREATE TABLE IF NOT EXISTS vault_files (
 		id           INTEGER PRIMARY KEY,
@@ -2129,6 +2142,18 @@ func createSchema(db *sql.DB) error {
 	if hasHomeworkSessionID == 0 {
 		if _, err := db.Exec(`ALTER TABLE homework_conversations ADD COLUMN session_id TEXT NOT NULL DEFAULT ''`); err != nil {
 			return fmt.Errorf("add homework_conversations session_id column: %w", err)
+		}
+	}
+
+	// Add chat_session_id column to stride_plans table (Hytte-78qv).
+	// Stores the Claude CLI session ID for --resume continuity within a plan week's chat.
+	var hasChatSessionID int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('stride_plans') WHERE name = 'chat_session_id'`).Scan(&hasChatSessionID); err != nil {
+		return fmt.Errorf("check stride_plans chat_session_id column: %w", err)
+	}
+	if hasChatSessionID == 0 {
+		if _, err := db.Exec(`ALTER TABLE stride_plans ADD COLUMN chat_session_id TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add stride_plans chat_session_id column: %w", err)
 		}
 	}
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1363,7 +1363,8 @@ func createSchema(db *sql.DB) error {
 		role          TEXT NOT NULL DEFAULT '',
 		content       TEXT NOT NULL DEFAULT '',
 		plan_modified INTEGER NOT NULL DEFAULT 0,
-		created_at    TEXT NOT NULL DEFAULT ''
+		created_at    TEXT NOT NULL DEFAULT '',
+		FOREIGN KEY (user_id, plan_id) REFERENCES stride_plans(user_id, id)
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_stride_chat_messages_plan ON stride_chat_messages(plan_id);

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1321,8 +1321,9 @@ func createSchema(db *sql.DB) error {
 		plan_json   TEXT NOT NULL,
 		prompt      TEXT NOT NULL DEFAULT '',
 		response    TEXT NOT NULL DEFAULT '',
-		model       TEXT NOT NULL DEFAULT '',
-		created_at  TEXT NOT NULL DEFAULT '',
+		model           TEXT NOT NULL DEFAULT '',
+		chat_session_id TEXT NOT NULL DEFAULT '',
+		created_at      TEXT NOT NULL DEFAULT '',
 		UNIQUE(user_id, week_start),
 		UNIQUE(user_id, id)
 	);

--- a/internal/stride/chat_store.go
+++ b/internal/stride/chat_store.go
@@ -1,0 +1,140 @@
+package stride
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+// ChatMessage represents a single message in a stride plan's coaching chat.
+type ChatMessage struct {
+	ID           int64  `json:"id"`
+	PlanID       int64  `json:"plan_id"`
+	UserID       int64  `json:"user_id"`
+	Role         string `json:"role"`
+	Content      string `json:"content"`
+	PlanModified bool   `json:"plan_modified"`
+	CreatedAt    string `json:"created_at"`
+}
+
+// ListChatMessages returns all messages for a plan, ordered by created_at ASC.
+// Content is decrypted before returning. Scoped to userID for safety.
+func ListChatMessages(db *sql.DB, planID, userID int64) ([]ChatMessage, error) {
+	rows, err := db.Query(`
+		SELECT id, plan_id, user_id, role, content, plan_modified, created_at
+		FROM stride_chat_messages
+		WHERE plan_id = ? AND user_id = ?
+		ORDER BY created_at ASC
+	`, planID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var msgs []ChatMessage
+	for rows.Next() {
+		var m ChatMessage
+		var planMod int
+		if err := rows.Scan(&m.ID, &m.PlanID, &m.UserID, &m.Role, &m.Content, &planMod, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		m.PlanModified = planMod != 0
+		if m.Content, err = encryption.DecryptField(m.Content); err != nil {
+			return nil, fmt.Errorf("decrypt chat message content: %w", err)
+		}
+		msgs = append(msgs, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if msgs == nil {
+		msgs = []ChatMessage{}
+	}
+	return msgs, nil
+}
+
+// AddChatMessage inserts a new chat message with encrypted content.
+// Validates that role is "user" or "assistant", content is non-empty,
+// and the plan exists and belongs to the user.
+func AddChatMessage(db *sql.DB, msg ChatMessage) (ChatMessage, error) {
+	if msg.Role != "user" && msg.Role != "assistant" {
+		return ChatMessage{}, fmt.Errorf("invalid role %q: must be \"user\" or \"assistant\"", msg.Role)
+	}
+	if msg.Content == "" {
+		return ChatMessage{}, fmt.Errorf("content must not be empty")
+	}
+
+	// Verify plan exists and belongs to the user.
+	var exists int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM stride_plans WHERE id = ? AND user_id = ?`, msg.PlanID, msg.UserID).Scan(&exists); err != nil {
+		return ChatMessage{}, fmt.Errorf("check plan ownership: %w", err)
+	}
+	if exists == 0 {
+		return ChatMessage{}, fmt.Errorf("plan %d not found for user %d", msg.PlanID, msg.UserID)
+	}
+
+	encContent, err := encryption.EncryptField(msg.Content)
+	if err != nil {
+		return ChatMessage{}, fmt.Errorf("encrypt chat content: %w", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`
+		INSERT INTO stride_chat_messages (plan_id, user_id, role, content, plan_modified, created_at)
+		VALUES (?, ?, ?, ?, 0, ?)
+	`, msg.PlanID, msg.UserID, msg.Role, encContent, now)
+	if err != nil {
+		return ChatMessage{}, fmt.Errorf("insert chat message: %w", err)
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return ChatMessage{}, fmt.Errorf("last insert id: %w", err)
+	}
+
+	msg.ID = id
+	msg.CreatedAt = now
+	msg.PlanModified = false
+	return msg, nil
+}
+
+// GetChatSessionID returns the chat_session_id for a plan.
+// Returns empty string if not set or plan not found.
+func GetChatSessionID(db *sql.DB, planID, userID int64) (string, error) {
+	var sessionID string
+	err := db.QueryRow(`SELECT chat_session_id FROM stride_plans WHERE id = ? AND user_id = ?`, planID, userID).Scan(&sessionID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get chat session id: %w", err)
+	}
+	return sessionID, nil
+}
+
+// UpdateChatSessionID updates the chat_session_id on the plan row. Scoped to userID.
+func UpdateChatSessionID(db *sql.DB, planID, userID int64, sessionID string) error {
+	_, err := db.Exec(`UPDATE stride_plans SET chat_session_id = ? WHERE id = ? AND user_id = ?`, sessionID, planID, userID)
+	if err != nil {
+		return fmt.Errorf("update chat session id: %w", err)
+	}
+	return nil
+}
+
+// MarkMessagePlanModified sets plan_modified=1 on a message. Scoped to userID.
+func MarkMessagePlanModified(db *sql.DB, messageID, userID int64) error {
+	res, err := db.Exec(`UPDATE stride_chat_messages SET plan_modified = 1 WHERE id = ? AND user_id = ?`, messageID, userID)
+	if err != nil {
+		return fmt.Errorf("mark message plan modified: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/internal/stride/chat_store.go
+++ b/internal/stride/chat_store.go
@@ -26,7 +26,7 @@ func ListChatMessages(db *sql.DB, planID, userID int64) ([]ChatMessage, error) {
 		SELECT id, plan_id, user_id, role, content, plan_modified, created_at
 		FROM stride_chat_messages
 		WHERE plan_id = ? AND user_id = ?
-		ORDER BY created_at ASC
+		ORDER BY created_at ASC, id ASC
 	`, planID, userID)
 	if err != nil {
 		return nil, err
@@ -116,9 +116,16 @@ func GetChatSessionID(db *sql.DB, planID, userID int64) (string, error) {
 
 // UpdateChatSessionID updates the chat_session_id on the plan row. Scoped to userID.
 func UpdateChatSessionID(db *sql.DB, planID, userID int64, sessionID string) error {
-	_, err := db.Exec(`UPDATE stride_plans SET chat_session_id = ? WHERE id = ? AND user_id = ?`, sessionID, planID, userID)
+	res, err := db.Exec(`UPDATE stride_plans SET chat_session_id = ? WHERE id = ? AND user_id = ?`, sessionID, planID, userID)
 	if err != nil {
 		return fmt.Errorf("update chat session id: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return sql.ErrNoRows
 	}
 	return nil
 }

--- a/internal/stride/chat_store_test.go
+++ b/internal/stride/chat_store_test.go
@@ -1,0 +1,244 @@
+package stride
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestListChatMessages_Empty(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Create a plan so we have a valid plan_id.
+	_, err := db.Exec(`INSERT INTO stride_plans (id, user_id, week_start, week_end, plan_json, created_at) VALUES (1, 1, '2026-04-13', '2026-04-19', '{}', '2026-04-13T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	msgs, err := ListChatMessages(db, 1, 1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if msgs == nil {
+		t.Fatal("expected empty slice, got nil")
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("expected 0 messages, got %d", len(msgs))
+	}
+}
+
+func TestAddChatMessage_RoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO stride_plans (id, user_id, week_start, week_end, plan_json, created_at) VALUES (1, 1, '2026-04-13', '2026-04-19', '{}', '2026-04-13T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	// Add a user message.
+	msg, err := AddChatMessage(db, ChatMessage{
+		PlanID:  1,
+		UserID:  1,
+		Role:    "user",
+		Content: "Move Thursday's tempo to Friday",
+	})
+	if err != nil {
+		t.Fatalf("add user message: %v", err)
+	}
+	if msg.ID == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+	if msg.CreatedAt == "" {
+		t.Fatal("expected non-empty created_at")
+	}
+
+	// Add an assistant message.
+	_, err = AddChatMessage(db, ChatMessage{
+		PlanID:  1,
+		UserID:  1,
+		Role:    "assistant",
+		Content: "Done! I moved the tempo run to Friday.",
+	})
+	if err != nil {
+		t.Fatalf("add assistant message: %v", err)
+	}
+
+	// List and verify content is decrypted.
+	msgs, err := ListChatMessages(db, 1, 1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+
+	if msgs[0].Role != "user" {
+		t.Errorf("expected role 'user', got %q", msgs[0].Role)
+	}
+	if msgs[0].Content != "Move Thursday's tempo to Friday" {
+		t.Errorf("unexpected content: %q", msgs[0].Content)
+	}
+	if msgs[1].Role != "assistant" {
+		t.Errorf("expected role 'assistant', got %q", msgs[1].Role)
+	}
+	if msgs[1].Content != "Done! I moved the tempo run to Friday." {
+		t.Errorf("unexpected content: %q", msgs[1].Content)
+	}
+
+	// Verify content is actually encrypted in DB.
+	var raw string
+	if err := db.QueryRow(`SELECT content FROM stride_chat_messages WHERE id = ?`, msgs[0].ID).Scan(&raw); err != nil {
+		t.Fatalf("read raw: %v", err)
+	}
+	if !strings.HasPrefix(raw, "enc:") {
+		t.Errorf("expected encrypted content (enc: prefix), got %q", raw)
+	}
+}
+
+func TestAddChatMessage_InvalidRole(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO stride_plans (id, user_id, week_start, week_end, plan_json, created_at) VALUES (1, 1, '2026-04-13', '2026-04-19', '{}', '2026-04-13T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	_, err = AddChatMessage(db, ChatMessage{
+		PlanID:  1,
+		UserID:  1,
+		Role:    "system",
+		Content: "hello",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid role")
+	}
+	if !strings.Contains(err.Error(), "invalid role") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAddChatMessage_EmptyContent(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO stride_plans (id, user_id, week_start, week_end, plan_json, created_at) VALUES (1, 1, '2026-04-13', '2026-04-19', '{}', '2026-04-13T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	_, err = AddChatMessage(db, ChatMessage{
+		PlanID:  1,
+		UserID:  1,
+		Role:    "user",
+		Content: "",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty content")
+	}
+	if !strings.Contains(err.Error(), "content must not be empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAddChatMessage_WrongUser(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Plan belongs to user 1.
+	_, err := db.Exec(`INSERT INTO stride_plans (id, user_id, week_start, week_end, plan_json, created_at) VALUES (1, 1, '2026-04-13', '2026-04-19', '{}', '2026-04-13T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	// Insert user 2.
+	_, err = db.Exec("INSERT INTO users (id, email, name, google_id) VALUES (2, 'other@example.com', 'Other', 'g456')")
+	if err != nil {
+		t.Fatalf("insert user 2: %v", err)
+	}
+
+	// User 2 tries to add a message to user 1's plan.
+	_, err = AddChatMessage(db, ChatMessage{
+		PlanID:  1,
+		UserID:  2,
+		Role:    "user",
+		Content: "sneaky",
+	})
+	if err == nil {
+		t.Fatal("expected error for wrong user")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestChatSessionID_RoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO stride_plans (id, user_id, week_start, week_end, plan_json, created_at) VALUES (1, 1, '2026-04-13', '2026-04-19', '{}', '2026-04-13T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	if err := UpdateChatSessionID(db, 1, 1, "session-abc-123"); err != nil {
+		t.Fatalf("update session id: %v", err)
+	}
+
+	sid, err := GetChatSessionID(db, 1, 1)
+	if err != nil {
+		t.Fatalf("get session id: %v", err)
+	}
+	if sid != "session-abc-123" {
+		t.Errorf("expected 'session-abc-123', got %q", sid)
+	}
+}
+
+func TestChatSessionID_DefaultEmpty(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO stride_plans (id, user_id, week_start, week_end, plan_json, created_at) VALUES (1, 1, '2026-04-13', '2026-04-19', '{}', '2026-04-13T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	sid, err := GetChatSessionID(db, 1, 1)
+	if err != nil {
+		t.Fatalf("get session id: %v", err)
+	}
+	if sid != "" {
+		t.Errorf("expected empty string, got %q", sid)
+	}
+}
+
+func TestMarkMessagePlanModified(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO stride_plans (id, user_id, week_start, week_end, plan_json, created_at) VALUES (1, 1, '2026-04-13', '2026-04-19', '{}', '2026-04-13T00:00:00Z')`)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	msg, err := AddChatMessage(db, ChatMessage{
+		PlanID:  1,
+		UserID:  1,
+		Role:    "assistant",
+		Content: "Updated your plan.",
+	})
+	if err != nil {
+		t.Fatalf("add message: %v", err)
+	}
+	if msg.PlanModified {
+		t.Fatal("expected plan_modified=false initially")
+	}
+
+	if err := MarkMessagePlanModified(db, msg.ID, 1); err != nil {
+		t.Fatalf("mark modified: %v", err)
+	}
+
+	msgs, err := ListChatMessages(db, 1, 1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if !msgs[0].PlanModified {
+		t.Error("expected plan_modified=true after marking")
+	}
+}

--- a/internal/stride/stride_test.go
+++ b/internal/stride/stride_test.go
@@ -62,7 +62,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 			model           TEXT NOT NULL DEFAULT '',
 			chat_session_id TEXT NOT NULL DEFAULT '',
 			created_at      TEXT NOT NULL DEFAULT '',
-			UNIQUE(user_id, week_start)
+			UNIQUE(user_id, week_start),
+			UNIQUE(user_id, id)
 		);
 		CREATE TABLE stride_notes (
 			id          INTEGER PRIMARY KEY,
@@ -108,7 +109,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 			role          TEXT NOT NULL DEFAULT '',
 			content       TEXT NOT NULL DEFAULT '',
 			plan_modified INTEGER NOT NULL DEFAULT 0,
-			created_at    TEXT NOT NULL DEFAULT ''
+			created_at    TEXT NOT NULL DEFAULT '',
+			FOREIGN KEY (user_id, plan_id) REFERENCES stride_plans(user_id, id)
 		);
 		CREATE INDEX idx_stride_chat_messages_plan ON stride_chat_messages(plan_id);
 		CREATE TABLE stride_evaluations (

--- a/internal/stride/stride_test.go
+++ b/internal/stride/stride_test.go
@@ -51,16 +51,17 @@ func setupTestDB(t *testing.T) *sql.DB {
 			created_at  TEXT NOT NULL DEFAULT ''
 		);
 		CREATE TABLE stride_plans (
-			id          INTEGER PRIMARY KEY,
-			user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-			week_start  TEXT NOT NULL,
-			week_end    TEXT NOT NULL,
-			phase       TEXT NOT NULL DEFAULT '',
-			plan_json   TEXT NOT NULL,
-			prompt      TEXT NOT NULL DEFAULT '',
-			response    TEXT NOT NULL DEFAULT '',
-			model       TEXT NOT NULL DEFAULT '',
-			created_at  TEXT NOT NULL DEFAULT '',
+			id              INTEGER PRIMARY KEY,
+			user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			week_start      TEXT NOT NULL,
+			week_end        TEXT NOT NULL,
+			phase           TEXT NOT NULL DEFAULT '',
+			plan_json       TEXT NOT NULL,
+			prompt          TEXT NOT NULL DEFAULT '',
+			response        TEXT NOT NULL DEFAULT '',
+			model           TEXT NOT NULL DEFAULT '',
+			chat_session_id TEXT NOT NULL DEFAULT '',
+			created_at      TEXT NOT NULL DEFAULT '',
 			UNIQUE(user_id, week_start)
 		);
 		CREATE TABLE stride_notes (
@@ -100,6 +101,16 @@ func setupTestDB(t *testing.T) *sql.DB {
 			race_id             INTEGER REFERENCES stride_races(id) ON DELETE SET NULL,
 			UNIQUE(user_id, fit_file_hash)
 		);
+		CREATE TABLE stride_chat_messages (
+			id            INTEGER PRIMARY KEY,
+			plan_id       INTEGER NOT NULL REFERENCES stride_plans(id) ON DELETE CASCADE,
+			user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			role          TEXT NOT NULL DEFAULT '',
+			content       TEXT NOT NULL DEFAULT '',
+			plan_modified INTEGER NOT NULL DEFAULT 0,
+			created_at    TEXT NOT NULL DEFAULT ''
+		);
+		CREATE INDEX idx_stride_chat_messages_plan ON stride_chat_messages(plan_id);
 		CREATE TABLE stride_evaluations (
 			id          INTEGER PRIMARY KEY,
 			user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Changes

- **Stride Chat data layer** - Schema, store helpers, and session management for per-plan coaching chat conversations. (Hytte-78qv)

## Original Issue (feature): Stride Chat: schema, store helpers, and session management

## Summary

First bead in a chain to add a real-time coaching chat to Stride. This bead covers the data layer: schema, store helpers, and session management plumbing. No handlers, no frontend.

## Context

Stride is getting a conversational chat where the user can talk directly to their AI running coach. The chat is scoped per-plan-week: each `stride_plans` row gets its own conversation. The coach can read the current plan, recent evaluations, training profile, and race calendar, and can modify the plan in response to user requests ("move Thursday's tempo to Friday"). Plan modifications are handled in a later bead — this one just sets up the persistence layer.

## Schema

### New table: `stride_chat_messages`

```sql
CREATE TABLE IF NOT EXISTS stride_chat_messages (
    id            INTEGER PRIMARY KEY,
    plan_id       INTEGER NOT NULL REFERENCES stride_plans(id) ON DELETE CASCADE,
    user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
    role          TEXT NOT NULL DEFAULT '',   -- 'user' | 'assistant'
    content       TEXT NOT NULL DEFAULT '',   -- encrypted at rest
    plan_modified INTEGER NOT NULL DEFAULT 0, -- 1 if this message triggered a plan update
    created_at    TEXT NOT NULL DEFAULT ''
);
CREATE INDEX idx_stride_chat_messages_plan ON stride_chat_messages(plan_id);
```

Content is encrypted via `encryption.EncryptField` on write, `DecryptField` on read — same pattern as homework messages.

`plan_modified` is a flag set by the handler (in a later bead) when the assistant response contains a valid plan JSON block that was successfully persisted. It's stored here so the frontend can show a visual indicator ("plan updated") next to messages that changed the plan.

### New column on `stride_plans`: `chat_session_id`

```sql
ALTER TABLE stride_plans ADD COLUMN chat_session_id TEXT NOT NULL DEFAULT '';
```

Stores the Claude CLI session ID for `--resume` continuity within a plan week's conversation. Same pattern as `homework_conversations.session_id` and `chat_conversations.session_id`.

## Store helpers

All in `internal/stride/chat_store.go` (new file):

### Types

```go
type ChatMessage struct {
    ID           int64  `json:"id"`
    PlanID       int64  `json:"plan_id"`
    UserID       int64  `json:"user_id"`
    Role         string `json:"role"`
    Content      string `json:"content"`
    PlanModified bool   `json:"plan_modified"`
    CreatedAt    string `json:"created_at"`
}
```

### Functions

- `ListChatMessages(db, planID, userID) ([]ChatMessage, error)` — returns messages for a plan, ordered by created_at ASC. Decrypts content. Scoped to userID for safety.
- `AddChatMessage(db, msg ChatMessage) (ChatMessage, error)` — inserts a message with encrypted content, returns the inserted row with ID and created_at populated. Validates: role must be "user" or "assistant", content must be non-empty, plan must exist and belong to the user.
- `GetChatSessionID(db, planID, userID) (string, error)` — returns the chat_session_id for a plan. Returns empty string if not set.
- `UpdateChatSessionID(db, planID, userID, sessionID) error` — updates the chat_session_id on the plan row. Scoped to userID.
- `MarkMessagePlanModified(db, messageID, userID) error` — sets plan_modified=1 on a message. Called by the handler after a successful plan update.

### Tests

`internal/stride/chat_store_test.go` — using the existing `setupTestDB` pattern from `stride_test.go`:

- `TestListChatMessages_Empty` — no messages returns empty slice (not nil).
- `TestAddChatMessage_RoundTrip` — insert + list, verify content is decrypted, timestamps populated.
- `TestAddChatMessage_InvalidRole` — role "system" rejected.
- `TestAddChatMessage_EmptyContent` — rejected.
- `TestAddChatMessage_WrongUser` — plan belongs to user 1, message from user 2 rejected.
- `TestChatSessionID_RoundTrip` — update + get, verify value.
- `TestChatSessionID_DefaultEmpty` — new plan has empty session ID.
- `TestMarkMessagePlanModified` — flag flips from 0 to 1.

## Schema migration

Add to `internal/db/db.go:createSchema()`:
- `CREATE TABLE IF NOT EXISTS stride_chat_messages` with index.
- `ALTER TABLE stride_plans ADD COLUMN chat_session_id` with the standard existence check pattern.

## Files touched

- `internal/db/db.go` — schema migration
- `internal/stride/chat_store.go` — new file, types + store helpers
- `internal/stride/chat_store_test.go` — new file, tests
- `changelog.d/Hytte-<id>.md` — Added category fragment

## Acceptance criteria

- `sqlite3 hytte.db '.schema stride_chat_messages'` shows the table after deploy.
- `sqlite3 hytte.db 'SELECT chat_session_id FROM stride_plans LIMIT 1'` returns empty string (column exists).
- All store tests pass.
- Content round-trips through encryption (insert plaintext → DB has `enc:...` → list returns plaintext).

---
Bead: Hytte-78qv | Branch: forge/Hytte-78qv
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)