### PR TITLE
Stride Chat: handlers with streaming, plan modification, and route wiring (Hytte-zhuj)

### DIFF
--- a/changelog.d/Hytte-zhuj.md
+++ b/changelog.d/Hytte-zhuj.md
@@ -1,0 +1,2 @@
+category: Added
+- **Stride Chat API** - Added chat handlers with SSE streaming for real-time coaching conversations on weekly plans, including plan modification detection and session resumption. (Hytte-zhuj)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -467,6 +467,8 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Get("/stride/plans/current", stride.GetCurrentPlanHandler(db))
 				r.Post("/stride/plans/generate", stride.GeneratePlanHandler(db))
 				r.Get("/stride/plans/{id}", stride.GetPlanHandler(db))
+				r.Get("/stride/plans/{planId}/chat", stride.StrideChatListHandler(db))
+				r.Post("/stride/plans/{planId}/chat", stride.StrideChatSendHandler(db))
 				r.Get("/stride/evaluations", stride.ListEvaluationsHandler(db))
 				r.Post("/stride/evaluate", stride.TriggerEvaluationHandler(db))
 				r.Get("/stride/history", stride.PlanHistoryHandler(db))

--- a/internal/stride/chat_handlers.go
+++ b/internal/stride/chat_handlers.go
@@ -1,0 +1,416 @@
+package stride
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/training"
+	"github.com/go-chi/chi/v5"
+)
+
+// execCommand creates an exec.Cmd. Extracted for test substitution.
+var execCommand = execCommandImpl
+
+func execCommandImpl(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, name, args...)
+}
+
+// claudeStreamLine represents a line from Claude CLI's stream-json output.
+type claudeStreamLine struct {
+	Type      string `json:"type"`
+	Result    string `json:"result"`
+	SessionID string `json:"session_id"`
+	IsError   bool   `json:"is_error"`
+	Message   struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"message"`
+}
+
+// fencedJSONRe matches fenced ```json ... ``` blocks (with optional language tag).
+var fencedJSONRe = regexp.MustCompile("(?s)```(?:json)?\\s*\\n(\\[.*?\\])\\s*\\n```")
+
+// extractPlanJSON scans the response for a fenced JSON code block containing a
+// JSON array. If multiple fenced blocks exist, the last one is used (Claude
+// sometimes shows a "before" and "after"). Returns the raw JSON string and
+// whether one was found.
+func extractPlanJSON(response string) (string, bool) {
+	matches := fencedJSONRe.FindAllStringSubmatch(response, -1)
+	if len(matches) == 0 {
+		return "", false
+	}
+	last := matches[len(matches)-1]
+	return strings.TrimSpace(last[1]), true
+}
+
+// validatePlanUpdate parses the extracted plan JSON and verifies it covers
+// exactly the 7 days of the given week range with no duplicates. Returns the
+// validated []DayPlan or a descriptive error.
+func validatePlanUpdate(planJSON string, weekStart, weekEnd string) ([]DayPlan, error) {
+	days, err := parsePlanResponse(planJSON, weekStart, weekEnd)
+	if err != nil {
+		return nil, fmt.Errorf("validate plan update: %w", err)
+	}
+	return days, nil
+}
+
+// StrideChatListHandler returns all messages for a plan's chat conversation.
+// GET /api/stride/plans/{planId}/chat
+func StrideChatListHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		planIDStr := chi.URLParam(r, "planId")
+		planID, err := strconv.ParseInt(planIDStr, 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid plan ID"})
+			return
+		}
+
+		// Verify plan exists and belongs to user.
+		_, err = GetPlanByID(db, planID, user.ID)
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "plan not found"})
+			return
+		}
+
+		msgs, err := ListChatMessages(db, planID, user.ID)
+		if err != nil {
+			log.Printf("stride chat: list messages plan %d: %v", planID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list messages"})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"messages": msgs,
+			"plan_id":  planID,
+		})
+	}
+}
+
+// StrideChatSendHandler accepts a user message and streams Claude's response
+// via SSE with plan modification detection.
+// POST /api/stride/plans/{planId}/chat
+func StrideChatSendHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		planIDStr := chi.URLParam(r, "planId")
+		planID, err := strconv.ParseInt(planIDStr, 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid plan ID"})
+			return
+		}
+
+		// Parse request body.
+		var body struct {
+			Content string `json:"content"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			return
+		}
+		if strings.TrimSpace(body.Content) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "content must not be empty"})
+			return
+		}
+
+		// Verify plan exists and belongs to user.
+		plan, err := GetPlanByID(db, planID, user.ID)
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "plan not found"})
+			return
+		}
+
+		// Load Claude config.
+		cfg, err := training.LoadClaudeConfig(db, user.ID)
+		if err != nil {
+			log.Printf("stride chat: load claude config user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load Claude configuration"})
+			return
+		}
+		if !cfg.Enabled {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Claude is not enabled — enable it in settings"})
+			return
+		}
+
+		// Store user message.
+		userMsg, err := AddChatMessage(db, ChatMessage{
+			PlanID:  planID,
+			UserID:  user.ID,
+			Role:    "user",
+			Content: body.Content,
+		})
+		if err != nil {
+			log.Printf("stride chat: add user message plan %d: %v", planID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save message"})
+			return
+		}
+
+		// Get existing session ID for conversation continuity.
+		sessionID, err := GetChatSessionID(db, planID, user.ID)
+		if err != nil {
+			log.Printf("stride chat: get session ID plan %d: %v", planID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		// Set up SSE streaming.
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "streaming not supported"})
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		// Send the saved user message first.
+		userMsgJSON, _ := json.Marshal(userMsg)
+		fmt.Fprintf(w, "event: user_message\ndata: %s\n\n", userMsgJSON)
+		flusher.Flush()
+
+		// Load context for the system prompt.
+		systemPrompt := buildChatContext(db, user.ID, *plan)
+
+		// Stream Claude response.
+		ctx, cancel := context.WithTimeout(r.Context(), 120*time.Second)
+		defer cancel()
+
+		fullResponse, newSessionID, err := streamChatClaude(ctx, cfg, systemPrompt, body.Content, sessionID, w, flusher)
+		if err != nil && sessionID != "" {
+			// Session may have expired — retry without session.
+			log.Printf("stride chat: session resume failed, retrying fresh: %v", err)
+			fmt.Fprintf(w, "event: retry\ndata: {\"reason\":\"session expired, retrying\"}\n\n")
+			flusher.Flush()
+			fullResponse, newSessionID, err = streamChatClaude(ctx, cfg, systemPrompt, body.Content, "", w, flusher)
+		}
+
+		if err != nil {
+			log.Printf("stride chat: claude error plan %d: %v", planID, err)
+			errJSON, _ := json.Marshal(map[string]string{"error": "Claude failed to respond. Please try again."})
+			fmt.Fprintf(w, "event: error\ndata: %s\n\n", errJSON)
+			flusher.Flush()
+			return
+		}
+
+		// Save session ID for future resumption.
+		if newSessionID != "" && newSessionID != sessionID {
+			if dbErr := UpdateChatSessionID(db, planID, user.ID, newSessionID); dbErr != nil {
+				log.Printf("stride chat: save session ID plan %d: %v", planID, dbErr)
+			}
+		}
+
+		// Check for plan modification in the response.
+		planModified := false
+		if planJSON, found := extractPlanJSON(fullResponse); found {
+			days, err := validatePlanUpdate(planJSON, plan.WeekStart, plan.WeekEnd)
+			if err != nil {
+				log.Printf("stride chat: plan update validation failed plan %d: %v (json: %s)", planID, err, planJSON)
+			} else {
+				// Update plan_json in the database.
+				updatedJSON, err := json.Marshal(days)
+				if err != nil {
+					log.Printf("stride chat: marshal updated plan: %v", err)
+				} else if err := updatePlanJSON(db, planID, user.ID, string(updatedJSON)); err != nil {
+					log.Printf("stride chat: update plan_json plan %d: %v", planID, err)
+				} else {
+					planModified = true
+					// Send plan_updated SSE event so the frontend can re-render.
+					planEvt, _ := json.Marshal(map[string]any{"plan": days})
+					fmt.Fprintf(w, "event: plan_updated\ndata: %s\n\n", planEvt)
+					flusher.Flush()
+				}
+			}
+		}
+
+		// Store assistant message.
+		assistantMsg, err := AddChatMessage(db, ChatMessage{
+			PlanID:  planID,
+			UserID:  user.ID,
+			Role:    "assistant",
+			Content: fullResponse,
+		})
+		if err != nil {
+			log.Printf("stride chat: add assistant message plan %d: %v", planID, err)
+			fmt.Fprintf(w, "event: error\ndata: {\"error\":\"failed to save response\"}\n\n")
+			flusher.Flush()
+			return
+		}
+
+		// Mark as plan-modified if applicable.
+		if planModified {
+			if err := MarkMessagePlanModified(db, assistantMsg.ID, user.ID); err != nil {
+				log.Printf("stride chat: mark plan_modified msg %d: %v", assistantMsg.ID, err)
+			}
+			assistantMsg.PlanModified = true
+		}
+
+		// Send done event.
+		doneJSON, _ := json.Marshal(assistantMsg)
+		fmt.Fprintf(w, "event: done\ndata: %s\n\n", doneJSON)
+		flusher.Flush()
+	}
+}
+
+// buildChatContext loads all context needed for the chat system prompt.
+func buildChatContext(db *sql.DB, userID int64, plan Plan) string {
+	profile := training.BuildUserTrainingProfile(db, userID)
+
+	pid := plan.ID
+	evaluations, err := ListEvaluations(db, userID, &pid, nil)
+	if err != nil {
+		log.Printf("stride chat: list evaluations plan %d: %v", plan.ID, err)
+	}
+
+	allRaces, err := ListRaces(db, userID)
+	if err != nil {
+		log.Printf("stride chat: list races: %v", err)
+	}
+	today := time.Now().UTC().Format("2006-01-02")
+	var races []Race
+	for _, r := range allRaces {
+		if r.Date >= today && r.ResultTime == nil {
+			races = append(races, r)
+		}
+	}
+
+	acr, acute, chronic, acrErr := training.ComputeACR(db, userID, time.Now().UTC())
+	if acrErr != nil {
+		log.Printf("stride chat: compute ACR user %d: %v", userID, acrErr)
+	}
+
+	notes, err := listUnconsumedNotes(context.Background(), db, userID)
+	if err != nil {
+		log.Printf("stride chat: list notes: %v", err)
+	}
+
+	return BuildChatSystemPrompt(profile, plan, evaluations, races, acr, acute, chronic, notes)
+}
+
+// streamChatClaude runs the Claude CLI with stream-json output and sends text
+// deltas as SSE events. Returns the full response text and session ID.
+func streamChatClaude(ctx context.Context, cfg *training.ClaudeConfig, systemPrompt, prompt, sessionID string, w http.ResponseWriter, flusher http.Flusher) (string, string, error) {
+	args := []string{"--model", cfg.Model, "-p", "-", "--output-format", "stream-json", "--verbose", "--system-prompt", systemPrompt}
+	if sessionID != "" {
+		args = append(args, "--resume", sessionID)
+	}
+
+	cmd := execCommand(ctx, cfg.CLIPath, args...)
+	cmd.Stdin = strings.NewReader(prompt)
+
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", "", fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return "", "", fmt.Errorf("start claude: %w", err)
+	}
+
+	var fullText strings.Builder
+	var resultSessionID string
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var ev claudeStreamLine
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+
+		switch ev.Type {
+		case "assistant":
+			for _, block := range ev.Message.Content {
+				if block.Type == "text" && block.Text != "" {
+					fullText.WriteString(block.Text)
+					data, _ := json.Marshal(map[string]string{"text": block.Text})
+					fmt.Fprintf(w, "event: delta\ndata: %s\n\n", data)
+					flusher.Flush()
+				}
+			}
+		case "content_block_delta":
+			var delta struct {
+				Delta struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"delta"`
+			}
+			if err := json.Unmarshal(line, &delta); err == nil && delta.Delta.Text != "" {
+				fullText.WriteString(delta.Delta.Text)
+				data, _ := json.Marshal(map[string]string{"text": delta.Delta.Text})
+				fmt.Fprintf(w, "event: delta\ndata: %s\n\n", data)
+				flusher.Flush()
+			}
+		case "result":
+			if ev.IsError {
+				cmd.Wait()
+				stderr := strings.TrimSpace(stderrBuf.String())
+				if stderr != "" {
+					return "", "", fmt.Errorf("claude returned error: %s: %s", ev.Result, stderr)
+				}
+				return "", "", fmt.Errorf("claude returned error: %s", ev.Result)
+			}
+			if ev.Result != "" {
+				fullText.Reset()
+				fullText.WriteString(ev.Result)
+			}
+			resultSessionID = ev.SessionID
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		cmd.Wait()
+		if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
+			return "", "", fmt.Errorf("scan claude output: %w: %s", err, stderr)
+		}
+		return "", "", fmt.Errorf("scan claude output: %w", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
+			return "", "", fmt.Errorf("claude exit: %w: %s", err, stderr)
+		}
+		return "", "", fmt.Errorf("claude exit: %w", err)
+	}
+
+	return strings.TrimSpace(fullText.String()), resultSessionID, nil
+}
+
+// updatePlanJSON updates the plan_json column for a plan. Scoped to userID.
+func updatePlanJSON(db *sql.DB, planID, userID int64, planJSON string) error {
+	res, err := db.Exec(`UPDATE stride_plans SET plan_json = ? WHERE id = ? AND user_id = ?`, planJSON, planID, userID)
+	if err != nil {
+		return fmt.Errorf("update plan_json: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/internal/stride/chat_handlers.go
+++ b/internal/stride/chat_handlers.go
@@ -6,11 +6,11 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -41,20 +41,46 @@ type claudeStreamLine struct {
 	} `json:"message"`
 }
 
-// fencedJSONRe matches fenced ```json ... ``` blocks (with optional language tag).
-var fencedJSONRe = regexp.MustCompile("(?s)```(?:json)?\\s*\\n(\\[.*?\\])\\s*\\n```")
-
-// extractPlanJSON scans the response for a fenced JSON code block containing a
-// JSON array. If multiple fenced blocks exist, the last one is used (Claude
-// sometimes shows a "before" and "after"). Returns the raw JSON string and
-// whether one was found.
+// extractPlanJSON scans the response for the last fenced ```json ... ``` block
+// containing a JSON array. Using the last block means Claude can show a
+// "before" version and an "after" version and we always act on the final one.
+// The extraction finds fence boundaries first and takes the full fenced content,
+// so JSON strings containing ']' are handled correctly. Both \n and \r\n line
+// endings are supported.
 func extractPlanJSON(response string) (string, bool) {
-	matches := fencedJSONRe.FindAllStringSubmatch(response, -1)
-	if len(matches) == 0 {
+	// Find the last closing fence (``` on its own line, \r?\n```).
+	const fence = "```"
+	lastClose := strings.LastIndex(response, "\n"+fence)
+	if lastClose < 0 {
 		return "", false
 	}
-	last := matches[len(matches)-1]
-	return strings.TrimSpace(last[1]), true
+	// Find the opening fence that precedes the closing one.
+	openStart := strings.LastIndex(response[:lastClose], fence)
+	if openStart < 0 {
+		return "", false
+	}
+	// Skip past the opening fence and optional language tag to the newline that
+	// ends the opening fence line.
+	afterTag := response[openStart+len(fence):]
+	nl := strings.IndexByte(afterTag, '\n')
+	if nl < 0 {
+		return "", false
+	}
+	// innerStart is the absolute position in response of the first content line.
+	innerStart := openStart + len(fence) + nl + 1
+	// innerEnd is lastClose (the \n before closing fence); strip trailing \r too.
+	innerEnd := lastClose
+	if innerEnd > innerStart && response[innerEnd-1] == '\r' {
+		innerEnd--
+	}
+	if innerEnd <= innerStart {
+		return "", false
+	}
+	inner := strings.TrimSpace(response[innerStart:innerEnd])
+	if !strings.HasPrefix(inner, "[") {
+		return "", false
+	}
+	return inner, true
 }
 
 // validatePlanUpdate parses the extracted plan JSON and verifies it covers
@@ -83,7 +109,12 @@ func StrideChatListHandler(db *sql.DB) http.HandlerFunc {
 		// Verify plan exists and belongs to user.
 		_, err = GetPlanByID(db, planID, user.ID)
 		if err != nil {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "plan not found"})
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "plan not found"})
+				return
+			}
+			log.Printf("stride chat: get plan %d: %v", planID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get plan"})
 			return
 		}
 
@@ -130,7 +161,12 @@ func StrideChatSendHandler(db *sql.DB) http.HandlerFunc {
 		// Verify plan exists and belongs to user.
 		plan, err := GetPlanByID(db, planID, user.ID)
 		if err != nil {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "plan not found"})
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "plan not found"})
+				return
+			}
+			log.Printf("stride chat: get plan %d: %v", planID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get plan"})
 			return
 		}
 
@@ -184,12 +220,12 @@ func StrideChatSendHandler(db *sql.DB) http.HandlerFunc {
 		fmt.Fprintf(w, "event: user_message\ndata: %s\n\n", userMsgJSON)
 		flusher.Flush()
 
-		// Load context for the system prompt.
-		systemPrompt := buildChatContext(db, user.ID, *plan)
-
 		// Stream Claude response.
 		ctx, cancel := context.WithTimeout(r.Context(), 120*time.Second)
 		defer cancel()
+
+		// Load context for the system prompt.
+		systemPrompt := buildChatContext(ctx, db, user.ID, *plan)
 
 		fullResponse, newSessionID, err := streamChatClaude(ctx, cfg, systemPrompt, body.Content, sessionID, w, flusher)
 		if err != nil && sessionID != "" {
@@ -220,7 +256,7 @@ func StrideChatSendHandler(db *sql.DB) http.HandlerFunc {
 		if planJSON, found := extractPlanJSON(fullResponse); found {
 			days, err := validatePlanUpdate(planJSON, plan.WeekStart, plan.WeekEnd)
 			if err != nil {
-				log.Printf("stride chat: plan update validation failed plan %d: %v (json: %s)", planID, err, planJSON)
+				log.Printf("stride chat: plan update validation failed plan %d msg %d: %v", planID, userMsg.ID, err)
 			} else {
 				// Update plan_json in the database.
 				updatedJSON, err := json.Marshal(days)
@@ -268,7 +304,8 @@ func StrideChatSendHandler(db *sql.DB) http.HandlerFunc {
 }
 
 // buildChatContext loads all context needed for the chat system prompt.
-func buildChatContext(db *sql.DB, userID int64, plan Plan) string {
+// ctx is threaded through to DB calls so they respect request cancellation.
+func buildChatContext(ctx context.Context, db *sql.DB, userID int64, plan Plan) string {
 	profile := training.BuildUserTrainingProfile(db, userID)
 
 	pid := plan.ID
@@ -294,7 +331,7 @@ func buildChatContext(db *sql.DB, userID int64, plan Plan) string {
 		log.Printf("stride chat: compute ACR user %d: %v", userID, acrErr)
 	}
 
-	notes, err := listUnconsumedNotes(context.Background(), db, userID)
+	notes, err := listUnconsumedNotes(ctx, db, userID)
 	if err != nil {
 		log.Printf("stride chat: list notes: %v", err)
 	}

--- a/internal/stride/chat_handlers_test.go
+++ b/internal/stride/chat_handlers_test.go
@@ -159,11 +159,6 @@ func fakeExecCommandChatCapture(lines []string, captured *[][]string) func(ctx c
 func TestStrideChatListHandler_Empty(t *testing.T) {
 	db := setupTestDB(t)
 
-	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
-	if err != nil {
-		t.Fatalf("insert user: %v", err)
-	}
-
 	weekStart := "2026-04-13"
 	weekEnd := "2026-04-19"
 	planJSON := buildValidPlanJSON(weekStart)
@@ -209,13 +204,9 @@ func TestStrideChatListHandler_Empty(t *testing.T) {
 func TestStrideChatListHandler_WrongUser(t *testing.T) {
 	db := setupTestDB(t)
 
-	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'a@b.com', 'A', 'g-1')`)
+	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (2, 'c@d.com', 'B', 'g-2')`)
 	if err != nil {
-		t.Fatalf("insert user: %v", err)
-	}
-	_, err = db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (2, 'c@d.com', 'B', 'g-2')`)
-	if err != nil {
-		t.Fatalf("insert user: %v", err)
+		t.Fatalf("insert user 2: %v", err)
 	}
 
 	weekStart := "2026-04-13"
@@ -247,11 +238,6 @@ func TestStrideChatListHandler_WrongUser(t *testing.T) {
 // TestStrideChatSendHandler_Success tests streaming a message and getting a response.
 func TestStrideChatSendHandler_Success(t *testing.T) {
 	db := setupTestDB(t)
-
-	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
-	if err != nil {
-		t.Fatalf("insert user: %v", err)
-	}
 
 	for _, kv := range [][2]string{
 		{"claude_enabled", "true"},
@@ -345,11 +331,6 @@ func TestStrideChatSendHandler_Success(t *testing.T) {
 // a valid fenced plan JSON block updates the plan and emits plan_updated.
 func TestStrideChatSendHandler_PlanModification(t *testing.T) {
 	db := setupTestDB(t)
-
-	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
-	if err != nil {
-		t.Fatalf("insert user: %v", err)
-	}
 
 	for _, kv := range [][2]string{
 		{"claude_enabled", "true"},
@@ -473,11 +454,6 @@ func TestStrideChatSendHandler_PlanModification(t *testing.T) {
 func TestStrideChatSendHandler_SessionResume(t *testing.T) {
 	db := setupTestDB(t)
 
-	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
-	if err != nil {
-		t.Fatalf("insert user: %v", err)
-	}
-
 	for _, kv := range [][2]string{{"claude_enabled", "true"}} {
 		if _, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, ?, ?)`, kv[0], kv[1]); err != nil {
 			t.Fatalf("insert pref %s: %v", kv[0], err)
@@ -548,11 +524,6 @@ func TestStrideChatSendHandler_SessionResume(t *testing.T) {
 func TestStrideChatSendHandler_ClaudeDisabled(t *testing.T) {
 	db := setupTestDB(t)
 
-	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
-	if err != nil {
-		t.Fatalf("insert user: %v", err)
-	}
-
 	// No claude_enabled preference — default is disabled.
 
 	weekStart := "2026-04-13"
@@ -586,11 +557,6 @@ func TestStrideChatSendHandler_ClaudeDisabled(t *testing.T) {
 func TestStrideChatSendHandler_PlanNotFound(t *testing.T) {
 	db := setupTestDB(t)
 
-	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
-	if err != nil {
-		t.Fatalf("insert user: %v", err)
-	}
-
 	handler := StrideChatSendHandler(db)
 	rec := httptest.NewRecorder()
 	reqBody := strings.NewReader(`{"content":"Hello"}`)
@@ -613,11 +579,6 @@ func TestStrideChatSendHandler_PlanNotFound(t *testing.T) {
 // no plan_updated event is emitted.
 func TestStrideChatSendHandler_InvalidPlanJSON(t *testing.T) {
 	db := setupTestDB(t)
-
-	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
-	if err != nil {
-		t.Fatalf("insert user: %v", err)
-	}
 
 	for _, kv := range [][2]string{{"claude_enabled", "true"}} {
 		if _, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, ?, ?)`, kv[0], kv[1]); err != nil {

--- a/internal/stride/chat_handlers_test.go
+++ b/internal/stride/chat_handlers_test.go
@@ -1,0 +1,695 @@
+package stride
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// --- extractPlanJSON tests ---
+
+func TestExtractPlanJSON_Found(t *testing.T) {
+	response := "Here's the updated plan:\n```json\n[{\"date\":\"2026-04-13\",\"rest_day\":true}]\n```\nLet me know if you need changes."
+	got, ok := extractPlanJSON(response)
+	if !ok {
+		t.Fatal("expected to find plan JSON")
+	}
+	if !strings.HasPrefix(got, "[") {
+		t.Errorf("expected JSON array, got: %s", got)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(got), &arr); err != nil {
+		t.Errorf("extracted JSON is not valid: %v", err)
+	}
+}
+
+func TestExtractPlanJSON_NotFound(t *testing.T) {
+	response := "I think you should rest tomorrow. No plan changes needed."
+	_, ok := extractPlanJSON(response)
+	if ok {
+		t.Fatal("expected not to find plan JSON in a text-only response")
+	}
+}
+
+func TestExtractPlanJSON_MultipleFencedBlocks(t *testing.T) {
+	response := "Before:\n```json\n[{\"date\":\"old\"}]\n```\n\nAfter:\n```json\n[{\"date\":\"new\"}]\n```\n"
+	got, ok := extractPlanJSON(response)
+	if !ok {
+		t.Fatal("expected to find plan JSON")
+	}
+	if !strings.Contains(got, "new") {
+		t.Errorf("expected last block (containing 'new'), got: %s", got)
+	}
+}
+
+func TestExtractPlanJSON_UnfencedJSON(t *testing.T) {
+	response := "Here is the plan: [{\"date\":\"2026-04-13\",\"rest_day\":true}]"
+	_, ok := extractPlanJSON(response)
+	if ok {
+		t.Fatal("expected not to extract unfenced JSON")
+	}
+}
+
+// --- validatePlanUpdate tests ---
+
+func buildValidPlanJSON(weekStart string) string {
+	start, _ := time.Parse("2006-01-02", weekStart)
+	var days []map[string]any
+	for i := 0; i < 7; i++ {
+		date := start.AddDate(0, 0, i).Format("2006-01-02")
+		days = append(days, map[string]any{
+			"date":     date,
+			"rest_day": true,
+		})
+	}
+	b, _ := json.Marshal(days)
+	return string(b)
+}
+
+func TestValidatePlanUpdate_ValidSevenDays(t *testing.T) {
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	planJSON := buildValidPlanJSON(weekStart)
+
+	days, err := validatePlanUpdate(planJSON, weekStart, weekEnd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(days) != 7 {
+		t.Fatalf("expected 7 days, got %d", len(days))
+	}
+}
+
+func TestValidatePlanUpdate_WrongDateRange(t *testing.T) {
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	// Build plan for a different week.
+	planJSON := buildValidPlanJSON("2026-04-20")
+
+	_, err := validatePlanUpdate(planJSON, weekStart, weekEnd)
+	if err == nil {
+		t.Fatal("expected error for out-of-range dates")
+	}
+}
+
+func TestValidatePlanUpdate_DuplicateDates(t *testing.T) {
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	start, _ := time.Parse("2006-01-02", weekStart)
+	var days []map[string]any
+	for i := 0; i < 6; i++ {
+		date := start.AddDate(0, 0, i).Format("2006-01-02")
+		days = append(days, map[string]any{"date": date, "rest_day": true})
+	}
+	// Duplicate the first date instead of adding the 7th.
+	days = append(days, map[string]any{"date": weekStart, "rest_day": true})
+	b, _ := json.Marshal(days)
+
+	_, err := validatePlanUpdate(string(b), weekStart, weekEnd)
+	if err == nil {
+		t.Fatal("expected error for duplicate dates")
+	}
+}
+
+func TestValidatePlanUpdate_NotSevenDays(t *testing.T) {
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	start, _ := time.Parse("2006-01-02", weekStart)
+	var days []map[string]any
+	for i := 0; i < 5; i++ {
+		date := start.AddDate(0, 0, i).Format("2006-01-02")
+		days = append(days, map[string]any{"date": date, "rest_day": true})
+	}
+	b, _ := json.Marshal(days)
+
+	_, err := validatePlanUpdate(string(b), weekStart, weekEnd)
+	if err == nil {
+		t.Fatal("expected error for non-7-day plan")
+	}
+}
+
+// --- fakeExecCommand helpers for handler integration tests ---
+
+func fakeExecCommandChat(lines []string) func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		output := strings.Join(lines, "\n") + "\n"
+		cmd := exec.CommandContext(ctx, "echo", "-n", output)
+		return cmd
+	}
+}
+
+func fakeExecCommandChatCapture(lines []string, captured *[][]string) func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		*captured = append(*captured, args)
+		output := strings.Join(lines, "\n") + "\n"
+		cmd := exec.CommandContext(ctx, "echo", "-n", output)
+		return cmd
+	}
+}
+
+// TestStrideChatListHandler_Empty tests listing messages for a plan with no messages.
+func TestStrideChatListHandler_Empty(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	planJSON := buildValidPlanJSON(weekStart)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	res, err := db.Exec(`INSERT INTO stride_plans (user_id, week_start, week_end, plan_json, created_at) VALUES (1, ?, ?, ?, ?)`,
+		weekStart, weekEnd, planJSON, now)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+	planID, _ := res.LastInsertId()
+
+	handler := StrideChatListHandler(db)
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/stride/plans/%d/chat", planID), nil)
+	r = withUser(r, 1)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("planId", fmt.Sprintf("%d", planID))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Messages []ChatMessage `json:"messages"`
+		PlanID   int64         `json:"plan_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Messages) != 0 {
+		t.Errorf("expected 0 messages, got %d", len(resp.Messages))
+	}
+	if resp.PlanID != planID {
+		t.Errorf("expected plan_id %d, got %d", planID, resp.PlanID)
+	}
+}
+
+// TestStrideChatListHandler_WrongUser tests that a plan belonging to another user returns 404.
+func TestStrideChatListHandler_WrongUser(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'a@b.com', 'A', 'g-1')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (2, 'c@d.com', 'B', 'g-2')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	weekStart := "2026-04-13"
+	planJSON := buildValidPlanJSON(weekStart)
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO stride_plans (user_id, week_start, week_end, plan_json, created_at) VALUES (1, ?, ?, ?, ?)`,
+		weekStart, "2026-04-19", planJSON, now)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+	planID, _ := res.LastInsertId()
+
+	handler := StrideChatListHandler(db)
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/stride/plans/%d/chat", planID), nil)
+	// Request as user 2 — should not have access to user 1's plan.
+	r = withUser(r, 2)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("planId", fmt.Sprintf("%d", planID))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestStrideChatSendHandler_Success tests streaming a message and getting a response.
+func TestStrideChatSendHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	for _, kv := range [][2]string{
+		{"claude_enabled", "true"},
+	} {
+		if _, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, ?, ?)`, kv[0], kv[1]); err != nil {
+			t.Fatalf("insert pref %s: %v", kv[0], err)
+		}
+	}
+
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	planJSON := buildValidPlanJSON(weekStart)
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO stride_plans (user_id, week_start, week_end, plan_json, created_at) VALUES (1, ?, ?, ?, ?)`,
+		weekStart, weekEnd, planJSON, now)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+	planID, _ := res.LastInsertId()
+
+	// Stub Claude CLI.
+	origExec := execCommand
+	execCommand = fakeExecCommandChat([]string{
+		`{"type":"content_block_delta","delta":{"type":"text_delta","text":"Sure, I can "}}`,
+		`{"type":"content_block_delta","delta":{"type":"text_delta","text":"help with that."}}`,
+		`{"type":"result","result":"Sure, I can help with that.","session_id":"sess-abc","is_error":false}`,
+	})
+	t.Cleanup(func() { execCommand = origExec })
+
+	handler := StrideChatSendHandler(db)
+	rec := httptest.NewRecorder()
+	reqBody := strings.NewReader(`{"content":"Can I move Thursday's run to Friday?"}`)
+	r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/stride/plans/%d/chat", planID), reqBody)
+	r.Header.Set("Content-Type", "application/json")
+	r = withUser(r, 1)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("planId", fmt.Sprintf("%d", planID))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("expected Content-Type text/event-stream, got %q", ct)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: user_message") {
+		t.Errorf("expected user_message event, got: %s", body)
+	}
+	if !strings.Contains(body, "event: delta") {
+		t.Errorf("expected delta events, got: %s", body)
+	}
+	if !strings.Contains(body, "event: done") {
+		t.Errorf("expected done event, got: %s", body)
+	}
+
+	// Verify messages persisted.
+	msgs, err := ListChatMessages(db, planID, 1)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages (user + assistant), got %d", len(msgs))
+	}
+	if msgs[0].Role != "user" {
+		t.Errorf("first message should be user, got %s", msgs[0].Role)
+	}
+	if msgs[1].Role != "assistant" {
+		t.Errorf("second message should be assistant, got %s", msgs[1].Role)
+	}
+	if msgs[1].PlanModified {
+		t.Error("assistant message should not be plan_modified for a plain response")
+	}
+
+	// Verify session ID saved.
+	sid, err := GetChatSessionID(db, planID, 1)
+	if err != nil {
+		t.Fatalf("get session id: %v", err)
+	}
+	if sid != "sess-abc" {
+		t.Errorf("expected session_id 'sess-abc', got %q", sid)
+	}
+}
+
+// TestStrideChatSendHandler_PlanModification tests that a response containing
+// a valid fenced plan JSON block updates the plan and emits plan_updated.
+func TestStrideChatSendHandler_PlanModification(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	for _, kv := range [][2]string{
+		{"claude_enabled", "true"},
+	} {
+		if _, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, ?, ?)`, kv[0], kv[1]); err != nil {
+			t.Fatalf("insert pref %s: %v", kv[0], err)
+		}
+	}
+
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	planJSON := buildValidPlanJSON(weekStart)
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO stride_plans (user_id, week_start, week_end, plan_json, created_at) VALUES (1, ?, ?, ?, ?)`,
+		weekStart, weekEnd, planJSON, now)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+	planID, _ := res.LastInsertId()
+
+	// Build a valid updated plan with a session on Wednesday.
+	start, _ := time.Parse("2006-01-02", weekStart)
+	var updatedDays []map[string]any
+	for i := 0; i < 7; i++ {
+		date := start.AddDate(0, 0, i).Format("2006-01-02")
+		if i == 2 { // Wednesday — add a session.
+			updatedDays = append(updatedDays, map[string]any{
+				"date":     date,
+				"rest_day": false,
+				"session": map[string]any{
+					"warmup":        "10 min easy",
+					"main_set":      "5x1000m at threshold",
+					"cooldown":      "10 min easy",
+					"strides":       "",
+					"target_hr_cap": 170,
+					"description":   "Threshold intervals",
+				},
+			})
+		} else {
+			updatedDays = append(updatedDays, map[string]any{
+				"date":     date,
+				"rest_day": true,
+			})
+		}
+	}
+	updatedPlanBytes, _ := json.Marshal(updatedDays)
+	updatedPlanStr := string(updatedPlanBytes)
+
+	// Claude response with fenced plan JSON.
+	fullResponse := fmt.Sprintf("I've moved the session to Wednesday. Here's the updated plan:\n```json\n%s\n```\nLet me know if that works.", updatedPlanStr)
+
+	origExec := execCommand
+	execCommand = fakeExecCommandChat([]string{
+		fmt.Sprintf(`{"type":"result","result":%s,"session_id":"sess-mod","is_error":false}`, mustJSON(t, fullResponse)),
+	})
+	t.Cleanup(func() { execCommand = origExec })
+
+	handler := StrideChatSendHandler(db)
+	rec := httptest.NewRecorder()
+	reqBody := strings.NewReader(`{"content":"Move the run to Wednesday"}`)
+	r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/stride/plans/%d/chat", planID), reqBody)
+	r.Header.Set("Content-Type", "application/json")
+	r = withUser(r, 1)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("planId", fmt.Sprintf("%d", planID))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: plan_updated") {
+		t.Errorf("expected plan_updated event, got: %s", body)
+	}
+	if !strings.Contains(body, "event: done") {
+		t.Errorf("expected done event, got: %s", body)
+	}
+
+	// Verify plan_json was updated in DB.
+	plan, err := GetPlanByID(db, planID, 1)
+	if err != nil {
+		t.Fatalf("get plan: %v", err)
+	}
+	var days []DayPlan
+	if err := json.Unmarshal(plan.Plan, &days); err != nil {
+		t.Fatalf("unmarshal plan: %v", err)
+	}
+	// Wednesday (index 2) should have a session.
+	if days[2].RestDay {
+		t.Error("expected Wednesday to not be a rest day after plan modification")
+	}
+	if days[2].Session == nil {
+		t.Error("expected Wednesday to have a session after plan modification")
+	}
+
+	// Verify assistant message has plan_modified=true.
+	msgs, err := ListChatMessages(db, planID, 1)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	var assistantMsg *ChatMessage
+	for i, m := range msgs {
+		if m.Role == "assistant" {
+			assistantMsg = &msgs[i]
+			break
+		}
+	}
+	if assistantMsg == nil {
+		t.Fatal("expected assistant message")
+	}
+	if !assistantMsg.PlanModified {
+		t.Error("expected assistant message to have plan_modified=true")
+	}
+}
+
+// TestStrideChatSendHandler_SessionResume tests that the session ID is passed
+// via --resume on subsequent messages.
+func TestStrideChatSendHandler_SessionResume(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	for _, kv := range [][2]string{{"claude_enabled", "true"}} {
+		if _, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, ?, ?)`, kv[0], kv[1]); err != nil {
+			t.Fatalf("insert pref %s: %v", kv[0], err)
+		}
+	}
+
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	planJSON := buildValidPlanJSON(weekStart)
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO stride_plans (user_id, week_start, week_end, plan_json, chat_session_id, created_at) VALUES (1, ?, ?, ?, 'existing-sess', ?)`,
+		weekStart, weekEnd, planJSON, now)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+	planID, _ := res.LastInsertId()
+
+	var captured [][]string
+	origExec := execCommand
+	execCommand = fakeExecCommandChatCapture([]string{
+		`{"type":"result","result":"Got it.","session_id":"new-sess","is_error":false}`,
+	}, &captured)
+	t.Cleanup(func() { execCommand = origExec })
+
+	handler := StrideChatSendHandler(db)
+	rec := httptest.NewRecorder()
+	reqBody := strings.NewReader(`{"content":"How am I doing?"}`)
+	r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/stride/plans/%d/chat", planID), reqBody)
+	r.Header.Set("Content-Type", "application/json")
+	r = withUser(r, 1)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("planId", fmt.Sprintf("%d", planID))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify --resume was passed.
+	if len(captured) == 0 {
+		t.Fatal("expected at least one exec call")
+	}
+	args := captured[0]
+	foundResume := false
+	for i, a := range args {
+		if a == "--resume" && i+1 < len(args) && args[i+1] == "existing-sess" {
+			foundResume = true
+			break
+		}
+	}
+	if !foundResume {
+		t.Errorf("expected --resume existing-sess in args: %v", args)
+	}
+
+	// Verify session updated.
+	sid, err := GetChatSessionID(db, planID, 1)
+	if err != nil {
+		t.Fatalf("get session id: %v", err)
+	}
+	if sid != "new-sess" {
+		t.Errorf("expected session_id 'new-sess', got %q", sid)
+	}
+}
+
+// TestStrideChatSendHandler_ClaudeDisabled tests 400 when Claude is not enabled.
+func TestStrideChatSendHandler_ClaudeDisabled(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	// No claude_enabled preference — default is disabled.
+
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	planJSON := buildValidPlanJSON(weekStart)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err = db.Exec(`INSERT INTO stride_plans (user_id, week_start, week_end, plan_json, created_at) VALUES (1, ?, ?, ?, ?)`,
+		weekStart, weekEnd, planJSON, now)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+
+	handler := StrideChatSendHandler(db)
+	rec := httptest.NewRecorder()
+	reqBody := strings.NewReader(`{"content":"Hello"}`)
+	r := httptest.NewRequest(http.MethodPost, "/api/stride/plans/1/chat", reqBody)
+	r.Header.Set("Content-Type", "application/json")
+	r = withUser(r, 1)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("planId", "1")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestStrideChatSendHandler_PlanNotFound tests 404 for a non-existent plan.
+func TestStrideChatSendHandler_PlanNotFound(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	handler := StrideChatSendHandler(db)
+	rec := httptest.NewRecorder()
+	reqBody := strings.NewReader(`{"content":"Hello"}`)
+	r := httptest.NewRequest(http.MethodPost, "/api/stride/plans/999/chat", reqBody)
+	r.Header.Set("Content-Type", "application/json")
+	r = withUser(r, 1)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("planId", "999")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestStrideChatSendHandler_InvalidPlanJSON tests soft failure when Claude
+// returns an invalid plan JSON (wrong dates). The message is still saved but
+// no plan_updated event is emitted.
+func TestStrideChatSendHandler_InvalidPlanJSON(t *testing.T) {
+	db := setupTestDB(t)
+
+	_, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'test@example.com', 'Test', 'g-1')`)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	for _, kv := range [][2]string{{"claude_enabled", "true"}} {
+		if _, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, ?, ?)`, kv[0], kv[1]); err != nil {
+			t.Fatalf("insert pref: %v", err)
+		}
+	}
+
+	weekStart := "2026-04-13"
+	weekEnd := "2026-04-19"
+	planJSON := buildValidPlanJSON(weekStart)
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO stride_plans (user_id, week_start, week_end, plan_json, created_at) VALUES (1, ?, ?, ?, ?)`,
+		weekStart, weekEnd, planJSON, now)
+	if err != nil {
+		t.Fatalf("insert plan: %v", err)
+	}
+	planID, _ := res.LastInsertId()
+
+	// Claude returns plan JSON with wrong dates.
+	wrongPlan := buildValidPlanJSON("2026-05-01") // Different week.
+	fullResponse := fmt.Sprintf("Updated:\n```json\n%s\n```\n", wrongPlan)
+
+	origExec := execCommand
+	execCommand = fakeExecCommandChat([]string{
+		fmt.Sprintf(`{"type":"result","result":%s,"session_id":"sess-bad","is_error":false}`, mustJSON(t, fullResponse)),
+	})
+	t.Cleanup(func() { execCommand = origExec })
+
+	handler := StrideChatSendHandler(db)
+	rec := httptest.NewRecorder()
+	reqBody := strings.NewReader(`{"content":"Change all days"}`)
+	r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/stride/plans/%d/chat", planID), reqBody)
+	r.Header.Set("Content-Type", "application/json")
+	r = withUser(r, 1)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("planId", fmt.Sprintf("%d", planID))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	// Should NOT have plan_updated event.
+	if strings.Contains(body, "event: plan_updated") {
+		t.Error("expected no plan_updated event for invalid plan JSON")
+	}
+	// Should still have done event.
+	if !strings.Contains(body, "event: done") {
+		t.Error("expected done event")
+	}
+
+	// Verify assistant message does not have plan_modified.
+	msgs, err := ListChatMessages(db, planID, 1)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	for _, m := range msgs {
+		if m.Role == "assistant" && m.PlanModified {
+			t.Error("expected assistant message NOT to have plan_modified for invalid plan JSON")
+		}
+	}
+}
+
+// mustJSON marshals v to a JSON string, failing the test on error.
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return string(b)
+}

--- a/internal/stride/chat_handlers_test.go
+++ b/internal/stride/chat_handlers_test.go
@@ -530,7 +530,7 @@ func TestStrideChatSendHandler_ClaudeDisabled(t *testing.T) {
 	weekEnd := "2026-04-19"
 	planJSON := buildValidPlanJSON(weekStart)
 	now := time.Now().UTC().Format(time.RFC3339)
-	_, err = db.Exec(`INSERT INTO stride_plans (user_id, week_start, week_end, plan_json, created_at) VALUES (1, ?, ?, ?, ?)`,
+	_, err := db.Exec(`INSERT INTO stride_plans (user_id, week_start, week_end, plan_json, created_at) VALUES (1, ?, ?, ?, ?)`,
 		weekStart, weekEnd, planJSON, now)
 	if err != nil {
 		t.Fatalf("insert plan: %v", err)


### PR DESCRIPTION
## Changes

- **Stride Chat API** - Added chat handlers with SSE streaming for real-time coaching conversations on weekly plans, including plan modification detection and session resumption. (Hytte-zhuj)

## Original Issue (feature): Stride Chat: handlers with streaming, plan modification, and route wiring

## Summary

Third bead in the Stride chat chain. Implements the HTTP handlers: send message (with SSE streaming and plan modification detection), list messages, and route registration. This is the core backend logic that ties schema (bead 1) and prompt (bead 2) together.

## Handlers

All in `internal/stride/chat_handlers.go` (new file).

### `StrideChatListHandler` — GET /api/stride/plans/{planId}/chat

Returns all messages for the given plan's chat conversation. Plan must exist and belong to the authenticated user.

Response: `{"messages": [...], "plan_id": 123}`

### `StrideChatSendHandler` — POST /api/stride/plans/{planId}/chat

Accepts JSON body `{"content": "Move Thursday's tempo to Friday"}`.

Flow:
1. Validate plan exists and belongs to user.
2. Store the user message (encrypted).
3. Load context: current plan, evaluations for this plan, user training profile, races, ACR, active notes.
4. Build system prompt via `BuildChatSystemPrompt` (from bead 2).
5. Load Claude config from user preferences (`training.LoadClaudeConfig`).
6. Get or create session ID from `stride_plans.chat_session_id`.
7. Stream Claude's response via SSE (same `streamClaude` pattern as homework chat — `--output-format stream-json --verbose`, with the homework bug fix already in place).
8. After stream completes, scan the full response for a fenced JSON plan block.
9. If plan JSON found:
   a. Parse and validate via `parsePlanResponse` (existing function in generate.go).
   b. Verify it has exactly 7 days matching the plan's week_start to week_end.
   c. Update `stride_plans.plan_json` with the new plan.
   d. Set `plan_modified=1` on the assistant message.
   e. Send an SSE event `plan_updated` with the new plan JSON so the frontend can re-render day cards without a full page reload.
10. Store the assistant message (encrypted).
11. Save the session ID for future resumption.
12. Send the `done` SSE event with the full assistant message + plan_modified flag.

### SSE event stream

Same shape as homework chat:
- `event: user_message` — the saved user message (sent immediately after step 2)
- `event: delta` — streaming text chunks from Claude
- `event: plan_updated` — sent after a successful plan modification with `{"plan": [...]}`
- `event: done` — the final assistant message + metadata
- `event: error` — on failure
- `event: retry` — on session expiry, before fresh retry

### Plan modification parsing

New helper `extractPlanJSON(response string) (string, bool)`:
- Scans for a fenced code block: `\`\`\`json\n[...]\n\`\`\``
- Returns the raw JSON string and whether one was found.
- Does NOT parse — that's `parsePlanResponse`'s job. This just extracts the block.
- If multiple fenced blocks exist, use the last one (Claude sometimes shows a "before" and "after").

New helper `validatePlanUpdate(planJSON string, weekStart, weekEnd string) ([]DayPlan, error)`:
- Parses via `parsePlanResponse`.
- Verifies all 7 dates are present and within the week range.
- Verifies no duplicate dates.
- Returns the validated `[]DayPlan` or an error.

### Session resumption with retry

Same pattern as homework (`handlers.go:534-540`): if the first call with `--resume <sessionId>` fails, log a warning, send an SSE `retry` event, and retry without the session ID. This handles session expiry gracefully.

## Route registration

In `internal/api/router.go`, inside the stride feature group:

```go
r.Get("/stride/plans/{planId}/chat", stride.StrideChatListHandler(db))
r.Post("/stride/plans/{planId}/chat", stride.StrideChatSendHandler(db))
```

Nested under the existing `/stride/plans/{id}` pattern so the plan ID is in the URL and auth is already handled by the enclosing group.

## Error handling

- Plan not found → 404
- Plan belongs to different user → 404 (don't leak existence)
- Claude not enabled → 400 with clear message
- Claude CLI exits non-zero → SSE error event (include stderr in the log per the homework fix)
- Plan modification parse failure → log warning, store the message without plan_modified, do NOT send plan_updated event. The user still sees Claude's text response; they just need to ask Claude to fix the JSON. This is a soft failure, not a hard error.
- Plan modification validation failure (wrong dates, schema mismatch) → same soft failure. Log the invalid JSON for debugging.

## Tests

`internal/stride/chat_handlers_test.go`:

- `TestExtractPlanJSON_Found` — response with a fenced JSON block, verify extraction.
- `TestExtractPlanJSON_NotFound` — response without JSON block returns false.
- `TestExtractPlanJSON_MultipleFencedBlocks` — uses the last one.
- `TestExtractPlanJSON_UnfencedJSON` — does NOT extract bare JSON (must be fenced).
- `TestValidatePlanUpdate_ValidSevenDays` — correct plan passes.
- `TestValidatePlanUpdate_WrongDateRange` — dates outside week_start/week_end rejected.
- `TestValidatePlanUpdate_DuplicateDates` — rejected.
- `TestValidatePlanUpdate_NotSevenDays` — rejected.
- Handler integration tests using the `execCommand` override pattern from homework (stub Claude CLI, verify SSE events, verify plan update persisted).

## Files touched

- `internal/stride/chat_handlers.go` — new file
- `internal/stride/chat_handlers_test.go` — new file
- `internal/api/router.go` — add two routes
- `changelog.d/Hytte-<id>.md` — Added category fragment

## Acceptance criteria

- `POST /api/stride/plans/{planId}/chat` streams an SSE response with delta events.
- A response containing a valid fenced plan JSON block updates `stride_plans.plan_json` and emits a `plan_updated` SSE event.
- A response without plan JSON stores the message normally without modification.
- Invalid plan JSON in the response is logged but does not error the request — the text response is still saved and shown.
- Session resumption works (second message in same plan week uses `--resume`).
- Session expiry is handled gracefully with a retry.

---
Bead: Hytte-zhuj | Branch: forge/Hytte-zhuj
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)