### PR TITLE
Deferred credit-card transaction invisible in target month (Hytte-l74q)

### DIFF
--- a/changelog.d/Hytte-l74q.md
+++ b/changelog.d/Hytte-l74q.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Credit-card transactions deferred to next month now appear in the target month's transaction list** - The deferred row was already counted in the next month's total, but the row itself was hidden. It is now shown in both the source month (greyed out as before) and the target month (active, labelled "from last month"). (Hytte-l74q)

--- a/internal/creditcard/transactions.go
+++ b/internal/creditcard/transactions.go
@@ -14,17 +14,24 @@ import (
 )
 
 // TransactionRow is a single credit card transaction returned by the list endpoint.
+//
+// DeferredFromPreviousMonth is true when the row's transaction date is before
+// the requested billing period and the row is being shown only because it was
+// deferred forward into the requested period. The frontend uses this to
+// distinguish a carry-over (active in this month) from a deferral away
+// (greyed out in its source month).
 type TransactionRow struct {
-	ID                   int64   `json:"id"`
-	Transaksjonsdato     string  `json:"transaksjonsdato"`
-	Beskrivelse          string  `json:"beskrivelse"`
-	Belop                float64 `json:"belop"`
-	BelopIValuta         float64 `json:"belop_i_valuta"`
-	IsPending            bool    `json:"is_pending"`
-	IsInnbetaling        bool    `json:"is_innbetaling"`
-	DeferredToNextMonth  bool    `json:"deferred_to_next_month"`
-	GroupID              *int64  `json:"group_id"`
-	GroupName            string  `json:"group_name"`
+	ID                        int64   `json:"id"`
+	Transaksjonsdato          string  `json:"transaksjonsdato"`
+	Beskrivelse               string  `json:"beskrivelse"`
+	Belop                     float64 `json:"belop"`
+	BelopIValuta              float64 `json:"belop_i_valuta"`
+	IsPending                 bool    `json:"is_pending"`
+	IsInnbetaling             bool    `json:"is_innbetaling"`
+	DeferredToNextMonth       bool    `json:"deferred_to_next_month"`
+	DeferredFromPreviousMonth bool    `json:"deferred_from_previous_month"`
+	GroupID                   *int64  `json:"group_id"`
+	GroupName                 string  `json:"group_name"`
 }
 
 // TransactionsListResponse is returned by TransactionsListHandler.
@@ -64,7 +71,13 @@ func TransactionsListHandler(db *sql.DB) http.HandlerFunc {
 		}
 		startStr := periodStart.Format("2006-01-02")
 		endStr := periodStart.AddDate(0, 1, 0).Format("2006-01-02")
+		prevStartStr := periodStart.AddDate(0, -1, 0).Format("2006-01-02")
 
+		// Include transactions dated within the requested period, plus any settled
+		// transactions from the previous period that were deferred forward. The
+		// latter would otherwise be invisible in the period whose statement they
+		// actually belong to (the variable bill total already accounts for them
+		// via SyncCreditCardExpense).
 		rows, err := db.Query(`
 			SELECT t.id, t.transaksjonsdato, t.beskrivelse, t.belop, t.belop_i_valuta,
 			       t.is_pending, t.is_innbetaling, t.deferred_to_next_month,
@@ -72,9 +85,14 @@ func TransactionsListHandler(db *sql.DB) http.HandlerFunc {
 			FROM credit_card_transactions t
 			LEFT JOIN credit_card_groups g ON g.id = t.group_id AND g.user_id = t.user_id
 			WHERE t.user_id = ? AND t.credit_card_id = ?
-			  AND t.transaksjonsdato >= ? AND t.transaksjonsdato < ?
+			  AND (
+			      (t.transaksjonsdato >= ? AND t.transaksjonsdato < ?)
+			      OR
+			      (t.transaksjonsdato >= ? AND t.transaksjonsdato < ?
+			       AND t.deferred_to_next_month = 1 AND t.is_pending = 0)
+			  )
 			ORDER BY t.transaksjonsdato DESC, t.id DESC
-		`, user.ID, creditCardID, startStr, endStr)
+		`, user.ID, creditCardID, startStr, endStr, prevStartStr, startStr)
 		if err != nil {
 			log.Printf("creditcard: transactions list query: %v", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list transactions"})
@@ -106,6 +124,7 @@ func TransactionsListHandler(db *sql.DB) http.HandlerFunc {
 			t.IsPending = isPending == 1
 			t.IsInnbetaling = isInnbetaling == 1
 			t.DeferredToNextMonth = deferredToNextMonth == 1
+			t.DeferredFromPreviousMonth = t.Transaksjonsdato < startStr
 			if groupID.Valid {
 				gid := groupID.Int64
 				t.GroupID = &gid

--- a/internal/creditcard/transactions_test.go
+++ b/internal/creditcard/transactions_test.go
@@ -146,6 +146,135 @@ func TestTransactionsListHandler_FiltersByMonth(t *testing.T) {
 	}
 }
 
+func TestTransactionsListHandler_DeferredCarryoverShownInTargetMonth(t *testing.T) {
+	db := setupTestDB(t)
+
+	// March transaction deferred forward to April; plus a regular April transaction.
+	encDeferred, err := encryption.EncryptField("Deferred March")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	encApril, err := encryption.EncryptField("Plain April")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	if _, err := db.Exec(`
+		INSERT INTO credit_card_transactions
+			(user_id, credit_card_id, transaksjonsdato, beskrivelse, belop, belop_i_valuta, is_pending, is_innbetaling, deferred_to_next_month)
+		VALUES
+			(1, '1', '2026-03-20', ?, -300, -300, 0, 0, 1),
+			(1, '1', '2026-04-05', ?, -100, -100, 0, 0, 0)
+	`, encDeferred, encApril); err != nil {
+		t.Fatalf("insert transactions: %v", err)
+	}
+
+	handler := TransactionsListHandler(db)
+
+	// April list must include both rows: the regular April txn and the deferred
+	// March txn carried forward, with the carryover flagged appropriately.
+	req := httptest.NewRequest(http.MethodGet, "/api/credit-card/transactions?credit_card_id=1&month=2026-04", nil)
+	req = withUser(req, 1)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp TransactionsListResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Transactions) != 2 {
+		t.Fatalf("expected 2 transactions for April, got %d", len(resp.Transactions))
+	}
+
+	var carryover, plain *TransactionRow
+	for i := range resp.Transactions {
+		switch resp.Transactions[i].Beskrivelse {
+		case "Deferred March":
+			carryover = &resp.Transactions[i]
+		case "Plain April":
+			plain = &resp.Transactions[i]
+		}
+	}
+	if carryover == nil {
+		t.Fatal("deferred March transaction missing from April list")
+	}
+	if !carryover.DeferredToNextMonth {
+		t.Errorf("carryover deferred_to_next_month = false, want true")
+	}
+	if !carryover.DeferredFromPreviousMonth {
+		t.Errorf("carryover deferred_from_previous_month = false, want true")
+	}
+	if plain == nil {
+		t.Fatal("plain April transaction missing from April list")
+	}
+	if plain.DeferredFromPreviousMonth {
+		t.Errorf("plain April transaction deferred_from_previous_month = true, want false")
+	}
+
+	// Source month (March) still shows the deferred row, but flagged as deferred-away,
+	// not as a carryover.
+	reqMar := httptest.NewRequest(http.MethodGet, "/api/credit-card/transactions?credit_card_id=1&month=2026-03", nil)
+	reqMar = withUser(reqMar, 1)
+	rrMar := httptest.NewRecorder()
+	handler.ServeHTTP(rrMar, reqMar)
+
+	if rrMar.Code != http.StatusOK {
+		t.Fatalf("march status = %d; body: %s", rrMar.Code, rrMar.Body.String())
+	}
+	var respMar TransactionsListResponse
+	if err := json.NewDecoder(rrMar.Body).Decode(&respMar); err != nil {
+		t.Fatalf("march decode: %v", err)
+	}
+	if len(respMar.Transactions) != 1 {
+		t.Fatalf("expected 1 transaction for March, got %d", len(respMar.Transactions))
+	}
+	if !respMar.Transactions[0].DeferredToNextMonth {
+		t.Errorf("march row deferred_to_next_month = false, want true")
+	}
+	if respMar.Transactions[0].DeferredFromPreviousMonth {
+		t.Errorf("march row deferred_from_previous_month = true, want false")
+	}
+}
+
+func TestTransactionsListHandler_PendingPreviousMonthNotCarriedOver(t *testing.T) {
+	db := setupTestDB(t)
+
+	// A pending row from the previous month should never appear as a carryover,
+	// matching the rule that only settled transactions can be deferred.
+	encDesc, err := encryption.EncryptField("Pending March")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO credit_card_transactions
+			(user_id, credit_card_id, transaksjonsdato, beskrivelse, belop, belop_i_valuta, is_pending, is_innbetaling, deferred_to_next_month)
+		VALUES (1, '1', '2026-03-25', ?, -50, -50, 1, 0, 1)
+	`, encDesc); err != nil {
+		t.Fatalf("insert transaction: %v", err)
+	}
+
+	handler := TransactionsListHandler(db)
+	req := httptest.NewRequest(http.MethodGet, "/api/credit-card/transactions?credit_card_id=1&month=2026-04", nil)
+	req = withUser(req, 1)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp TransactionsListResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Transactions) != 0 {
+		t.Errorf("expected 0 transactions for April, got %d", len(resp.Transactions))
+	}
+}
+
 func TestTransactionsListHandler_VariableBillDecrypted(t *testing.T) {
 	db := setupTestDB(t)
 	if _, err := db.Exec(budgetSchema); err != nil {

--- a/web/public/locales/en/budget.json
+++ b/web/public/locales/en/budget.json
@@ -317,6 +317,7 @@
     "deferTransaction": "Defer to next month",
     "undeferTransaction": "Remove deferral",
     "deferredToNextMonth": "Next month",
+    "deferredFromPreviousMonth": "From last month",
     "resync": "Resync",
     "openingBalance": "Opening balance",
     "saveOpeningBalance": "Save",

--- a/web/public/locales/nb/budget.json
+++ b/web/public/locales/nb/budget.json
@@ -317,6 +317,7 @@
     "deferTransaction": "Utsett til neste måned",
     "undeferTransaction": "Fjern utsettelse",
     "deferredToNextMonth": "Neste måned",
+    "deferredFromPreviousMonth": "Fra forrige måned",
     "resync": "Synkroniser",
     "openingBalance": "Inngående saldo",
     "saveOpeningBalance": "Lagre",

--- a/web/public/locales/th/budget.json
+++ b/web/public/locales/th/budget.json
@@ -317,6 +317,7 @@
     "deferTransaction": "เลื่อนไปเดือนหน้า",
     "undeferTransaction": "ยกเลิกการเลื่อน",
     "deferredToNextMonth": "เดือนหน้า",
+    "deferredFromPreviousMonth": "จากเดือนที่แล้ว",
     "resync": "ซิงค์ใหม่",
     "openingBalance": "ยอดยกมา",
     "saveOpeningBalance": "บันทึก",

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -52,6 +52,7 @@ interface Transaction {
   is_pending: boolean
   is_innbetaling: boolean
   deferred_to_next_month: boolean
+  deferred_from_previous_month: boolean
   group_id: number | null
   group_name: string
 }
@@ -144,8 +145,10 @@ interface GroupSectionProps {
 }
 
 function GroupSection({ title, transactions, groups, currency, t, onAssign, onDelete, onDefer }: GroupSectionProps) {
+  // A carry-over (deferred_from_previous_month) is active in the viewed month and
+  // counts toward its total; a row deferred forward out of this month does not.
   const expenseTotal = transactions
-    .filter(tx => !tx.is_innbetaling && !tx.deferred_to_next_month)
+    .filter(tx => !tx.is_innbetaling && (tx.deferred_from_previous_month || !tx.deferred_to_next_month))
     .reduce((sum, tx) => sum + Math.abs(tx.belop), 0)
   const innbetalingTotal = transactions
     .filter(tx => tx.is_innbetaling)
@@ -200,8 +203,13 @@ function TransactionItem({ tx, groups, currency, t, onAssign, onDelete, onDefer 
     tx.belop_i_valuta !== 0 &&
     Math.abs(Math.abs(tx.belop_i_valuta) - Math.abs(tx.belop)) > 0.01
 
+  // Carry-overs are deferred rows shown in their target month — active here,
+  // not greyed out, and labelled to indicate they came from the previous month.
+  const isCarryover = tx.deferred_from_previous_month
+  const isDeferredAway = tx.deferred_to_next_month && !isCarryover
+
   return (
-    <div className={`flex items-start gap-2 px-3 py-2 ${tx.deferred_to_next_month ? 'opacity-60' : ''}`}>
+    <div className={`flex items-start gap-2 px-3 py-2 ${isDeferredAway ? 'opacity-60' : ''}`}>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5 flex-wrap">
           <span className={`text-sm truncate ${tx.is_innbetaling ? 'text-green-400' : 'text-gray-200'}`}>
@@ -217,9 +225,14 @@ function TransactionItem({ tx, groups, currency, t, onAssign, onDelete, onDefer 
               {t('creditCards.payment')}
             </span>
           )}
-          {tx.deferred_to_next_month && (
+          {isDeferredAway && (
             <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-900/50 text-purple-300 border border-purple-700/50 flex-shrink-0">
               {t('creditCards.deferredToNextMonth')}
+            </span>
+          )}
+          {isCarryover && (
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-900/50 text-purple-300 border border-purple-700/50 flex-shrink-0">
+              {t('creditCards.deferredFromPreviousMonth')}
             </span>
           )}
         </div>
@@ -1012,12 +1025,13 @@ export default function BudgetCreditCards() {
   ]
 
   // When a variable bill is linked, derive the monthly total from the backend-computed
-  // closing balance so it stays consistent with SyncCreditCardExpense (which accounts
-  // for deferred carry-overs from the previous month that are not in the transaction list).
+  // closing balance so it stays consistent with SyncCreditCardExpense. Otherwise sum
+  // the visible rows: include carry-overs from the previous month, exclude rows
+  // deferred forward out of this month.
   const expenseTotal = variableBillName !== null
     ? variableBillAmount - openingBalance
     : transactions
-        .filter(tx => !tx.is_innbetaling && !tx.deferred_to_next_month)
+        .filter(tx => !tx.is_innbetaling && (tx.deferred_from_previous_month || !tx.deferred_to_next_month))
         .reduce((sum, tx) => sum + Math.abs(tx.belop), 0)
 
   // Groups to show in dropdown for reassignment (include Diverse so any

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -203,9 +203,9 @@ function TransactionItem({ tx, groups, currency, t, onAssign, onDelete, onDefer 
     tx.belop_i_valuta !== 0 &&
     Math.abs(Math.abs(tx.belop_i_valuta) - Math.abs(tx.belop)) > 0.01
 
-  // Carry-overs are deferred rows shown in their target month — active here,
-  // not greyed out, and labelled to indicate they came from the previous month.
-  const isCarryover = tx.deferred_from_previous_month
+  // During optimistic undefer, `deferred_to_next_month` is toggled immediately,
+  // so require both flags to keep UI semantics in sync before the reload.
+  const isCarryover = tx.deferred_from_previous_month && tx.deferred_to_next_month
   const isDeferredAway = tx.deferred_to_next_month && !isCarryover
 
   return (


### PR DESCRIPTION
## Changes

- **Credit-card transactions deferred to next month now appear in the target month's transaction list** - The deferred row was already counted in the next month's total, but the row itself was hidden. It is now shown in both the source month (greyed out as before) and the target month (active, labelled "from last month"). (Hytte-l74q)

## Original Issue (bug): Deferred credit-card transaction invisible in target month

When a credit-card transaction is deferred to the next month on the budget credit-cards page, the deferred transaction is correctly reflected in the next month's monthly total, but the transaction row itself is not visible in the next month's transaction list. In the previous (source) month, the transaction appears greyed out as expected.

---
Bead: Hytte-l74q | Branch: forge/Hytte-l74q
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)