### PR TITLE
Regnemester: Blitz mode (Hytte-j3ll)

### DIFF
--- a/changelog.d/Hytte-j3ll.md
+++ b/changelog.d/Hytte-j3ll.md
@@ -1,0 +1,2 @@
+category: Added
+- **Regnemester: Blitz mode** - New 60-second sprint mode at `/math/play/blitz`. Questions are drawn uniformly at random from the full 200-fact pool; score is weighted by answer speed (under 1s = ×1.5, under 2s = ×1.2) and current streak (cap ×3). Result screen shows final score, best streak, correct/wrong counts and a New PB badge. (Hytte-j3ll)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -651,6 +651,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/math/sessions/{id}/finish", mathgame.FinishSessionHandler(db))
 				r.Get("/math/stats", mathgame.StatsHandler(db))
 				r.Get("/math/marathon/best", mathgame.MarathonBestHandler(db))
+				r.Get("/math/blitz/best", mathgame.BlitzBestHandler(db))
 			})
 
 			// Transit departures — gated by "transit" feature.

--- a/internal/math/generator.go
+++ b/internal/math/generator.go
@@ -26,6 +26,11 @@ const (
 // recorded a different attempt count.
 const MarathonFactCount = (MaxOperand - MinOperand + 1) * (MaxOperand - MinOperand + 1) * 2
 
+// BlitzDurationMs is the fixed length of a Blitz run in milliseconds — one
+// minute. The client drives the countdown; the server stores duration_ms
+// from the first-attempt-to-last-attempt window when Finish is called.
+const BlitzDurationMs = 60000
+
 // Mode constants for question generation. New modes can be added without
 // breaking older sessions because the engine falls back to ModeMixed for
 // unknown values.
@@ -39,6 +44,11 @@ const (
 	// itself — but the mode tag distinguishes marathon sessions from other
 	// modes for personal-best lookups.
 	ModeMarathon = "marathon"
+	// ModeBlitz is a 60-second sprint: questions are drawn uniformly at
+	// random from the full 200-fact pool (repeats allowed) and scoring is
+	// weighted by speed and consecutive-correct streak. Finish computes the
+	// score from the recorded attempts — see ComputeBlitzPoints.
+	ModeBlitz = "blitz"
 )
 
 // Fact represents a single math fact. For multiplication, A and B are the
@@ -111,7 +121,7 @@ func NextQuestion(mode string, _ []Fact) Fact {
 // mixed), but the session layer rejects them at Start time.
 func IsValidMode(mode string) bool {
 	switch mode {
-	case ModeMixed, ModeMultiplication, ModeDivision, ModeMarathon:
+	case ModeMixed, ModeMultiplication, ModeDivision, ModeMarathon, ModeBlitz:
 		return true
 	default:
 		return false

--- a/internal/math/generator.go
+++ b/internal/math/generator.go
@@ -27,8 +27,9 @@ const (
 const MarathonFactCount = (MaxOperand - MinOperand + 1) * (MaxOperand - MinOperand + 1) * 2
 
 // BlitzDurationMs is the fixed length of a Blitz run in milliseconds — one
-// minute. The client drives the countdown; the server stores duration_ms
-// from the first-attempt-to-last-attempt window when Finish is called.
+// minute. The server enforces this deadline by rejecting RecordAttempt calls
+// after started_at + BlitzDurationMs. Finish computes duration_ms from
+// started_at to ended_at and clamps it to BlitzDurationMs.
 const BlitzDurationMs = 60000
 
 // Mode constants for question generation. New modes can be added without

--- a/internal/math/generator_test.go
+++ b/internal/math/generator_test.go
@@ -119,7 +119,7 @@ func TestNextQuestionRespectsMode(t *testing.T) {
 }
 
 func TestIsValidMode(t *testing.T) {
-	for _, m := range []string{ModeMixed, ModeMultiplication, ModeDivision} {
+	for _, m := range []string{ModeMixed, ModeMultiplication, ModeDivision, ModeMarathon, ModeBlitz} {
 		if !IsValidMode(m) {
 			t.Errorf("expected %q to be a valid mode", m)
 		}

--- a/internal/math/handlers.go
+++ b/internal/math/handlers.go
@@ -190,6 +190,28 @@ func MarathonBestHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
+// BlitzBestHandler returns GET /api/math/blitz/best: the user's
+// highest-scoring finished Blitz run, or {"best": null} if they have not
+// finished one yet. The Blitz UI uses this to decide whether to show a
+// "New PB!" badge after a run.
+func BlitzBestHandler(db *sql.DB) http.HandlerFunc {
+	svc := NewService(db)
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			writeErr(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		best, err := svc.BestBlitz(r.Context(), user.ID)
+		if err != nil {
+			log.Printf("math: best blitz: %v", err)
+			writeErr(w, http.StatusInternalServerError, "failed to load best blitz")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"best": best})
+	}
+}
+
 // statsEntry is the per-fact payload in the stats response. Operands are
 // repeated alongside FactStats so the client can render without rebuilding
 // the key.

--- a/internal/math/handlers_test.go
+++ b/internal/math/handlers_test.go
@@ -224,6 +224,74 @@ func TestMarathonBestHandlerReturnsFastest(t *testing.T) {
 	}
 }
 
+func TestBlitzBestHandlerEmpty(t *testing.T) {
+	d := setupTestDB(t)
+	h := BlitzBestHandler(d)
+	r := withUser(httptest.NewRequest(http.MethodGet, "/api/math/blitz/best", nil), testUser)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Best *BlitzBest `json:"best"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Best != nil {
+		t.Errorf("expected null best, got %+v", resp.Best)
+	}
+}
+
+func TestBlitzBestHandlerReturnsHighestScore(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	// Finish a small Blitz run so there's something to rank.
+	id, _, err := svc.Start(ctx, 1, ModeBlitz)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 3, 4, OpMultiply, 12, 500); err != nil {
+		t.Fatalf("RecordAttempt: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 5, 5, OpMultiply, 25, 500); err != nil {
+		t.Fatalf("RecordAttempt: %v", err)
+	}
+	if _, err := svc.Finish(ctx, id, 1); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	h := BlitzBestHandler(d)
+	r := withUser(httptest.NewRequest(http.MethodGet, "/api/math/blitz/best", nil), testUser)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Best *BlitzBest `json:"best"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Best == nil {
+		t.Fatal("expected non-nil best")
+	}
+	// Two fast correct answers: streak 0 → round(1.5*1.0)=2, streak 1 →
+	// round(1.5*1.1)=round(1.65)=2. Total = 4.
+	if resp.Best.ScoreNum != 4 {
+		t.Errorf("ScoreNum=%d, want 4", resp.Best.ScoreNum)
+	}
+	if resp.Best.BestStreak != 2 {
+		t.Errorf("BestStreak=%d, want 2", resp.Best.BestStreak)
+	}
+}
+
 func TestStatsHandlerSorted(t *testing.T) {
 	d := setupTestDB(t)
 	svc := NewService(d)

--- a/internal/math/session.go
+++ b/internal/math/session.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"time"
 )
 
@@ -36,8 +37,12 @@ type Service struct {
 // NewService wraps the given DB handle.
 func NewService(db *sql.DB) *Service { return &Service{db: db} }
 
-// Summary captures the result of finishing a session. ScoreNum currently
-// equals total_correct; the achievements bead can change the formula later.
+// Summary captures the result of finishing a session. ScoreNum's formula
+// depends on the mode: for most modes it equals total_correct; for Blitz
+// it is the streak/speed-weighted sum computed by ComputeBlitzPoints.
+// BestStreak is the longest run of consecutive correct attempts in the
+// session — always computed so the result screen can show it without a
+// second round-trip.
 type Summary struct {
 	SessionID    int64  `json:"session_id"`
 	Mode         string `json:"mode"`
@@ -47,6 +52,38 @@ type Summary struct {
 	TotalCorrect int    `json:"total_correct"`
 	TotalWrong   int    `json:"total_wrong"`
 	ScoreNum     int    `json:"score_num"`
+	BestStreak   int    `json:"best_streak"`
+}
+
+// ComputeBlitzPoints returns the points awarded for one correct Blitz
+// answer. streakBefore is the number of consecutive correct answers
+// immediately preceding this one (0 for the first correct after a wrong
+// or the very first attempt). The formula mirrors the client-side display
+// logic in the Blitz UI so live score and final stored score agree.
+//
+//	speed_bonus       = 1.5 if responseMs < 1000
+//	                    1.2 if responseMs < 2000
+//	                    1.0 otherwise
+//	streak_multiplier = min(3.0, 1.0 + streakBefore/10)
+//	points            = round(1 * speed_bonus * streak_multiplier)
+func ComputeBlitzPoints(responseMs, streakBefore int) int {
+	if streakBefore < 0 {
+		streakBefore = 0
+	}
+	var speedBonus float64
+	switch {
+	case responseMs < 1000:
+		speedBonus = 1.5
+	case responseMs < 2000:
+		speedBonus = 1.2
+	default:
+		speedBonus = 1.0
+	}
+	streakMult := 1.0 + float64(streakBefore)/10.0
+	if streakMult > 3.0 {
+		streakMult = 3.0
+	}
+	return int(math.Round(speedBonus * streakMult))
 }
 
 // Start creates a new math_sessions row, returning its id and the first
@@ -145,19 +182,54 @@ func (s *Service) Finish(ctx context.Context, sessionID, userID int64) (Summary,
 		return Summary{}, ErrSessionNotOwned
 	}
 
-	var (
-		total   int
-		correct sql.NullInt64
-	)
-	if err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*), SUM(is_correct) FROM math_attempts WHERE session_id = ?`,
+	// Walk attempts in insertion order so we can compute mode-specific
+	// scoring (Blitz weights each correct answer by speed and streak) and
+	// the longest consecutive-correct run in one pass.
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT is_correct, response_ms FROM math_attempts WHERE session_id = ? ORDER BY id ASC`,
 		sessionID,
-	).Scan(&total, &correct); err != nil {
-		return Summary{}, fmt.Errorf("aggregate math_attempts: %w", err)
+	)
+	if err != nil {
+		return Summary{}, fmt.Errorf("select math_attempts: %w", err)
 	}
-	correctCount := int(correct.Int64)
-	wrong := total - correctCount
-	score := correctCount
+	defer rows.Close()
+
+	var (
+		correctCount int
+		wrong        int
+		score        int
+		bestStreak   int
+		curStreak    int
+	)
+	for rows.Next() {
+		var (
+			isCorrect  int
+			responseMs int
+		)
+		if err := rows.Scan(&isCorrect, &responseMs); err != nil {
+			return Summary{}, fmt.Errorf("scan math_attempt: %w", err)
+		}
+		if isCorrect == 1 {
+			// streakBefore is the streak prior to this answer, which is
+			// what the Blitz formula keys on.
+			if mode == ModeBlitz {
+				score += ComputeBlitzPoints(responseMs, curStreak)
+			} else {
+				score++
+			}
+			correctCount++
+			curStreak++
+			if curStreak > bestStreak {
+				bestStreak = curStreak
+			}
+		} else {
+			wrong++
+			curStreak = 0
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return Summary{}, fmt.Errorf("iterate math_attempts: %w", err)
+	}
 
 	// Preserve ended_at and duration_ms if the session was already finished.
 	var endedStr string
@@ -203,6 +275,7 @@ func (s *Service) Finish(ctx context.Context, sessionID, userID int64) (Summary,
 		TotalCorrect: correctCount,
 		TotalWrong:   wrong,
 		ScoreNum:     score,
+		BestStreak:   bestStreak,
 	}, nil
 }
 
@@ -241,6 +314,82 @@ func (s *Service) BestMarathon(ctx context.Context, userID int64) (*MarathonBest
 		return nil, fmt.Errorf("select best marathon: %w", err)
 	}
 	return &best, nil
+}
+
+// BlitzBest holds the personal-best Blitz run for a user. ScoreNum is the
+// primary ranking (higher is better); BestStreak and TotalCorrect are
+// returned for display only, not used as tiebreakers.
+type BlitzBest struct {
+	SessionID    int64  `json:"session_id"`
+	ScoreNum     int    `json:"score_num"`
+	BestStreak   int    `json:"best_streak"`
+	TotalCorrect int    `json:"total_correct"`
+	TotalWrong   int    `json:"total_wrong"`
+	EndedAt      string `json:"ended_at"`
+}
+
+// BestBlitz returns the user's highest-scoring finished Blitz session, or
+// nil if they have not finished one yet. Best_streak is re-derived from
+// math_attempts because math_sessions does not store it as a column.
+func (s *Service) BestBlitz(ctx context.Context, userID int64) (*BlitzBest, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, score_num, total_correct, total_wrong, ended_at
+		FROM math_sessions
+		WHERE user_id = ?
+		  AND mode = ?
+		  AND ended_at IS NOT NULL AND ended_at != ''
+		ORDER BY score_num DESC, duration_ms ASC
+		LIMIT 1`,
+		userID, ModeBlitz,
+	)
+	var best BlitzBest
+	if err := row.Scan(&best.SessionID, &best.ScoreNum, &best.TotalCorrect, &best.TotalWrong, &best.EndedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("select best blitz: %w", err)
+	}
+	// Recover best_streak from the attempts log. Keeping this off the
+	// math_sessions row avoids a schema change; the attempt count per
+	// session is small (≤ a few hundred) so the cost is negligible.
+	streak, err := s.longestCorrectStreak(ctx, best.SessionID)
+	if err != nil {
+		return nil, err
+	}
+	best.BestStreak = streak
+	return &best, nil
+}
+
+// longestCorrectStreak returns the longest run of consecutive correct
+// attempts in the given session, ordered by insertion.
+func (s *Service) longestCorrectStreak(ctx context.Context, sessionID int64) (int, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT is_correct FROM math_attempts WHERE session_id = ? ORDER BY id ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("select math_attempts for streak: %w", err)
+	}
+	defer rows.Close()
+	best, cur := 0, 0
+	for rows.Next() {
+		var isCorrect int
+		if err := rows.Scan(&isCorrect); err != nil {
+			return 0, fmt.Errorf("scan is_correct: %w", err)
+		}
+		if isCorrect == 1 {
+			cur++
+			if cur > best {
+				best = cur
+			}
+		} else {
+			cur = 0
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate is_correct: %w", err)
+	}
+	return best, nil
 }
 
 // loadSession returns the owner, mode and finished flag for a session id,

--- a/internal/math/session.go
+++ b/internal/math/session.go
@@ -109,10 +109,10 @@ func (s *Service) Start(ctx context.Context, userID int64, mode string) (int64, 
 
 // RecordAttempt validates the answer, persists a math_attempts row, and
 // returns the next question. Returns ErrSessionFinished if the session has
-// already been finished, or ErrSessionNotOwned if the session belongs to a
-// different user.
+// already been finished or the Blitz deadline has passed, or
+// ErrSessionNotOwned if the session belongs to a different user.
 func (s *Service) RecordAttempt(ctx context.Context, sessionID, userID int64, a, b int, op string, userAnswer, responseMs int) (bool, int, *Fact, error) {
-	owner, mode, ended, err := s.loadSession(ctx, sessionID)
+	owner, mode, startedAt, ended, err := s.loadSession(ctx, sessionID)
 	if err != nil {
 		return false, 0, nil, err
 	}
@@ -121,6 +121,15 @@ func (s *Service) RecordAttempt(ctx context.Context, sessionID, userID int64, a,
 	}
 	if ended {
 		return false, 0, nil, ErrSessionFinished
+	}
+	if mode == ModeBlitz {
+		startedT, parseErr := time.Parse(timeFormat, startedAt)
+		if parseErr == nil {
+			deadline := startedT.Add(time.Duration(BlitzDurationMs) * time.Millisecond)
+			if time.Now().UTC().After(deadline) {
+				return false, 0, nil, ErrSessionFinished
+			}
+		}
 	}
 
 	isCorrect, expected, err := Validate(a, b, op, userAnswer)
@@ -253,6 +262,9 @@ func (s *Service) Finish(ctx context.Context, sessionID, userID int64) (Summary,
 				duration = 0
 			}
 		}
+	}
+	if mode == ModeBlitz && duration > BlitzDurationMs {
+		duration = BlitzDurationMs
 	}
 
 	if _, err := s.db.ExecContext(ctx, `
@@ -392,23 +404,24 @@ func (s *Service) longestCorrectStreak(ctx context.Context, sessionID int64) (in
 	return best, nil
 }
 
-// loadSession returns the owner, mode and finished flag for a session id,
-// or ErrSessionNotFound if no row exists.
-func (s *Service) loadSession(ctx context.Context, sessionID int64) (int64, string, bool, error) {
+// loadSession returns the owner, mode, startedAt and finished flag for a
+// session id, or ErrSessionNotFound if no row exists.
+func (s *Service) loadSession(ctx context.Context, sessionID int64) (int64, string, string, bool, error) {
 	var (
-		owner   int64
-		mode    string
-		endedAt sql.NullString
+		owner     int64
+		mode      string
+		startedAt string
+		endedAt   sql.NullString
 	)
 	err := s.db.QueryRowContext(ctx,
-		`SELECT user_id, mode, ended_at FROM math_sessions WHERE id = ?`,
+		`SELECT user_id, mode, started_at, ended_at FROM math_sessions WHERE id = ?`,
 		sessionID,
-	).Scan(&owner, &mode, &endedAt)
+	).Scan(&owner, &mode, &startedAt, &endedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, "", false, ErrSessionNotFound
+			return 0, "", "", false, ErrSessionNotFound
 		}
-		return 0, "", false, fmt.Errorf("select math_session: %w", err)
+		return 0, "", "", false, fmt.Errorf("select math_session: %w", err)
 	}
-	return owner, mode, endedAt.Valid && endedAt.String != "", nil
+	return owner, mode, startedAt, endedAt.Valid && endedAt.String != "", nil
 }

--- a/internal/math/session_test.go
+++ b/internal/math/session_test.go
@@ -236,6 +236,230 @@ func TestBestMarathonScopedToUser(t *testing.T) {
 	}
 }
 
+func TestComputeBlitzPoints(t *testing.T) {
+	cases := []struct {
+		name         string
+		responseMs   int
+		streakBefore int
+		want         int
+	}{
+		// Speed bonus boundaries (streakBefore=0, so streak_mult = 1.0).
+		{"fast under 1s", 500, 0, 2},       // round(1.5 * 1.0) = 2
+		{"exactly 1000 is medium", 1000, 0, 1}, // round(1.2 * 1.0) = 1
+		{"medium under 2s", 1500, 0, 1},    // round(1.2 * 1.0) = 1
+		{"exactly 2000 is slow", 2000, 0, 1}, // round(1.0 * 1.0) = 1
+		{"slow over 2s", 3000, 0, 1},       // round(1.0 * 1.0) = 1
+
+		// Streak multiplier steps (responseMs=500, so speed_bonus=1.5).
+		{"streak 0 fast", 500, 0, 2},   // round(1.5 * 1.0) = 2
+		{"streak 10 fast", 500, 10, 3}, // round(1.5 * 2.0) = 3
+		{"streak 20 fast capped at 3.0", 500, 20, 5}, // round(1.5 * 3.0) = 5 (half-away rounds 4.5 → 5)
+		{"streak 30 still capped", 500, 30, 5},       // same as 20
+
+		// Streak cap with slow answer.
+		{"slow but long streak", 3000, 25, 3}, // round(1.0 * 3.0) = 3
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeBlitzPoints(tc.responseMs, tc.streakBefore)
+			if got != tc.want {
+				t.Errorf("ComputeBlitzPoints(%d, %d) = %d, want %d",
+					tc.responseMs, tc.streakBefore, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFinishBlitzUsesWeightedScoring(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	id, _, err := svc.Start(ctx, 1, ModeBlitz)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Sequence: fast-correct (streak 0), fast-correct (streak 1),
+	// wrong, medium-correct (streak 0), fast-correct (streak 1).
+	steps := []struct {
+		a, b, userAnswer, responseMs int
+		op                           string
+	}{
+		{3, 4, 12, 500, OpMultiply},   // correct, streak 0 → round(1.5*1.0)=2
+		{5, 6, 30, 700, OpMultiply},   // correct, streak 1 → round(1.5*1.1)=2
+		{2, 2, 5, 800, OpMultiply},    // WRONG
+		{4, 4, 16, 1500, OpMultiply},  // correct, streak 0 → round(1.2*1.0)=1
+		{7, 2, 14, 900, OpMultiply},   // correct, streak 1 → round(1.5*1.1)=2
+	}
+	for _, s := range steps {
+		if _, _, _, err := svc.RecordAttempt(ctx, id, 1, s.a, s.b, s.op, s.userAnswer, s.responseMs); err != nil {
+			t.Fatalf("RecordAttempt: %v", err)
+		}
+	}
+
+	summary, err := svc.Finish(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if summary.Mode != ModeBlitz {
+		t.Errorf("Mode=%q, want %q", summary.Mode, ModeBlitz)
+	}
+	if summary.TotalCorrect != 4 {
+		t.Errorf("TotalCorrect=%d, want 4", summary.TotalCorrect)
+	}
+	if summary.TotalWrong != 1 {
+		t.Errorf("TotalWrong=%d, want 1", summary.TotalWrong)
+	}
+	// Expected score = 2 + 2 + 1 + 2 = 7
+	if summary.ScoreNum != 7 {
+		t.Errorf("ScoreNum=%d, want 7", summary.ScoreNum)
+	}
+	// Best streak was 2 (first two correct answers before the wrong).
+	if summary.BestStreak != 2 {
+		t.Errorf("BestStreak=%d, want 2", summary.BestStreak)
+	}
+}
+
+func TestFinishNonBlitzUsesCorrectCountScore(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	id, _, err := svc.Start(ctx, 1, ModeMixed)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Two correct (fast) and one wrong. In Blitz this would score ≥ 4;
+	// in other modes it should be exactly total_correct = 2.
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 3, 4, OpMultiply, 12, 300); err != nil {
+		t.Fatalf("RecordAttempt: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 5, 5, OpMultiply, 25, 400); err != nil {
+		t.Fatalf("RecordAttempt: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 1, 7, 6, OpMultiply, 41, 900); err != nil {
+		t.Fatalf("RecordAttempt: %v", err)
+	}
+
+	summary, err := svc.Finish(ctx, id, 1)
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if summary.ScoreNum != 2 {
+		t.Errorf("ScoreNum=%d, want 2 (total_correct) for non-Blitz mode", summary.ScoreNum)
+	}
+	if summary.BestStreak != 2 {
+		t.Errorf("BestStreak=%d, want 2", summary.BestStreak)
+	}
+}
+
+func TestBestBlitzNoneRecorded(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	best, err := svc.BestBlitz(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("BestBlitz: %v", err)
+	}
+	if best != nil {
+		t.Errorf("expected nil best, got %+v", best)
+	}
+}
+
+func TestBestBlitzPicksHighestScore(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	// Run three Blitz sessions via the service so math_attempts is populated
+	// (which BestBlitz needs to re-derive best_streak).
+	runSession := func(userID int64, steps []struct {
+		a, b, userAnswer, responseMs int
+		op                           string
+	}) int64 {
+		t.Helper()
+		id, _, err := svc.Start(ctx, userID, ModeBlitz)
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		for _, s := range steps {
+			if _, _, _, err := svc.RecordAttempt(ctx, id, userID, s.a, s.b, s.op, s.userAnswer, s.responseMs); err != nil {
+				t.Fatalf("RecordAttempt: %v", err)
+			}
+		}
+		if _, err := svc.Finish(ctx, id, userID); err != nil {
+			t.Fatalf("Finish: %v", err)
+		}
+		return id
+	}
+
+	type step = struct {
+		a, b, userAnswer, responseMs int
+		op                           string
+	}
+	// Session A: 3 fast correct answers (streak 0,1,2) → 2 + 2 + 2 = 6.
+	runSession(1, []step{
+		{3, 4, 12, 400, OpMultiply},
+		{5, 5, 25, 400, OpMultiply},
+		{6, 6, 36, 400, OpMultiply},
+	})
+	// Session B (target): 5 fast correct answers → 2+2+2+2+2 = 10.
+	targetID := runSession(1, []step{
+		{2, 3, 6, 400, OpMultiply},
+		{3, 3, 9, 400, OpMultiply},
+		{4, 3, 12, 400, OpMultiply},
+		{5, 3, 15, 400, OpMultiply},
+		{6, 3, 18, 400, OpMultiply},
+	})
+	// Session C: 2 slow correct answers → 1 + 1 = 2.
+	runSession(1, []step{
+		{2, 2, 4, 2500, OpMultiply},
+		{3, 2, 6, 2500, OpMultiply},
+	})
+
+	best, err := svc.BestBlitz(ctx, 1)
+	if err != nil {
+		t.Fatalf("BestBlitz: %v", err)
+	}
+	if best == nil {
+		t.Fatal("expected non-nil best")
+	}
+	if best.SessionID != targetID {
+		t.Errorf("SessionID=%d, want %d", best.SessionID, targetID)
+	}
+	if best.ScoreNum != 10 {
+		t.Errorf("ScoreNum=%d, want 10", best.ScoreNum)
+	}
+	if best.BestStreak != 5 {
+		t.Errorf("BestStreak=%d, want 5", best.BestStreak)
+	}
+}
+
+func TestBestBlitzScopedToUser(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	ctx := context.Background()
+
+	// User 2 posts a finished Blitz run with a nonzero score.
+	id, _, err := svc.Start(ctx, 2, ModeBlitz)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, _, _, err := svc.RecordAttempt(ctx, id, 2, 3, 4, OpMultiply, 12, 500); err != nil {
+		t.Fatalf("RecordAttempt: %v", err)
+	}
+	if _, err := svc.Finish(ctx, id, 2); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	best, err := svc.BestBlitz(ctx, 1)
+	if err != nil {
+		t.Fatalf("BestBlitz: %v", err)
+	}
+	if best != nil {
+		t.Errorf("expected nil best for user 1, got %+v", best)
+	}
+}
+
 func TestFinishWithNoAttempts(t *testing.T) {
 	d := setupTestDB(t)
 	svc := NewService(d)

--- a/web/public/locales/en/regnemester.json
+++ b/web/public/locales/en/regnemester.json
@@ -45,9 +45,35 @@
     "playAgain": "Play again",
     "backToModes": "Back to modes"
   },
+  "blitz": {
+    "title": "Blitz",
+    "intro": "You have 60 seconds. Answer as many facts as you can — fast answers and long streaks multiply your score. Wrong answers don't end the run, they just reset your streak.",
+    "start": "Start Blitz",
+    "starting": "Starting…",
+    "priorBestLabel": "Your best score",
+    "priorBestRecap": "Best streak: {{streak}}",
+    "priorBestDetailedRecap": "Previous best: {{score}} points with a {{streak}}-answer streak.",
+    "scoreShort": "Score",
+    "streakShort": "Streak",
+    "fastLabel": "Fast!",
+    "timeLeftAria": "Time remaining",
+    "answerInputLabel": "Your answer",
+    "backspaceAria": "Backspace",
+    "enterAria": "Submit answer",
+    "enter": "Enter",
+    "resultTitle": "Time's up!",
+    "resultSubtitle": "Here's how this run went.",
+    "newPB": "New personal best!",
+    "scoreLabel": "Score",
+    "bestStreakLabel": "Best streak",
+    "correctLabel": "Correct",
+    "wrongLabel": "Wrong",
+    "playAgain": "Play again",
+    "backToModes": "Back to modes"
+  },
   "errors": {
-    "failedToStart": "Could not start the Marathon. Try again.",
+    "failedToStart": "Could not start the run. Try again.",
     "failedToRecord": "Could not record your answer. The run was stopped.",
-    "failedToFinish": "Could not finish the Marathon. Your run was saved but the result could not be loaded."
+    "failedToFinish": "Could not finish the run. Your progress was saved but the result could not be loaded."
   }
 }

--- a/web/public/locales/en/regnemester.json
+++ b/web/public/locales/en/regnemester.json
@@ -22,6 +22,12 @@
       "blurb": "Track your mastery of every fact across multiplication and division."
     }
   },
+  "keypad": {
+    "answerInputLabel": "Your answer",
+    "backspaceAria": "Backspace",
+    "enterAria": "Submit answer",
+    "enter": "Enter"
+  },
   "marathon": {
     "title": "Marathon",
     "intro": "Answer all {{count}} multiplication and division facts. Wrong answers count against you, but you keep moving — there's no retry. Score is your time; ties are broken by fewer wrongs.",
@@ -31,10 +37,6 @@
     "wrongCount_one": "{{count}} wrong",
     "wrongCount_other": "{{count}} wrongs",
     "wrongShort": "Wrong",
-    "answerInputLabel": "Your answer",
-    "backspaceAria": "Backspace",
-    "enterAria": "Submit answer",
-    "enter": "Enter",
     "resultTitle": "Marathon complete",
     "resultSubtitle": "Here's how this run went.",
     "newPB": "New personal best!",
@@ -57,10 +59,6 @@
     "streakShort": "Streak",
     "fastLabel": "Fast!",
     "timeLeftAria": "Time remaining",
-    "answerInputLabel": "Your answer",
-    "backspaceAria": "Backspace",
-    "enterAria": "Submit answer",
-    "enter": "Enter",
     "resultTitle": "Time's up!",
     "resultSubtitle": "Here's how this run went.",
     "newPB": "New personal best!",

--- a/web/public/locales/nb/regnemester.json
+++ b/web/public/locales/nb/regnemester.json
@@ -45,9 +45,35 @@
     "playAgain": "Spill igjen",
     "backToModes": "Tilbake til moduser"
   },
+  "blitz": {
+    "title": "Blitz",
+    "intro": "Du har 60 sekunder. Svar på så mange stykker du klarer — raske svar og lange rekker ganger opp poengsummen. Feil svar avslutter ikke runden, men nullstiller rekka.",
+    "start": "Start Blitz",
+    "starting": "Starter…",
+    "priorBestLabel": "Din beste poengsum",
+    "priorBestRecap": "Lengste rekke: {{streak}}",
+    "priorBestDetailedRecap": "Forrige rekord: {{score}} poeng med en rekke på {{streak}}.",
+    "scoreShort": "Poeng",
+    "streakShort": "Rekke",
+    "fastLabel": "Raskt!",
+    "timeLeftAria": "Tid igjen",
+    "answerInputLabel": "Svaret ditt",
+    "backspaceAria": "Slett",
+    "enterAria": "Send inn svar",
+    "enter": "OK",
+    "resultTitle": "Tiden er ute!",
+    "resultSubtitle": "Slik gikk det denne gangen.",
+    "newPB": "Ny personlig rekord!",
+    "scoreLabel": "Poeng",
+    "bestStreakLabel": "Lengste rekke",
+    "correctLabel": "Riktig",
+    "wrongLabel": "Feil",
+    "playAgain": "Spill igjen",
+    "backToModes": "Tilbake til moduser"
+  },
   "errors": {
-    "failedToStart": "Kunne ikke starte maraton. Prøv igjen.",
+    "failedToStart": "Kunne ikke starte runden. Prøv igjen.",
     "failedToRecord": "Kunne ikke lagre svaret ditt. Runden ble stoppet.",
-    "failedToFinish": "Kunne ikke fullføre maraton. Runden ble lagret, men resultatet kunne ikke lastes."
+    "failedToFinish": "Kunne ikke fullføre runden. Fremgangen ble lagret, men resultatet kunne ikke lastes."
   }
 }

--- a/web/public/locales/nb/regnemester.json
+++ b/web/public/locales/nb/regnemester.json
@@ -22,6 +22,12 @@
       "blurb": "Følg med på hvor godt du behersker hver gange- og delingsfakta."
     }
   },
+  "keypad": {
+    "answerInputLabel": "Svaret ditt",
+    "backspaceAria": "Slett",
+    "enterAria": "Send inn svar",
+    "enter": "OK"
+  },
   "marathon": {
     "title": "Maraton",
     "intro": "Svar på alle {{count}} gange- og delingsstykker. Feil svar teller mot deg, men du går videre — ingen ny sjanse. Tiden din er poengsummen; lik tid avgjøres av færrest feil.",
@@ -31,10 +37,6 @@
     "wrongCount_one": "{{count}} feil",
     "wrongCount_other": "{{count}} feil",
     "wrongShort": "Feil",
-    "answerInputLabel": "Svaret ditt",
-    "backspaceAria": "Slett",
-    "enterAria": "Send inn svar",
-    "enter": "OK",
     "resultTitle": "Maraton fullført",
     "resultSubtitle": "Slik gikk det denne gangen.",
     "newPB": "Ny personlig rekord!",
@@ -57,10 +59,6 @@
     "streakShort": "Rekke",
     "fastLabel": "Raskt!",
     "timeLeftAria": "Tid igjen",
-    "answerInputLabel": "Svaret ditt",
-    "backspaceAria": "Slett",
-    "enterAria": "Send inn svar",
-    "enter": "OK",
     "resultTitle": "Tiden er ute!",
     "resultSubtitle": "Slik gikk det denne gangen.",
     "newPB": "Ny personlig rekord!",

--- a/web/public/locales/th/regnemester.json
+++ b/web/public/locales/th/regnemester.json
@@ -22,6 +22,12 @@
       "blurb": "ติดตามความแม่นยำของแต่ละข้อในการคูณและการหาร"
     }
   },
+  "keypad": {
+    "answerInputLabel": "คำตอบของคุณ",
+    "backspaceAria": "ลบ",
+    "enterAria": "ส่งคำตอบ",
+    "enter": "ตกลง"
+  },
   "marathon": {
     "title": "มาราธอน",
     "intro": "ตอบโจทย์การคูณและการหารทั้งหมด {{count}} ข้อ คำตอบที่ผิดจะถูกนับ แต่คุณยังต้องไปต่อ ไม่มีโอกาสแก้ตัว เวลาที่ใช้คือคะแนน หากเสมอกันจะตัดสินด้วยจำนวนข้อที่ผิดน้อยกว่า",
@@ -31,10 +37,6 @@
     "wrongCount_one": "ผิด {{count}} ข้อ",
     "wrongCount_other": "ผิด {{count}} ข้อ",
     "wrongShort": "ผิด",
-    "answerInputLabel": "คำตอบของคุณ",
-    "backspaceAria": "ลบ",
-    "enterAria": "ส่งคำตอบ",
-    "enter": "ตกลง",
     "resultTitle": "มาราธอนจบแล้ว",
     "resultSubtitle": "นี่คือผลของรอบนี้",
     "newPB": "สถิติใหม่!",
@@ -57,10 +59,6 @@
     "streakShort": "สตรีค",
     "fastLabel": "เร็ว!",
     "timeLeftAria": "เวลาที่เหลือ",
-    "answerInputLabel": "คำตอบของคุณ",
-    "backspaceAria": "ลบ",
-    "enterAria": "ส่งคำตอบ",
-    "enter": "ตกลง",
     "resultTitle": "หมดเวลา!",
     "resultSubtitle": "นี่คือผลของรอบนี้",
     "newPB": "สถิติใหม่!",

--- a/web/public/locales/th/regnemester.json
+++ b/web/public/locales/th/regnemester.json
@@ -45,9 +45,35 @@
     "playAgain": "เล่นอีกครั้ง",
     "backToModes": "กลับไปยังโหมด"
   },
+  "blitz": {
+    "title": "บลิตซ์",
+    "intro": "คุณมีเวลา 60 วินาที ตอบให้ได้มากที่สุด — ตอบเร็วและตอบถูกติดต่อกันจะเพิ่มตัวคูณคะแนน ตอบผิดไม่ทำให้เกมจบ เพียงแต่จะรีเซ็ตสตรีคของคุณ",
+    "start": "เริ่มบลิตซ์",
+    "starting": "กำลังเริ่ม…",
+    "priorBestLabel": "คะแนนสูงสุดของคุณ",
+    "priorBestRecap": "สตรีคยาวที่สุด: {{streak}}",
+    "priorBestDetailedRecap": "สถิติก่อนหน้า: {{score}} คะแนน สตรีค {{streak}} ข้อ",
+    "scoreShort": "คะแนน",
+    "streakShort": "สตรีค",
+    "fastLabel": "เร็ว!",
+    "timeLeftAria": "เวลาที่เหลือ",
+    "answerInputLabel": "คำตอบของคุณ",
+    "backspaceAria": "ลบ",
+    "enterAria": "ส่งคำตอบ",
+    "enter": "ตกลง",
+    "resultTitle": "หมดเวลา!",
+    "resultSubtitle": "นี่คือผลของรอบนี้",
+    "newPB": "สถิติใหม่!",
+    "scoreLabel": "คะแนน",
+    "bestStreakLabel": "สตรีคยาวที่สุด",
+    "correctLabel": "ถูก",
+    "wrongLabel": "ผิด",
+    "playAgain": "เล่นอีกครั้ง",
+    "backToModes": "กลับไปยังโหมด"
+  },
   "errors": {
-    "failedToStart": "ไม่สามารถเริ่มมาราธอนได้ กรุณาลองใหม่",
+    "failedToStart": "ไม่สามารถเริ่มรอบได้ กรุณาลองใหม่",
     "failedToRecord": "ไม่สามารถบันทึกคำตอบได้ การเล่นถูกหยุด",
-    "failedToFinish": "ไม่สามารถจบมาราธอนได้ การเล่นถูกบันทึกแล้วแต่โหลดผลไม่ได้"
+    "failedToFinish": "ไม่สามารถจบรอบได้ ความคืบหน้าถูกบันทึกแล้วแต่โหลดผลไม่ได้"
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,6 +68,7 @@ import HomeworkSettings from './pages/HomeworkSettings'
 import HomeworkParentReview from './pages/HomeworkParentReview'
 import MathLanding from './pages/Math'
 import MathMarathon from './pages/MathMarathon'
+import MathBlitz from './pages/MathBlitz'
 
 function MainLayout() {
   const { user } = useAuth()
@@ -502,6 +503,14 @@ function MainLayout() {
             element={
               <FeatureRoute feature="regnemester">
                 <MathMarathon />
+              </FeatureRoute>
+            }
+          />
+          <Route
+            path="/math/play/blitz"
+            element={
+              <FeatureRoute feature="regnemester">
+                <MathBlitz />
               </FeatureRoute>
             }
           />

--- a/web/src/components/math/MathAnswerPad.tsx
+++ b/web/src/components/math/MathAnswerPad.tsx
@@ -11,16 +11,6 @@ export interface MathAnswerPadProps {
   busy?: boolean
 }
 
-// Applies a digit press to the current answer string with consistent
-// validation across game modes: caps at 3 digits (answers never exceed
-// 1–100) and avoids leading-zero strings like "07".
-export function appendAnswerDigit(current: string, digit: string): string {
-  if (current.length >= 3) return current
-  if (current === '' && digit === '0') return '0'
-  if (current === '0') return digit
-  return current + digit
-}
-
 // Shared answer display + numeric keypad for Regnemester game modes.
 // Owns the physical-keyboard listener so callers don't have to re-wire
 // identical handlers in every mode.

--- a/web/src/components/math/MathAnswerPad.tsx
+++ b/web/src/components/math/MathAnswerPad.tsx
@@ -1,0 +1,117 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Delete } from 'lucide-react'
+
+export interface MathAnswerPadProps {
+  input: string
+  onDigit: (digit: string) => void
+  onBackspace: () => void
+  onSubmit: () => void
+  disabled?: boolean
+  busy?: boolean
+}
+
+// Applies a digit press to the current answer string with consistent
+// validation across game modes: caps at 3 digits (answers never exceed
+// 1–100) and avoids leading-zero strings like "07".
+export function appendAnswerDigit(current: string, digit: string): string {
+  if (current.length >= 3) return current
+  if (current === '' && digit === '0') return '0'
+  if (current === '0') return digit
+  return current + digit
+}
+
+// Shared answer display + numeric keypad for Regnemester game modes.
+// Owns the physical-keyboard listener so callers don't have to re-wire
+// identical handlers in every mode.
+export function MathAnswerPad({ input, onDigit, onBackspace, onSubmit, disabled, busy }: MathAnswerPadProps) {
+  const { t } = useTranslation('regnemester')
+
+  useEffect(() => {
+    if (disabled) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      if (e.key >= '0' && e.key <= '9') {
+        onDigit(e.key)
+        e.preventDefault()
+      } else if (e.key === 'Backspace') {
+        onBackspace()
+        e.preventDefault()
+      } else if (e.key === 'Enter') {
+        onSubmit()
+        e.preventDefault()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [disabled, onDigit, onBackspace, onSubmit])
+
+  const inputsDisabled = disabled || busy
+  const submitDisabled = inputsDisabled || input.length === 0
+
+  return (
+    <>
+      <div
+        aria-live="polite"
+        aria-label={t('keypad.answerInputLabel')}
+        className="w-full max-w-xs mx-auto h-16 sm:h-20 rounded-lg border-2 border-gray-700 bg-gray-800 flex items-center justify-center text-3xl sm:text-4xl font-bold text-white tabular-nums select-none"
+      >
+        {input || <span className="text-gray-600">_</span>}
+      </div>
+      <div className="grid grid-cols-3 gap-2 sm:gap-3 max-w-md mx-auto w-full pb-2 mt-6">
+        {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map(d => (
+          <KeypadButton key={d} onClick={() => onDigit(d)} disabled={inputsDisabled}>
+            {d}
+          </KeypadButton>
+        ))}
+        <KeypadButton
+          onClick={onBackspace}
+          disabled={inputsDisabled}
+          variant="muted"
+          ariaLabel={t('keypad.backspaceAria')}
+        >
+          <Delete size={28} />
+        </KeypadButton>
+        <KeypadButton onClick={() => onDigit('0')} disabled={inputsDisabled}>
+          0
+        </KeypadButton>
+        <KeypadButton
+          onClick={onSubmit}
+          disabled={submitDisabled}
+          variant="primary"
+          ariaLabel={t('keypad.enterAria')}
+        >
+          {busy ? '…' : t('keypad.enter')}
+        </KeypadButton>
+      </div>
+    </>
+  )
+}
+
+interface KeypadButtonProps {
+  onClick: () => void
+  disabled?: boolean
+  variant?: 'default' | 'primary' | 'muted'
+  ariaLabel?: string
+  children: React.ReactNode
+}
+
+function KeypadButton({ onClick, disabled, variant = 'default', ariaLabel, children }: KeypadButtonProps) {
+  const base = 'h-16 sm:h-20 rounded-lg text-2xl sm:text-3xl font-bold flex items-center justify-center select-none transition-colors disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation'
+  const styles = {
+    default: 'bg-gray-800 hover:bg-gray-700 active:bg-gray-600 text-white border border-gray-700',
+    primary: 'bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white',
+    muted: 'bg-gray-800 hover:bg-gray-700 active:bg-gray-600 text-gray-300 border border-gray-700',
+  }[variant]
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      className={`${base} ${styles}`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/web/src/components/math/MathAnswerPad.tsx
+++ b/web/src/components/math/MathAnswerPad.tsx
@@ -18,7 +18,7 @@ export function MathAnswerPad({ input, onDigit, onBackspace, onSubmit, disabled,
   const { t } = useTranslation('regnemester')
 
   useEffect(() => {
-    if (disabled) return
+    if (disabled || busy) return
     const onKey = (e: KeyboardEvent) => {
       if (e.metaKey || e.ctrlKey || e.altKey) return
       if (e.key >= '0' && e.key <= '9') {
@@ -34,7 +34,7 @@ export function MathAnswerPad({ input, onDigit, onBackspace, onSubmit, disabled,
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [disabled, onDigit, onBackspace, onSubmit])
+  }, [disabled, busy, onDigit, onBackspace, onSubmit])
 
   const inputsDisabled = disabled || busy
   const submitDisabled = inputsDisabled || input.length === 0

--- a/web/src/components/math/mathUtils.ts
+++ b/web/src/components/math/mathUtils.ts
@@ -1,0 +1,9 @@
+// Applies a digit press to the current answer string with consistent
+// validation across game modes: caps at 3 digits (answers never exceed
+// 1–100) and avoids leading-zero strings like "07".
+export function appendAnswerDigit(current: string, digit: string): string {
+  if (current.length >= 3) return current
+  if (current === '' && digit === '0') return '0'
+  if (current === '0') return digit
+  return current + digit
+}

--- a/web/src/pages/Math.tsx
+++ b/web/src/pages/Math.tsx
@@ -12,7 +12,7 @@ interface ModeTile {
 
 const modes: ModeTile[] = [
   { to: '/math/play/marathon', icon: <Timer size={28} />, titleKey: 'modes.marathon.title', blurbKey: 'modes.marathon.blurb' },
-  { to: null, icon: <Zap size={28} />, titleKey: 'modes.blitz.title', blurbKey: 'modes.blitz.blurb' },
+  { to: '/math/play/blitz', icon: <Zap size={28} />, titleKey: 'modes.blitz.title', blurbKey: 'modes.blitz.blurb' },
   { to: null, icon: <Target size={28} />, titleKey: 'modes.practice.title', blurbKey: 'modes.practice.blurb' },
   { to: null, icon: <Trophy size={28} />, titleKey: 'modes.mastery.title', blurbKey: 'modes.mastery.blurb' },
 ]

--- a/web/src/pages/MathBlitz.tsx
+++ b/web/src/pages/MathBlitz.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ArrowLeft, Trophy, Zap } from 'lucide-react'
-import { MathAnswerPad, appendAnswerDigit } from '../components/math/MathAnswerPad'
+import { MathAnswerPad } from '../components/math/MathAnswerPad'
+import { appendAnswerDigit } from '../components/math/mathUtils'
 
 const DURATION_MS = 60_000
 

--- a/web/src/pages/MathBlitz.tsx
+++ b/web/src/pages/MathBlitz.tsx
@@ -204,11 +204,16 @@ export default function MathBlitz() {
         }),
       })
       if (!res.ok) {
-        // If the timer expired between the user pressing Enter and the
-        // request landing, the server will 409 because the session is
-        // finished. Treat that as a benign end-of-run — no need to crash
-        // the result screen.
         if (res.status === 409) {
+          // The session expired server-side while this request was in flight.
+          // Immediately sync the UI to the server-authoritative finished state.
+          setLastAnswerMs(responseMs)
+          setInput('')
+          setCurrentFact(null)
+          endAtRef.current = performance.now()
+          if (phaseRef.current === 'playing') {
+            void finishGame(sessionId)
+          }
           return
         }
         throw new Error(t('errors.failedToRecord'))
@@ -240,7 +245,7 @@ export default function MathBlitz() {
     } finally {
       setSubmitting(false)
     }
-  }, [phase, submitting, sessionId, currentFact, input, streak, t])
+  }, [phase, submitting, sessionId, currentFact, input, streak, t, finishGame])
 
   const appendDigit = useCallback((digit: string) => {
     if (phase !== 'playing' || submitting) return

--- a/web/src/pages/MathBlitz.tsx
+++ b/web/src/pages/MathBlitz.tsx
@@ -188,7 +188,6 @@ export default function MathBlitz() {
     const now = performance.now()
     const responseMs = Math.max(0, Math.round(now - questionShownAtRef.current))
     const fact = currentFact
-    const isCorrect = userAnswer === fact.expected
 
     setSubmitting(true)
     try {
@@ -216,7 +215,7 @@ export default function MathBlitz() {
       }
       const data = await res.json() as { is_correct: boolean; next_question: Fact | null }
 
-      if (isCorrect) {
+      if (data.is_correct) {
         const pointsEarned = computeBlitzPoints(responseMs, streak)
         setScore(prev => prev + pointsEarned)
         setStreak(prev => prev + 1)

--- a/web/src/pages/MathBlitz.tsx
+++ b/web/src/pages/MathBlitz.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { ArrowLeft, Delete, Trophy, Zap } from 'lucide-react'
+import { ArrowLeft, Trophy, Zap } from 'lucide-react'
+import { MathAnswerPad, appendAnswerDigit } from '../components/math/MathAnswerPad'
 
 const DURATION_MS = 60_000
 
@@ -243,12 +244,7 @@ export default function MathBlitz() {
 
   const appendDigit = useCallback((digit: string) => {
     if (phase !== 'playing' || submitting) return
-    setInput(prev => {
-      if (prev.length >= 3) return prev
-      if (prev === '' && digit === '0') return '0'
-      if (prev === '0') return digit
-      return prev + digit
-    })
+    setInput(prev => appendAnswerDigit(prev, digit))
   }, [phase, submitting])
 
   const backspace = useCallback(() => {
@@ -256,25 +252,7 @@ export default function MathBlitz() {
     setInput(prev => prev.slice(0, -1))
   }, [phase, submitting])
 
-  // Physical keyboard support for desktop play.
-  useEffect(() => {
-    if (phase !== 'playing') return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.metaKey || e.ctrlKey || e.altKey) return
-      if (e.key >= '0' && e.key <= '9') {
-        appendDigit(e.key)
-        e.preventDefault()
-      } else if (e.key === 'Backspace') {
-        backspace()
-        e.preventDefault()
-      } else if (e.key === 'Enter') {
-        void submitAnswer()
-        e.preventDefault()
-      }
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [phase, appendDigit, backspace, submitAnswer])
+  const handleSubmit = useCallback(() => { void submitAnswer() }, [submitAnswer])
 
   // Warn before navigating away from a Blitz in progress.
   useEffect(() => {
@@ -454,67 +432,19 @@ export default function MathBlitz() {
             </span>
           )}
         </div>
-        <div className="text-4xl sm:text-6xl md:text-7xl font-bold text-white text-center mb-6 sm:mb-8 tabular-nums">
+        <div className="text-4xl sm:text-6xl md:text-7xl font-bold text-white text-center tabular-nums">
           {currentFact ? renderProblem(currentFact) : ''}
         </div>
-        <div
-          aria-live="polite"
-          aria-label={t('blitz.answerInputLabel')}
-          className="w-full max-w-xs h-16 sm:h-20 rounded-lg border-2 border-gray-700 bg-gray-800 flex items-center justify-center text-3xl sm:text-4xl font-bold text-white tabular-nums select-none"
-        >
-          {input || <span className="text-gray-600">_</span>}
-        </div>
       </div>
 
-      <div className="grid grid-cols-3 gap-2 sm:gap-3 max-w-md mx-auto w-full pb-2">
-        {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map(d => (
-          <KeypadButton key={d} onClick={() => appendDigit(d)} disabled={isFinishing}>
-            {d}
-          </KeypadButton>
-        ))}
-        <KeypadButton onClick={backspace} disabled={isFinishing} variant="muted" ariaLabel={t('blitz.backspaceAria')}>
-          <Delete size={28} />
-        </KeypadButton>
-        <KeypadButton onClick={() => appendDigit('0')} disabled={isFinishing}>
-          0
-        </KeypadButton>
-        <KeypadButton
-          onClick={() => { void submitAnswer() }}
-          disabled={isFinishing || input.length === 0}
-          variant="primary"
-          ariaLabel={t('blitz.enterAria')}
-        >
-          {isFinishing ? '…' : t('blitz.enter')}
-        </KeypadButton>
-      </div>
+      <MathAnswerPad
+        input={input}
+        onDigit={appendDigit}
+        onBackspace={backspace}
+        onSubmit={handleSubmit}
+        disabled={isFinishing}
+        busy={isFinishing}
+      />
     </div>
-  )
-}
-
-interface KeypadButtonProps {
-  onClick: () => void
-  disabled?: boolean
-  variant?: 'default' | 'primary' | 'muted'
-  ariaLabel?: string
-  children: React.ReactNode
-}
-
-function KeypadButton({ onClick, disabled, variant = 'default', ariaLabel, children }: KeypadButtonProps) {
-  const base = 'h-16 sm:h-20 rounded-lg text-2xl sm:text-3xl font-bold flex items-center justify-center select-none transition-colors disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation'
-  const styles = {
-    default: 'bg-gray-800 hover:bg-gray-700 active:bg-gray-600 text-white border border-gray-700',
-    primary: 'bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white',
-    muted: 'bg-gray-800 hover:bg-gray-700 active:bg-gray-600 text-gray-300 border border-gray-700',
-  }[variant]
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      aria-label={ariaLabel}
-      className={`${base} ${styles}`}
-    >
-      {children}
-    </button>
   )
 }

--- a/web/src/pages/MathBlitz.tsx
+++ b/web/src/pages/MathBlitz.tsx
@@ -1,0 +1,520 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { ArrowLeft, Delete, Trophy, Zap } from 'lucide-react'
+
+const DURATION_MS = 60_000
+
+type Op = '*' | '/'
+
+interface Fact {
+  a: number
+  b: number
+  op: Op
+  expected: number
+}
+
+interface BlitzBest {
+  session_id: number
+  score_num: number
+  best_streak: number
+  total_correct: number
+  total_wrong: number
+  ended_at: string
+}
+
+interface FinishSummary {
+  session_id: number
+  mode: string
+  started_at: string
+  ended_at: string
+  duration_ms: number
+  total_correct: number
+  total_wrong: number
+  score_num: number
+  best_streak: number
+}
+
+type Phase = 'idle' | 'starting' | 'playing' | 'finishing' | 'done' | 'error'
+
+// Mirrors ComputeBlitzPoints in internal/math/session.go so the live score
+// displayed during play matches the server-computed score stored in Finish.
+function computeBlitzPoints(responseMs: number, streakBefore: number): number {
+  const safeStreak = Math.max(0, streakBefore)
+  let speedBonus: number
+  if (responseMs < 1000) speedBonus = 1.5
+  else if (responseMs < 2000) speedBonus = 1.2
+  else speedBonus = 1.0
+  const streakMult = Math.min(3.0, 1.0 + safeStreak / 10)
+  return Math.round(speedBonus * streakMult)
+}
+
+function renderProblem(fact: Fact): string {
+  const op = fact.op === '*' ? '×' : '÷'
+  return `${fact.a} ${op} ${fact.b} = ?`
+}
+
+function formatSeconds(ms: number): string {
+  const s = Math.max(0, Math.ceil(ms / 1000))
+  return `${s}s`
+}
+
+export default function MathBlitz() {
+  const { t } = useTranslation('regnemester')
+
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [error, setError] = useState('')
+  const [sessionId, setSessionId] = useState<number | null>(null)
+  const [currentFact, setCurrentFact] = useState<Fact | null>(null)
+  const [score, setScore] = useState(0)
+  const [streak, setStreak] = useState(0)
+  const [lastAnswerMs, setLastAnswerMs] = useState<number | null>(null)
+  const [input, setInput] = useState('')
+  const [summary, setSummary] = useState<FinishSummary | null>(null)
+  const [priorBest, setPriorBest] = useState<BlitzBest | null>(null)
+  const [timeLeftMs, setTimeLeftMs] = useState(DURATION_MS)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Wall-clock anchors; kept in refs so timer updates don't thrash React state.
+  const endAtRef = useRef<number>(0)
+  const questionShownAtRef = useRef<number>(0)
+  // phaseRef mirrors phase so async callers (the attempt POST) can tell
+  // whether the run still owns the UI by the time their request lands —
+  // if Finish ran while we were in flight, we must not clobber 'done'
+  // with an 'error' from a late network failure.
+  const phaseRef = useRef<Phase>('idle')
+  useEffect(() => { phaseRef.current = phase }, [phase])
+
+  // Fetch the user's prior PB once on mount so the result screen can show
+  // a New PB badge when beaten.
+  useEffect(() => {
+    const controller = new AbortController()
+    fetch('/api/math/blitz/best', { credentials: 'include', signal: controller.signal })
+      .then(res => (res.ok ? res.json() : { best: null }))
+      .then((data: { best: BlitzBest | null }) => {
+        setPriorBest(data.best ?? null)
+      })
+      .catch(() => { /* PB lookup is non-critical */ })
+    return () => { controller.abort() }
+  }, [])
+
+  const finishGame = useCallback(async (id: number) => {
+    setPhase('finishing')
+    try {
+      const res = await fetch(`/api/math/sessions/${id}/finish`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error(t('errors.failedToFinish'))
+      const data = await res.json()
+      const s = data.summary as FinishSummary
+      setSummary(s)
+      // Trust the server's score for the result banner — the client tally
+      // should already match, but the stored value is what future PB lookups
+      // compare against.
+      setScore(s.score_num)
+      setTimeLeftMs(0)
+      setPhase('done')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('errors.failedToFinish')
+      setError(message)
+      setPhase('error')
+    }
+  }, [t])
+
+  // Countdown timer: ticks off the wall-clock deadline so a backgrounded tab
+  // still finishes at the right moment when it returns to the foreground.
+  useEffect(() => {
+    if (phase !== 'playing') return
+    let id: number | null = null
+    const tick = () => {
+      const remaining = endAtRef.current - performance.now()
+      if (remaining <= 0) {
+        setTimeLeftMs(0)
+        if (id !== null) window.clearInterval(id)
+        if (sessionId != null) void finishGame(sessionId)
+        return
+      }
+      setTimeLeftMs(remaining)
+    }
+    id = window.setInterval(tick, 100)
+    tick()
+    return () => {
+      if (id !== null) window.clearInterval(id)
+    }
+  }, [phase, sessionId, finishGame])
+
+  const startGame = useCallback(async () => {
+    setError('')
+    setPhase('starting')
+    try {
+      const res = await fetch('/api/math/sessions', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'blitz' }),
+      })
+      if (!res.ok) throw new Error(t('errors.failedToStart'))
+      const data = await res.json()
+      setSessionId(data.session_id)
+      setCurrentFact(data.first_question as Fact)
+      setScore(0)
+      setStreak(0)
+      setLastAnswerMs(null)
+      setInput('')
+      setSummary(null)
+      // Anchor the countdown to "now" rather than the server-request start —
+      // the player shouldn't lose seconds to network latency.
+      const now = performance.now()
+      endAtRef.current = now + DURATION_MS
+      questionShownAtRef.current = now
+      setTimeLeftMs(DURATION_MS)
+      setPhase('playing')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('errors.failedToStart')
+      setError(message)
+      setPhase('error')
+    }
+  }, [t])
+
+  const submitAnswer = useCallback(async () => {
+    if (phase !== 'playing' || submitting) return
+    if (sessionId == null || currentFact == null) return
+    if (input.length === 0) return
+    const userAnswer = parseInt(input, 10)
+    if (Number.isNaN(userAnswer)) return
+    const now = performance.now()
+    const responseMs = Math.max(0, Math.round(now - questionShownAtRef.current))
+    const fact = currentFact
+    const isCorrect = userAnswer === fact.expected
+
+    setSubmitting(true)
+    try {
+      const res = await fetch(`/api/math/sessions/${sessionId}/attempts`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          a: fact.a,
+          b: fact.b,
+          op: fact.op,
+          user_answer: userAnswer,
+          response_ms: responseMs,
+        }),
+      })
+      if (!res.ok) {
+        // If the timer expired between the user pressing Enter and the
+        // request landing, the server will 409 because the session is
+        // finished. Treat that as a benign end-of-run — no need to crash
+        // the result screen.
+        if (res.status === 409) {
+          return
+        }
+        throw new Error(t('errors.failedToRecord'))
+      }
+      const data = await res.json() as { is_correct: boolean; next_question: Fact | null }
+
+      if (isCorrect) {
+        const pointsEarned = computeBlitzPoints(responseMs, streak)
+        setScore(prev => prev + pointsEarned)
+        setStreak(prev => prev + 1)
+      } else {
+        setStreak(0)
+      }
+      setLastAnswerMs(responseMs)
+      setInput('')
+      // Use the server-supplied next question so the draw is authoritative.
+      if (data.next_question) {
+        setCurrentFact(data.next_question)
+      }
+      questionShownAtRef.current = performance.now()
+    } catch (err) {
+      // Don't override 'finishing' or 'done' with an error from a late
+      // attempt POST — the timer already finished the run cleanly.
+      if (phaseRef.current === 'playing') {
+        const message = err instanceof Error ? err.message : t('errors.failedToRecord')
+        setError(message)
+        setPhase('error')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }, [phase, submitting, sessionId, currentFact, input, streak, t])
+
+  const appendDigit = useCallback((digit: string) => {
+    if (phase !== 'playing' || submitting) return
+    setInput(prev => {
+      if (prev.length >= 3) return prev
+      if (prev === '' && digit === '0') return '0'
+      if (prev === '0') return digit
+      return prev + digit
+    })
+  }, [phase, submitting])
+
+  const backspace = useCallback(() => {
+    if (phase !== 'playing' || submitting) return
+    setInput(prev => prev.slice(0, -1))
+  }, [phase, submitting])
+
+  // Physical keyboard support for desktop play.
+  useEffect(() => {
+    if (phase !== 'playing') return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      if (e.key >= '0' && e.key <= '9') {
+        appendDigit(e.key)
+        e.preventDefault()
+      } else if (e.key === 'Backspace') {
+        backspace()
+        e.preventDefault()
+      } else if (e.key === 'Enter') {
+        void submitAnswer()
+        e.preventDefault()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [phase, appendDigit, backspace, submitAnswer])
+
+  // Warn before navigating away from a Blitz in progress.
+  useEffect(() => {
+    if (phase !== 'playing') return
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
+  }, [phase])
+
+  const isNewPB = useMemo(() => {
+    if (!summary) return false
+    if (summary.score_num === 0) return false
+    if (!priorBest) return true
+    return summary.score_num > priorBest.score_num
+  }, [summary, priorBest])
+
+  const showFast = phase === 'playing' && lastAnswerMs !== null && lastAnswerMs < 1000
+
+  if (phase === 'idle' || phase === 'starting' || phase === 'error') {
+    return (
+      <div className="max-w-2xl mx-auto p-4 sm:p-6">
+        <Link to="/math" className="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white mb-4">
+          <ArrowLeft size={16} />
+          {t('back')}
+        </Link>
+        <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2">{t('blitz.title')}</h1>
+        <p className="text-gray-400 mb-6">{t('blitz.intro')}</p>
+        {priorBest && (
+          <div className="rounded-lg border border-gray-700 bg-gray-800 p-4 mb-6 flex items-center gap-3">
+            <Trophy size={20} className="text-yellow-400 shrink-0" />
+            <div>
+              <div className="text-sm text-gray-400">{t('blitz.priorBestLabel')}</div>
+              <div className="text-lg font-semibold text-white tabular-nums">
+                {priorBest.score_num}
+                <span className="text-sm font-normal text-gray-400 ml-2">
+                  {t('blitz.priorBestRecap', { streak: priorBest.best_streak })}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+        {error && (
+          <div className="mb-4 rounded border border-red-500/50 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            {error}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => { void startGame() }}
+          disabled={phase === 'starting'}
+          className="w-full sm:w-auto px-6 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {phase === 'starting' ? t('blitz.starting') : t('blitz.start')}
+        </button>
+      </div>
+    )
+  }
+
+  if (phase === 'done' && summary) {
+    return (
+      <div className="max-w-2xl mx-auto p-4 sm:p-6">
+        <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2">{t('blitz.resultTitle')}</h1>
+        <p className="text-gray-400 mb-6">{t('blitz.resultSubtitle')}</p>
+
+        {isNewPB && (
+          <div className="mb-6 rounded-lg border border-yellow-400/40 bg-yellow-400/10 px-4 py-3 flex items-center gap-3">
+            <Trophy size={24} className="text-yellow-400 shrink-0" />
+            <div className="font-semibold text-yellow-300">{t('blitz.newPB')}</div>
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-3 sm:gap-4 mb-6">
+          <div className="rounded-lg border border-gray-700 bg-gray-800 p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-400 mb-1">{t('blitz.scoreLabel')}</div>
+            <div className="text-3xl sm:text-4xl font-bold text-white tabular-nums">{summary.score_num}</div>
+          </div>
+          <div className="rounded-lg border border-gray-700 bg-gray-800 p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-400 mb-1">{t('blitz.bestStreakLabel')}</div>
+            <div className="text-3xl sm:text-4xl font-bold text-white tabular-nums">{summary.best_streak}</div>
+          </div>
+          <div className="rounded-lg border border-gray-700 bg-gray-800 p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-400 mb-1">{t('blitz.correctLabel')}</div>
+            <div className="text-3xl sm:text-4xl font-bold text-green-400 tabular-nums">{summary.total_correct}</div>
+          </div>
+          <div className="rounded-lg border border-gray-700 bg-gray-800 p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-400 mb-1">{t('blitz.wrongLabel')}</div>
+            <div className="text-3xl sm:text-4xl font-bold text-red-400 tabular-nums">{summary.total_wrong}</div>
+          </div>
+        </div>
+
+        {priorBest && !isNewPB && (
+          <div className="mb-6 text-sm text-gray-400">
+            {t('blitz.priorBestDetailedRecap', {
+              score: priorBest.score_num,
+              streak: priorBest.best_streak,
+            })}
+          </div>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              const latest = summary
+              setSummary(null)
+              setSessionId(null)
+              setCurrentFact(null)
+              setScore(0)
+              setStreak(0)
+              setLastAnswerMs(null)
+              setInput('')
+              setTimeLeftMs(DURATION_MS)
+              setPhase('idle')
+              // Refresh prior best so a back-to-back run compares against
+              // the run we just stored.
+              setPriorBest(prev => {
+                if (!latest) return prev
+                const candidate: BlitzBest = {
+                  session_id: latest.session_id,
+                  score_num: latest.score_num,
+                  best_streak: latest.best_streak,
+                  total_correct: latest.total_correct,
+                  total_wrong: latest.total_wrong,
+                  ended_at: latest.ended_at,
+                }
+                if (!prev) return candidate
+                if (latest.score_num > prev.score_num) return candidate
+                return prev
+              })
+            }}
+            className="px-5 py-3 rounded-lg bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white font-semibold"
+          >
+            {t('blitz.playAgain')}
+          </button>
+          <Link
+            to="/math"
+            className="px-5 py-3 rounded-lg border border-gray-700 hover:border-gray-500 text-gray-300 hover:text-white font-medium text-center"
+          >
+            {t('blitz.backToModes')}
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  // playing or finishing — render the play surface.
+  const isFinishing = phase === 'finishing'
+  const lowTime = timeLeftMs <= 10_000
+
+  return (
+    <div className="min-h-[calc(100vh-3.5rem)] md:min-h-screen flex flex-col max-w-3xl mx-auto p-3 sm:p-6">
+      <div className="flex items-center justify-between mb-4 sm:mb-6 gap-2 flex-wrap">
+        <div className="text-sm sm:text-base text-gray-400 tabular-nums">
+          {t('blitz.scoreShort')} <span className="text-white font-semibold">{score}</span>
+        </div>
+        <div
+          className={`text-2xl sm:text-3xl font-bold tabular-nums ${lowTime ? 'text-red-400' : 'text-white'}`}
+          aria-live="polite"
+          aria-label={t('blitz.timeLeftAria')}
+        >
+          {formatSeconds(timeLeftMs)}
+        </div>
+        <div className="text-sm sm:text-base text-gray-400 tabular-nums">
+          {t('blitz.streakShort')} <span className="text-white font-semibold">{streak}</span>
+        </div>
+      </div>
+
+      <div className="flex-1 flex flex-col items-center justify-center mb-6">
+        <div className="h-6 mb-2 flex items-center justify-center">
+          {showFast && (
+            <span className="inline-flex items-center gap-1 text-sm font-bold text-yellow-300 uppercase tracking-wider">
+              <Zap size={16} />
+              {t('blitz.fastLabel')}
+            </span>
+          )}
+        </div>
+        <div className="text-4xl sm:text-6xl md:text-7xl font-bold text-white text-center mb-6 sm:mb-8 tabular-nums">
+          {currentFact ? renderProblem(currentFact) : ''}
+        </div>
+        <div
+          aria-live="polite"
+          aria-label={t('blitz.answerInputLabel')}
+          className="w-full max-w-xs h-16 sm:h-20 rounded-lg border-2 border-gray-700 bg-gray-800 flex items-center justify-center text-3xl sm:text-4xl font-bold text-white tabular-nums select-none"
+        >
+          {input || <span className="text-gray-600">_</span>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 sm:gap-3 max-w-md mx-auto w-full pb-2">
+        {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map(d => (
+          <KeypadButton key={d} onClick={() => appendDigit(d)} disabled={isFinishing}>
+            {d}
+          </KeypadButton>
+        ))}
+        <KeypadButton onClick={backspace} disabled={isFinishing} variant="muted" ariaLabel={t('blitz.backspaceAria')}>
+          <Delete size={28} />
+        </KeypadButton>
+        <KeypadButton onClick={() => appendDigit('0')} disabled={isFinishing}>
+          0
+        </KeypadButton>
+        <KeypadButton
+          onClick={() => { void submitAnswer() }}
+          disabled={isFinishing || input.length === 0}
+          variant="primary"
+          ariaLabel={t('blitz.enterAria')}
+        >
+          {isFinishing ? '…' : t('blitz.enter')}
+        </KeypadButton>
+      </div>
+    </div>
+  )
+}
+
+interface KeypadButtonProps {
+  onClick: () => void
+  disabled?: boolean
+  variant?: 'default' | 'primary' | 'muted'
+  ariaLabel?: string
+  children: React.ReactNode
+}
+
+function KeypadButton({ onClick, disabled, variant = 'default', ariaLabel, children }: KeypadButtonProps) {
+  const base = 'h-16 sm:h-20 rounded-lg text-2xl sm:text-3xl font-bold flex items-center justify-center select-none transition-colors disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation'
+  const styles = {
+    default: 'bg-gray-800 hover:bg-gray-700 active:bg-gray-600 text-white border border-gray-700',
+    primary: 'bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white',
+    muted: 'bg-gray-800 hover:bg-gray-700 active:bg-gray-600 text-gray-300 border border-gray-700',
+  }[variant]
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      className={`${base} ${styles}`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/web/src/pages/MathMarathon.tsx
+++ b/web/src/pages/MathMarathon.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ArrowLeft, Trophy } from 'lucide-react'
-import { MathAnswerPad, appendAnswerDigit } from '../components/math/MathAnswerPad'
+import { MathAnswerPad } from '../components/math/MathAnswerPad'
+import { appendAnswerDigit } from '../components/math/mathUtils'
 
 const TOTAL = 200
 

--- a/web/src/pages/MathMarathon.tsx
+++ b/web/src/pages/MathMarathon.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { ArrowLeft, Delete, Trophy } from 'lucide-react'
+import { ArrowLeft, Trophy } from 'lucide-react'
+import { MathAnswerPad, appendAnswerDigit } from '../components/math/MathAnswerPad'
 
 const TOTAL = 200
 
@@ -225,14 +226,7 @@ export default function MathMarathon() {
 
   const appendDigit = useCallback((digit: string) => {
     if (phase !== 'playing' || submitting) return
-    setInput(prev => {
-      // Cap at 3 digits — answers in the 1–100 range never need more.
-      if (prev.length >= 3) return prev
-      // Avoid leading zero (e.g. "07" reads as 7 anyway).
-      if (prev === '' && digit === '0') return '0'
-      if (prev === '0') return digit
-      return prev + digit
-    })
+    setInput(prev => appendAnswerDigit(prev, digit))
   }, [phase, submitting])
 
   const backspace = useCallback(() => {
@@ -240,25 +234,7 @@ export default function MathMarathon() {
     setInput(prev => prev.slice(0, -1))
   }, [phase, submitting])
 
-  // Physical keyboard support for desktop play.
-  useEffect(() => {
-    if (phase !== 'playing') return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.metaKey || e.ctrlKey || e.altKey) return
-      if (e.key >= '0' && e.key <= '9') {
-        appendDigit(e.key)
-        e.preventDefault()
-      } else if (e.key === 'Backspace') {
-        backspace()
-        e.preventDefault()
-      } else if (e.key === 'Enter') {
-        void submitAnswer()
-        e.preventDefault()
-      }
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [phase, appendDigit, backspace, submitAnswer])
+  const handleSubmit = useCallback(() => { void submitAnswer() }, [submitAnswer])
 
   // Warn before navigating away from a run in progress so a stray back-
   // tap or refresh doesn't silently lose 5 minutes of grinding.
@@ -431,67 +407,19 @@ export default function MathMarathon() {
       </div>
 
       <div className="flex-1 flex flex-col items-center justify-center mb-6">
-        <div className="text-4xl sm:text-6xl md:text-7xl font-bold text-white text-center mb-6 sm:mb-8 tabular-nums">
+        <div className="text-4xl sm:text-6xl md:text-7xl font-bold text-white text-center tabular-nums">
           {currentFact ? renderProblem(currentFact) : ''}
         </div>
-        <div
-          aria-live="polite"
-          aria-label={t('marathon.answerInputLabel')}
-          className="w-full max-w-xs h-16 sm:h-20 rounded-lg border-2 border-gray-700 bg-gray-800 flex items-center justify-center text-3xl sm:text-4xl font-bold text-white tabular-nums select-none"
-        >
-          {input || <span className="text-gray-600">_</span>}
-        </div>
       </div>
 
-      <div className="grid grid-cols-3 gap-2 sm:gap-3 max-w-md mx-auto w-full pb-2">
-        {['1', '2', '3', '4', '5', '6', '7', '8', '9'].map(d => (
-          <KeypadButton key={d} onClick={() => appendDigit(d)} disabled={isFinishing}>
-            {d}
-          </KeypadButton>
-        ))}
-        <KeypadButton onClick={backspace} disabled={isFinishing} variant="muted" ariaLabel={t('marathon.backspaceAria')}>
-          <Delete size={28} />
-        </KeypadButton>
-        <KeypadButton onClick={() => appendDigit('0')} disabled={isFinishing}>
-          0
-        </KeypadButton>
-        <KeypadButton
-          onClick={() => { void submitAnswer() }}
-          disabled={isFinishing || input.length === 0}
-          variant="primary"
-          ariaLabel={t('marathon.enterAria')}
-        >
-          {isFinishing ? '…' : t('marathon.enter')}
-        </KeypadButton>
-      </div>
+      <MathAnswerPad
+        input={input}
+        onDigit={appendDigit}
+        onBackspace={backspace}
+        onSubmit={handleSubmit}
+        disabled={isFinishing}
+        busy={isFinishing}
+      />
     </div>
-  )
-}
-
-interface KeypadButtonProps {
-  onClick: () => void
-  disabled?: boolean
-  variant?: 'default' | 'primary' | 'muted'
-  ariaLabel?: string
-  children: React.ReactNode
-}
-
-function KeypadButton({ onClick, disabled, variant = 'default', ariaLabel, children }: KeypadButtonProps) {
-  const base = 'h-16 sm:h-20 rounded-lg text-2xl sm:text-3xl font-bold flex items-center justify-center select-none transition-colors disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation'
-  const styles = {
-    default: 'bg-gray-800 hover:bg-gray-700 active:bg-gray-600 text-white border border-gray-700',
-    primary: 'bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white',
-    muted: 'bg-gray-800 hover:bg-gray-700 active:bg-gray-600 text-gray-300 border border-gray-700',
-  }[variant]
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      aria-label={ariaLabel}
-      className={`${base} ${styles}`}
-    >
-      {children}
-    </button>
   )
 }


### PR DESCRIPTION
## Changes

- **Regnemester: Blitz mode** - New 60-second sprint mode at `/math/play/blitz`. Questions are drawn uniformly at random from the full 200-fact pool; score is weighted by answer speed (under 1s = ×1.5, under 2s = ×1.2) and current streak (cap ×3). Result screen shows final score, best streak, correct/wrong counts and a New PB badge. (Hytte-j3ll)

## Original Issue (feature): Regnemester: Blitz mode

Bead 3 of 7 for Regnemester. Depends on Marathon (Hytte-7v57). Blitz = 60-second sprint optimized for max score via speed and streak.

Build:
- /math/play/blitz sub-route
- Enable Blitz on the /math mode picker
- Rules:
  - 60s fixed timer
  - Questions drawn randomly from the full 200-fact pool, infinite supply
  - Wrong answer: 0 points, streak resets, move on
  - Correct answer: round(1 × speed_bonus × streak_multiplier)
    - speed_bonus = 1.5 if response_ms < 1000 else 1.2 if < 2000 else 1.0
    - streak_multiplier = min(3.0, 1.0 + streak/10) where streak is the count of consecutive corrects BEFORE this one
  - Final score = integer sum of all round points
- UI:
  - Same keypad/layout as Marathon (reuse component)
  - Prominent countdown timer
  - Live score and current streak visible
  - Small 'FAST!' label when last answer was under 1s (purely textual here — confetti is in the polish bead)
- On timer expiry: submit session with score, show result screen (score, best streak, correct count, wrong count, PB status)

Non-goals: polish effects, leaderboard integration (leaderboard is next bead).

---
Bead: Hytte-j3ll | Branch: forge/Hytte-j3ll
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)