### PR TITLE
Backend: storage functions for parent-recorded completions (Hytte-tsfg)

### DIFF
--- a/internal/allowance/storage.go
+++ b/internal/allowance/storage.go
@@ -26,6 +26,8 @@ var (
 	ErrAlreadyJoined        = errors.New("child has already joined this team session")
 	ErrSessionNotWaiting    = errors.New("team session is not in waiting_for_team status")
 	ErrNotSessionInitiator  = errors.New("only the child who started the team session can cancel it")
+	ErrTeamTooSmall         = errors.New("not enough children for team completion")
+	ErrTeamSessionConflict  = errors.New("an active team session already exists for this chore and date")
 )
 
 // decryptOrPlaintext decrypts a stored field value. For enc:-prefixed values
@@ -1732,4 +1734,135 @@ func GetAllFamilyLinksWithAllowance(db *sql.DB) ([]struct{ ParentID, ChildID int
 		links = append(links, l)
 	}
 	return links, rows.Err()
+}
+
+// RecordSoloCompletionByParent inserts a completion row on behalf of a parent.
+// When status is "approved", approved_by and approved_at are set immediately.
+// Notes are encrypted at rest. Returns ErrCompletionExists on UNIQUE violation.
+func RecordSoloCompletionByParent(db *sql.DB, choreID, childID, parentID int64, date, notes, status string) (*Completion, error) {
+	encNotes, err := encryption.EncryptField(notes)
+	if err != nil {
+		return nil, err
+	}
+	now := nowRFC3339()
+
+	var approvedBy *int64
+	var approvedAt *string
+	if status == "approved" {
+		approvedBy = &parentID
+		approvedAt = &now
+	}
+
+	res, err := db.Exec(`
+		INSERT INTO allowance_completions (chore_id, child_id, date, status, approved_by, approved_at, notes, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, choreID, childID, date, status, approvedBy, approvedAt, encNotes, now)
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			return nil, ErrCompletionExists
+		}
+		return nil, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+	return &Completion{
+		ID:         id,
+		ChoreID:    choreID,
+		ChildID:    childID,
+		Date:       date,
+		Status:     status,
+		ApprovedBy: approvedBy,
+		ApprovedAt: approvedAt,
+		Notes:      notes,
+		CreatedAt:  now,
+	}, nil
+}
+
+// RecordTeamCompletionByParent inserts a team completion on behalf of a parent.
+// It creates a single allowance_completions row (child_id = first in childIDs)
+// and inserts all childIDs into allowance_team_completions within a transaction.
+// Rejects if fewer than min_team_size children are provided or if an active team
+// session already exists for the chore+date.
+func RecordTeamCompletionByParent(db *sql.DB, choreID, parentID int64, childIDs []int64, date, notes, status string) (*Completion, error) {
+	chore, err := GetChoreByID(db, choreID, parentID)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(childIDs)) < chore.MinTeamSize {
+		return nil, ErrTeamTooSmall
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var existingID int64
+	err = tx.QueryRow(`
+		SELECT id FROM allowance_completions
+		WHERE chore_id = ? AND date = ? AND status IN ('waiting_for_team', 'pending', 'approved')
+		LIMIT 1
+	`, choreID, date).Scan(&existingID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+	if err == nil {
+		return nil, ErrTeamSessionConflict
+	}
+
+	encNotes, err := encryption.EncryptField(notes)
+	if err != nil {
+		return nil, err
+	}
+	now := nowRFC3339()
+
+	var approvedBy *int64
+	var approvedAt *string
+	if status == "approved" {
+		approvedBy = &parentID
+		approvedAt = &now
+	}
+
+	res, err := tx.Exec(`
+		INSERT INTO allowance_completions (chore_id, child_id, date, status, approved_by, approved_at, notes, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, choreID, childIDs[0], date, status, approvedBy, approvedAt, encNotes, now)
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			return nil, ErrCompletionExists
+		}
+		return nil, err
+	}
+	completionID, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cid := range childIDs {
+		if _, err := tx.Exec(`
+			INSERT INTO allowance_team_completions (completion_id, child_id, joined_at)
+			VALUES (?, ?, ?)
+		`, completionID, cid, now); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &Completion{
+		ID:         completionID,
+		ChoreID:    choreID,
+		ChildID:    childIDs[0],
+		Date:       date,
+		Status:     status,
+		ApprovedBy: approvedBy,
+		ApprovedAt: approvedAt,
+		Notes:      notes,
+		CreatedAt:  now,
+	}, nil
 }

--- a/internal/allowance/storage.go
+++ b/internal/allowance/storage.go
@@ -27,7 +27,7 @@ var (
 	ErrSessionNotWaiting    = errors.New("team session is not in waiting_for_team status")
 	ErrNotSessionInitiator  = errors.New("only the child who started the team session can cancel it")
 	ErrTeamTooSmall         = errors.New("not enough children for team completion")
-	ErrTeamSessionConflict  = errors.New("an active team session already exists for this chore and date")
+	ErrTeamSessionConflict  = errors.New("a conflicting team completion already exists for this chore and date")
 )
 
 // decryptOrPlaintext decrypts a stored field value. For enc:-prefixed values
@@ -1740,6 +1740,17 @@ func GetAllFamilyLinksWithAllowance(db *sql.DB) ([]struct{ ParentID, ChildID int
 // When status is "approved", approved_by and approved_at are set immediately.
 // Notes are encrypted at rest. Returns ErrCompletionExists on UNIQUE violation.
 func RecordSoloCompletionByParent(db *sql.DB, choreID, childID, parentID int64, date, notes, status string) (*Completion, error) {
+	chore, err := GetChoreByID(db, choreID, parentID)
+	if err != nil {
+		return nil, err
+	}
+	if !chore.Active {
+		return nil, fmt.Errorf("chore is inactive")
+	}
+	if chore.CompletionMode != "solo" {
+		return nil, fmt.Errorf("chore is not configured for solo completion")
+	}
+
 	encNotes, err := encryption.EncryptField(notes)
 	if err != nil {
 		return nil, err
@@ -1786,9 +1797,19 @@ func RecordSoloCompletionByParent(db *sql.DB, choreID, childID, parentID int64, 
 // Rejects if fewer than min_team_size children are provided or if an active team
 // session already exists for the chore+date.
 func RecordTeamCompletionByParent(db *sql.DB, choreID, parentID int64, childIDs []int64, date, notes, status string) (*Completion, error) {
+	if len(childIDs) == 0 {
+		return nil, ErrTeamTooSmall
+	}
+
 	chore, err := GetChoreByID(db, choreID, parentID)
 	if err != nil {
 		return nil, err
+	}
+	if !chore.Active {
+		return nil, fmt.Errorf("chore is inactive")
+	}
+	if chore.CompletionMode != "team" {
+		return nil, fmt.Errorf("chore is not configured for team completion")
 	}
 	if int64(len(childIDs)) < chore.MinTeamSize {
 		return nil, ErrTeamTooSmall

--- a/internal/allowance/storage_test.go
+++ b/internal/allowance/storage_test.go
@@ -316,6 +316,25 @@ func TestRecordTeamCompletionByParent_BelowMinTeamSize(t *testing.T) {
 	}
 }
 
+func TestRecordTeamCompletionByParent_EmptyChildIDsReturnsErrTeamTooSmall(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	childID := int64(2)
+	choreID := insertTeamChore(t, db, 1, &childID, 20, 2, 10) // min_team_size=2
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RecordTeamCompletionByParent panicked for empty childIDs: %v", r)
+		}
+	}()
+
+	_, err := RecordTeamCompletionByParent(db, choreID, 1, []int64{}, "2026-04-15", "", "approved")
+	if err != ErrTeamTooSmall {
+		t.Fatalf("expected ErrTeamTooSmall for empty childIDs, got %v", err)
+	}
+}
+
 func TestRecordTeamCompletionByParent_ExistingActiveSessionConflicts(t *testing.T) {
 	db := setupTestDB(t)
 	linkParentChild(t, db)

--- a/internal/allowance/storage_test.go
+++ b/internal/allowance/storage_test.go
@@ -197,6 +197,152 @@ func TestGetChildChoresWithStatus_TeamParticipantSeesCompletion(t *testing.T) {
 	}
 }
 
+// ---- RecordSoloCompletionByParent tests ----
+
+func TestRecordSoloCompletionByParent_Approved(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+	choreID := insertSoloChore(t, db, 1)
+
+	comp, err := RecordSoloCompletionByParent(db, choreID, 2, 1, "2026-04-15", "great job", "approved")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if comp.Status != "approved" {
+		t.Errorf("status: got %q, want %q", comp.Status, "approved")
+	}
+	if comp.ApprovedBy == nil || *comp.ApprovedBy != 1 {
+		t.Errorf("approved_by: got %v, want 1", comp.ApprovedBy)
+	}
+	if comp.ApprovedAt == nil || *comp.ApprovedAt == "" {
+		t.Error("approved_at should be set")
+	}
+	if comp.Notes != "great job" {
+		t.Errorf("notes: got %q, want %q", comp.Notes, "great job")
+	}
+
+	// Verify the notes are encrypted in the DB.
+	var encNotes string
+	if err := db.QueryRow(`SELECT notes FROM allowance_completions WHERE id = ?`, comp.ID).Scan(&encNotes); err != nil {
+		t.Fatalf("query notes: %v", err)
+	}
+	if encNotes == "great job" {
+		t.Error("notes should be encrypted in the database")
+	}
+}
+
+func TestRecordSoloCompletionByParent_Pending(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+	choreID := insertSoloChore(t, db, 1)
+
+	comp, err := RecordSoloCompletionByParent(db, choreID, 2, 1, "2026-04-15", "", "pending")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if comp.Status != "pending" {
+		t.Errorf("status: got %q, want %q", comp.Status, "pending")
+	}
+	if comp.ApprovedBy != nil {
+		t.Errorf("approved_by should be nil for pending, got %v", *comp.ApprovedBy)
+	}
+	if comp.ApprovedAt != nil {
+		t.Errorf("approved_at should be nil for pending, got %v", *comp.ApprovedAt)
+	}
+}
+
+func TestRecordSoloCompletionByParent_DuplicateReturnsExists(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+	choreID := insertSoloChore(t, db, 1)
+
+	if _, err := RecordSoloCompletionByParent(db, choreID, 2, 1, "2026-04-15", "", "approved"); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	_, err := RecordSoloCompletionByParent(db, choreID, 2, 1, "2026-04-15", "", "approved")
+	if err != ErrCompletionExists {
+		t.Fatalf("expected ErrCompletionExists, got %v", err)
+	}
+}
+
+// ---- RecordTeamCompletionByParent tests ----
+
+func TestRecordTeamCompletionByParent_Success(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	// Add a second child.
+	if _, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (3, 'child2@test.com', 'Child2', 'gc3')`); err != nil {
+		t.Fatalf("insert child2: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO family_links (parent_id, child_id, created_at) VALUES (1, 3, '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("link child2: %v", err)
+	}
+
+	childID := int64(2)
+	choreID := insertTeamChore(t, db, 1, &childID, 20, 2, 10)
+
+	comp, err := RecordTeamCompletionByParent(db, choreID, 1, []int64{2, 3}, "2026-04-15", "team effort", "approved")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if comp.ChildID != 2 {
+		t.Errorf("child_id: got %d, want 2", comp.ChildID)
+	}
+	if comp.Status != "approved" {
+		t.Errorf("status: got %q, want %q", comp.Status, "approved")
+	}
+
+	// Verify team_completions rows.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM allowance_team_completions WHERE completion_id = ?`, comp.ID).Scan(&count); err != nil {
+		t.Fatalf("count team completions: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("team_completions count: got %d, want 2", count)
+	}
+}
+
+func TestRecordTeamCompletionByParent_BelowMinTeamSize(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	childID := int64(2)
+	choreID := insertTeamChore(t, db, 1, &childID, 20, 3, 10) // min_team_size=3
+
+	_, err := RecordTeamCompletionByParent(db, choreID, 1, []int64{2}, "2026-04-15", "", "approved")
+	if err != ErrTeamTooSmall {
+		t.Fatalf("expected ErrTeamTooSmall, got %v", err)
+	}
+}
+
+func TestRecordTeamCompletionByParent_ExistingActiveSessionConflicts(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	// Add a second child.
+	if _, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (3, 'child2@test.com', 'Child2', 'gc3')`); err != nil {
+		t.Fatalf("insert child2: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO family_links (parent_id, child_id, created_at) VALUES (1, 3, '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("link child2: %v", err)
+	}
+
+	childID := int64(2)
+	choreID := insertTeamChore(t, db, 1, &childID, 20, 2, 10)
+
+	// First: create an active session via StartTeamCompletion.
+	if _, err := StartTeamCompletion(db, 1, choreID, 2, "2026-04-15"); err != nil {
+		t.Fatalf("start team session: %v", err)
+	}
+
+	// Second: attempt parent-recorded team completion for the same chore+date.
+	_, err := RecordTeamCompletionByParent(db, choreID, 1, []int64{2, 3}, "2026-04-15", "", "approved")
+	if err != ErrTeamSessionConflict {
+		t.Fatalf("expected ErrTeamSessionConflict, got %v", err)
+	}
+}
+
 // TestGetPendingCompletions_TeamNamesEnriched verifies that GetPendingCompletions
 // populates TeamMemberNames for team completions end-to-end.
 func TestGetPendingCompletions_TeamNamesEnriched(t *testing.T) {


### PR DESCRIPTION
## Changes

Well-structured storage functions with proper encryption, transaction handling, and sentinel errors. Tests cover key paths. One minor suggestion.

## Original Issue (task): Backend: storage functions for parent-recorded completions

Add two new functions to `internal/allowance/storage.go`:

1. `RecordSoloCompletionByParent(db, choreID, childID, parentID int64, date, notes, status string) (*Completion, error)` — Inserts one row into `allowance_completions` with the given status. When status='approved', sets `approved_by=parentID` and `approved_at=now`. Notes go through `encryption.EncryptField`. Returns `ErrCompletionExists` on UNIQUE violation (chore+child+date).

2. `RecordTeamCompletionByParent(db, choreID, parentID int64, childIDs []int64, date, notes, status string) (*Completion, error)` — In a single transaction: inserts one `allowance_completions` row (child_id = first in list), then inserts all childIDs into `allowance_team_completions`. Rejects if an active team session already exists for chore+date. Enforces min team size check.

Add corresponding tests in `internal/allowance/storage_test.go`: TestRecordSoloCompletionByParent_Approved, _Pending, _DuplicateReturnsExists, TestRecordTeamCompletionByParent_Success, _BelowMinTeamSize, _ExistingActiveSessionConflicts.

This sub-task has no dependencies. The handler sub-task depends on these functions.

---
Bead: Hytte-tsfg | Branch: forge/Hytte-tsfg
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)