### PR TITLE
Plan diff highlighting on DayCard (Hytte-nrfu)

### DIFF
--- a/changelog.d/Hytte-nrfu.md
+++ b/changelog.d/Hytte-nrfu.md
@@ -1,0 +1,2 @@
+category: Added
+- **Plan diff highlighting on DayCard** - When Claude modifies the training plan via chat, changed day cards briefly highlight with a yellow ring that fades after 3 seconds. (Hytte-nrfu)

--- a/web/src/pages/StridePage.test.tsx
+++ b/web/src/pages/StridePage.test.tsx
@@ -4,6 +4,20 @@ import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import StridePage from './StridePage'
 import enStride from '../../public/locales/en/stride.json'
+import type { DayPlan } from '../types/stride'
+
+// ── StrideChatDrawer mock ─────────────────────────────────────────────────────
+
+const chatDrawerCallbacks = vi.hoisted(() => ({
+  onPlanUpdated: null as ((plan: DayPlan[]) => void) | null,
+}))
+
+vi.mock('../components/stride/StrideChatDrawer', () => ({
+  default: ({ onPlanUpdated }: { planId: number; onPlanUpdated: (plan: DayPlan[]) => void }) => {
+    chatDrawerCallbacks.onPlanUpdated = onPlanUpdated
+    return null
+  },
+}))
 
 // ── Translation helpers ───────────────────────────────────────────────────────
 
@@ -367,5 +381,84 @@ describe('StridePage – delete race', () => {
     await waitFor(() => {
       expect(screen.queryAllByText('Bergen City Marathon')).toHaveLength(0)
     })
+  })
+})
+
+describe('StridePage – plan highlight on update', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    chatDrawerCallbacks.onPlanUpdated = null
+  })
+
+  it('highlights changed day cards and removes highlight after 3s', async () => {
+    const planDay: DayPlan = { date: '2099-01-13', rest_day: true }
+    const plan = {
+      id: 1,
+      user_id: 1,
+      week_start: '2099-01-13',
+      week_end: '2099-01-19',
+      phase: 'Base',
+      model: 'test',
+      created_at: '2099-01-13T00:00:00Z',
+      plan: [planDay],
+    }
+
+    const fetchMock = vi.fn((url: string) => {
+      const make = (data: unknown) =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response)
+      if (url.includes('/api/stride/plans/current')) return make({ plan })
+      if (url.includes('/api/stride/plans?limit=2')) return make({ plans: [plan] })
+      if (url.includes('/api/stride/plans?limit=1')) return make({ total: 1 })
+      if (url.includes('/api/stride/evaluations')) return make({ evaluations: [] })
+      if (url.includes('/api/training/workouts')) return make({ workouts: [] })
+      if (url.includes('/api/stride/races')) return make({ races: [] })
+      if (url.includes('/api/stride/notes')) return make({ notes: [] })
+      return make({})
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container } = renderPage()
+
+    // Wait for the rest-day card to render (real timers for initial load)
+    await waitFor(() => {
+      expect(screen.getByText('Rest')).toBeInTheDocument()
+    })
+
+    // No highlight ring yet
+    expect(container.querySelector('.ring-2')).toBeNull()
+
+    // Switch to fake timers now that initial load is complete
+    vi.useFakeTimers()
+
+    // Trigger plan update with a changed day
+    const changedDay: DayPlan = {
+      date: '2099-01-13',
+      rest_day: false,
+      session: {
+        description: 'Easy run',
+        warmup: '',
+        main_set: '30 min easy',
+        cooldown: '',
+        strides: '',
+        target_hr_cap: 150,
+      },
+    }
+
+    await act(async () => {
+      chatDrawerCallbacks.onPlanUpdated!([changedDay])
+    })
+
+    // Ring should now be present on the changed card
+    expect(container.querySelector('.ring-2')).not.toBeNull()
+
+    // Advance time past the 3-second timeout
+    await act(async () => {
+      vi.advanceTimersByTime(3001)
+    })
+
+    // Ring should be cleared
+    expect(container.querySelector('.ring-2')).toBeNull()
   })
 })

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -117,7 +117,7 @@ function flagIsSevere(flag: string): boolean {
   return flag === 'overtraining' || flag === 'injury_risk'
 }
 
-function DayCard({ day, completed, evaluation }: { day: DayPlan; completed: boolean; evaluation?: StrideEvaluationRecord }) {
+function DayCard({ day, completed, evaluation, isHighlighted }: { day: DayPlan; completed: boolean; evaluation?: StrideEvaluationRecord; isHighlighted?: boolean }) {
   const { t } = useTranslation('stride')
   const [expanded, setExpanded] = useState(false)
 
@@ -129,7 +129,7 @@ function DayCard({ day, completed, evaluation }: { day: DayPlan; completed: bool
   const hasExpandableContent = (!day.rest_day && !!day.session) || (!!evaluation && (day.rest_day || !day.session))
 
   return (
-    <div className="bg-gray-800 rounded-xl border border-gray-700 overflow-hidden">
+    <div className={`bg-gray-800 rounded-xl border border-gray-700 overflow-hidden transition-all duration-1000 ${isHighlighted ? 'ring-2 ring-yellow-400/50' : ''}`}>
       <button
         type="button"
         onClick={() => hasExpandableContent && setExpanded(v => !v)}
@@ -461,6 +461,7 @@ export default function StridePage() {
   const [notes, setNotes] = useState<Note[]>([])
   const [consumedNotes, setConsumedNotes] = useState<Note[]>([])
   const [currentPlan, setCurrentPlan] = useState<Plan | null>(null)
+  const [changedDates, setChangedDates] = useState<Set<string>>(new Set())
   const [previousPlanId, setPreviousPlanId] = useState<number | null>(null)
   const [hasAnyPlan, setHasAnyPlan] = useState(false)
   const [completedDates, setCompletedDates] = useState<Set<string>>(new Set())
@@ -941,6 +942,7 @@ export default function StridePage() {
                   day={day}
                   completed={completedDates.has(day.date)}
                   evaluation={dayEvaluationMap.get(day.date)}
+                  isHighlighted={changedDates.has(day.date)}
                 />
               ))}
             </div>
@@ -949,7 +951,21 @@ export default function StridePage() {
             <StrideChatDrawer
               planId={currentPlan.id}
               onPlanUpdated={(newPlan) => {
-                setCurrentPlan(prev => prev ? { ...prev, plan: newPlan } : prev)
+                setCurrentPlan(prev => {
+                  if (!prev) return prev
+                  const oldMap = new Map(prev.plan.map(d => [d.date, JSON.stringify(d)]))
+                  const changed = new Set<string>()
+                  for (const day of newPlan) {
+                    if (oldMap.get(day.date) !== JSON.stringify(day)) {
+                      changed.add(day.date)
+                    }
+                  }
+                  if (changed.size > 0) {
+                    setChangedDates(changed)
+                    setTimeout(() => setChangedDates(new Set()), 3000)
+                  }
+                  return { ...prev, plan: newPlan }
+                })
               }}
             />
           </div>

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Trash2, Plus, Trophy, Zap, ChevronDown, ChevronUp, RefreshCw, CheckCircle2, Circle, AlertTriangle, XCircle, History } from 'lucide-react'
 import { formatDate, formatDateTime } from '../utils/formatDate'
@@ -462,6 +462,7 @@ export default function StridePage() {
   const [consumedNotes, setConsumedNotes] = useState<Note[]>([])
   const [currentPlan, setCurrentPlan] = useState<Plan | null>(null)
   const [changedDates, setChangedDates] = useState<Set<string>>(new Set())
+  const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [previousPlanId, setPreviousPlanId] = useState<number | null>(null)
   const [hasAnyPlan, setHasAnyPlan] = useState(false)
   const [completedDates, setCompletedDates] = useState<Set<string>>(new Set())
@@ -635,6 +636,12 @@ export default function StridePage() {
       return []
     }
   }
+
+  useEffect(() => {
+    return () => {
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current)
+    }
+  }, [])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -962,7 +969,8 @@ export default function StridePage() {
                   }
                   if (changed.size > 0) {
                     setChangedDates(changed)
-                    setTimeout(() => setChangedDates(new Set()), 3000)
+                    if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current)
+                    highlightTimerRef.current = setTimeout(() => setChangedDates(new Set()), 3000)
                   }
                   return { ...prev, plan: newPlan }
                 })

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -117,7 +117,7 @@ function flagIsSevere(flag: string): boolean {
   return flag === 'overtraining' || flag === 'injury_risk'
 }
 
-function DayCard({ day, completed, evaluation, isHighlighted }: { day: DayPlan; completed: boolean; evaluation?: StrideEvaluationRecord; isHighlighted?: boolean }) {
+function DayCard({ day, completed, evaluation, changedDates }: { day: DayPlan; completed: boolean; evaluation?: StrideEvaluationRecord; changedDates?: Set<string> }) {
   const { t } = useTranslation('stride')
   const [expanded, setExpanded] = useState(false)
 
@@ -127,6 +127,7 @@ function DayCard({ day, completed, evaluation, isHighlighted }: { day: DayPlan; 
 
   const complianceLabel = evaluation ? t(`evaluation.${evaluation.eval.compliance}`) : null
   const hasExpandableContent = (!day.rest_day && !!day.session) || (!!evaluation && (day.rest_day || !day.session))
+  const isHighlighted = changedDates?.has(day.date) ?? false
 
   return (
     <div className={`bg-gray-800 rounded-xl border border-gray-700 overflow-hidden transition-all duration-1000 ${isHighlighted ? 'ring-2 ring-yellow-400/50' : ''}`}>
@@ -949,7 +950,7 @@ export default function StridePage() {
                   day={day}
                   completed={completedDates.has(day.date)}
                   evaluation={dayEvaluationMap.get(day.date)}
-                  isHighlighted={changedDates.has(day.date)}
+                  changedDates={changedDates}
                 />
               ))}
             </div>
@@ -958,9 +959,8 @@ export default function StridePage() {
             <StrideChatDrawer
               planId={currentPlan.id}
               onPlanUpdated={(newPlan) => {
-                setCurrentPlan(prev => {
-                  if (!prev) return prev
-                  const oldMap = new Map(prev.plan.map(d => [d.date, JSON.stringify(d)]))
+                if (currentPlan) {
+                  const oldMap = new Map(currentPlan.plan.map(d => [d.date, JSON.stringify(d)]))
                   const changed = new Set<string>()
                   for (const day of newPlan) {
                     if (oldMap.get(day.date) !== JSON.stringify(day)) {
@@ -972,8 +972,8 @@ export default function StridePage() {
                     if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current)
                     highlightTimerRef.current = setTimeout(() => setChangedDates(new Set()), 3000)
                   }
-                  return { ...prev, plan: newPlan }
-                })
+                }
+                setCurrentPlan(prev => prev ? { ...prev, plan: newPlan } : prev)
               }}
             />
           </div>


### PR DESCRIPTION
## Changes

- **Plan diff highlighting on DayCard** - When Claude modifies the training plan via chat, changed day cards briefly highlight with a yellow ring that fades after 3 seconds. (Hytte-nrfu)

## Original Issue (task): Plan diff highlighting on DayCard

Implement visual highlighting when Claude modifies the plan via chat.

Files to modify:
- `web/src/pages/StridePage.tsx` — Add `previousPlan` state. In the `onPlanUpdated` callback, before updating `currentPlan`, snapshot the old plan into `previousPlan`. Compute `changedDates: Set<string>` by comparing `JSON.stringify(oldDay)` vs `JSON.stringify(newDay)` per date. Pass `changedDates` as a prop to DayCard. Set a 3-second timeout to clear the set.
- `web/src/pages/StridePage.tsx` (DayCard component) — Accept `changedDates?: Set<string>` prop. When the card's date is in the set, apply `ring-2 ring-yellow-400/50 transition-all duration-1000` classes. When cleared, the transition fades the ring out naturally.

Approach: Pure frontend state diffing using shallow JSON.stringify comparison. No backend changes. This sub-task is independent of the others but the DayCard prop interface should be stable before the mobile polish sub-task tests it.

---
Bead: Hytte-nrfu | Branch: forge/Hytte-nrfu
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)