### PR TITLE
Backend: handler, route wiring, and handler tests (Hytte-i1m4)

### DIFF
--- a/changelog.d/Hytte-i1m4.md
+++ b/changelog.d/Hytte-i1m4.md
@@ -1,0 +1,2 @@
+category: Added
+- **Parent-recorded chore completions** - Parents can now record chore completions on behalf of their children via POST /api/allowance/chores/{id}/record, supporting both solo and team chores with duplicate detection. (Hytte-i1m4)

--- a/internal/allowance/handlers.go
+++ b/internal/allowance/handlers.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1744,5 +1745,134 @@ func UpdateMyGoalHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, http.StatusOK, goal)
+	}
+}
+
+func RecordCompletionHandler(db *sql.DB) http.HandlerFunc {
+	type request struct {
+		ChildIDs []int64 `json:"child_ids"`
+		Date     string  `json:"date"`
+		Notes    string  `json:"notes"`
+		Status   string  `json:"status"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			writeJSON(w, http.StatusUnauthorized, errResponse("not authenticated"))
+			return
+		}
+		if !requireParent(db, w, user) {
+			return
+		}
+
+		choreID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errResponse("invalid chore id"))
+			return
+		}
+
+		var req request
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, errResponse("invalid JSON body"))
+			return
+		}
+
+		if len(req.ChildIDs) == 0 {
+			writeJSON(w, http.StatusBadRequest, errResponse("child_ids is required"))
+			return
+		}
+
+		if req.Date == "" {
+			req.Date = time.Now().Format("2006-01-02")
+		}
+		if req.Status == "" {
+			req.Status = "approved"
+		}
+		if req.Status != "approved" && req.Status != "pending" {
+			writeJSON(w, http.StatusBadRequest, errResponse("status must be 'approved' or 'pending'"))
+			return
+		}
+
+		chore, err := GetChoreByID(db, choreID, user.ID)
+		if err != nil {
+			if errors.Is(err, ErrChoreNotFound) {
+				writeJSON(w, http.StatusNotFound, errResponse("chore not found"))
+				return
+			}
+			log.Printf("allowance: record completion get chore %d: %v", choreID, err)
+			writeJSON(w, http.StatusInternalServerError, errResponse("failed to get chore"))
+			return
+		}
+		if !chore.Active {
+			writeJSON(w, http.StatusBadRequest, errResponse("chore is not active"))
+			return
+		}
+
+		slices.Sort(req.ChildIDs)
+		req.ChildIDs = slices.Compact(req.ChildIDs)
+
+		for _, cid := range req.ChildIDs {
+			if !verifyParentChildLink(db, w, user.ID, cid) {
+				return
+			}
+		}
+
+		if chore.ChildID != nil {
+			for _, cid := range req.ChildIDs {
+				if cid != *chore.ChildID {
+					writeJSON(w, http.StatusBadRequest, errResponse(fmt.Sprintf("child %d is not assigned to this chore", cid)))
+					return
+				}
+			}
+		}
+
+		type completionResult struct {
+			Completion
+			TeamMembers []int64 `json:"team_members,omitempty"`
+		}
+
+		var completions []completionResult
+		var skipped []int64
+
+		if chore.CompletionMode == "team" {
+			comp, err := RecordTeamCompletionByParent(db, choreID, user.ID, req.ChildIDs, req.Date, req.Notes, req.Status)
+			if err != nil {
+				if errors.Is(err, ErrCompletionExists) || errors.Is(err, ErrTeamSessionConflict) {
+					writeJSON(w, http.StatusConflict, errResponse("completion already exists for this chore and date"))
+					return
+				}
+				if errors.Is(err, ErrTeamTooSmall) {
+					writeJSON(w, http.StatusBadRequest, errResponse(fmt.Sprintf("team chore requires at least %d children", chore.MinTeamSize)))
+					return
+				}
+				log.Printf("allowance: record team completion chore %d: %v", choreID, err)
+				writeJSON(w, http.StatusInternalServerError, errResponse("failed to record completion"))
+				return
+			}
+			completions = append(completions, completionResult{
+				Completion:  *comp,
+				TeamMembers: req.ChildIDs,
+			})
+		} else {
+			for _, cid := range req.ChildIDs {
+				comp, err := RecordSoloCompletionByParent(db, choreID, cid, user.ID, req.Date, req.Notes, req.Status)
+				if err != nil {
+					if errors.Is(err, ErrCompletionExists) {
+						skipped = append(skipped, cid)
+						continue
+					}
+					log.Printf("allowance: record solo completion chore %d child %d: %v", choreID, cid, err)
+					writeJSON(w, http.StatusInternalServerError, errResponse("failed to record completion"))
+					return
+				}
+				completions = append(completions, completionResult{Completion: *comp})
+			}
+		}
+
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"completions": completions,
+			"skipped":     skipped,
+		})
 	}
 }

--- a/internal/allowance/handlers.go
+++ b/internal/allowance/handlers.go
@@ -1768,13 +1768,18 @@ func RecordCompletionHandler(db *sql.DB) http.HandlerFunc {
 
 		choreID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, errResponse("invalid chore id"))
+			writeJSON(w, http.StatusBadRequest, errResponse("invalid chore ID"))
 			return
 		}
 
-		r.Body = http.MaxBytesReader(w, r.Body, 1<<10)
+		r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
 		var req request
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				writeJSON(w, http.StatusRequestEntityTooLarge, errResponse("request body too large"))
+				return
+			}
 			writeJSON(w, http.StatusBadRequest, errResponse("invalid JSON body"))
 			return
 		}
@@ -1824,10 +1829,22 @@ func RecordCompletionHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		if chore.ChildID != nil {
-			for _, cid := range req.ChildIDs {
-				if cid != *chore.ChildID {
-					writeJSON(w, http.StatusBadRequest, errResponse(fmt.Sprintf("child %d is not assigned to this chore", cid)))
+			if chore.CompletionMode == "team" {
+				assignedIdx := slices.Index(req.ChildIDs, *chore.ChildID)
+				if assignedIdx == -1 {
+					writeJSON(w, http.StatusBadRequest, errResponse(fmt.Sprintf("child %d must be included for this chore", *chore.ChildID)))
 					return
+				}
+				if assignedIdx > 0 {
+					assignedChildID := req.ChildIDs[assignedIdx]
+					req.ChildIDs = append([]int64{assignedChildID}, append(req.ChildIDs[:assignedIdx], req.ChildIDs[assignedIdx+1:]...)...)
+				}
+			} else {
+				for _, cid := range req.ChildIDs {
+					if cid != *chore.ChildID {
+						writeJSON(w, http.StatusBadRequest, errResponse(fmt.Sprintf("child %d is not assigned to this chore", cid)))
+						return
+					}
 				}
 			}
 		}

--- a/internal/allowance/handlers.go
+++ b/internal/allowance/handlers.go
@@ -1772,6 +1772,7 @@ func RecordCompletionHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<10)
 		var req request
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeJSON(w, http.StatusBadRequest, errResponse("invalid JSON body"))
@@ -1784,7 +1785,11 @@ func RecordCompletionHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		if req.Date == "" {
-			req.Date = time.Now().Format("2006-01-02")
+			req.Date = time.Now().UTC().Format("2006-01-02")
+		}
+		if _, err := time.Parse("2006-01-02", req.Date); err != nil {
+			writeJSON(w, http.StatusBadRequest, errResponse("date must be in YYYY-MM-DD format"))
+			return
 		}
 		if req.Status == "" {
 			req.Status = "approved"
@@ -1832,8 +1837,8 @@ func RecordCompletionHandler(db *sql.DB) http.HandlerFunc {
 			TeamMembers []int64 `json:"team_members,omitempty"`
 		}
 
-		var completions []completionResult
-		var skipped []int64
+		completions := []completionResult{}
+		skipped := []int64{}
 
 		if chore.CompletionMode == "team" {
 			comp, err := RecordTeamCompletionByParent(db, choreID, user.ID, req.ChildIDs, req.Date, req.Notes, req.Status)

--- a/internal/allowance/handlers_test.go
+++ b/internal/allowance/handlers_test.go
@@ -2381,3 +2381,175 @@ func TestMySiblingsHandler_NoSiblings(t *testing.T) {
 	}
 }
 
+// ---- RecordCompletionHandler tests ----
+
+func TestRecordCompletionHandler_ChildNotInFamily(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	chore, err := CreateChore(db, 1, nil, "Dishes", "", 10, "daily", "🍽", true, "solo", 2, 10.0)
+	if err != nil {
+		t.Fatalf("CreateChore: %v", err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (99, 'stranger@test.com', 'Stranger', 'gs99')`); err != nil {
+		t.Fatalf("seed stranger: %v", err)
+	}
+
+	handler := RecordCompletionHandler(db)
+	body := map[string]any{"child_ids": []int64{99}, "date": "2026-04-15"}
+	r := withChiParam(withUser(newRequest(http.MethodPost, "/api/allowance/chores/"+strconv.FormatInt(chore.ID, 10)+"/record", body), testParent), "id", strconv.FormatInt(chore.ID, 10))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRecordCompletionHandler_SoloWithSkippedDuplicates(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	chore, err := CreateChore(db, 1, nil, "Dishes", "", 10, "daily", "🍽", true, "solo", 2, 10.0)
+	if err != nil {
+		t.Fatalf("CreateChore: %v", err)
+	}
+
+	handler := RecordCompletionHandler(db)
+	id := strconv.FormatInt(chore.ID, 10)
+
+	body := map[string]any{"child_ids": []int64{2}, "date": "2026-04-15"}
+	r := withChiParam(withUser(newRequest(http.MethodPost, "/api/allowance/chores/"+id+"/record", body), testParent), "id", id)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("first call: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Completions []json.RawMessage `json:"completions"`
+		Skipped     []int64           `json:"skipped"`
+	}
+	decode(t, w.Body.Bytes(), &resp)
+	if len(resp.Completions) != 1 {
+		t.Errorf("expected 1 completion, got %d", len(resp.Completions))
+	}
+
+	r = withChiParam(withUser(newRequest(http.MethodPost, "/api/allowance/chores/"+id+"/record", body), testParent), "id", id)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("second call: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	decode(t, w.Body.Bytes(), &resp)
+	if len(resp.Completions) != 0 {
+		t.Errorf("expected 0 completions on duplicate, got %d", len(resp.Completions))
+	}
+	if len(resp.Skipped) != 1 || resp.Skipped[0] != 2 {
+		t.Errorf("expected skipped=[2], got %v", resp.Skipped)
+	}
+}
+
+func TestRecordCompletionHandler_TeamAutoDispatches(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	if _, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (3, 'child2@test.com', 'Child2', 'gc3')`); err != nil {
+		t.Fatalf("seed child2: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO family_links (parent_id, child_id, created_at) VALUES (1, 3, '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("link child2: %v", err)
+	}
+
+	chore, err := CreateChore(db, 1, nil, "Team clean", "", 30, "daily", "🧹", true, "team", 2, 10.0)
+	if err != nil {
+		t.Fatalf("CreateChore: %v", err)
+	}
+
+	handler := RecordCompletionHandler(db)
+	id := strconv.FormatInt(chore.ID, 10)
+	body := map[string]any{"child_ids": []int64{2, 3}, "date": "2026-04-15", "status": "approved"}
+	r := withChiParam(withUser(newRequest(http.MethodPost, "/api/allowance/chores/"+id+"/record", body), testParent), "id", id)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Completions []struct {
+			ID          int64   `json:"id"`
+			Status      string  `json:"status"`
+			TeamMembers []int64 `json:"team_members"`
+		} `json:"completions"`
+		Skipped []int64 `json:"skipped"`
+	}
+	decode(t, w.Body.Bytes(), &resp)
+	if len(resp.Completions) != 1 {
+		t.Fatalf("expected 1 team completion, got %d", len(resp.Completions))
+	}
+	if resp.Completions[0].Status != "approved" {
+		t.Errorf("expected status approved, got %q", resp.Completions[0].Status)
+	}
+	if len(resp.Completions[0].TeamMembers) != 2 {
+		t.Errorf("expected 2 team members, got %d", len(resp.Completions[0].TeamMembers))
+	}
+}
+
+func TestRecordCompletionHandler_NotParent(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	chore, err := CreateChore(db, 1, nil, "Dishes", "", 10, "daily", "🍽", true, "solo", 2, 10.0)
+	if err != nil {
+		t.Fatalf("CreateChore: %v", err)
+	}
+
+	handler := RecordCompletionHandler(db)
+	id := strconv.FormatInt(chore.ID, 10)
+	body := map[string]any{"child_ids": []int64{2}, "date": "2026-04-15"}
+	r := withChiParam(withUser(newRequest(http.MethodPost, "/api/allowance/chores/"+id+"/record", body), testChild), "id", id)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRecordCompletionHandler_ChoreOwnedByDifferentParent(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	if _, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (10, 'parent2@test.com', 'Parent2', 'gp10')`); err != nil {
+		t.Fatalf("seed parent2: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (11, 'child11@test.com', 'Child11', 'gc11')`); err != nil {
+		t.Fatalf("seed child11: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO family_links (parent_id, child_id, created_at) VALUES (10, 11, '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("link parent2-child11: %v", err)
+	}
+
+	chore, err := CreateChore(db, 10, nil, "Other chore", "", 15, "daily", "🧹", true, "solo", 2, 10.0)
+	if err != nil {
+		t.Fatalf("CreateChore: %v", err)
+	}
+
+	handler := RecordCompletionHandler(db)
+	id := strconv.FormatInt(chore.ID, 10)
+	body := map[string]any{"child_ids": []int64{2}, "date": "2026-04-15"}
+	r := withChiParam(withUser(newRequest(http.MethodPost, "/api/allowance/chores/"+id+"/record", body), testParent), "id", id)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -566,6 +566,8 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/allowance/approve/{id}", allowance.ApproveCompletionHandler(db))
 				r.Post("/allowance/reject/{id}", allowance.RejectCompletionHandler(db))
 				r.Post("/allowance/quality-bonus/{id}", allowance.QualityBonusHandler(db))
+				// Parent: record completions on behalf of children.
+				r.Post("/allowance/chores/{id}/record", allowance.RecordCompletionHandler(db))
 				// Parent: extra tasks.
 				r.Get("/allowance/extras", allowance.ListExtrasHandler(db))
 				r.Post("/allowance/extras", allowance.CreateExtraHandler(db))


### PR DESCRIPTION
## Changes

- **Parent-recorded chore completions** - Parents can now record chore completions on behalf of their children via POST /api/allowance/chores/{id}/record, supporting both solo and team chores with duplicate detection. (Hytte-i1m4)

## Original Issue (task): Backend: handler, route wiring, and handler tests

Add `RecordCompletionHandler` in `internal/allowance/handlers.go` (parent-gated via `requireParent`):

- Parse JSON body: `child_ids []int64`, `date string` (optional, default today), `notes string` (optional), `status string` (optional, default 'approved', accepts 'approved'|'pending').
- Validate: chore exists and belongs to parent (`GetChoreByID(db, choreID, parentID)`), chore is active, all child_ids are linked to parent via family_links (deduplicate first), if chore has assigned child_id then all request child_ids must match.
- Dispatch: if `completion_mode='team'` call `RecordTeamCompletionByParent`, else loop over child_ids calling `RecordSoloCompletionByParent` per child — on `ErrCompletionExists` add to `skipped` list instead of failing.
- Return 201 with `{completions: [...], skipped: [...]}` JSON.

Wire route in `internal/api/router.go`: `r.Post("/allowance/chores/{id}/record", allowance.RecordCompletionHandler(db))`

Add handler tests in `internal/allowance/handlers_test.go`: TestRecordCompletionHandler_ChildNotInFamily, _SoloWithSkippedDuplicates, _TeamAutoDispatches, _NotParent (403), _ChoreOwnedByDifferentParent (404).

Depends on the storage functions from sub-task 1.

---
Bead: Hytte-i1m4 | Branch: forge/Hytte-i1m4
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)