### PR TITLE
Regnemester: schema and core game engine (Hytte-rh4h)

### DIFF
--- a/changelog.d/Hytte-rh4h.md
+++ b/changelog.d/Hytte-rh4h.md
@@ -1,0 +1,2 @@
+category: Added
+- **Regnemester math game engine** - Backend foundation for a multiplication (1–10) and division math game. Adds the `regnemester` feature flag, `math_sessions` / `math_attempts` / `math_achievements` tables, an `internal/math` package with question generation, answer validation, session lifecycle and per-fact mastery aggregation, and the authenticated API endpoints `POST /api/math/sessions`, `POST /api/math/sessions/{id}/attempts`, `POST /api/math/sessions/{id}/finish` and `GET /api/math/stats`. UI ships in a follow-up bead. (Hytte-rh4h)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Robin831/Hytte/internal/kiosk"
 	"github.com/Robin831/Hytte/internal/lactate"
 	"github.com/Robin831/Hytte/internal/links"
+	mathgame "github.com/Robin831/Hytte/internal/math"
 	"github.com/Robin831/Hytte/internal/netatmo"
 	"github.com/Robin831/Hytte/internal/notes"
 	"github.com/Robin831/Hytte/internal/push"
@@ -640,6 +641,15 @@ func NewRouter(db *sql.DB) http.Handler {
 					r.Use(family.RequireParentOrAdmin(db))
 					r.Get("/homework/children/{childId}/review", homework.HandleParentReview(db))
 				})
+			})
+
+			// Regnemester math game — gated by "regnemester" feature (Hytte-rh4h).
+			r.Group(func(r chi.Router) {
+				r.Use(auth.RequireFeature(db, "regnemester"))
+				r.Post("/math/sessions", mathgame.StartSessionHandler(db))
+				r.Post("/math/sessions/{id}/attempts", mathgame.RecordAttemptHandler(db))
+				r.Post("/math/sessions/{id}/finish", mathgame.FinishSessionHandler(db))
+				r.Get("/math/stats", mathgame.StatsHandler(db))
 			})
 
 			// Transit departures — gated by "transit" feature.

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -33,6 +33,7 @@ var FeatureDefaults = map[string]bool{
 	"vault":            false,
 	"grocery":          false,
 	"homework":         false,
+	"regnemester":     false,
 }
 
 // FeatureKeys is a sorted list of all known feature keys, used for stable

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -33,7 +33,7 @@ var FeatureDefaults = map[string]bool{
 	"vault":            false,
 	"grocery":          false,
 	"homework":         false,
-	"regnemester":     false,
+	"regnemester":      false,
 }
 
 // FeatureKeys is a sorted list of all known feature keys, used for stable

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1487,6 +1487,49 @@ func createSchema(db *sql.DB) error {
 
 	CREATE INDEX IF NOT EXISTS idx_homework_messages_conversation ON homework_messages(conversation_id);
 
+	-- Regnemester math game tables (Hytte-rh4h).
+	CREATE TABLE IF NOT EXISTS math_sessions (
+		id             INTEGER PRIMARY KEY,
+		user_id        INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		mode           TEXT NOT NULL DEFAULT '',
+		started_at     TEXT NOT NULL DEFAULT '',
+		ended_at       TEXT NOT NULL DEFAULT '',
+		score_num      INTEGER NOT NULL DEFAULT 0,
+		duration_ms    INTEGER NOT NULL DEFAULT 0,
+		total_correct  INTEGER NOT NULL DEFAULT 0,
+		total_wrong    INTEGER NOT NULL DEFAULT 0,
+		meta           TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_math_sessions_user_started ON math_sessions(user_id, started_at);
+
+	CREATE TABLE IF NOT EXISTS math_attempts (
+		id              INTEGER PRIMARY KEY,
+		session_id      INTEGER NOT NULL REFERENCES math_sessions(id) ON DELETE CASCADE,
+		user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		fact_a          INTEGER NOT NULL,
+		fact_b          INTEGER NOT NULL,
+		op              TEXT NOT NULL CHECK(op IN ('*','/')),
+		expected_answer INTEGER NOT NULL,
+		user_answer     INTEGER NOT NULL,
+		is_correct      INTEGER NOT NULL DEFAULT 0,
+		response_ms     INTEGER NOT NULL DEFAULT 0,
+		created_at      TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_math_attempts_user_fact ON math_attempts(user_id, fact_a, fact_b, op);
+	CREATE INDEX IF NOT EXISTS idx_math_attempts_session ON math_attempts(session_id);
+
+	CREATE TABLE IF NOT EXISTS math_achievements (
+		id          INTEGER PRIMARY KEY,
+		user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		code        TEXT NOT NULL,
+		unlocked_at TEXT NOT NULL DEFAULT '',
+		session_id  INTEGER REFERENCES math_sessions(id) ON DELETE SET NULL,
+		meta        TEXT NOT NULL DEFAULT '',
+		UNIQUE(user_id, code)
+	);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/math/generator.go
+++ b/internal/math/generator.go
@@ -1,0 +1,107 @@
+// Package math implements the Regnemester math game engine: question
+// generation, answer validation, session lifecycle, and per-fact mastery
+// aggregation for multiplication (1–10) and the matching division facts.
+package math
+
+import (
+	mrand "math/rand/v2"
+)
+
+// OpMultiply represents a multiplication fact (a × b).
+const OpMultiply = "*"
+
+// OpDivide represents a division fact (a ÷ b).
+const OpDivide = "/"
+
+// MinOperand and MaxOperand define the inclusive range for the small
+// multiplicands that drive both multiplication and division facts.
+const (
+	MinOperand = 1
+	MaxOperand = 10
+)
+
+// Mode constants for question generation. New modes can be added without
+// breaking older sessions because the engine falls back to ModeMixed for
+// unknown values.
+const (
+	ModeMixed          = "mixed"
+	ModeMultiplication = "mult"
+	ModeDivision       = "div"
+)
+
+// Fact represents a single math fact. For multiplication, A and B are the
+// multiplicands and Expected = A*B. For division, A is the dividend, B is
+// the divisor and Expected = A/B (which always lies in [MinOperand, MaxOperand]).
+type Fact struct {
+	A        int    `json:"a"`
+	B        int    `json:"b"`
+	Op       string `json:"op"`
+	Expected int    `json:"expected"`
+}
+
+// AllFacts returns the canonical 200-fact universe: 100 multiplication facts
+// for every (a, b) with a, b ∈ [MinOperand, MaxOperand], followed by 100
+// division facts c÷b=a (one for every (a, b) pair, covering both divisor
+// variants because a and b iterate independently).
+func AllFacts() []Fact {
+	facts := make([]Fact, 0, 200)
+	for a := MinOperand; a <= MaxOperand; a++ {
+		for b := MinOperand; b <= MaxOperand; b++ {
+			facts = append(facts, Fact{A: a, B: b, Op: OpMultiply, Expected: a * b})
+		}
+	}
+	for a := MinOperand; a <= MaxOperand; a++ {
+		for b := MinOperand; b <= MaxOperand; b++ {
+			c := a * b
+			facts = append(facts, Fact{A: c, B: b, Op: OpDivide, Expected: a})
+		}
+	}
+	return facts
+}
+
+// FactsForMode returns the slice of facts that the given mode draws from.
+// Unknown modes fall back to the mixed pool so that older clients that send
+// new mode strings still get a valid question.
+func FactsForMode(mode string) []Fact {
+	all := AllFacts()
+	switch mode {
+	case ModeMultiplication:
+		out := make([]Fact, 0, 100)
+		for _, f := range all {
+			if f.Op == OpMultiply {
+				out = append(out, f)
+			}
+		}
+		return out
+	case ModeDivision:
+		out := make([]Fact, 0, 100)
+		for _, f := range all {
+			if f.Op == OpDivide {
+				out = append(out, f)
+			}
+		}
+		return out
+	default:
+		return all
+	}
+}
+
+// NextQuestion returns a random fact for the given mode. The history slice is
+// accepted for future mastery-weighted selection but is currently unused —
+// foundation bead only delivers uniform random sampling.
+func NextQuestion(mode string, _ []Fact) Fact {
+	pool := FactsForMode(mode)
+	return pool[mrand.IntN(len(pool))]
+}
+
+// IsValidMode reports whether the given mode is one of the recognised values.
+// Unknown modes are still accepted by NextQuestion (which falls back to
+// mixed), but the session layer rejects them at Start time.
+func IsValidMode(mode string) bool {
+	switch mode {
+	case ModeMixed, ModeMultiplication, ModeDivision:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/math/generator_test.go
+++ b/internal/math/generator_test.go
@@ -37,7 +37,7 @@ func TestAllFactsEnumeratesEveryMultiplication(t *testing.T) {
 
 func TestAllFactsEnumeratesEveryDivision(t *testing.T) {
 	facts := AllFacts()
-	// Divison facts are keyed by (dividend, divisor); each ordered (a,b) pair
+	// Division facts are keyed by (dividend, divisor); each ordered (a,b) pair
 	// in the multiplication table produces one division fact (c=a*b)÷b=a, so
 	// both divisor variants of every product appear.
 	got := make(map[[2]int]int)

--- a/internal/math/generator_test.go
+++ b/internal/math/generator_test.go
@@ -1,0 +1,133 @@
+package math
+
+import "testing"
+
+func TestAllFactsCount(t *testing.T) {
+	facts := AllFacts()
+	if len(facts) != 200 {
+		t.Fatalf("expected 200 facts, got %d", len(facts))
+	}
+}
+
+func TestAllFactsEnumeratesEveryMultiplication(t *testing.T) {
+	facts := AllFacts()
+	got := make(map[[2]int]int) // (a,b) -> expected
+	for _, f := range facts {
+		if f.Op != OpMultiply {
+			continue
+		}
+		got[[2]int{f.A, f.B}] = f.Expected
+	}
+	if len(got) != 100 {
+		t.Fatalf("expected 100 unique multiplication facts, got %d", len(got))
+	}
+	for a := MinOperand; a <= MaxOperand; a++ {
+		for b := MinOperand; b <= MaxOperand; b++ {
+			expected, ok := got[[2]int{a, b}]
+			if !ok {
+				t.Errorf("missing multiplication fact %d×%d", a, b)
+				continue
+			}
+			if expected != a*b {
+				t.Errorf("fact %d×%d expected %d, got %d", a, b, a*b, expected)
+			}
+		}
+	}
+}
+
+func TestAllFactsEnumeratesEveryDivision(t *testing.T) {
+	facts := AllFacts()
+	// Divison facts are keyed by (dividend, divisor); each ordered (a,b) pair
+	// in the multiplication table produces one division fact (c=a*b)÷b=a, so
+	// both divisor variants of every product appear.
+	got := make(map[[2]int]int)
+	for _, f := range facts {
+		if f.Op != OpDivide {
+			continue
+		}
+		got[[2]int{f.A, f.B}] = f.Expected
+	}
+	if len(got) != 100 {
+		t.Fatalf("expected 100 unique division facts, got %d", len(got))
+	}
+	for a := MinOperand; a <= MaxOperand; a++ {
+		for b := MinOperand; b <= MaxOperand; b++ {
+			c := a * b
+			expected, ok := got[[2]int{c, b}]
+			if !ok {
+				t.Errorf("missing division fact %d÷%d", c, b)
+				continue
+			}
+			if expected != a {
+				t.Errorf("fact %d÷%d expected %d, got %d", c, b, a, expected)
+			}
+		}
+	}
+}
+
+func TestAllFactsBothDivisorVariants(t *testing.T) {
+	// For any pair a≠b, both c÷a=b and c÷b=a should be present.
+	facts := AllFacts()
+	have := make(map[[2]int]bool)
+	for _, f := range facts {
+		if f.Op == OpDivide {
+			have[[2]int{f.A, f.B}] = true
+		}
+	}
+	if !have[[2]int{6, 2}] {
+		t.Error("missing 6÷2")
+	}
+	if !have[[2]int{6, 3}] {
+		t.Error("missing 6÷3")
+	}
+	if !have[[2]int{12, 3}] {
+		t.Error("missing 12÷3")
+	}
+	if !have[[2]int{12, 4}] {
+		t.Error("missing 12÷4")
+	}
+}
+
+func TestFactsForMode(t *testing.T) {
+	if got := len(FactsForMode(ModeMultiplication)); got != 100 {
+		t.Errorf("ModeMultiplication: got %d, want 100", got)
+	}
+	if got := len(FactsForMode(ModeDivision)); got != 100 {
+		t.Errorf("ModeDivision: got %d, want 100", got)
+	}
+	if got := len(FactsForMode(ModeMixed)); got != 200 {
+		t.Errorf("ModeMixed: got %d, want 200", got)
+	}
+	if got := len(FactsForMode("unknown-mode")); got != 200 {
+		t.Errorf("unknown mode should fall back to mixed pool, got %d", got)
+	}
+}
+
+func TestNextQuestionRespectsMode(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		q := NextQuestion(ModeMultiplication, nil)
+		if q.Op != OpMultiply {
+			t.Fatalf("ModeMultiplication produced non-mult fact: %+v", q)
+		}
+	}
+	for i := 0; i < 50; i++ {
+		q := NextQuestion(ModeDivision, nil)
+		if q.Op != OpDivide {
+			t.Fatalf("ModeDivision produced non-div fact: %+v", q)
+		}
+	}
+}
+
+func TestIsValidMode(t *testing.T) {
+	for _, m := range []string{ModeMixed, ModeMultiplication, ModeDivision} {
+		if !IsValidMode(m) {
+			t.Errorf("expected %q to be a valid mode", m)
+		}
+	}
+	if IsValidMode("") {
+		t.Error("empty mode should not be valid")
+	}
+	if IsValidMode("nope") {
+		t.Error("unknown mode should not be valid")
+	}
+}

--- a/internal/math/handlers.go
+++ b/internal/math/handlers.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -11,6 +12,12 @@ import (
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/go-chi/chi/v5"
 )
+
+// maxBodyBytes caps incoming JSON payloads for the math handlers. All
+// request shapes are tiny objects with a handful of integer/string fields,
+// so 1 KiB is generous and prevents a caller from exhausting memory by
+// streaming a huge body through json.Decoder.
+const maxBodyBytes = 1 << 10
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
@@ -34,10 +41,13 @@ func StartSessionHandler(db *sql.DB) http.HandlerFunc {
 			writeErr(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 		var body struct {
 			Mode string `json:"mode"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		// An empty body is allowed (it means "use ModeMixed"); only reject
+		// a body that is present but not valid JSON.
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
 			writeErr(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
@@ -73,10 +83,11 @@ func RecordAttemptHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 		sessionID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-		if err != nil {
+		if err != nil || sessionID <= 0 {
 			writeErr(w, http.StatusBadRequest, "invalid session id")
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 		var body struct {
 			A          int    `json:"a"`
 			B          int    `json:"b"`
@@ -132,10 +143,13 @@ func FinishSessionHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 		sessionID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
-		if err != nil {
+		if err != nil || sessionID <= 0 {
 			writeErr(w, http.StatusBadRequest, "invalid session id")
 			return
 		}
+		// Finish takes no body but callers may still send one; cap it so a
+		// client can't stream an arbitrary payload at this endpoint.
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 		summary, err := svc.Finish(r.Context(), sessionID, user.ID)
 		if err != nil {
 			switch {

--- a/internal/math/handlers.go
+++ b/internal/math/handlers.go
@@ -73,7 +73,8 @@ func StartSessionHandler(db *sql.DB) http.HandlerFunc {
 
 // RecordAttemptHandler returns POST /api/math/sessions/:id/attempts: body
 // {a, b, op, user_answer, response_ms}, response {is_correct,
-// expected_answer, next_question}.
+// expected_answer, next_question}. next_question is always present; the
+// session continues until the client calls the finish endpoint.
 func RecordAttemptHandler(db *sql.DB) http.HandlerFunc {
 	svc := NewService(db)
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/math/handlers.go
+++ b/internal/math/handlers.go
@@ -1,0 +1,222 @@
+package math
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("math: writeJSON encode error: %v", err)
+	}
+}
+
+func writeErr(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// StartSessionHandler returns POST /api/math/sessions: body {mode}, response
+// {session_id, first_question}.
+func StartSessionHandler(db *sql.DB) http.HandlerFunc {
+	svc := NewService(db)
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			writeErr(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		var body struct {
+			Mode string `json:"mode"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		if body.Mode == "" {
+			body.Mode = ModeMixed
+		}
+		id, first, err := svc.Start(r.Context(), user.ID, body.Mode)
+		if err != nil {
+			if errors.Is(err, ErrInvalidMode) {
+				writeErr(w, http.StatusBadRequest, "invalid mode")
+				return
+			}
+			log.Printf("math: start session: %v", err)
+			writeErr(w, http.StatusInternalServerError, "failed to start session")
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"session_id":     id,
+			"first_question": first,
+		})
+	}
+}
+
+// RecordAttemptHandler returns POST /api/math/sessions/:id/attempts: body
+// {a, b, op, user_answer, response_ms}, response {is_correct,
+// expected_answer, next_question}.
+func RecordAttemptHandler(db *sql.DB) http.HandlerFunc {
+	svc := NewService(db)
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			writeErr(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		sessionID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid session id")
+			return
+		}
+		var body struct {
+			A          int    `json:"a"`
+			B          int    `json:"b"`
+			Op         string `json:"op"`
+			UserAnswer int    `json:"user_answer"`
+			ResponseMs int    `json:"response_ms"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		if body.ResponseMs < 0 {
+			writeErr(w, http.StatusBadRequest, "response_ms must be non-negative")
+			return
+		}
+
+		isCorrect, expected, next, err := svc.RecordAttempt(
+			r.Context(), sessionID, user.ID, body.A, body.B, body.Op, body.UserAnswer, body.ResponseMs,
+		)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrSessionNotFound):
+				writeErr(w, http.StatusNotFound, "session not found")
+			case errors.Is(err, ErrSessionNotOwned):
+				writeErr(w, http.StatusForbidden, "session not owned")
+			case errors.Is(err, ErrSessionFinished):
+				writeErr(w, http.StatusConflict, "session already finished")
+			default:
+				// Validation errors (invalid op, out-of-range) come back here as
+				// generic errors — surface them as 400 so the client can correct.
+				writeErr(w, http.StatusBadRequest, err.Error())
+			}
+			return
+		}
+
+		resp := map[string]any{
+			"is_correct":      isCorrect,
+			"expected_answer": expected,
+			"next_question":   next,
+		}
+		writeJSON(w, http.StatusOK, resp)
+	}
+}
+
+// FinishSessionHandler returns POST /api/math/sessions/:id/finish, response
+// {summary}.
+func FinishSessionHandler(db *sql.DB) http.HandlerFunc {
+	svc := NewService(db)
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			writeErr(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		sessionID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid session id")
+			return
+		}
+		summary, err := svc.Finish(r.Context(), sessionID, user.ID)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrSessionNotFound):
+				writeErr(w, http.StatusNotFound, "session not found")
+			case errors.Is(err, ErrSessionNotOwned):
+				writeErr(w, http.StatusForbidden, "session not owned")
+			default:
+				log.Printf("math: finish session: %v", err)
+				writeErr(w, http.StatusInternalServerError, "failed to finish session")
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"summary": summary})
+	}
+}
+
+// statsEntry is the per-fact payload in the stats response. Operands are
+// repeated alongside FactStats so the client can render without rebuilding
+// the key.
+type statsEntry struct {
+	A int `json:"a"`
+	B int `json:"b"`
+	FactStats
+}
+
+// StatsHandler returns GET /api/math/stats: the user's per-fact mastery for
+// both ops, sorted (a, b) ascending for a stable client-side render.
+func StatsHandler(db *sql.DB) http.HandlerFunc {
+	svc := NewService(db)
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			writeErr(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		mastery, err := svc.Mastery(r.Context(), user.ID)
+		if err != nil {
+			log.Printf("math: mastery: %v", err)
+			writeErr(w, http.StatusInternalServerError, "failed to load stats")
+			return
+		}
+		mult := make([]statsEntry, 0)
+		div := make([]statsEntry, 0)
+		for k, v := range mastery {
+			entry := statsEntry{A: k.A, B: k.B, FactStats: v}
+			switch k.Op {
+			case OpMultiply:
+				mult = append(mult, entry)
+			case OpDivide:
+				div = append(div, entry)
+			}
+		}
+		sortStats(mult)
+		sortStats(div)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"multiplication": mult,
+			"division":       div,
+		})
+	}
+}
+
+// sortStats orders entries by (A, B) ascending. We sort in-place using a
+// simple comparator-based sort rather than pulling in sort.Slice's reflection.
+func sortStats(entries []statsEntry) {
+	// Insertion sort — slices are at most 100 long, and this avoids a
+	// reflection-based sort.Slice call.
+	for i := 1; i < len(entries); i++ {
+		for j := i; j > 0; j-- {
+			if statsLess(entries[j], entries[j-1]) {
+				entries[j], entries[j-1] = entries[j-1], entries[j]
+				continue
+			}
+			break
+		}
+	}
+}
+
+func statsLess(a, b statsEntry) bool {
+	if a.A != b.A {
+		return a.A < b.A
+	}
+	return a.B < b.B
+}

--- a/internal/math/handlers_test.go
+++ b/internal/math/handlers_test.go
@@ -1,0 +1,217 @@
+package math
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+func newJSONRequest(t *testing.T, method, path string, body any) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+	}
+	r := httptest.NewRequest(method, path, &buf)
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+func withUser(r *http.Request, user *auth.User) *http.Request {
+	return r.WithContext(auth.ContextWithUser(r.Context(), user))
+}
+
+func withChi(r *http.Request, params map[string]string) *http.Request {
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+var testUser = &auth.User{ID: 1, Email: "u@test.com", Name: "U"}
+
+func TestStartSessionHandler(t *testing.T) {
+	d := setupTestDB(t)
+	h := StartSessionHandler(d)
+
+	r := withUser(newJSONRequest(t, http.MethodPost, "/api/math/sessions", map[string]string{"mode": ModeMixed}), testUser)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		SessionID     int64 `json:"session_id"`
+		FirstQuestion Fact  `json:"first_question"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.SessionID == 0 {
+		t.Error("expected non-zero session id")
+	}
+	if resp.FirstQuestion.Op != OpMultiply && resp.FirstQuestion.Op != OpDivide {
+		t.Errorf("first question op=%q", resp.FirstQuestion.Op)
+	}
+}
+
+func TestStartSessionInvalidMode(t *testing.T) {
+	d := setupTestDB(t)
+	h := StartSessionHandler(d)
+
+	r := withUser(newJSONRequest(t, http.MethodPost, "/api/math/sessions", map[string]string{"mode": "nope"}), testUser)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestRecordAttemptHandlerRoundTrip(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Start a session directly so we know the id.
+	id, _, err := NewService(d).Start(context.Background(), 1, ModeMixed)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	h := RecordAttemptHandler(d)
+	body := map[string]any{
+		"a":           3,
+		"b":           4,
+		"op":          OpMultiply,
+		"user_answer": 12,
+		"response_ms": 1500,
+	}
+	r := withChi(withUser(newJSONRequest(t, http.MethodPost, "/api/math/sessions/"+strconv.FormatInt(id, 10)+"/attempts", body), testUser), map[string]string{"id": strconv.FormatInt(id, 10)})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		IsCorrect      bool  `json:"is_correct"`
+		ExpectedAnswer int   `json:"expected_answer"`
+		NextQuestion   *Fact `json:"next_question"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.IsCorrect {
+		t.Error("expected is_correct=true")
+	}
+	if resp.ExpectedAnswer != 12 {
+		t.Errorf("expected_answer=%d, want 12", resp.ExpectedAnswer)
+	}
+	if resp.NextQuestion == nil {
+		t.Error("expected non-nil next_question")
+	}
+}
+
+func TestRecordAttemptHandlerForeignSession(t *testing.T) {
+	d := setupTestDB(t)
+	id, _, err := NewService(d).Start(context.Background(), 1, ModeMixed)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	other := &auth.User{ID: 2, Email: "x@test.com"}
+
+	h := RecordAttemptHandler(d)
+	body := map[string]any{"a": 3, "b": 4, "op": OpMultiply, "user_answer": 12, "response_ms": 100}
+	r := withChi(withUser(newJSONRequest(t, http.MethodPost, "/api/math/sessions/"+strconv.FormatInt(id, 10)+"/attempts", body), other), map[string]string{"id": strconv.FormatInt(id, 10)})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestFinishSessionHandler(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	id, _, err := svc.Start(context.Background(), 1, ModeMixed)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(context.Background(), id, 1, 3, 4, OpMultiply, 12, 100); err != nil {
+		t.Fatalf("RecordAttempt: %v", err)
+	}
+
+	h := FinishSessionHandler(d)
+	r := withChi(withUser(newJSONRequest(t, http.MethodPost, "/api/math/sessions/"+strconv.FormatInt(id, 10)+"/finish", nil), testUser), map[string]string{"id": strconv.FormatInt(id, 10)})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Summary Summary `json:"summary"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Summary.SessionID != id {
+		t.Errorf("Summary.SessionID=%d, want %d", resp.Summary.SessionID, id)
+	}
+	if resp.Summary.TotalCorrect != 1 {
+		t.Errorf("TotalCorrect=%d, want 1", resp.Summary.TotalCorrect)
+	}
+}
+
+func TestStatsHandlerSorted(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+	id, _, err := svc.Start(ctx, 1, ModeMixed)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Record attempts in random order.
+	pairs := [][2]int{{5, 5}, {2, 3}, {7, 4}}
+	for _, p := range pairs {
+		if _, _, _, err := svc.RecordAttempt(ctx, id, 1, p[0], p[1], OpMultiply, p[0]*p[1], 100); err != nil {
+			t.Fatalf("RecordAttempt: %v", err)
+		}
+	}
+
+	h := StatsHandler(d)
+	r := withUser(httptest.NewRequest(http.MethodGet, "/api/math/stats", nil), testUser)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Multiplication []statsEntry `json:"multiplication"`
+		Division       []statsEntry `json:"division"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Multiplication) != 3 {
+		t.Fatalf("got %d mult entries, want 3", len(resp.Multiplication))
+	}
+	// Verify ascending (A, B) order.
+	for i := 1; i < len(resp.Multiplication); i++ {
+		prev, cur := resp.Multiplication[i-1], resp.Multiplication[i]
+		if prev.A > cur.A || (prev.A == cur.A && prev.B > cur.B) {
+			t.Errorf("entries not sorted: %+v then %+v", prev, cur)
+		}
+	}
+}

--- a/internal/math/mastery.go
+++ b/internal/math/mastery.go
@@ -1,0 +1,90 @@
+package math
+
+import (
+	"context"
+	"fmt"
+)
+
+// FactKey identifies one of the 200 facts (a, b, op).
+type FactKey struct {
+	A  int    `json:"a"`
+	B  int    `json:"b"`
+	Op string `json:"op"`
+}
+
+// FactStats holds the aggregated mastery numbers for a single fact.
+// Last5 is ordered oldest-first (last element = most recent attempt) so
+// the frontend can render a left-to-right correctness streak.
+type FactStats struct {
+	Count        int     `json:"count"`
+	CorrectCount int     `json:"correct_count"`
+	AvgMs        float64 `json:"avg_ms"`
+	Last5        []bool  `json:"last5"`
+}
+
+// Mastery returns one FactStats per fact the user has ever attempted, keyed
+// by (a, b, op). Facts the user has not yet attempted are omitted from the
+// map — callers can fill in zero-stats by enumerating AllFacts on the side
+// when they need to render an exhaustive grid.
+func (s *Service) Mastery(ctx context.Context, userID int64) (map[FactKey]FactStats, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT fact_a, fact_b, op, is_correct, response_ms
+		FROM math_attempts
+		WHERE user_id = ?
+		ORDER BY id ASC`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("query math_attempts: %w", err)
+	}
+	defer rows.Close()
+
+	type acc struct {
+		count        int
+		correctCount int
+		totalMs      int64
+		recent       []bool
+	}
+	bucket := make(map[FactKey]*acc)
+
+	for rows.Next() {
+		var (
+			a, b, isCorrect, responseMs int
+			op                          string
+		)
+		if err := rows.Scan(&a, &b, &op, &isCorrect, &responseMs); err != nil {
+			return nil, fmt.Errorf("scan math_attempts: %w", err)
+		}
+		k := FactKey{A: a, B: b, Op: op}
+		entry, ok := bucket[k]
+		if !ok {
+			entry = &acc{}
+			bucket[k] = entry
+		}
+		entry.count++
+		if isCorrect != 0 {
+			entry.correctCount++
+		}
+		entry.totalMs += int64(responseMs)
+		entry.recent = append(entry.recent, isCorrect != 0)
+		if len(entry.recent) > 5 {
+			entry.recent = entry.recent[len(entry.recent)-5:]
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate math_attempts: %w", err)
+	}
+
+	out := make(map[FactKey]FactStats, len(bucket))
+	for k, e := range bucket {
+		var avg float64
+		if e.count > 0 {
+			avg = float64(e.totalMs) / float64(e.count)
+		}
+		out[k] = FactStats{
+			Count:        e.count,
+			CorrectCount: e.correctCount,
+			AvgMs:        avg,
+			Last5:        append([]bool(nil), e.recent...),
+		}
+	}
+	return out, nil
+}

--- a/internal/math/mastery_test.go
+++ b/internal/math/mastery_test.go
@@ -1,0 +1,157 @@
+package math
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMasteryAggregatesCounts(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	id, _, err := svc.Start(ctx, 1, ModeMixed)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Same fact 3×4=12 attempted three times: correct, wrong, correct.
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 3, 4, OpMultiply, 12, 1000); err != nil {
+		t.Fatalf("attempt 1: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 3, 4, OpMultiply, 11, 2000); err != nil {
+		t.Fatalf("attempt 2: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 3, 4, OpMultiply, 12, 3000); err != nil {
+		t.Fatalf("attempt 3: %v", err)
+	}
+	// One division attempt 12÷4=3 (correct).
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 12, 4, OpDivide, 3, 500); err != nil {
+		t.Fatalf("attempt 4: %v", err)
+	}
+
+	mastery, err := svc.Mastery(ctx, 1)
+	if err != nil {
+		t.Fatalf("Mastery: %v", err)
+	}
+	multStats, ok := mastery[FactKey{A: 3, B: 4, Op: OpMultiply}]
+	if !ok {
+		t.Fatal("missing 3×4 stats")
+	}
+	if multStats.Count != 3 {
+		t.Errorf("Count=%d, want 3", multStats.Count)
+	}
+	if multStats.CorrectCount != 2 {
+		t.Errorf("CorrectCount=%d, want 2", multStats.CorrectCount)
+	}
+	wantAvg := float64(1000+2000+3000) / 3.0
+	if multStats.AvgMs != wantAvg {
+		t.Errorf("AvgMs=%v, want %v", multStats.AvgMs, wantAvg)
+	}
+	if len(multStats.Last5) != 3 {
+		t.Fatalf("Last5 length=%d, want 3", len(multStats.Last5))
+	}
+	// Order: oldest first → [true, false, true].
+	if !(multStats.Last5[0] == true && multStats.Last5[1] == false && multStats.Last5[2] == true) {
+		t.Errorf("Last5=%v, want [true false true]", multStats.Last5)
+	}
+
+	divStats, ok := mastery[FactKey{A: 12, B: 4, Op: OpDivide}]
+	if !ok {
+		t.Fatal("missing 12÷4 stats")
+	}
+	if divStats.Count != 1 || divStats.CorrectCount != 1 {
+		t.Errorf("div stats=%+v", divStats)
+	}
+}
+
+func TestMasteryLast5Window(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	id, _, err := svc.Start(ctx, 1, ModeMultiplication)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// 7 attempts of 2×2=4 with alternating correctness: T,F,T,F,T,F,T.
+	answers := []int{4, 3, 4, 3, 4, 3, 4}
+	for _, ans := range answers {
+		if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 2, 2, OpMultiply, ans, 100); err != nil {
+			t.Fatalf("attempt: %v", err)
+		}
+	}
+
+	mastery, err := svc.Mastery(ctx, 1)
+	if err != nil {
+		t.Fatalf("Mastery: %v", err)
+	}
+	stats := mastery[FactKey{A: 2, B: 2, Op: OpMultiply}]
+	if stats.Count != 7 {
+		t.Errorf("Count=%d, want 7", stats.Count)
+	}
+	if len(stats.Last5) != 5 {
+		t.Fatalf("Last5 length=%d, want 5", len(stats.Last5))
+	}
+	// The last 5 attempts (indices 2..6) → answers [4,3,4,3,4] → [T,F,T,F,T].
+	want := []bool{true, false, true, false, true}
+	for i, w := range want {
+		if stats.Last5[i] != w {
+			t.Errorf("Last5[%d]=%v, want %v (full=%v)", i, stats.Last5[i], w, stats.Last5)
+		}
+	}
+}
+
+func TestMasteryScopedToUser(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	id1, _, err := svc.Start(ctx, 1, ModeMultiplication)
+	if err != nil {
+		t.Fatalf("Start user 1: %v", err)
+	}
+	id2, _, err := svc.Start(ctx, 2, ModeMultiplication)
+	if err != nil {
+		t.Fatalf("Start user 2: %v", err)
+	}
+
+	if _, _, _, err := svc.RecordAttempt(ctx, id1, 1, 5, 5, OpMultiply, 25, 100); err != nil {
+		t.Fatalf("attempt 1: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(ctx, id2, 2, 6, 6, OpMultiply, 36, 100); err != nil {
+		t.Fatalf("attempt 2: %v", err)
+	}
+
+	m1, err := svc.Mastery(ctx, 1)
+	if err != nil {
+		t.Fatalf("Mastery 1: %v", err)
+	}
+	if _, ok := m1[FactKey{A: 6, B: 6, Op: OpMultiply}]; ok {
+		t.Error("user 1 should not see user 2's facts")
+	}
+	if _, ok := m1[FactKey{A: 5, B: 5, Op: OpMultiply}]; !ok {
+		t.Error("user 1 should see their own fact")
+	}
+
+	m2, err := svc.Mastery(ctx, 2)
+	if err != nil {
+		t.Fatalf("Mastery 2: %v", err)
+	}
+	if _, ok := m2[FactKey{A: 5, B: 5, Op: OpMultiply}]; ok {
+		t.Error("user 2 should not see user 1's facts")
+	}
+}
+
+func TestMasteryEmpty(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	mastery, err := svc.Mastery(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Mastery: %v", err)
+	}
+	if len(mastery) != 0 {
+		t.Errorf("expected empty mastery, got %d entries", len(mastery))
+	}
+}

--- a/internal/math/session.go
+++ b/internal/math/session.go
@@ -96,13 +96,24 @@ func (s *Service) RecordAttempt(ctx context.Context, sessionID, userID int64, a,
 		correctInt = 1
 	}
 	now := time.Now().UTC().Format(timeFormat)
-	if _, err := s.db.ExecContext(ctx, `
+	result, err := s.db.ExecContext(ctx, `
 		INSERT INTO math_attempts
 			(session_id, user_id, fact_a, fact_b, op, expected_answer, user_answer, is_correct, response_ms, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		FROM math_sessions
+		WHERE id = ? AND user_id = ? AND (ended_at IS NULL OR ended_at = '')`,
 		sessionID, userID, a, b, op, expected, userAnswer, correctInt, responseMs, now,
-	); err != nil {
+		sessionID, userID,
+	)
+	if err != nil {
 		return false, 0, nil, fmt.Errorf("insert math_attempt: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, 0, nil, fmt.Errorf("rows affected math_attempt: %w", err)
+	}
+	if rowsAffected == 0 {
+		return false, 0, nil, ErrSessionFinished
 	}
 
 	next := NextQuestion(mode, nil)
@@ -110,19 +121,21 @@ func (s *Service) RecordAttempt(ctx context.Context, sessionID, userID int64, a,
 }
 
 // Finish marks the session as completed, computes totals from math_attempts,
-// and returns a Summary. Calling Finish twice is idempotent — the second
-// call just recomputes totals against the latest attempts and returns them
-// without changing started_at.
+// and returns a Summary. ended_at and duration_ms are set only on the first
+// call; subsequent calls recompute totals against the latest attempts while
+// preserving the original completion timestamps.
 func (s *Service) Finish(ctx context.Context, sessionID, userID int64) (Summary, error) {
 	var (
-		owner     int64
-		mode      string
-		startedAt string
+		owner       int64
+		mode        string
+		startedAt   string
+		endedAtSQL  sql.NullString
+		durationSQL sql.NullInt64
 	)
 	if err := s.db.QueryRowContext(ctx,
-		`SELECT user_id, mode, started_at FROM math_sessions WHERE id = ?`,
+		`SELECT user_id, mode, started_at, ended_at, duration_ms FROM math_sessions WHERE id = ?`,
 		sessionID,
-	).Scan(&owner, &mode, &startedAt); err != nil {
+	).Scan(&owner, &mode, &startedAt, &endedAtSQL, &durationSQL); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return Summary{}, ErrSessionNotFound
 		}
@@ -144,30 +157,39 @@ func (s *Service) Finish(ctx context.Context, sessionID, userID int64) (Summary,
 	}
 	correctCount := int(correct.Int64)
 	wrong := total - correctCount
+	score := correctCount
 
-	now := time.Now().UTC()
-	endedStr := now.Format(timeFormat)
+	// Preserve ended_at and duration_ms if the session was already finished.
+	var endedStr string
 	var duration int64
-	startedT, parseErr := time.Parse(timeFormat, startedAt)
-	if parseErr != nil {
-		// started_at should always be written as RFC3339 by Start, so a parse
-		// failure here means either legacy data or a concurrent writer that
-		// clobbered the value. Log and record zero duration rather than
-		// silently attributing a large duration to clock skew.
-		log.Printf("math: parse started_at %q for session %d: %v", startedAt, sessionID, parseErr)
+	if endedAtSQL.Valid && endedAtSQL.String != "" {
+		endedStr = endedAtSQL.String
+		duration = durationSQL.Int64
 	} else {
-		duration = now.Sub(startedT).Milliseconds()
-		if duration < 0 {
-			duration = 0
+		now := time.Now().UTC()
+		endedStr = now.Format(timeFormat)
+		startedT, parseErr := time.Parse(timeFormat, startedAt)
+		if parseErr != nil {
+			// started_at should always be written as RFC3339 by Start, so a parse
+			// failure here means either legacy data or a concurrent writer that
+			// clobbered the value. Log and record zero duration rather than
+			// silently attributing a large duration to clock skew.
+			log.Printf("math: parse started_at %q for session %d: %v", startedAt, sessionID, parseErr)
+		} else {
+			duration = now.Sub(startedT).Milliseconds()
+			if duration < 0 {
+				duration = 0
+			}
 		}
 	}
-	score := correctCount
 
 	if _, err := s.db.ExecContext(ctx, `
 		UPDATE math_sessions
-		SET ended_at = ?, duration_ms = ?, total_correct = ?, total_wrong = ?, score_num = ?
+		SET total_correct = ?, total_wrong = ?, score_num = ?,
+		    ended_at    = CASE WHEN (ended_at IS NULL OR ended_at = '') THEN ? ELSE ended_at END,
+		    duration_ms = CASE WHEN (ended_at IS NULL OR ended_at = '') THEN ? ELSE duration_ms END
 		WHERE id = ?`,
-		endedStr, duration, correctCount, wrong, score, sessionID,
+		correctCount, wrong, score, endedStr, duration, sessionID,
 	); err != nil {
 		return Summary{}, fmt.Errorf("update math_session: %w", err)
 	}

--- a/internal/math/session.go
+++ b/internal/math/session.go
@@ -1,0 +1,199 @@
+package math
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// timeFormat is the canonical RFC3339 format used by every Hytte module that
+// persists timestamps as TEXT.
+const timeFormat = time.RFC3339
+
+// ErrInvalidMode is returned by Start when the supplied mode is not one of
+// the recognised IsValidMode values.
+var ErrInvalidMode = errors.New("invalid math session mode")
+
+// ErrSessionNotOwned is returned when a user tries to record an attempt or
+// finish a session that belongs to a different user.
+var ErrSessionNotOwned = errors.New("session not owned by user")
+
+// ErrSessionFinished is returned when an attempt is recorded against a
+// session that already has ended_at set.
+var ErrSessionFinished = errors.New("session already finished")
+
+// ErrSessionNotFound is returned when the session id does not exist.
+var ErrSessionNotFound = errors.New("session not found")
+
+// Service exposes the persistent session lifecycle on top of *sql.DB.
+type Service struct {
+	db *sql.DB
+}
+
+// NewService wraps the given DB handle.
+func NewService(db *sql.DB) *Service { return &Service{db: db} }
+
+// Summary captures the result of finishing a session. ScoreNum currently
+// equals total_correct; the achievements bead can change the formula later.
+type Summary struct {
+	SessionID    int64  `json:"session_id"`
+	Mode         string `json:"mode"`
+	StartedAt    string `json:"started_at"`
+	EndedAt      string `json:"ended_at"`
+	DurationMs   int64  `json:"duration_ms"`
+	TotalCorrect int    `json:"total_correct"`
+	TotalWrong   int    `json:"total_wrong"`
+	ScoreNum     int    `json:"score_num"`
+}
+
+// Start creates a new math_sessions row, returning its id and the first
+// question. Mode is validated against IsValidMode.
+func (s *Service) Start(ctx context.Context, userID int64, mode string) (int64, Fact, error) {
+	if !IsValidMode(mode) {
+		return 0, Fact{}, ErrInvalidMode
+	}
+	now := time.Now().UTC().Format(timeFormat)
+	res, err := s.db.ExecContext(ctx,
+		`INSERT INTO math_sessions (user_id, mode, started_at) VALUES (?, ?, ?)`,
+		userID, mode, now,
+	)
+	if err != nil {
+		return 0, Fact{}, fmt.Errorf("insert math_session: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, Fact{}, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, NextQuestion(mode, nil), nil
+}
+
+// RecordAttempt validates the answer, persists a math_attempts row, and
+// returns the next question. Returns ErrSessionFinished if the session has
+// already been finished, or ErrSessionNotOwned if the session belongs to a
+// different user.
+func (s *Service) RecordAttempt(ctx context.Context, sessionID, userID int64, a, b int, op string, userAnswer, responseMs int) (bool, int, *Fact, error) {
+	owner, mode, ended, err := s.loadSession(ctx, sessionID)
+	if err != nil {
+		return false, 0, nil, err
+	}
+	if owner != userID {
+		return false, 0, nil, ErrSessionNotOwned
+	}
+	if ended {
+		return false, 0, nil, ErrSessionFinished
+	}
+
+	isCorrect, expected, err := Validate(a, b, op, userAnswer)
+	if err != nil {
+		return false, 0, nil, err
+	}
+
+	correctInt := 0
+	if isCorrect {
+		correctInt = 1
+	}
+	now := time.Now().UTC().Format(timeFormat)
+	if _, err := s.db.ExecContext(ctx, `
+		INSERT INTO math_attempts
+			(session_id, user_id, fact_a, fact_b, op, expected_answer, user_answer, is_correct, response_ms, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sessionID, userID, a, b, op, expected, userAnswer, correctInt, responseMs, now,
+	); err != nil {
+		return false, 0, nil, fmt.Errorf("insert math_attempt: %w", err)
+	}
+
+	next := NextQuestion(mode, nil)
+	return isCorrect, expected, &next, nil
+}
+
+// Finish marks the session as completed, computes totals from math_attempts,
+// and returns a Summary. Calling Finish twice is idempotent — the second
+// call just recomputes totals against the latest attempts and returns them
+// without changing started_at.
+func (s *Service) Finish(ctx context.Context, sessionID, userID int64) (Summary, error) {
+	var (
+		owner     int64
+		mode      string
+		startedAt string
+	)
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT user_id, mode, started_at FROM math_sessions WHERE id = ?`,
+		sessionID,
+	).Scan(&owner, &mode, &startedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Summary{}, ErrSessionNotFound
+		}
+		return Summary{}, fmt.Errorf("select math_session: %w", err)
+	}
+	if owner != userID {
+		return Summary{}, ErrSessionNotOwned
+	}
+
+	var (
+		total   int
+		correct sql.NullInt64
+	)
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*), SUM(is_correct) FROM math_attempts WHERE session_id = ?`,
+		sessionID,
+	).Scan(&total, &correct); err != nil {
+		return Summary{}, fmt.Errorf("aggregate math_attempts: %w", err)
+	}
+	correctCount := int(correct.Int64)
+	wrong := total - correctCount
+
+	now := time.Now().UTC()
+	endedStr := now.Format(timeFormat)
+	startedT, parseErr := time.Parse(timeFormat, startedAt)
+	if parseErr != nil {
+		startedT = now
+	}
+	duration := now.Sub(startedT).Milliseconds()
+	if duration < 0 {
+		duration = 0
+	}
+	score := correctCount
+
+	if _, err := s.db.ExecContext(ctx, `
+		UPDATE math_sessions
+		SET ended_at = ?, duration_ms = ?, total_correct = ?, total_wrong = ?, score_num = ?
+		WHERE id = ?`,
+		endedStr, duration, correctCount, wrong, score, sessionID,
+	); err != nil {
+		return Summary{}, fmt.Errorf("update math_session: %w", err)
+	}
+
+	return Summary{
+		SessionID:    sessionID,
+		Mode:         mode,
+		StartedAt:    startedAt,
+		EndedAt:      endedStr,
+		DurationMs:   duration,
+		TotalCorrect: correctCount,
+		TotalWrong:   wrong,
+		ScoreNum:     score,
+	}, nil
+}
+
+// loadSession returns the owner, mode and finished flag for a session id,
+// or ErrSessionNotFound if no row exists.
+func (s *Service) loadSession(ctx context.Context, sessionID int64) (int64, string, bool, error) {
+	var (
+		owner   int64
+		mode    string
+		endedAt sql.NullString
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT user_id, mode, ended_at FROM math_sessions WHERE id = ?`,
+		sessionID,
+	).Scan(&owner, &mode, &endedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, "", false, ErrSessionNotFound
+		}
+		return 0, "", false, fmt.Errorf("select math_session: %w", err)
+	}
+	return owner, mode, endedAt.Valid && endedAt.String != "", nil
+}

--- a/internal/math/session.go
+++ b/internal/math/session.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 )
 
@@ -146,13 +147,19 @@ func (s *Service) Finish(ctx context.Context, sessionID, userID int64) (Summary,
 
 	now := time.Now().UTC()
 	endedStr := now.Format(timeFormat)
+	var duration int64
 	startedT, parseErr := time.Parse(timeFormat, startedAt)
 	if parseErr != nil {
-		startedT = now
-	}
-	duration := now.Sub(startedT).Milliseconds()
-	if duration < 0 {
-		duration = 0
+		// started_at should always be written as RFC3339 by Start, so a parse
+		// failure here means either legacy data or a concurrent writer that
+		// clobbered the value. Log and record zero duration rather than
+		// silently attributing a large duration to clock skew.
+		log.Printf("math: parse started_at %q for session %d: %v", startedAt, sessionID, parseErr)
+	} else {
+		duration = now.Sub(startedT).Milliseconds()
+		if duration < 0 {
+			duration = 0
+		}
 	}
 	score := correctCount
 

--- a/internal/math/session_test.go
+++ b/internal/math/session_test.go
@@ -1,0 +1,169 @@
+package math
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/db"
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-key-for-math-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+	database, err := db.Init(":memory:")
+	if err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	t.Cleanup(func() { database.Close() })
+
+	if _, err := database.Exec(`INSERT INTO users (id, email, name, picture, google_id, created_at) VALUES (1, 'a@example.com', 'A', '', 'g1', '')`); err != nil {
+		t.Fatalf("insert user 1: %v", err)
+	}
+	if _, err := database.Exec(`INSERT INTO users (id, email, name, picture, google_id, created_at) VALUES (2, 'b@example.com', 'B', '', 'g2', '')`); err != nil {
+		t.Fatalf("insert user 2: %v", err)
+	}
+	return database
+}
+
+func TestServiceStartRejectsInvalidMode(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	if _, _, err := svc.Start(context.Background(), 1, "bogus"); !errors.Is(err, ErrInvalidMode) {
+		t.Fatalf("expected ErrInvalidMode, got %v", err)
+	}
+}
+
+func TestSessionLifecycle(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	id, first, err := svc.Start(ctx, 1, ModeMixed)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("expected non-zero session id")
+	}
+	if first.Op != OpMultiply && first.Op != OpDivide {
+		t.Fatalf("first question has bogus op: %+v", first)
+	}
+
+	// Two correct attempts.
+	if ok, exp, _, err := svc.RecordAttempt(ctx, id, 1, 3, 4, OpMultiply, 12, 1500); err != nil {
+		t.Fatalf("RecordAttempt 1: %v", err)
+	} else if !ok || exp != 12 {
+		t.Errorf("attempt 1: ok=%v exp=%d", ok, exp)
+	}
+	if ok, exp, _, err := svc.RecordAttempt(ctx, id, 1, 20, 4, OpDivide, 5, 2000); err != nil {
+		t.Fatalf("RecordAttempt 2: %v", err)
+	} else if !ok || exp != 5 {
+		t.Errorf("attempt 2: ok=%v exp=%d", ok, exp)
+	}
+	// One wrong attempt.
+	if ok, exp, _, err := svc.RecordAttempt(ctx, id, 1, 7, 6, OpMultiply, 41, 3000); err != nil {
+		t.Fatalf("RecordAttempt 3: %v", err)
+	} else if ok || exp != 42 {
+		t.Errorf("attempt 3: ok=%v exp=%d", ok, exp)
+	}
+
+	// Validation error from RecordAttempt should not insert a row.
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 99, 99, OpMultiply, 0, 100); err == nil {
+		t.Error("expected validation error for out-of-range operands")
+	}
+
+	summary, err := svc.Finish(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if summary.SessionID != id {
+		t.Errorf("summary.SessionID=%d, want %d", summary.SessionID, id)
+	}
+	if summary.TotalCorrect != 2 {
+		t.Errorf("TotalCorrect=%d, want 2", summary.TotalCorrect)
+	}
+	if summary.TotalWrong != 1 {
+		t.Errorf("TotalWrong=%d, want 1", summary.TotalWrong)
+	}
+	if summary.ScoreNum != 2 {
+		t.Errorf("ScoreNum=%d, want 2", summary.ScoreNum)
+	}
+	if summary.EndedAt == "" {
+		t.Error("EndedAt should be set")
+	}
+
+	// Verify row counts in DB.
+	var attemptCount int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM math_attempts WHERE session_id = ?`, id).Scan(&attemptCount); err != nil {
+		t.Fatalf("count attempts: %v", err)
+	}
+	if attemptCount != 3 {
+		t.Errorf("attempt rows=%d, want 3", attemptCount)
+	}
+
+	// Recording after finish should fail.
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 2, 2, OpMultiply, 4, 100); !errors.Is(err, ErrSessionFinished) {
+		t.Errorf("expected ErrSessionFinished, got %v", err)
+	}
+}
+
+func TestRecordAttemptOwnership(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	id, _, err := svc.Start(ctx, 1, ModeMixed)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 2, 3, 4, OpMultiply, 12, 100); !errors.Is(err, ErrSessionNotOwned) {
+		t.Errorf("expected ErrSessionNotOwned, got %v", err)
+	}
+}
+
+func TestFinishOwnership(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	id, _, err := svc.Start(ctx, 1, ModeMixed)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := svc.Finish(ctx, id, 2); !errors.Is(err, ErrSessionNotOwned) {
+		t.Errorf("expected ErrSessionNotOwned, got %v", err)
+	}
+}
+
+func TestFinishNotFound(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	if _, err := svc.Finish(context.Background(), 9999, 1); !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("expected ErrSessionNotFound, got %v", err)
+	}
+}
+
+func TestFinishWithNoAttempts(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	id, _, err := svc.Start(ctx, 1, ModeDivision)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	summary, err := svc.Finish(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if summary.TotalCorrect != 0 || summary.TotalWrong != 0 || summary.ScoreNum != 0 {
+		t.Errorf("expected zero totals, got %+v", summary)
+	}
+}

--- a/internal/math/validator.go
+++ b/internal/math/validator.go
@@ -1,0 +1,43 @@
+package math
+
+import "fmt"
+
+// Validate checks that (a, b, op) describes a fact within the supported
+// 1–10 universe and computes the expected answer. It returns whether the
+// supplied user answer matches the expected answer.
+//
+// For multiplication, both a and b must lie in [MinOperand, MaxOperand].
+// For division, b (the divisor) must lie in [MinOperand, MaxOperand], a
+// (the dividend) must be divisible by b, and the resulting quotient must
+// also lie in [MinOperand, MaxOperand]. This restricts division facts to
+// the same 100-fact universe enumerated by AllFacts.
+func Validate(a, b int, op string, userAnswer int) (isCorrect bool, expected int, err error) {
+	switch op {
+	case OpMultiply:
+		if a < MinOperand || a > MaxOperand || b < MinOperand || b > MaxOperand {
+			return false, 0, fmt.Errorf("multiplication operands out of range [%d,%d]: a=%d b=%d",
+				MinOperand, MaxOperand, a, b)
+		}
+		expected = a * b
+	case OpDivide:
+		if b < MinOperand || b > MaxOperand {
+			return false, 0, fmt.Errorf("division divisor out of range [%d,%d]: b=%d",
+				MinOperand, MaxOperand, b)
+		}
+		if a < MinOperand*MinOperand || a > MaxOperand*MaxOperand {
+			return false, 0, fmt.Errorf("division dividend out of range [1,100]: a=%d", a)
+		}
+		if a%b != 0 {
+			return false, 0, fmt.Errorf("division dividend %d not divisible by divisor %d", a, b)
+		}
+		q := a / b
+		if q < MinOperand || q > MaxOperand {
+			return false, 0, fmt.Errorf("division quotient out of range [%d,%d]: q=%d",
+				MinOperand, MaxOperand, q)
+		}
+		expected = q
+	default:
+		return false, 0, fmt.Errorf("unknown op %q (expected %q or %q)", op, OpMultiply, OpDivide)
+	}
+	return userAnswer == expected, expected, nil
+}

--- a/internal/math/validator_test.go
+++ b/internal/math/validator_test.go
@@ -1,0 +1,111 @@
+package math
+
+import "testing"
+
+func TestValidateMultiplicationCorrect(t *testing.T) {
+	ok, expected, err := Validate(7, 8, OpMultiply, 56)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !ok {
+		t.Error("expected isCorrect=true")
+	}
+	if expected != 56 {
+		t.Errorf("expected=%d, want 56", expected)
+	}
+}
+
+func TestValidateMultiplicationWrong(t *testing.T) {
+	ok, expected, err := Validate(7, 8, OpMultiply, 55)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Error("expected isCorrect=false")
+	}
+	if expected != 56 {
+		t.Errorf("expected=%d, want 56", expected)
+	}
+}
+
+func TestValidateDivisionCorrect(t *testing.T) {
+	ok, expected, err := Validate(56, 7, OpDivide, 8)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !ok {
+		t.Error("expected isCorrect=true for 56÷7=8")
+	}
+	if expected != 8 {
+		t.Errorf("expected=%d, want 8", expected)
+	}
+}
+
+func TestValidateDivisionWrong(t *testing.T) {
+	ok, expected, err := Validate(56, 7, OpDivide, 7)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Error("expected isCorrect=false")
+	}
+	if expected != 8 {
+		t.Errorf("expected=%d, want 8", expected)
+	}
+}
+
+func TestValidateInvalidOp(t *testing.T) {
+	_, _, err := Validate(2, 3, "+", 5)
+	if err == nil {
+		t.Fatal("expected error for unsupported op")
+	}
+}
+
+func TestValidateMultiplicationOutOfRange(t *testing.T) {
+	cases := [][2]int{{0, 5}, {5, 0}, {11, 2}, {2, 11}, {-1, 3}}
+	for _, c := range cases {
+		if _, _, err := Validate(c[0], c[1], OpMultiply, 0); err == nil {
+			t.Errorf("expected err for multiplication operands %v", c)
+		}
+	}
+}
+
+func TestValidateDivisionInvalid(t *testing.T) {
+	t.Run("non-divisible", func(t *testing.T) {
+		if _, _, err := Validate(7, 2, OpDivide, 3); err == nil {
+			t.Error("expected err for non-divisible 7/2")
+		}
+	})
+	t.Run("divisor-out-of-range", func(t *testing.T) {
+		if _, _, err := Validate(20, 11, OpDivide, 0); err == nil {
+			t.Error("expected err for divisor=11")
+		}
+	})
+	t.Run("dividend-out-of-range", func(t *testing.T) {
+		if _, _, err := Validate(101, 1, OpDivide, 101); err == nil {
+			t.Error("expected err for dividend=101")
+		}
+	})
+	t.Run("quotient-out-of-range", func(t *testing.T) {
+		// 100 / 1 = 100 > MaxOperand
+		if _, _, err := Validate(100, 1, OpDivide, 100); err == nil {
+			t.Error("expected err for quotient=100")
+		}
+	})
+}
+
+func TestValidateAllFactsRoundTrip(t *testing.T) {
+	for _, f := range AllFacts() {
+		ok, expected, err := Validate(f.A, f.B, f.Op, f.Expected)
+		if err != nil {
+			t.Errorf("fact %+v: unexpected err %v", f, err)
+			continue
+		}
+		if !ok {
+			t.Errorf("fact %+v: expected isCorrect=true", f)
+		}
+		if expected != f.Expected {
+			t.Errorf("fact %+v: expected=%d, got %d", f, f.Expected, expected)
+		}
+	}
+}


### PR DESCRIPTION
## Changes

- **Regnemester math game engine** - Backend foundation for a multiplication (1–10) and division math game. Adds the `regnemester` feature flag, `math_sessions` / `math_attempts` / `math_achievements` tables, an `internal/math` package with question generation, answer validation, session lifecycle and per-fact mastery aggregation, and the authenticated API endpoints `POST /api/math/sessions`, `POST /api/math/sessions/{id}/attempts`, `POST /api/math/sessions/{id}/finish` and `GET /api/math/stats`. UI ships in a follow-up bead. (Hytte-rh4h)

## Original Issue (feature): Regnemester: schema and core game engine

Foundation for Regnemester, a family multiplication (1–10) and division math game. This is bead 1 of 7 chained beads that build the full feature. This bead delivers the data model and core engine only — no UI.

Build:
- SQLite migrations (follow existing Hytte migration pattern) for:
  - math_sessions(id, user_id, mode, started_at, ended_at, score_num, duration_ms, total_correct, total_wrong, meta TEXT)
  - math_attempts(id, session_id, user_id, fact_a, fact_b, op TEXT CHECK(op IN ('*','/')), expected_answer, user_answer, is_correct, response_ms, created_at) — indexed on (user_id, fact_a, fact_b, op) for mastery aggregation
  - math_achievements(id, user_id, code, unlocked_at, session_id, meta TEXT) with UNIQUE(user_id, code)
- Go package internal/math/ with:
  - Question generator producing the 100 mult facts (a×b for a,b in 1..10) and 100 div facts (c÷b=a where a×b=c, both divisor variants)
  - Session lifecycle: Start, RecordAttempt, Finish (computes totals)
  - Per-fact mastery aggregator: given user_id, returns map keyed by (a,b,op) with {count, correct_count, avg_ms, last5 correctness bits}
- HTTP handlers under /api/math/ (authenticated):
  - POST /sessions — body {mode}, returns {session_id, first_question}
  - POST /sessions/:id/attempts — body {a, b, op, user_answer, response_ms}, returns {is_correct, expected_answer, next_question|null}
  - POST /sessions/:id/finish — returns {summary}
  - GET /stats — returns current user's per-fact mastery for both ops
- Register routes in the API router
- Unit tests for generator (verify all 200 facts enumerated), validator, and session lifecycle

Non-goals: no UI, no achievements logic, no leaderboards — those are later beads.

---
Bead: Hytte-rh4h | Branch: forge/Hytte-rh4h
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)