### PR TITLE
Stride (Hytte-riho)

### DIFF
--- a/changelog.d/Hytte-riho.md
+++ b/changelog.d/Hytte-riho.md
@@ -1,0 +1,2 @@
+category: Added
+- **Stride: manual re-run of coach evaluation** - Each day in the current week's plan now has a refresh icon that re-runs Claude's coach evaluation for that day. Any open (unconsumed) coach note targeting the date is included as context and marked as used after the re-run, so you can correct the coach when it misinterprets a workout. (Hytte-riho)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -471,6 +471,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/stride/plans/{planId}/chat", stride.StrideChatSendHandler(db))
 				r.Get("/stride/evaluations", stride.ListEvaluationsHandler(db))
 				r.Post("/stride/evaluate", stride.TriggerEvaluationHandler(db))
+				r.Post("/stride/days/{date}/reevaluate", stride.ReEvaluateDayHandler(db))
 				r.Get("/stride/history", stride.PlanHistoryHandler(db))
 			})
 

--- a/internal/stride/evaluate.go
+++ b/internal/stride/evaluate.go
@@ -374,6 +374,10 @@ func ReEvaluateDate(ctx context.Context, db *sql.DB, httpClient *http.Client, us
 		}
 	}
 
+	if len(newRecords) == 0 {
+		return 0, nil
+	}
+
 	// Phase 2: encrypt new payloads up-front so any encryption error fails before
 	// we delete anything.
 	type insertPayload struct {

--- a/internal/stride/evaluate.go
+++ b/internal/stride/evaluate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -14,6 +15,11 @@ import (
 	"github.com/Robin831/Hytte/internal/push"
 	"github.com/Robin831/Hytte/internal/training"
 )
+
+// ErrNoStridePlan is returned by re-evaluation operations when no stride plan
+// covers the requested date. Handlers can match on this to return 404 without
+// string-matching the error message.
+var ErrNoStridePlan = errors.New("no stride plan covers this date")
 
 // Evaluation note templates for rest days and missed sessions.
 const (
@@ -283,11 +289,22 @@ func queryWorkoutsOnDate(ctx context.Context, db *sql.DB, userID int64, date str
 	return workouts, rows.Err()
 }
 
-// ReEvaluateDate deletes any existing stride evaluations for the given user and
-// date (both workout-linked and date-only entries for plans covering the date)
-// and re-runs the coach evaluation with any currently active notes targeting
-// that date. Active notes used during the re-run are marked consumed_by="manual".
-// It returns the number of new evaluations produced.
+// reEvalRecord is a Claude-produced evaluation held in memory by ReEvaluateDate
+// before any DB mutation. workoutID == nil indicates a date-only (rest day or
+// missed session) evaluation.
+type reEvalRecord struct {
+	workoutID *int64
+	eval      *Evaluation
+}
+
+// ReEvaluateDate re-runs the coach evaluation for a single date for one user.
+// It first calls Claude to produce all new evaluations in memory, then atomically
+// swaps them in (delete existing + insert new + mark notes consumed) inside a
+// single transaction. If Claude fails for any workout, no DB rows are touched
+// so the prior coach output is preserved. Active notes used during the re-run
+// are marked consumed_by="manual" only when the new evaluations actually persist.
+// Returns the number of new evaluations produced and ErrNoStridePlan when no
+// plan covers the date.
 func ReEvaluateDate(ctx context.Context, db *sql.DB, httpClient *http.Client, userID int64, date string) (int, error) {
 	if _, err := time.Parse("2006-01-02", date); err != nil {
 		return 0, fmt.Errorf("parse date %q: %w", date, err)
@@ -306,7 +323,7 @@ func ReEvaluateDate(ctx context.Context, db *sql.DB, httpClient *http.Client, us
 		return 0, fmt.Errorf("find plan for date %s: %w", date, err)
 	}
 	if plan == nil {
-		return 0, fmt.Errorf("no stride plan covers date %s", date)
+		return 0, ErrNoStridePlan
 	}
 
 	workouts, err := queryWorkoutsOnDate(ctx, db, userID, date)
@@ -327,44 +344,101 @@ func ReEvaluateDate(ctx context.Context, db *sql.DB, httpClient *http.Client, us
 		}
 	}
 
-	// Remove any existing evaluations for this date so the re-run produces a
-	// single fresh record per workout (or per plan+date for non-workout days).
+	// Phase 1: build all new evaluations in memory by calling Claude. If anything
+	// fails we return without touching the existing rows, so the prior coach
+	// output for this date stays intact.
+	profile := training.BuildUserTrainingProfile(db, userID)
+	sessions := extractPlannedSessions(*plan)
+	var newRecords []reEvalRecord
+	for _, workout := range workouts {
+		matchedSession := MatchWorkoutToSession(workout, sessions)
+		evalCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+		eval, err := EvaluateWorkout(evalCtx, claudeCfg, workout, matchedSession, *plan, profile, notes)
+		cancel()
+		if err != nil {
+			return 0, fmt.Errorf("evaluate workout %d: %w", workout.ID, err)
+		}
+		wid := workout.ID
+		newRecords = append(newRecords, reEvalRecord{workoutID: &wid, eval: eval})
+	}
+
+	if len(workouts) == 0 {
+		evalCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+		eval, err := buildDateEval(evalCtx, claudeCfg, *plan, date, notes)
+		cancel()
+		if err != nil {
+			return 0, fmt.Errorf("evaluate rest/missed for %s: %w", date, err)
+		}
+		if eval != nil {
+			newRecords = append(newRecords, reEvalRecord{workoutID: nil, eval: eval})
+		}
+	}
+
+	// Phase 2: encrypt new payloads up-front so any encryption error fails before
+	// we delete anything.
+	type insertPayload struct {
+		workoutID *int64
+		encJSON   string
+	}
+	inserts := make([]insertPayload, 0, len(newRecords))
+	for _, rec := range newRecords {
+		evalBytes, err := json.Marshal(rec.eval)
+		if err != nil {
+			return 0, fmt.Errorf("marshal eval: %w", err)
+		}
+		encEval, err := encryption.EncryptField(string(evalBytes))
+		if err != nil {
+			return 0, fmt.Errorf("encrypt eval: %w", err)
+		}
+		inserts = append(inserts, insertPayload{workoutID: rec.workoutID, encJSON: encEval})
+	}
+
+	// Phase 3: atomically swap in the new records in a single transaction.
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
 	if len(workouts) > 0 {
-		ids := make([]any, 0, len(workouts)+1)
-		ids = append(ids, userID)
+		args := make([]any, 0, len(workouts)+1)
+		args = append(args, userID)
 		placeholders := make([]string, len(workouts))
 		for i, w := range workouts {
 			placeholders[i] = "?"
-			ids = append(ids, w.ID)
+			args = append(args, w.ID)
 		}
 		q := `DELETE FROM stride_evaluations WHERE user_id = ? AND workout_id IN (` + strings.Join(placeholders, ",") + `)`
-		if _, err := db.ExecContext(ctx, q, ids...); err != nil {
+		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
 			return 0, fmt.Errorf("delete existing workout evaluations: %w", err)
 		}
 	}
-	if err := deleteDateEvaluationsForPlan(ctx, db, userID, plan.ID, date); err != nil {
+	if err := deleteDateEvaluationsForPlanTx(ctx, tx, userID, plan.ID, date); err != nil {
 		return 0, fmt.Errorf("delete existing date evaluations: %w", err)
 	}
 
-	profile := training.BuildUserTrainingProfile(db, userID)
-	produced := 0
-	for _, workout := range workouts {
-		evalCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
-		if err := evaluateSingleWorkout(evalCtx, db, httpClient, userID, workout, claudeCfg, profile, notes); err != nil {
-			cancel()
-			return produced, fmt.Errorf("evaluate workout %d: %w", workout.ID, err)
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, ins := range inserts {
+		if ins.workoutID != nil {
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO stride_evaluations (user_id, plan_id, workout_id, eval_json, created_at)
+				VALUES (?, ?, ?, ?, ?)
+			`, userID, plan.ID, *ins.workoutID, ins.encJSON, now); err != nil {
+				return 0, fmt.Errorf("insert eval: %w", err)
+			}
+		} else {
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO stride_evaluations (user_id, plan_id, workout_id, eval_json, created_at)
+				VALUES (?, ?, NULL, ?, ?)
+			`, userID, plan.ID, ins.encJSON, now); err != nil {
+				return 0, fmt.Errorf("insert date eval: %w", err)
+			}
 		}
-		cancel()
-		produced++
-	}
-
-	// No workout uploaded for the date — run the rest-day / missed-session path
-	// so the evaluation reflects the planned session against an empty slot.
-	if len(workouts) == 0 {
-		if err := evaluateRestDaysAndMissedSessions(ctx, db, claudeCfg, userID, date); err != nil {
-			return produced, fmt.Errorf("evaluate rest/missed for %s: %w", date, err)
-		}
-		produced++
 	}
 
 	if len(notes) > 0 {
@@ -372,41 +446,102 @@ func ReEvaluateDate(ctx context.Context, db *sql.DB, httpClient *http.Client, us
 		for i, n := range notes {
 			noteIDs[i] = n.ID
 		}
-		tx, err := db.BeginTx(ctx, nil)
-		if err != nil {
-			log.Printf("stride eval: begin tx to mark notes consumed for user %d: %v", userID, err)
-		} else {
-			defer tx.Rollback() //nolint:errcheck
-			if err := MarkNotesConsumed(ctx, tx, userID, noteIDs, "manual"); err != nil {
-				log.Printf("stride eval: mark notes consumed for user %d: %v", userID, err)
-			} else if err := tx.Commit(); err != nil {
-				log.Printf("stride eval: commit notes consumed for user %d: %v", userID, err)
-			}
+		if err := MarkNotesConsumed(ctx, tx, userID, noteIDs, "manual"); err != nil {
+			return 0, fmt.Errorf("mark notes consumed: %w", err)
 		}
 	}
 
-	return produced, nil
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+	committed = true
+
+	// Push notifications fire only after commit, so a flag-laden evaluation that
+	// failed to persist does not page the user.
+	for _, rec := range newRecords {
+		if rec.workoutID == nil || !hasCriticalFlag(rec.eval.Flags) {
+			continue
+		}
+		notif := push.Notification{
+			Title: "Stride Alert",
+			Body:  buildCriticalNotifBody(rec.eval),
+			Tag:   "stride-eval-alert",
+		}
+		payload, err := json.Marshal(notif)
+		if err != nil {
+			log.Printf("stride eval: marshal notification for user %d: %v", userID, err)
+			continue
+		}
+		if _, err := push.SendToUser(db, httpClient, userID, payload); err != nil {
+			log.Printf("stride eval: push notification for user %d: %v", userID, err)
+		}
+	}
+
+	return len(newRecords), nil
 }
 
-// deleteDateEvaluationsForPlan scans non-workout evaluations for the given plan
-// and removes any whose decrypted Evaluation.Date matches the target date.
-// Used by ReEvaluateDate to clear prior rest-day / missed-session records
-// before generating a fresh one.
-func deleteDateEvaluationsForPlan(ctx context.Context, db *sql.DB, userID, planID int64, date string) error {
-	rows, err := db.QueryContext(ctx, `
+// buildDateEval constructs an Evaluation in memory for a date with no workout.
+// Returns nil, nil when the date has neither a planned session nor a rest day
+// (nothing to evaluate). When the user left notes for the date and Claude is
+// available, it asks Claude for a contextual evaluation; otherwise it returns
+// the static template used by the nightly job.
+func buildDateEval(ctx context.Context, claudeCfg *training.ClaudeConfig, plan Plan, date string, notes []Note) (*Evaluation, error) {
+	session, isRestDay := PlannedSessionForDate(plan, date)
+	if !isRestDay && session == nil {
+		return nil, nil
+	}
+
+	if isRestDay {
+		if len(notes) > 0 && claudeCfg != nil && claudeCfg.Enabled {
+			return evaluateDateWithNotes(ctx, claudeCfg, plan, date, nil, notes, true)
+		}
+		return &Evaluation{
+			PlannedType: "rest",
+			ActualType:  "rest",
+			Compliance:  "rest_day",
+			Notes:       noteRestDay,
+			Flags:       []string{},
+			Adjustments: "",
+			Date:        date,
+		}, nil
+	}
+
+	sessionType := "session"
+	if session.Session != nil && session.Session.Description != "" {
+		sessionType = session.Session.Description
+	}
+	if len(notes) > 0 && claudeCfg != nil && claudeCfg.Enabled {
+		return evaluateDateWithNotes(ctx, claudeCfg, plan, date, session, notes, false)
+	}
+	return &Evaluation{
+		PlannedType: sessionType,
+		ActualType:  "none",
+		Compliance:  "missed",
+		Notes:       fmt.Sprintf(noteMissedSession, sessionType),
+		Flags:       []string{},
+		Adjustments: "",
+		Date:        date,
+	}, nil
+}
+
+// deleteDateEvaluationsForPlanTx scans non-workout evaluations for the given plan
+// inside a transaction and removes any whose decrypted Evaluation.Date matches
+// the target date. Used by ReEvaluateDate to clear prior rest-day /
+// missed-session records inside the same transaction that inserts the new ones.
+func deleteDateEvaluationsForPlanTx(ctx context.Context, tx *sql.Tx, userID, planID int64, date string) error {
+	rows, err := tx.QueryContext(ctx, `
 		SELECT id, eval_json FROM stride_evaluations
 		WHERE user_id = ? AND plan_id = ? AND workout_id IS NULL
 	`, userID, planID)
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
-
 	var toDelete []int64
 	for rows.Next() {
 		var id int64
 		var encJSON string
 		if err := rows.Scan(&id, &encJSON); err != nil {
+			rows.Close()
 			return err
 		}
 		decJSON, derr := encryption.DecryptField(encJSON)
@@ -424,10 +559,12 @@ func deleteDateEvaluationsForPlan(ctx context.Context, db *sql.DB, userID, planI
 		}
 	}
 	if err := rows.Err(); err != nil {
+		rows.Close()
 		return err
 	}
+	rows.Close()
 	for _, id := range toDelete {
-		if _, err := db.ExecContext(ctx, `DELETE FROM stride_evaluations WHERE id = ?`, id); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM stride_evaluations WHERE id = ?`, id); err != nil {
 			return err
 		}
 	}

--- a/internal/stride/evaluate.go
+++ b/internal/stride/evaluate.go
@@ -220,6 +220,220 @@ func evaluateUserWorkouts(ctx context.Context, db *sql.DB, httpClient *http.Clie
 	return nil
 }
 
+// queryWorkoutsOnDate returns all workouts for a user that started on the given
+// YYYY-MM-DD date. Workout titles are decrypted.
+func queryWorkoutsOnDate(ctx context.Context, db *sql.DB, userID int64, date string) ([]training.Workout, error) {
+	t, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return nil, fmt.Errorf("parse date %q: %w", date, err)
+	}
+	dayStart := date + "T00:00:00Z"
+	dayEnd := t.AddDate(0, 0, 1).Format("2006-01-02") + "T00:00:00Z"
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT w.id, w.user_id, w.sport, w.sub_sport, w.is_indoor, w.title, w.started_at,
+		       w.duration_seconds, w.distance_meters, w.avg_heart_rate, w.max_heart_rate,
+		       w.avg_pace_sec_per_km, w.avg_cadence, w.calories,
+		       w.ascent_meters, w.descent_meters, w.fit_file_hash, w.analysis_status, w.title_source,
+		       w.created_at, w.training_load, w.hr_drift_pct, w.pace_cv_pct
+		FROM workouts w
+		WHERE w.user_id = ?
+		  AND w.started_at >= ?
+		  AND w.started_at < ?
+		ORDER BY w.started_at ASC
+	`, userID, dayStart, dayEnd)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var workouts []training.Workout
+	for rows.Next() {
+		var w training.Workout
+		var isIndoor int
+		var trainingLoad, hrDriftPct, paceCVPct sql.NullFloat64
+		if err := rows.Scan(
+			&w.ID, &w.UserID, &w.Sport, &w.SubSport, &isIndoor, &w.Title, &w.StartedAt,
+			&w.DurationSeconds, &w.DistanceMeters, &w.AvgHeartRate, &w.MaxHeartRate,
+			&w.AvgPaceSecPerKm, &w.AvgCadence, &w.Calories,
+			&w.AscentMeters, &w.DescentMeters, &w.FitFileHash, &w.AnalysisStatus, &w.TitleSource,
+			&w.CreatedAt, &trainingLoad, &hrDriftPct, &paceCVPct,
+		); err != nil {
+			log.Printf("stride eval: scan workout: %v", err)
+			continue
+		}
+		w.IsIndoor = isIndoor != 0
+		if trainingLoad.Valid {
+			w.TrainingLoad = &trainingLoad.Float64
+		}
+		if hrDriftPct.Valid {
+			w.HRDriftPct = &hrDriftPct.Float64
+		}
+		if paceCVPct.Valid {
+			w.PaceCVPct = &paceCVPct.Float64
+		}
+		if decTitle, decErr := encryption.DecryptField(w.Title); decErr != nil {
+			log.Printf("stride eval: workout %d: failed to decrypt title: %v; omitting from prompt", w.ID, decErr)
+			w.Title = ""
+		} else {
+			w.Title = decTitle
+		}
+		workouts = append(workouts, w)
+	}
+	return workouts, rows.Err()
+}
+
+// ReEvaluateDate deletes any existing stride evaluations for the given user and
+// date (both workout-linked and date-only entries for plans covering the date)
+// and re-runs the coach evaluation with any currently active notes targeting
+// that date. Active notes used during the re-run are marked consumed_by="manual".
+// It returns the number of new evaluations produced.
+func ReEvaluateDate(ctx context.Context, db *sql.DB, httpClient *http.Client, userID int64, date string) (int, error) {
+	if _, err := time.Parse("2006-01-02", date); err != nil {
+		return 0, fmt.Errorf("parse date %q: %w", date, err)
+	}
+
+	claudeCfg, err := training.LoadClaudeConfig(db, userID)
+	if err != nil {
+		return 0, fmt.Errorf("load claude config: %w", err)
+	}
+	if !claudeCfg.Enabled {
+		return 0, training.ErrClaudeNotEnabled
+	}
+
+	plan, err := getPlanContainingDate(ctx, db, userID, date)
+	if err != nil {
+		return 0, fmt.Errorf("find plan for date %s: %w", date, err)
+	}
+	if plan == nil {
+		return 0, fmt.Errorf("no stride plan covers date %s", date)
+	}
+
+	workouts, err := queryWorkoutsOnDate(ctx, db, userID, date)
+	if err != nil {
+		return 0, fmt.Errorf("query workouts for date %s: %w", date, err)
+	}
+
+	// Gather active notes targeting this date so the re-run picks up any
+	// correcting context the user added after the original evaluation.
+	allNotes, err := GetNotesByTargetDate(db, userID, date)
+	if err != nil {
+		log.Printf("stride eval: fetch notes for user %d date %s: %v", userID, date, err)
+	}
+	notes := make([]Note, 0, len(allNotes))
+	for _, n := range allNotes {
+		if n.ConsumedAt == nil {
+			notes = append(notes, n)
+		}
+	}
+
+	// Remove any existing evaluations for this date so the re-run produces a
+	// single fresh record per workout (or per plan+date for non-workout days).
+	if len(workouts) > 0 {
+		ids := make([]any, 0, len(workouts)+1)
+		ids = append(ids, userID)
+		placeholders := make([]string, len(workouts))
+		for i, w := range workouts {
+			placeholders[i] = "?"
+			ids = append(ids, w.ID)
+		}
+		q := `DELETE FROM stride_evaluations WHERE user_id = ? AND workout_id IN (` + strings.Join(placeholders, ",") + `)`
+		if _, err := db.ExecContext(ctx, q, ids...); err != nil {
+			return 0, fmt.Errorf("delete existing workout evaluations: %w", err)
+		}
+	}
+	if err := deleteDateEvaluationsForPlan(ctx, db, userID, plan.ID, date); err != nil {
+		return 0, fmt.Errorf("delete existing date evaluations: %w", err)
+	}
+
+	profile := training.BuildUserTrainingProfile(db, userID)
+	produced := 0
+	for _, workout := range workouts {
+		evalCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+		if err := evaluateSingleWorkout(evalCtx, db, httpClient, userID, workout, claudeCfg, profile, notes); err != nil {
+			cancel()
+			return produced, fmt.Errorf("evaluate workout %d: %w", workout.ID, err)
+		}
+		cancel()
+		produced++
+	}
+
+	// No workout uploaded for the date — run the rest-day / missed-session path
+	// so the evaluation reflects the planned session against an empty slot.
+	if len(workouts) == 0 {
+		if err := evaluateRestDaysAndMissedSessions(ctx, db, claudeCfg, userID, date); err != nil {
+			return produced, fmt.Errorf("evaluate rest/missed for %s: %w", date, err)
+		}
+		produced++
+	}
+
+	if len(notes) > 0 {
+		noteIDs := make([]int64, len(notes))
+		for i, n := range notes {
+			noteIDs[i] = n.ID
+		}
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			log.Printf("stride eval: begin tx to mark notes consumed for user %d: %v", userID, err)
+		} else {
+			defer tx.Rollback() //nolint:errcheck
+			if err := MarkNotesConsumed(ctx, tx, userID, noteIDs, "manual"); err != nil {
+				log.Printf("stride eval: mark notes consumed for user %d: %v", userID, err)
+			} else if err := tx.Commit(); err != nil {
+				log.Printf("stride eval: commit notes consumed for user %d: %v", userID, err)
+			}
+		}
+	}
+
+	return produced, nil
+}
+
+// deleteDateEvaluationsForPlan scans non-workout evaluations for the given plan
+// and removes any whose decrypted Evaluation.Date matches the target date.
+// Used by ReEvaluateDate to clear prior rest-day / missed-session records
+// before generating a fresh one.
+func deleteDateEvaluationsForPlan(ctx context.Context, db *sql.DB, userID, planID int64, date string) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, eval_json FROM stride_evaluations
+		WHERE user_id = ? AND plan_id = ? AND workout_id IS NULL
+	`, userID, planID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var toDelete []int64
+	for rows.Next() {
+		var id int64
+		var encJSON string
+		if err := rows.Scan(&id, &encJSON); err != nil {
+			return err
+		}
+		decJSON, derr := encryption.DecryptField(encJSON)
+		if derr != nil {
+			log.Printf("stride eval: decrypt date-eval %d: %v", id, derr)
+			continue
+		}
+		var e Evaluation
+		if err := json.Unmarshal([]byte(decJSON), &e); err != nil {
+			log.Printf("stride eval: unmarshal date-eval %d: %v", id, err)
+			continue
+		}
+		if e.Date == date {
+			toDelete = append(toDelete, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, id := range toDelete {
+		if _, err := db.ExecContext(ctx, `DELETE FROM stride_evaluations WHERE id = ?`, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // queryUnevaluatedWorkouts returns workouts for a user started at or after since
 // that do not yet have a stride_evaluation record.
 func queryUnevaluatedWorkouts(ctx context.Context, db *sql.DB, userID int64, since string) ([]training.Workout, error) {

--- a/internal/stride/handlers.go
+++ b/internal/stride/handlers.go
@@ -130,7 +130,7 @@ func ReEvaluateDayHandler(db *sql.DB) http.HandlerFunc {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 				return
 			}
-			if strings.Contains(err.Error(), "no stride plan") {
+			if errors.Is(err, ErrNoStridePlan) {
 				writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
 				return
 			}

--- a/internal/stride/handlers.go
+++ b/internal/stride/handlers.go
@@ -110,6 +110,42 @@ func ListEvaluationsHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
+// ReEvaluateDayHandler re-runs the coach evaluation for a single date in the
+// authenticated user's plan week. Any currently active notes targeting that
+// date are fed into the re-run and marked consumed_by="manual" on success.
+// POST /api/stride/days/{date}/reevaluate
+func ReEvaluateDayHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		date := chi.URLParam(r, "date")
+		if _, err := time.Parse("2006-01-02", date); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "date must be in YYYY-MM-DD format"})
+			return
+		}
+
+		produced, err := ReEvaluateDate(r.Context(), db, http.DefaultClient, user.ID, date)
+		if err != nil {
+			if errors.Is(err, training.ErrClaudeNotEnabled) {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			if strings.Contains(err.Error(), "no stride plan") {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+				return
+			}
+			log.Printf("stride: reevaluate date %s for user %d: %v", date, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "re-evaluation failed"})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"evaluated": produced,
+			"status":    "ok",
+		})
+	}
+}
+
 // TriggerEvaluationHandler manually triggers evaluation of the authenticated user's
 // unevaluated workouts from the past 24 hours via the stride AI engine.
 // POST /api/stride/evaluate

--- a/internal/stride/reevaluate_test.go
+++ b/internal/stride/reevaluate_test.go
@@ -1,0 +1,620 @@
+package stride
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+// reevalSetup wires the in-memory DB with the user_preferences rows ReEvaluateDate
+// reads via training.LoadClaudeConfig. Pass claudeEnabled=false to simulate the
+// disabled branch.
+func reevalSetup(t *testing.T, db *sql.DB, claudeEnabled bool) {
+	t.Helper()
+	enabled := "false"
+	if claudeEnabled {
+		enabled = "true"
+	}
+	rows := []struct{ key, value string }{
+		{"stride_enabled", "true"},
+		{"claude_enabled", enabled},
+		{"claude_cli_path", "/usr/bin/claude"},
+	}
+	for _, r := range rows {
+		if _, err := db.Exec(`INSERT INTO user_preferences (user_id, key, value) VALUES (1, ?, ?)`, r.key, r.value); err != nil {
+			t.Fatalf("insert pref %s: %v", r.key, err)
+		}
+	}
+}
+
+// stubRunPrompt swaps the Claude callable for a test fixture and registers
+// cleanup to restore the original.
+func stubRunPrompt(t *testing.T, fn func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error)) {
+	t.Helper()
+	orig := runPromptFunc
+	runPromptFunc = fn
+	t.Cleanup(func() { runPromptFunc = orig })
+}
+
+// --- ReEvaluateDate ---
+
+func TestReEvaluateDate_ReplacesExistingWorkoutEvaluation(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-08"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: false, Session: &Session{MainSet: "easy run", Description: "Easy"}},
+	})
+	planID := insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	if _, err := db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (200, 1, 'running', ?, 'hash-200', ?)
+	`, date+"T07:00:00Z", date+"T08:00:00Z"); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	// Pre-existing evaluation that the re-run should replace.
+	stale := &Evaluation{Compliance: "missed", Notes: "STALE", Flags: []string{}}
+	if err := storeEvaluation(context.Background(), db, 1, 200, planID, stale); err != nil {
+		t.Fatalf("seed stale eval: %v", err)
+	}
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return `{"planned_type":"easy","actual_type":"easy","compliance":"compliant","notes":"FRESH","flags":[],"adjustments":""}`, nil
+	})
+
+	produced, err := ReEvaluateDate(context.Background(), db, nil, 1, date)
+	if err != nil {
+		t.Fatalf("ReEvaluateDate: %v", err)
+	}
+	if produced != 1 {
+		t.Errorf("produced = %d, want 1", produced)
+	}
+
+	records, err := ListEvaluations(db, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("ListEvaluations: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1 (stale should be replaced)", len(records))
+	}
+	if records[0].Eval.Notes != "FRESH" {
+		t.Errorf("notes = %q, want FRESH", records[0].Eval.Notes)
+	}
+	if records[0].Eval.Compliance != "compliant" {
+		t.Errorf("compliance = %q, want compliant", records[0].Eval.Compliance)
+	}
+}
+
+func TestReEvaluateDate_PreservesExistingOnClaudeFailure(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-09"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: false, Session: &Session{MainSet: "threshold", Description: "Threshold"}},
+	})
+	planID := insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	if _, err := db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (210, 1, 'running', ?, 'hash-210', ?)
+	`, date+"T07:00:00Z", date+"T08:00:00Z"); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	// Seed a prior coach evaluation that we MUST not lose if Claude fails.
+	original := &Evaluation{Compliance: "compliant", Notes: "PRIOR-COACH-OUTPUT", Flags: []string{}}
+	if err := storeEvaluation(context.Background(), db, 1, 210, planID, original); err != nil {
+		t.Fatalf("seed original: %v", err)
+	}
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return "", errors.New("claude is down")
+	})
+
+	if _, err := ReEvaluateDate(context.Background(), db, nil, 1, date); err == nil {
+		t.Fatal("expected error when Claude fails")
+	}
+
+	// Verify the prior coach evaluation is untouched — that's the regression
+	// the warden flagged.
+	records, err := ListEvaluations(db, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("ListEvaluations: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1 (original must be preserved)", len(records))
+	}
+	if records[0].Eval.Notes != "PRIOR-COACH-OUTPUT" {
+		t.Errorf("notes = %q, want PRIOR-COACH-OUTPUT (original lost)", records[0].Eval.Notes)
+	}
+}
+
+func TestReEvaluateDate_PreservesExistingOnClaudeFailure_RestDay(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-10"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: true},
+	})
+	planID := insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	// Seed an existing rest-day evaluation.
+	original := &Evaluation{Compliance: "rest_day", Notes: "PRIOR-REST", Flags: []string{}, Date: date}
+	if err := storeEvaluationForDate(context.Background(), db, 1, planID, original); err != nil {
+		t.Fatalf("seed original: %v", err)
+	}
+
+	// Add an unconsumed note so ReEvaluateDate calls Claude (notes drive AI path).
+	if _, err := CreateNote(db, 1, nil, "felt great today, took a walk", date); err != nil {
+		t.Fatalf("create note: %v", err)
+	}
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return "", errors.New("claude is down")
+	})
+
+	if _, err := ReEvaluateDate(context.Background(), db, nil, 1, date); err == nil {
+		t.Fatal("expected error when Claude fails")
+	}
+
+	records, err := ListEvaluations(db, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("ListEvaluations: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	if records[0].Eval.Notes != "PRIOR-REST" {
+		t.Errorf("notes = %q, want PRIOR-REST (original rest-day eval was wiped)", records[0].Eval.Notes)
+	}
+
+	// Notes must remain unconsumed since the re-run failed.
+	var consumedAt sql.NullString
+	if err := db.QueryRow(`SELECT consumed_at FROM stride_notes WHERE user_id = 1`).Scan(&consumedAt); err != nil {
+		t.Fatalf("query note: %v", err)
+	}
+	if consumedAt.Valid {
+		t.Errorf("note must not be consumed when re-eval fails, got %v", consumedAt.String)
+	}
+}
+
+func TestReEvaluateDate_NoStridePlanReturnsSentinel(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		t.Fatal("Claude should not be called when there is no plan")
+		return "", nil
+	})
+
+	_, err := ReEvaluateDate(context.Background(), db, nil, 1, "2026-04-08")
+	if !errors.Is(err, ErrNoStridePlan) {
+		t.Errorf("expected ErrNoStridePlan, got %v", err)
+	}
+}
+
+func TestReEvaluateDate_ClaudeDisabledReturnsSentinel(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, false)
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		t.Fatal("Claude should not be called when disabled")
+		return "", nil
+	})
+
+	_, err := ReEvaluateDate(context.Background(), db, nil, 1, "2026-04-08")
+	if !errors.Is(err, training.ErrClaudeNotEnabled) {
+		t.Errorf("expected ErrClaudeNotEnabled, got %v", err)
+	}
+}
+
+func TestReEvaluateDate_MarksNotesConsumedManual(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-08"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: false, Session: &Session{MainSet: "easy run"}},
+	})
+	insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	if _, err := db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (220, 1, 'running', ?, 'hash-220', ?)
+	`, date+"T07:00:00Z", date+"T08:00:00Z"); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	note, err := CreateNote(db, 1, nil, "the coach got it wrong, this was easy not threshold", date)
+	if err != nil {
+		t.Fatalf("create note: %v", err)
+	}
+
+	var capturedPrompt string
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, prompt string) (string, error) {
+		capturedPrompt = prompt
+		return `{"planned_type":"easy","actual_type":"easy","compliance":"compliant","notes":"OK","flags":[],"adjustments":""}`, nil
+	})
+
+	if _, err := ReEvaluateDate(context.Background(), db, nil, 1, date); err != nil {
+		t.Fatalf("ReEvaluateDate: %v", err)
+	}
+
+	if !strings.Contains(capturedPrompt, "the coach got it wrong") {
+		t.Error("expected note content to be passed to Claude")
+	}
+
+	var consumedBy sql.NullString
+	if err := db.QueryRow(`SELECT consumed_by FROM stride_notes WHERE id = ?`, note.ID).Scan(&consumedBy); err != nil {
+		t.Fatalf("query note: %v", err)
+	}
+	if !consumedBy.Valid || consumedBy.String != "manual" {
+		t.Errorf("consumed_by = %v, want 'manual'", consumedBy)
+	}
+}
+
+func TestReEvaluateDate_NoWorkoutMissedSession(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-08"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: false, Session: &Session{MainSet: "4x10min", Description: "Threshold"}},
+	})
+	insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	// No notes, no Claude call expected for the template path.
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		t.Fatal("Claude should not be called when there are no notes for the missed session")
+		return "", nil
+	})
+
+	produced, err := ReEvaluateDate(context.Background(), db, nil, 1, date)
+	if err != nil {
+		t.Fatalf("ReEvaluateDate: %v", err)
+	}
+	if produced != 1 {
+		t.Errorf("produced = %d, want 1 (template-driven missed-session eval)", produced)
+	}
+
+	records, err := ListEvaluations(db, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("ListEvaluations: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	if records[0].Eval.Compliance != "missed" {
+		t.Errorf("compliance = %q, want missed", records[0].Eval.Compliance)
+	}
+}
+
+func TestReEvaluateDate_InvalidDate(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	if _, err := ReEvaluateDate(context.Background(), db, nil, 1, "not-a-date"); err == nil {
+		t.Error("expected error for invalid date")
+	}
+}
+
+// --- ReEvaluateDayHandler ---
+
+func TestReEvaluateDayHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-08"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: false, Session: &Session{MainSet: "easy"}},
+	})
+	insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	if _, err := db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (300, 1, 'running', ?, ?, ?)
+	`, date+"T07:00:00Z", "hash-300", date+"T08:00:00Z"); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return `{"planned_type":"easy","actual_type":"easy","compliance":"compliant","notes":"good","flags":[],"adjustments":""}`, nil
+	})
+
+	req := withChiParam(withUser(httptest.NewRequest(http.MethodPost, "/api/stride/days/"+date+"/reevaluate", nil), 1), "date", date)
+	rec := httptest.NewRecorder()
+	ReEvaluateDayHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Evaluated int    `json:"evaluated"`
+		Status    string `json:"status"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Evaluated != 1 {
+		t.Errorf("evaluated = %d, want 1", body.Evaluated)
+	}
+	if body.Status != "ok" {
+		t.Errorf("status = %q, want ok", body.Status)
+	}
+}
+
+func TestReEvaluateDayHandler_InvalidDate(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	req := withChiParam(withUser(httptest.NewRequest(http.MethodPost, "/api/stride/days/bogus/reevaluate", nil), 1), "date", "bogus")
+	rec := httptest.NewRecorder()
+	ReEvaluateDayHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid date, got %d", rec.Code)
+	}
+}
+
+func TestReEvaluateDayHandler_NoPlanReturns404(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		t.Fatal("Claude should not be called when there is no plan")
+		return "", nil
+	})
+
+	date := "2026-04-08"
+	req := withChiParam(withUser(httptest.NewRequest(http.MethodPost, "/api/stride/days/"+date+"/reevaluate", nil), 1), "date", date)
+	rec := httptest.NewRecorder()
+	ReEvaluateDayHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 when no plan covers date, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestReEvaluateDayHandler_ClaudeDisabledReturns400(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, false)
+
+	date := "2026-04-08"
+	req := withChiParam(withUser(httptest.NewRequest(http.MethodPost, "/api/stride/days/"+date+"/reevaluate", nil), 1), "date", date)
+	rec := httptest.NewRecorder()
+	ReEvaluateDayHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 when Claude disabled, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestReEvaluateDayHandler_ClaudeFailureReturns500(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-08"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: false, Session: &Session{MainSet: "easy"}},
+	})
+	insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	if _, err := db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (310, 1, 'running', ?, ?, ?)
+	`, date+"T07:00:00Z", "hash-310", date+"T08:00:00Z"); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return "", errors.New("claude crashed")
+	})
+
+	req := withChiParam(withUser(httptest.NewRequest(http.MethodPost, "/api/stride/days/"+date+"/reevaluate", nil), 1), "date", date)
+	rec := httptest.NewRecorder()
+	ReEvaluateDayHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- buildDateEval ---
+
+func TestBuildDateEval_RestDayTemplate(t *testing.T) {
+	plan := Plan{Plan: json.RawMessage(`[{"date":"2026-04-08","rest_day":true}]`)}
+	eval, err := buildDateEval(context.Background(), nil, plan, "2026-04-08", nil)
+	if err != nil {
+		t.Fatalf("buildDateEval: %v", err)
+	}
+	if eval == nil {
+		t.Fatal("expected rest-day eval, got nil")
+	}
+	if eval.Compliance != "rest_day" {
+		t.Errorf("compliance = %q, want rest_day", eval.Compliance)
+	}
+}
+
+func TestBuildDateEval_MissedSessionTemplate(t *testing.T) {
+	plan := Plan{Plan: json.RawMessage(`[{"date":"2026-04-08","rest_day":false,"session":{"main_set":"4x10","description":"Threshold"}}]`)}
+	eval, err := buildDateEval(context.Background(), nil, plan, "2026-04-08", nil)
+	if err != nil {
+		t.Fatalf("buildDateEval: %v", err)
+	}
+	if eval == nil {
+		t.Fatal("expected missed-session eval, got nil")
+	}
+	if eval.Compliance != "missed" {
+		t.Errorf("compliance = %q, want missed", eval.Compliance)
+	}
+}
+
+func TestBuildDateEval_UnknownDateReturnsNil(t *testing.T) {
+	plan := Plan{Plan: json.RawMessage(`[{"date":"2026-04-08","rest_day":true}]`)}
+	eval, err := buildDateEval(context.Background(), nil, plan, "2026-04-09", nil)
+	if err != nil {
+		t.Fatalf("buildDateEval: %v", err)
+	}
+	if eval != nil {
+		t.Errorf("expected nil for date not in plan, got %+v", eval)
+	}
+}
+
+func TestBuildDateEval_RestDayWithNotesUsesClaude(t *testing.T) {
+	cfg := &training.ClaudeConfig{Enabled: true, Model: "test"}
+	plan := Plan{Plan: json.RawMessage(`[{"date":"2026-04-08","rest_day":true}]`)}
+	notes := []Note{{ID: 1, TargetDate: "2026-04-08", Content: "took an active recovery walk"}}
+
+	called := false
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		called = true
+		return `{"planned_type":"rest","actual_type":"rest","compliance":"rest_day","notes":"AI-CONTEXT","flags":[],"adjustments":""}`, nil
+	})
+
+	eval, err := buildDateEval(context.Background(), cfg, plan, "2026-04-08", notes)
+	if err != nil {
+		t.Fatalf("buildDateEval: %v", err)
+	}
+	if !called {
+		t.Error("expected Claude to be called for rest day with notes")
+	}
+	if eval.Notes != "AI-CONTEXT" {
+		t.Errorf("notes = %q, want AI-CONTEXT", eval.Notes)
+	}
+}
+
+// Sanity check: re-evaluating with no existing rows should still insert the new
+// evaluation (no precondition that prior data exists).
+func TestReEvaluateDate_NoExistingRowsStillInserts(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-08"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: true},
+	})
+	insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		t.Fatal("Claude should not be called for rest day with no notes")
+		return "", nil
+	})
+
+	produced, err := ReEvaluateDate(context.Background(), db, nil, 1, date)
+	if err != nil {
+		t.Fatalf("ReEvaluateDate: %v", err)
+	}
+	if produced != 1 {
+		t.Errorf("produced = %d, want 1", produced)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM stride_evaluations WHERE user_id = 1`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row, got %d", count)
+	}
+}
+
+// Verify a successful re-eval also clears stale rest-day rows for the same date.
+func TestReEvaluateDate_ReplacesExistingDateOnlyEvaluation(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-08"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: true},
+	})
+	planID := insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	// Seed a stale rest-day evaluation for the date.
+	stale := &Evaluation{Compliance: "rest_day", Notes: "STALE", Flags: []string{}, Date: date}
+	if err := storeEvaluationForDate(context.Background(), db, 1, planID, stale); err != nil {
+		t.Fatalf("seed stale: %v", err)
+	}
+
+	// Add a note so Claude is invoked (with notes path).
+	if _, err := CreateNote(db, 1, nil, "did some yoga", date); err != nil {
+		t.Fatalf("create note: %v", err)
+	}
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return `{"planned_type":"rest","actual_type":"rest","compliance":"rest_day","notes":"FRESH","flags":[],"adjustments":"","date":"` + date + `"}`, nil
+	})
+
+	if _, err := ReEvaluateDate(context.Background(), db, nil, 1, date); err != nil {
+		t.Fatalf("ReEvaluateDate: %v", err)
+	}
+
+	records, err := ListEvaluations(db, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("ListEvaluations: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1 (stale rest-day eval should be replaced)", len(records))
+	}
+	if records[0].Eval.Notes != "FRESH" {
+		t.Errorf("notes = %q, want FRESH", records[0].Eval.Notes)
+	}
+}
+
+// Ensure the new ciphertext for a successful re-eval is decryptable round-trip.
+func TestReEvaluateDate_StoredCiphertextRoundTrips(t *testing.T) {
+	db := setupTestDB(t)
+	reevalSetup(t, db, true)
+
+	date := "2026-04-08"
+	weekStart, weekEnd := "2026-04-06", "2026-04-12"
+	planJSON, _ := json.Marshal([]DayPlan{
+		{Date: date, RestDay: false, Session: &Session{MainSet: "easy"}},
+	})
+	insertTestPlan(t, db, 1, weekStart, weekEnd, string(planJSON))
+
+	if _, err := db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (250, 1, 'running', ?, 'hash-250', ?)
+	`, date+"T07:00:00Z", date+"T08:00:00Z"); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	stubRunPrompt(t, func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return `{"planned_type":"easy","actual_type":"easy","compliance":"compliant","notes":"good","flags":[],"adjustments":""}`, nil
+	})
+
+	if _, err := ReEvaluateDate(context.Background(), db, nil, 1, date); err != nil {
+		t.Fatalf("ReEvaluateDate: %v", err)
+	}
+
+	var raw string
+	if err := db.QueryRow(`SELECT eval_json FROM stride_evaluations WHERE workout_id = 250`).Scan(&raw); err != nil {
+		t.Fatalf("query eval: %v", err)
+	}
+	if strings.HasPrefix(raw, "{") {
+		t.Fatal("eval_json should be encrypted at rest")
+	}
+	if _, err := encryption.DecryptField(raw); err != nil {
+		t.Errorf("decrypt round-trip: %v", err)
+	}
+}

--- a/web/public/locales/en/stride.json
+++ b/web/public/locales/en/stride.json
@@ -10,6 +10,8 @@
     "generating": "Generating...",
     "loadError": "Failed to load plan",
     "generateError": "Failed to generate plan",
+    "rerunCoach": "Re-run coach evaluation for this day",
+    "rerunError": "Failed to re-run coach evaluation",
     "weekOf": "Week of {{start}} – {{end}}",
     "phase": "Phase: {{phase}}",
     "generatedAt": "Generated {{date}}",
@@ -71,7 +73,8 @@
     "consumedBy": "Used by {{process}} on {{date}}",
     "consumedByProcess": {
       "nightly": "Nightly",
-      "weekly": "Weekly"
+      "weekly": "Weekly",
+      "manual": "Manual re-run"
     }
   },
   "history": {

--- a/web/public/locales/nb/stride.json
+++ b/web/public/locales/nb/stride.json
@@ -10,6 +10,8 @@
     "generating": "Genererer...",
     "loadError": "Kunne ikke laste plan",
     "generateError": "Kunne ikke generere plan",
+    "rerunCoach": "Kjør treneranalysen på nytt for denne dagen",
+    "rerunError": "Kunne ikke kjøre treneranalysen på nytt",
     "weekOf": "Uke {{start}} – {{end}}",
     "phase": "Fase: {{phase}}",
     "generatedAt": "Generert {{date}}",
@@ -71,7 +73,8 @@
     "consumedBy": "Brukt av {{process}} den {{date}}",
     "consumedByProcess": {
       "nightly": "Nattlig",
-      "weekly": "Ukentlig"
+      "weekly": "Ukentlig",
+      "manual": "Manuell ny kjøring"
     }
   },
   "history": {

--- a/web/public/locales/th/stride.json
+++ b/web/public/locales/th/stride.json
@@ -10,6 +10,8 @@
     "generating": "กำลังสร้าง...",
     "loadError": "ไม่สามารถโหลดแผนได้",
     "generateError": "ไม่สามารถสร้างแผนได้",
+    "rerunCoach": "รันการประเมินของโค้ชใหม่สำหรับวันนี้",
+    "rerunError": "ไม่สามารถรันการประเมินของโค้ชใหม่ได้",
     "weekOf": "สัปดาห์ {{start}} – {{end}}",
     "phase": "ระยะ: {{phase}}",
     "generatedAt": "สร้างเมื่อ {{date}}",
@@ -71,7 +73,8 @@
     "consumedBy": "ใช้โดย {{process}} เมื่อ {{date}}",
     "consumedByProcess": {
       "nightly": "ทุกคืน",
-      "weekly": "ทุกสัปดาห์"
+      "weekly": "ทุกสัปดาห์",
+      "manual": "รันใหม่ด้วยตนเอง"
     }
   },
   "history": {

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -117,7 +117,7 @@ function flagIsSevere(flag: string): boolean {
   return flag === 'overtraining' || flag === 'injury_risk'
 }
 
-function DayCard({ day, completed, evaluation, changedDates }: { day: DayPlan; completed: boolean; evaluation?: StrideEvaluationRecord; changedDates?: Set<string> }) {
+function DayCard({ day, completed, evaluation, changedDates, onRerun, rerunning }: { day: DayPlan; completed: boolean; evaluation?: StrideEvaluationRecord; changedDates?: Set<string>; onRerun?: (date: string) => void; rerunning?: boolean }) {
   const { t } = useTranslation('stride')
   const [expanded, setExpanded] = useState(false)
 
@@ -131,62 +131,78 @@ function DayCard({ day, completed, evaluation, changedDates }: { day: DayPlan; c
 
   return (
     <div className={`bg-gray-800 rounded-xl border border-gray-700 overflow-hidden transition-all duration-1000 ${isHighlighted ? 'ring-2 ring-yellow-400/50' : ''}`}>
-      <button
-        type="button"
-        onClick={() => hasExpandableContent && setExpanded(v => !v)}
-        className={`w-full flex items-center gap-3 p-3 text-left ${hasExpandableContent ? 'hover:bg-gray-700 active:bg-gray-600 cursor-pointer' : 'cursor-default'}`}
-        aria-expanded={expanded && hasExpandableContent}
-        aria-controls={`day-details-${day.date}`}
-        disabled={!hasExpandableContent}
-      >
-        {/* Completion / evaluation indicator */}
-        <div className="flex-shrink-0">
-          {evaluation ? (
-            complianceIcon(evaluation.eval.compliance)
-          ) : completed ? (
-            <CheckCircle2 size={18} className="text-green-400" />
-          ) : (
-            <Circle size={18} className="text-gray-600" />
-          )}
-        </div>
-
-        {/* Day + date */}
-        <div className="flex-shrink-0 w-16">
-          <p className="text-xs font-semibold text-gray-400 uppercase">{dayName}</p>
-          <p className="text-sm text-gray-300">{dateLabel}</p>
-        </div>
-
-        {/* Session summary + compliance badge + flag indicators */}
-        <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
-          {day.rest_day ? (
-            <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-700 text-gray-400">{t('plan.restDay')}</span>
-          ) : day.session ? (
-            <p className="text-sm text-white truncate">{day.session.description}</p>
-          ) : null}
-          {evaluation && complianceLabel && (
-            <span className={`text-xs font-medium px-2 py-0.5 rounded-full border ${complianceBadgeClass(evaluation.eval.compliance)}`}>
-              {complianceLabel}
-            </span>
-          )}
-          {evaluation && Array.isArray(evaluation.eval.flags) && evaluation.eval.flags.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-yellow-400" aria-label={t('evaluation.warnings')}>
-              <AlertTriangle size={12} />
-              {evaluation.eval.flags.length}
-            </span>
-          )}
-        </div>
-
-        {/* Expand chevron */}
-        {hasExpandableContent && (
+      <div className="relative flex items-stretch">
+        <button
+          type="button"
+          onClick={() => hasExpandableContent && setExpanded(v => !v)}
+          className={`flex-1 min-w-0 flex items-center gap-3 p-3 text-left ${hasExpandableContent ? 'hover:bg-gray-700 active:bg-gray-600 cursor-pointer' : 'cursor-default'}`}
+          aria-expanded={expanded && hasExpandableContent}
+          aria-controls={`day-details-${day.date}`}
+          disabled={!hasExpandableContent}
+        >
+          {/* Completion / evaluation indicator */}
           <div className="flex-shrink-0">
-            {expanded ? (
-              <ChevronUp size={16} className="text-gray-500" />
+            {evaluation ? (
+              complianceIcon(evaluation.eval.compliance)
+            ) : completed ? (
+              <CheckCircle2 size={18} className="text-green-400" />
             ) : (
-              <ChevronDown size={16} className="text-gray-500" />
+              <Circle size={18} className="text-gray-600" />
             )}
           </div>
+
+          {/* Day + date */}
+          <div className="flex-shrink-0 w-16">
+            <p className="text-xs font-semibold text-gray-400 uppercase">{dayName}</p>
+            <p className="text-sm text-gray-300">{dateLabel}</p>
+          </div>
+
+          {/* Session summary + compliance badge + flag indicators */}
+          <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
+            {day.rest_day ? (
+              <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-700 text-gray-400">{t('plan.restDay')}</span>
+            ) : day.session ? (
+              <p className="text-sm text-white truncate">{day.session.description}</p>
+            ) : null}
+            {evaluation && complianceLabel && (
+              <span className={`text-xs font-medium px-2 py-0.5 rounded-full border ${complianceBadgeClass(evaluation.eval.compliance)}`}>
+                {complianceLabel}
+              </span>
+            )}
+            {evaluation && Array.isArray(evaluation.eval.flags) && evaluation.eval.flags.length > 0 && (
+              <span className="flex items-center gap-1 text-xs text-yellow-400" aria-label={t('evaluation.warnings')}>
+                <AlertTriangle size={12} />
+                {evaluation.eval.flags.length}
+              </span>
+            )}
+          </div>
+
+          {/* Expand chevron */}
+          {hasExpandableContent && (
+            <div className="flex-shrink-0">
+              {expanded ? (
+                <ChevronUp size={16} className="text-gray-500" />
+              ) : (
+                <ChevronDown size={16} className="text-gray-500" />
+              )}
+            </div>
+          )}
+        </button>
+
+        {/* Rerun coach evaluation for this day */}
+        {onRerun && (
+          <button
+            type="button"
+            onClick={() => onRerun(day.date)}
+            disabled={rerunning}
+            className="flex-shrink-0 px-3 flex items-center text-gray-500 hover:text-yellow-400 disabled:text-gray-600 disabled:cursor-not-allowed transition-colors border-l border-gray-700"
+            aria-label={t('plan.rerunCoach')}
+            title={t('plan.rerunCoach')}
+          >
+            <RefreshCw size={14} className={rerunning ? 'animate-spin' : ''} />
+          </button>
         )}
-      </button>
+      </div>
 
       {/* Accordion panel — CSS grid transition so expand/collapse animates smoothly on mobile */}
       <div
@@ -476,6 +492,8 @@ export default function StridePage() {
   const [planError, setPlanError] = useState(false)
   const [generating, setGenerating] = useState(false)
   const [generateError, setGenerateError] = useState('')
+  const [rerunningDate, setRerunningDate] = useState<string | null>(null)
+  const [rerunError, setRerunError] = useState('')
 
   // Race form state
   const [showRaceForm, setShowRaceForm] = useState(false)
@@ -699,6 +717,39 @@ export default function StridePage() {
     if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2]
     if (parts.length === 2) return parts[0] * 3600 + parts[1] * 60 // H:MM for race times
     return null
+  }
+
+  async function handleRerunDay(date: string) {
+    setRerunError('')
+    setRerunningDate(date)
+    try {
+      const res = await fetch(`/api/stride/days/${date}/reevaluate`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setRerunError(data.error ?? t('plan.rerunError'))
+        return
+      }
+      if (currentPlan) {
+        const [curr, prev] = await Promise.all([
+          loadEvaluationsForPlan(currentPlan.id),
+          previousPlanId ? loadEvaluationsForPlan(previousPlanId) : Promise.resolve([]),
+        ])
+        const byId = new Map<number, StrideEvaluationRecord>()
+        for (const e of [...prev, ...curr]) byId.set(e.id, e)
+        setEvaluations(Array.from(byId.values()))
+      }
+      await loadNotes()
+      setChangedDates(new Set([date]))
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current)
+      highlightTimerRef.current = setTimeout(() => setChangedDates(new Set()), 3000)
+    } catch {
+      setRerunError(t('plan.rerunError'))
+    } finally {
+      setRerunningDate(null)
+    }
   }
 
   async function handleGeneratePlan() {
@@ -933,6 +984,10 @@ export default function StridePage() {
           <p className="mb-3 text-sm text-red-400">{generateError}</p>
         )}
 
+        {rerunError && (
+          <p className="mb-3 text-sm text-red-400">{rerunError}</p>
+        )}
+
         {planLoading ? (
           <p className="text-sm text-gray-400">{t('loading')}</p>
         ) : planError ? (
@@ -972,6 +1027,8 @@ export default function StridePage() {
                   completed={completedDates.has(day.date)}
                   evaluation={dayEvaluationMap.get(day.date)}
                   changedDates={changedDates}
+                  onRerun={handleRerunDay}
+                  rerunning={rerunningDate === day.date}
                 />
               ))}
             </div>
@@ -1281,7 +1338,9 @@ export default function StridePage() {
                               ? t('notes.consumedByProcess.nightly')
                               : note.consumed_by === 'weekly'
                                 ? t('notes.consumedByProcess.weekly')
-                                : null
+                                : note.consumed_by === 'manual'
+                                  ? t('notes.consumedByProcess.manual')
+                                  : null
                             const consumedDate = note.consumed_at ? formatDate(note.consumed_at) : null
                             if (!consumedByLabel || !consumedDate) return null
                             return (

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -494,6 +494,7 @@ export default function StridePage() {
   const [generateError, setGenerateError] = useState('')
   const [rerunningDate, setRerunningDate] = useState<string | null>(null)
   const [rerunError, setRerunError] = useState('')
+  const rerunAbortRef = useRef<AbortController | null>(null)
 
   // Race form state
   const [showRaceForm, setShowRaceForm] = useState(false)
@@ -660,6 +661,7 @@ export default function StridePage() {
   useEffect(() => {
     return () => {
       if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current)
+      if (rerunAbortRef.current) rerunAbortRef.current.abort()
     }
   }, [])
 
@@ -722,11 +724,16 @@ export default function StridePage() {
   async function handleRerunDay(date: string) {
     setRerunError('')
     setRerunningDate(date)
+    if (rerunAbortRef.current) rerunAbortRef.current.abort()
+    const controller = new AbortController()
+    rerunAbortRef.current = controller
     try {
       const res = await fetch(`/api/stride/days/${date}/reevaluate`, {
         method: 'POST',
         credentials: 'include',
+        signal: controller.signal,
       })
+      if (controller.signal.aborted) return
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
         setRerunError(data.error ?? t('plan.rerunError'))
@@ -737,18 +744,26 @@ export default function StridePage() {
           loadEvaluationsForPlan(currentPlan.id),
           previousPlanId ? loadEvaluationsForPlan(previousPlanId) : Promise.resolve([]),
         ])
+        if (controller.signal.aborted) return
         const byId = new Map<number, StrideEvaluationRecord>()
         for (const e of [...prev, ...curr]) byId.set(e.id, e)
         setEvaluations(Array.from(byId.values()))
       }
       await loadNotes()
+      if (controller.signal.aborted) return
       setChangedDates(new Set([date]))
       if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current)
       highlightTimerRef.current = setTimeout(() => setChangedDates(new Set()), 3000)
-    } catch {
+    } catch (err) {
+      if ((err as { name?: string })?.name === 'AbortError') return
       setRerunError(t('plan.rerunError'))
     } finally {
-      setRerunningDate(null)
+      if (rerunAbortRef.current === controller) {
+        rerunAbortRef.current = null
+      }
+      if (!controller.signal.aborted) {
+        setRerunningDate(null)
+      }
     }
   }
 

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -741,15 +741,15 @@ export default function StridePage() {
       }
       if (currentPlan) {
         const [curr, prev] = await Promise.all([
-          loadEvaluationsForPlan(currentPlan.id),
-          previousPlanId ? loadEvaluationsForPlan(previousPlanId) : Promise.resolve([]),
+          loadEvaluationsForPlan(currentPlan.id, controller.signal),
+          previousPlanId ? loadEvaluationsForPlan(previousPlanId, controller.signal) : Promise.resolve([]),
         ])
         if (controller.signal.aborted) return
         const byId = new Map<number, StrideEvaluationRecord>()
         for (const e of [...prev, ...curr]) byId.set(e.id, e)
         setEvaluations(Array.from(byId.values()))
       }
-      await loadNotes()
+      await loadNotes(controller.signal)
       if (controller.signal.aborted) return
       setChangedDates(new Set([date]))
       if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current)


### PR DESCRIPTION
## Changes

- **Stride: manual re-run of coach evaluation** - Each day in the current week's plan now has a refresh icon that re-runs Claude's coach evaluation for that day. Any open (unconsumed) coach note targeting the date is included as context and marked as used after the re-run, so you can correct the coach when it misinterprets a workout. (Hytte-riho)

## Original Issue (task): Stride

I can already backdate notes for the coach, but I need to able to manually rerun the coaches note on a previous workout in this weeks plan. A small rerun icon on every day in this weeks plan, it should use the note if there is an open one, and mark it as used.

I need this if the coach misinterpet the workout. 

Source: https://github.com/Robin831/Hytte/issues/645

---
Bead: Hytte-riho | Branch: forge/Hytte-riho
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)