### PR TITLE
Regnemester: leaderboards (per mode, all-time + weekly) (Hytte-0p6m)

### DIFF
--- a/changelog.d/Hytte-0p6m.md
+++ b/changelog.d/Hytte-0p6m.md
@@ -1,0 +1,2 @@
+category: Added
+- **Regnemester leaderboards** - Added family-scoped leaderboards for Marathon and Blitz with all-time and weekly (Monday 00:00 UTC) views at `/math/leaderboard`, plus a post-finish rank summary on both game-over screens. (Hytte-0p6m)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -652,6 +652,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Get("/math/stats", mathgame.StatsHandler(db))
 				r.Get("/math/marathon/best", mathgame.MarathonBestHandler(db))
 				r.Get("/math/blitz/best", mathgame.BlitzBestHandler(db))
+				r.Get("/math/leaderboard", mathgame.LeaderboardHandler(db))
 			})
 
 			// Transit departures — gated by "transit" feature.

--- a/internal/math/handlers.go
+++ b/internal/math/handlers.go
@@ -257,6 +257,39 @@ func StatsHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
+// LeaderboardHandler returns GET /api/math/leaderboard?mode=marathon|blitz&period=all|week:
+// the family-scoped leaderboard for the given mode and time window. Family
+// members with no qualifying run appear with a null score.
+func LeaderboardHandler(db *sql.DB) http.HandlerFunc {
+	svc := NewService(db)
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			writeErr(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		mode := r.URL.Query().Get("mode")
+		period := r.URL.Query().Get("period")
+		if period == "" {
+			period = PeriodAll
+		}
+		lb, err := svc.BuildLeaderboard(r.Context(), user.ID, mode, period)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrInvalidMode):
+				writeErr(w, http.StatusBadRequest, "invalid mode")
+			case errors.Is(err, ErrInvalidPeriod):
+				writeErr(w, http.StatusBadRequest, "invalid period")
+			default:
+				log.Printf("math: leaderboard: %v", err)
+				writeErr(w, http.StatusInternalServerError, "failed to load leaderboard")
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, lb)
+	}
+}
+
 // sortStats orders entries by (A, B) ascending. We sort in-place using a
 // simple comparator-based sort rather than pulling in sort.Slice's reflection.
 func sortStats(entries []statsEntry) {

--- a/internal/math/leaderboard.go
+++ b/internal/math/leaderboard.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/family"
@@ -127,6 +128,11 @@ func (s *Service) BuildLeaderboard(ctx context.Context, userID int64, mode, peri
 		sinceStr = weekStartUTC(time.Now()).Format(timeFormat)
 	}
 
+	bests, err := s.bestForMembers(ctx, members, mode, sinceStr)
+	if err != nil {
+		return nil, err
+	}
+
 	entries := make([]LeaderboardEntry, 0, len(members))
 	for _, m := range members {
 		entry := LeaderboardEntry{
@@ -135,11 +141,7 @@ func (s *Service) BuildLeaderboard(ctx context.Context, userID int64, mode, peri
 			AvatarEmoji: m.AvatarEmoji,
 			IsParent:    m.IsParent,
 		}
-		best, err := s.bestForMember(ctx, m.UserID, mode, sinceStr)
-		if err != nil {
-			return nil, err
-		}
-		if best != nil {
+		if best := bests[m.UserID]; best != nil {
 			score := best.Score
 			sid := best.SessionID
 			at := best.AchievedAt
@@ -162,84 +164,116 @@ type memberBest struct {
 	AchievedAt string
 }
 
-// bestForMember returns the given user's best run for mode, optionally
-// restricted to sessions whose started_at is at or after sinceStr. For
-// Marathon the "best" is the fastest finished run with the canonical attempt
-// count; for Blitz it is the highest-scoring finished run with duration as
-// the tiebreaker. Returns nil when no qualifying run exists.
-func (s *Service) bestForMember(ctx context.Context, userID int64, mode, sinceStr string) (*memberBest, error) {
+// bestForMembers fetches the best qualifying run for each member in a single
+// query, returning a map from user_id to their best. Members with no
+// qualifying run are absent from the map.
+//
+// For Marathon the "best" is the fastest finished run with the canonical
+// attempt count; for Blitz it is the highest-scoring finished run with
+// duration as the tiebreaker. Both modes use ended_at for the weekly window
+// so that a run completed in-week is not excluded because it started just
+// before the Monday boundary.
+func (s *Service) bestForMembers(ctx context.Context, members []FamilyMember, mode, sinceStr string) (map[int64]*memberBest, error) {
+	if len(members) == 0 {
+		return nil, nil
+	}
+
+	// Build "?,?,?" placeholder for the IN clause.
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(members)), ",")
+
+	// Collect member IDs as interface{} for variadic query args.
+	idArgs := make([]any, len(members))
+	for i, m := range members {
+		idArgs[i] = m.UserID
+	}
+
+	// Queries use ROW_NUMBER() OVER (PARTITION BY user_id ...) to pick each
+	// user's single best session without a separate query per member. Rows end
+	// with ORDER BY id ASC as a deterministic tiebreaker so the same session is
+	// always returned when every ranking column ties.
 	var (
-		row *sql.Row
+		rows *sql.Rows
+		err  error
 	)
-	// Queries end with `id ASC` so that if every ranking column ties the
-	// earliest-inserted qualifying run wins. Without this tiebreaker SQLite
-	// is free to return any of the tied rows, which surfaces as flaky
-	// session_id/achieved_at values on the leaderboard.
 	switch mode {
 	case ModeMarathon:
 		if sinceStr == "" {
-			row = s.db.QueryRowContext(ctx, `
-				SELECT id, duration_ms, ended_at
-				FROM math_sessions
-				WHERE user_id = ?
-				  AND mode = ?
-				  AND ended_at IS NOT NULL AND ended_at != ''
-				  AND (total_correct + total_wrong) = ?
-				ORDER BY duration_ms ASC, total_wrong ASC, id ASC
-				LIMIT 1`,
-				userID, ModeMarathon, MarathonFactCount,
-			)
+			args := append(append([]any{}, idArgs...), ModeMarathon, MarathonFactCount)
+			rows, err = s.db.QueryContext(ctx, fmt.Sprintf(`
+				SELECT user_id, id, duration_ms, ended_at
+				FROM (
+					SELECT user_id, id, duration_ms, ended_at,
+					       ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY duration_ms ASC, total_wrong ASC, id ASC) AS rn
+					FROM math_sessions
+					WHERE user_id IN (%s)
+					  AND mode = ?
+					  AND ended_at IS NOT NULL AND ended_at != ''
+					  AND (total_correct + total_wrong) = ?
+				)
+				WHERE rn = 1`, placeholders), args...)
 		} else {
-			row = s.db.QueryRowContext(ctx, `
-				SELECT id, duration_ms, ended_at
-				FROM math_sessions
-				WHERE user_id = ?
-				  AND mode = ?
-				  AND ended_at IS NOT NULL AND ended_at != ''
-				  AND (total_correct + total_wrong) = ?
-				  AND started_at >= ?
-				ORDER BY duration_ms ASC, total_wrong ASC, id ASC
-				LIMIT 1`,
-				userID, ModeMarathon, MarathonFactCount, sinceStr,
-			)
+			args := append(append([]any{}, idArgs...), ModeMarathon, MarathonFactCount, sinceStr)
+			rows, err = s.db.QueryContext(ctx, fmt.Sprintf(`
+				SELECT user_id, id, duration_ms, ended_at
+				FROM (
+					SELECT user_id, id, duration_ms, ended_at,
+					       ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY duration_ms ASC, total_wrong ASC, id ASC) AS rn
+					FROM math_sessions
+					WHERE user_id IN (%s)
+					  AND mode = ?
+					  AND ended_at IS NOT NULL AND ended_at != ''
+					  AND (total_correct + total_wrong) = ?
+					  AND ended_at >= ?
+				)
+				WHERE rn = 1`, placeholders), args...)
 		}
 	case ModeBlitz:
 		if sinceStr == "" {
-			row = s.db.QueryRowContext(ctx, `
-				SELECT id, score_num, ended_at
-				FROM math_sessions
-				WHERE user_id = ?
-				  AND mode = ?
-				  AND ended_at IS NOT NULL AND ended_at != ''
-				ORDER BY score_num DESC, duration_ms ASC, id ASC
-				LIMIT 1`,
-				userID, ModeBlitz,
-			)
+			args := append(append([]any{}, idArgs...), ModeBlitz)
+			rows, err = s.db.QueryContext(ctx, fmt.Sprintf(`
+				SELECT user_id, id, score_num, ended_at
+				FROM (
+					SELECT user_id, id, score_num, ended_at,
+					       ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY score_num DESC, duration_ms ASC, id ASC) AS rn
+					FROM math_sessions
+					WHERE user_id IN (%s)
+					  AND mode = ?
+					  AND ended_at IS NOT NULL AND ended_at != ''
+				)
+				WHERE rn = 1`, placeholders), args...)
 		} else {
-			row = s.db.QueryRowContext(ctx, `
-				SELECT id, score_num, ended_at
-				FROM math_sessions
-				WHERE user_id = ?
-				  AND mode = ?
-				  AND ended_at IS NOT NULL AND ended_at != ''
-				  AND started_at >= ?
-				ORDER BY score_num DESC, duration_ms ASC, id ASC
-				LIMIT 1`,
-				userID, ModeBlitz, sinceStr,
-			)
+			args := append(append([]any{}, idArgs...), ModeBlitz, sinceStr)
+			rows, err = s.db.QueryContext(ctx, fmt.Sprintf(`
+				SELECT user_id, id, score_num, ended_at
+				FROM (
+					SELECT user_id, id, score_num, ended_at,
+					       ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY score_num DESC, duration_ms ASC, id ASC) AS rn
+					FROM math_sessions
+					WHERE user_id IN (%s)
+					  AND mode = ?
+					  AND ended_at IS NOT NULL AND ended_at != ''
+					  AND ended_at >= ?
+				)
+				WHERE rn = 1`, placeholders), args...)
 		}
 	default:
 		return nil, ErrInvalidMode
 	}
-
-	var best memberBest
-	if err := row.Scan(&best.SessionID, &best.Score, &best.AchievedAt); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("scan best for member: %w", err)
+	if err != nil {
+		return nil, fmt.Errorf("query best for members: %w", err)
 	}
-	return &best, nil
+	defer rows.Close()
+
+	result := make(map[int64]*memberBest, len(members))
+	for rows.Next() {
+		var userID int64
+		var best memberBest
+		if err := rows.Scan(&userID, &best.SessionID, &best.Score, &best.AchievedAt); err != nil {
+			return nil, fmt.Errorf("scan best: %w", err)
+		}
+		result[userID] = &best
+	}
+	return result, rows.Err()
 }
 
 // sortLeaderboard orders entries for display. Members without a score go

--- a/internal/math/leaderboard.go
+++ b/internal/math/leaderboard.go
@@ -1,0 +1,281 @@
+package math
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/family"
+)
+
+// LeaderboardEntry is a single family member's best run for a mode and
+// period. Score, SessionID and AchievedAt are pointers so they can serialise
+// as JSON null when the member has not yet finished a run in the window.
+// Rank is also nullable: members without a score sort to the bottom and are
+// displayed as unranked.
+type LeaderboardEntry struct {
+	UserID      int64   `json:"user_id"`
+	Name        string  `json:"name"`
+	AvatarEmoji string  `json:"avatar_emoji"`
+	IsParent    bool    `json:"is_parent"`
+	Score       *int64  `json:"score"`
+	SessionID   *int64  `json:"session_id"`
+	AchievedAt  *string `json:"achieved_at"`
+	Rank        *int    `json:"rank"`
+}
+
+// Leaderboard is the full leaderboard response for a family.
+type Leaderboard struct {
+	Mode    string             `json:"mode"`
+	Period  string             `json:"period"`
+	Entries []LeaderboardEntry `json:"entries"`
+}
+
+// PeriodAll and PeriodWeek are the two supported time windows.
+const (
+	PeriodAll  = "all"
+	PeriodWeek = "week"
+)
+
+// ErrInvalidPeriod is returned by the leaderboard service when the caller
+// passes a period other than PeriodAll or PeriodWeek.
+var ErrInvalidPeriod = errors.New("invalid leaderboard period")
+
+// weekStartUTC returns the Monday 00:00:00 UTC of the ISO week containing t.
+// Matches the convention already used by the stars leaderboard.
+func weekStartUTC(t time.Time) time.Time {
+	t = t.UTC()
+	daysSinceMonday := (int(t.Weekday()) + 6) % 7
+	return t.AddDate(0, 0, -daysSinceMonday).Truncate(24 * time.Hour)
+}
+
+// FamilyMember is a single user considered for inclusion on the leaderboard:
+// either the family's parent or one of their linked children. Name is the
+// display name — the parent's user.name or the child's family_links.nickname.
+type FamilyMember struct {
+	UserID      int64
+	Name        string
+	AvatarEmoji string
+	IsParent    bool
+}
+
+// resolveFamily returns the set of users in the caller's family: the parent
+// plus every linked child. If the caller has no family links they are
+// returned alone so the leaderboard still renders a single-row response
+// instead of failing.
+func resolveFamily(ctx context.Context, db *sql.DB, userID int64) ([]FamilyMember, error) {
+	// If the caller is linked as a child, their parent is the family root.
+	// Otherwise treat the caller themselves as the root (they may be the
+	// parent, or an unlinked solo user).
+	var parentID int64
+	parentLink, err := family.GetParent(db, userID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve parent: %w", err)
+	}
+	if parentLink != nil {
+		parentID = parentLink.ParentID
+	} else {
+		parentID = userID
+	}
+
+	var parentName string
+	if err := db.QueryRowContext(ctx, `SELECT COALESCE(name, '') FROM users WHERE id = ?`, parentID).Scan(&parentName); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("load parent name: %w", err)
+	}
+
+	members := []FamilyMember{{
+		UserID:   parentID,
+		Name:     parentName,
+		IsParent: true,
+	}}
+
+	children, err := family.GetChildren(db, parentID)
+	if err != nil {
+		return nil, fmt.Errorf("load children: %w", err)
+	}
+	for _, child := range children {
+		members = append(members, FamilyMember{
+			UserID:      child.ChildID,
+			Name:        child.Nickname,
+			AvatarEmoji: child.AvatarEmoji,
+		})
+	}
+	return members, nil
+}
+
+// BuildLeaderboard fetches the best run for each family member for the given
+// mode and period and returns a ranked entry list. Members without a
+// qualifying run are included with nil score and no rank.
+func (s *Service) BuildLeaderboard(ctx context.Context, userID int64, mode, period string) (*Leaderboard, error) {
+	if mode != ModeMarathon && mode != ModeBlitz {
+		return nil, ErrInvalidMode
+	}
+	if period != PeriodAll && period != PeriodWeek {
+		return nil, ErrInvalidPeriod
+	}
+
+	members, err := resolveFamily(ctx, s.db, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	var sinceStr string
+	if period == PeriodWeek {
+		sinceStr = weekStartUTC(time.Now()).Format(timeFormat)
+	}
+
+	entries := make([]LeaderboardEntry, 0, len(members))
+	for _, m := range members {
+		entry := LeaderboardEntry{
+			UserID:      m.UserID,
+			Name:        m.Name,
+			AvatarEmoji: m.AvatarEmoji,
+			IsParent:    m.IsParent,
+		}
+		best, err := s.bestForMember(ctx, m.UserID, mode, sinceStr)
+		if err != nil {
+			return nil, err
+		}
+		if best != nil {
+			score := best.Score
+			sid := best.SessionID
+			at := best.AchievedAt
+			entry.Score = &score
+			entry.SessionID = &sid
+			entry.AchievedAt = &at
+		}
+		entries = append(entries, entry)
+	}
+
+	sortLeaderboard(entries, mode)
+	assignRanks(entries)
+	return &Leaderboard{Mode: mode, Period: period, Entries: entries}, nil
+}
+
+// memberBest carries the best-run stats for a single user.
+type memberBest struct {
+	SessionID  int64
+	Score      int64
+	AchievedAt string
+}
+
+// bestForMember returns the given user's best run for mode, optionally
+// restricted to sessions whose started_at is at or after sinceStr. For
+// Marathon the "best" is the fastest finished run with the canonical attempt
+// count; for Blitz it is the highest-scoring finished run with duration as
+// the tiebreaker. Returns nil when no qualifying run exists.
+func (s *Service) bestForMember(ctx context.Context, userID int64, mode, sinceStr string) (*memberBest, error) {
+	var (
+		row *sql.Row
+	)
+	switch mode {
+	case ModeMarathon:
+		if sinceStr == "" {
+			row = s.db.QueryRowContext(ctx, `
+				SELECT id, duration_ms, ended_at
+				FROM math_sessions
+				WHERE user_id = ?
+				  AND mode = ?
+				  AND ended_at IS NOT NULL AND ended_at != ''
+				  AND (total_correct + total_wrong) = ?
+				ORDER BY duration_ms ASC, total_wrong ASC
+				LIMIT 1`,
+				userID, ModeMarathon, MarathonFactCount,
+			)
+		} else {
+			row = s.db.QueryRowContext(ctx, `
+				SELECT id, duration_ms, ended_at
+				FROM math_sessions
+				WHERE user_id = ?
+				  AND mode = ?
+				  AND ended_at IS NOT NULL AND ended_at != ''
+				  AND (total_correct + total_wrong) = ?
+				  AND started_at >= ?
+				ORDER BY duration_ms ASC, total_wrong ASC
+				LIMIT 1`,
+				userID, ModeMarathon, MarathonFactCount, sinceStr,
+			)
+		}
+	case ModeBlitz:
+		if sinceStr == "" {
+			row = s.db.QueryRowContext(ctx, `
+				SELECT id, score_num, ended_at
+				FROM math_sessions
+				WHERE user_id = ?
+				  AND mode = ?
+				  AND ended_at IS NOT NULL AND ended_at != ''
+				ORDER BY score_num DESC, duration_ms ASC
+				LIMIT 1`,
+				userID, ModeBlitz,
+			)
+		} else {
+			row = s.db.QueryRowContext(ctx, `
+				SELECT id, score_num, ended_at
+				FROM math_sessions
+				WHERE user_id = ?
+				  AND mode = ?
+				  AND ended_at IS NOT NULL AND ended_at != ''
+				  AND started_at >= ?
+				ORDER BY score_num DESC, duration_ms ASC
+				LIMIT 1`,
+				userID, ModeBlitz, sinceStr,
+			)
+		}
+	default:
+		return nil, ErrInvalidMode
+	}
+
+	var best memberBest
+	if err := row.Scan(&best.SessionID, &best.Score, &best.AchievedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("scan best for member: %w", err)
+	}
+	return &best, nil
+}
+
+// sortLeaderboard orders entries for display. Members without a score go
+// last; among the rest the order is ascending duration for Marathon and
+// descending score for Blitz, with name as a deterministic tiebreaker.
+func sortLeaderboard(entries []LeaderboardEntry, mode string) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.Score == nil && b.Score == nil {
+			return a.Name < b.Name
+		}
+		if a.Score == nil {
+			return false
+		}
+		if b.Score == nil {
+			return true
+		}
+		if *a.Score != *b.Score {
+			if mode == ModeMarathon {
+				return *a.Score < *b.Score
+			}
+			return *a.Score > *b.Score
+		}
+		return a.Name < b.Name
+	})
+}
+
+// assignRanks fills in Rank for every entry that has a score. Ties on score
+// share the same rank; entries with no score are left unranked.
+func assignRanks(entries []LeaderboardEntry) {
+	rank := 0
+	for i := range entries {
+		if entries[i].Score == nil {
+			entries[i].Rank = nil
+			continue
+		}
+		if i == 0 || entries[i-1].Score == nil || *entries[i-1].Score != *entries[i].Score {
+			rank = i + 1
+		}
+		r := rank
+		entries[i].Rank = &r
+	}
+}

--- a/internal/math/leaderboard.go
+++ b/internal/math/leaderboard.go
@@ -171,6 +171,10 @@ func (s *Service) bestForMember(ctx context.Context, userID int64, mode, sinceSt
 	var (
 		row *sql.Row
 	)
+	// Queries end with `id ASC` so that if every ranking column ties the
+	// earliest-inserted qualifying run wins. Without this tiebreaker SQLite
+	// is free to return any of the tied rows, which surfaces as flaky
+	// session_id/achieved_at values on the leaderboard.
 	switch mode {
 	case ModeMarathon:
 		if sinceStr == "" {
@@ -181,7 +185,7 @@ func (s *Service) bestForMember(ctx context.Context, userID int64, mode, sinceSt
 				  AND mode = ?
 				  AND ended_at IS NOT NULL AND ended_at != ''
 				  AND (total_correct + total_wrong) = ?
-				ORDER BY duration_ms ASC, total_wrong ASC
+				ORDER BY duration_ms ASC, total_wrong ASC, id ASC
 				LIMIT 1`,
 				userID, ModeMarathon, MarathonFactCount,
 			)
@@ -194,7 +198,7 @@ func (s *Service) bestForMember(ctx context.Context, userID int64, mode, sinceSt
 				  AND ended_at IS NOT NULL AND ended_at != ''
 				  AND (total_correct + total_wrong) = ?
 				  AND started_at >= ?
-				ORDER BY duration_ms ASC, total_wrong ASC
+				ORDER BY duration_ms ASC, total_wrong ASC, id ASC
 				LIMIT 1`,
 				userID, ModeMarathon, MarathonFactCount, sinceStr,
 			)
@@ -207,7 +211,7 @@ func (s *Service) bestForMember(ctx context.Context, userID int64, mode, sinceSt
 				WHERE user_id = ?
 				  AND mode = ?
 				  AND ended_at IS NOT NULL AND ended_at != ''
-				ORDER BY score_num DESC, duration_ms ASC
+				ORDER BY score_num DESC, duration_ms ASC, id ASC
 				LIMIT 1`,
 				userID, ModeBlitz,
 			)
@@ -219,7 +223,7 @@ func (s *Service) bestForMember(ctx context.Context, userID int64, mode, sinceSt
 				  AND mode = ?
 				  AND ended_at IS NOT NULL AND ended_at != ''
 				  AND started_at >= ?
-				ORDER BY score_num DESC, duration_ms ASC
+				ORDER BY score_num DESC, duration_ms ASC, id ASC
 				LIMIT 1`,
 				userID, ModeBlitz, sinceStr,
 			)

--- a/internal/math/leaderboard_test.go
+++ b/internal/math/leaderboard_test.go
@@ -192,10 +192,12 @@ func TestBuildLeaderboardWeeklyExcludesOlderRuns(t *testing.T) {
 	// current wall-clock falling within a particular ISO week. Eight days
 	// ago is guaranteed to be before the Monday that starts the current
 	// week (at worst today is Monday, in which case the cutoff is today
-	// 00:00 UTC and a run 8 days ago is still excluded).
+	// 00:00 UTC and a run 8 days ago is still excluded). Derive the
+	// in-week timestamp from the current week's start so it remains inside
+	// the current ISO week even if the test runs just after Monday 00:00 UTC.
 	now := time.Now().UTC()
 	lastWeek := now.Add(-8 * 24 * time.Hour)
-	thisWeek := now.Add(-1 * time.Hour)
+	thisWeek := weekStartUTC(now).Add(1 * time.Hour)
 	finishedMarathon(t, d, 2, 200000, 0, lastWeek) // excluded in weekly view
 	thisID := finishedMarathon(t, d, 2, 260000, 1, thisWeek)
 

--- a/internal/math/leaderboard_test.go
+++ b/internal/math/leaderboard_test.go
@@ -294,6 +294,41 @@ func TestBuildLeaderboardChildCallerSeesWholeFamily(t *testing.T) {
 	}
 }
 
+func TestBuildLeaderboardTieBreaksDeterministically(t *testing.T) {
+	// When every ranking column ties, the earliest-inserted run should win.
+	// Without the id tiebreaker SQLite is free to return any row, which
+	// breaks the stable "my best session" link on the finish screen.
+	d := setupTestDB(t)
+	start := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+
+	// Marathon: two runs with identical duration and wrongs.
+	firstMarathon := finishedMarathon(t, d, 1, 250000, 0, start)
+	_ = finishedMarathon(t, d, 1, 250000, 0, start.Add(time.Hour))
+
+	// Blitz: two runs with identical score and duration.
+	firstBlitz := finishedBlitz(t, d, 1, 30, start)
+	_ = finishedBlitz(t, d, 1, 30, start.Add(time.Hour))
+
+	svc := NewService(d)
+	lbM, err := svc.BuildLeaderboard(context.Background(), 1, ModeMarathon, PeriodAll)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard(marathon): %v", err)
+	}
+	me := findEntry(t, lbM.Entries, 1)
+	if me.SessionID == nil || *me.SessionID != firstMarathon {
+		t.Errorf("marathon tie: got session %v, want %d (earliest)", me.SessionID, firstMarathon)
+	}
+
+	lbB, err := svc.BuildLeaderboard(context.Background(), 1, ModeBlitz, PeriodAll)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard(blitz): %v", err)
+	}
+	me = findEntry(t, lbB.Entries, 1)
+	if me.SessionID == nil || *me.SessionID != firstBlitz {
+		t.Errorf("blitz tie: got session %v, want %d (earliest)", me.SessionID, firstBlitz)
+	}
+}
+
 func TestLeaderboardHandlerUnknownMode(t *testing.T) {
 	d := setupTestDB(t)
 	h := LeaderboardHandler(d)

--- a/internal/math/leaderboard_test.go
+++ b/internal/math/leaderboard_test.go
@@ -1,0 +1,379 @@
+package math
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// linkChild creates a family_links row linking child to parent with the
+// given display name. Tests call this directly (bypassing family.CreateLink)
+// so they can set a deterministic created_at and avoid encryption noise —
+// family.decryptOrPlaintext falls back to plaintext when values are not
+// "enc:"-prefixed, which matches legacy data in production.
+func linkChild(t *testing.T, db *sql.DB, parentID, childID int64, nickname, avatar string) {
+	t.Helper()
+	linkAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	if _, err := db.Exec(`
+		INSERT INTO family_links (parent_id, child_id, nickname, avatar_emoji, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, parentID, childID, nickname, avatar, linkAt); err != nil {
+		t.Fatalf("link child %d→%d: %v", parentID, childID, err)
+	}
+}
+
+// finishedMarathon inserts a completed Marathon session for userID at a
+// specific start time so tests can pin sessions to "last week" vs "this week"
+// without time.Now skew.
+func finishedMarathon(t *testing.T, db *sql.DB, userID int64, durationMs int64, totalWrong int, startedAt time.Time) int64 {
+	t.Helper()
+	startStr := startedAt.UTC().Format(time.RFC3339)
+	endStr := startedAt.Add(time.Duration(durationMs) * time.Millisecond).UTC().Format(time.RFC3339)
+	res, err := db.Exec(`
+		INSERT INTO math_sessions
+			(user_id, mode, started_at, ended_at, duration_ms, total_correct, total_wrong, score_num)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, userID, ModeMarathon, startStr, endStr, durationMs, MarathonFactCount-totalWrong, totalWrong, MarathonFactCount-totalWrong)
+	if err != nil {
+		t.Fatalf("insert marathon session: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+// finishedBlitz inserts a completed Blitz session.
+func finishedBlitz(t *testing.T, db *sql.DB, userID int64, score int64, startedAt time.Time) int64 {
+	t.Helper()
+	startStr := startedAt.UTC().Format(time.RFC3339)
+	endStr := startedAt.Add(60 * time.Second).UTC().Format(time.RFC3339)
+	res, err := db.Exec(`
+		INSERT INTO math_sessions
+			(user_id, mode, started_at, ended_at, duration_ms, total_correct, total_wrong, score_num)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, userID, ModeBlitz, startStr, endStr, 60000, int(score), 0, score)
+	if err != nil {
+		t.Fatalf("insert blitz session: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func TestWeekStartUTC(t *testing.T) {
+	// 2026-04-22 is a Wednesday. Monday of that ISO week is 2026-04-20.
+	wed := time.Date(2026, 4, 22, 15, 0, 0, 0, time.UTC)
+	got := weekStartUTC(wed)
+	want := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("weekStartUTC(%v) = %v, want %v", wed, got, want)
+	}
+	// Sunday rolls back to the previous Monday.
+	sun := time.Date(2026, 4, 26, 23, 59, 0, 0, time.UTC)
+	got = weekStartUTC(sun)
+	if !got.Equal(want) {
+		t.Errorf("weekStartUTC(sunday %v) = %v, want %v", sun, got, want)
+	}
+}
+
+func TestBuildLeaderboardInvalidMode(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	if _, err := svc.BuildLeaderboard(context.Background(), 1, "mixed", PeriodAll); !errors.Is(err, ErrInvalidMode) {
+		t.Errorf("expected ErrInvalidMode, got %v", err)
+	}
+}
+
+func TestBuildLeaderboardInvalidPeriod(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService(d)
+	if _, err := svc.BuildLeaderboard(context.Background(), 1, ModeMarathon, "month"); !errors.Is(err, ErrInvalidPeriod) {
+		t.Errorf("expected ErrInvalidPeriod, got %v", err)
+	}
+}
+
+func TestBuildLeaderboardMarathonAllTime(t *testing.T) {
+	d := setupTestDB(t)
+	// User 1 is parent, user 2 is child; link them.
+	linkChild(t, d, 1, 2, "Alice", "🐼")
+
+	// Parent posts a slower run; child posts a faster run.
+	parentStart := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	childStart := time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC)
+	parentSess := finishedMarathon(t, d, 1, 300000, 2, parentStart)
+	childSess := finishedMarathon(t, d, 2, 250000, 0, childStart)
+
+	svc := NewService(d)
+	lb, err := svc.BuildLeaderboard(context.Background(), 1, ModeMarathon, PeriodAll)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard: %v", err)
+	}
+	if len(lb.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(lb.Entries))
+	}
+	// Child is fastest → rank 1.
+	first, second := lb.Entries[0], lb.Entries[1]
+	if first.UserID != 2 || first.Score == nil || *first.Score != 250000 {
+		t.Errorf("entry[0] = %+v (score=%v), want child with 250000", first, first.Score)
+	}
+	if first.SessionID == nil || *first.SessionID != childSess {
+		t.Errorf("entry[0].SessionID = %v, want %d", first.SessionID, childSess)
+	}
+	if first.Rank == nil || *first.Rank != 1 {
+		t.Errorf("entry[0].Rank = %v, want 1", first.Rank)
+	}
+	if second.UserID != 1 || second.Score == nil || *second.Score != 300000 {
+		t.Errorf("entry[1] = %+v, want parent with 300000", second)
+	}
+	if second.SessionID == nil || *second.SessionID != parentSess {
+		t.Errorf("entry[1].SessionID = %v, want %d", second.SessionID, parentSess)
+	}
+	if !second.IsParent {
+		t.Error("parent entry should have IsParent=true")
+	}
+}
+
+func TestBuildLeaderboardIncludesMembersWithoutSessions(t *testing.T) {
+	d := setupTestDB(t)
+	linkChild(t, d, 1, 2, "Alice", "🐼")
+
+	svc := NewService(d)
+	lb, err := svc.BuildLeaderboard(context.Background(), 2, ModeBlitz, PeriodAll)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard: %v", err)
+	}
+	if len(lb.Entries) != 2 {
+		t.Fatalf("expected 2 entries even without sessions, got %d", len(lb.Entries))
+	}
+	for _, e := range lb.Entries {
+		if e.Score != nil {
+			t.Errorf("entry %+v should have nil score", e)
+		}
+		if e.Rank != nil {
+			t.Errorf("entry %+v should be unranked", e)
+		}
+	}
+}
+
+func TestBuildLeaderboardBlitzSortsByHighestScore(t *testing.T) {
+	d := setupTestDB(t)
+	linkChild(t, d, 1, 2, "Alice", "🐼")
+	start := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	finishedBlitz(t, d, 1, 42, start)
+	// Child has two runs; the best is what should appear.
+	finishedBlitz(t, d, 2, 20, start)
+	finishedBlitz(t, d, 2, 55, start.Add(time.Hour))
+
+	svc := NewService(d)
+	lb, err := svc.BuildLeaderboard(context.Background(), 1, ModeBlitz, PeriodAll)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard: %v", err)
+	}
+	if len(lb.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(lb.Entries))
+	}
+	// Child (55) should rank 1 ahead of parent (42).
+	if lb.Entries[0].UserID != 2 || lb.Entries[0].Score == nil || *lb.Entries[0].Score != 55 {
+		t.Errorf("entry[0]=%+v, want child with 55", lb.Entries[0])
+	}
+	if lb.Entries[1].UserID != 1 || lb.Entries[1].Score == nil || *lb.Entries[1].Score != 42 {
+		t.Errorf("entry[1]=%+v, want parent with 42", lb.Entries[1])
+	}
+}
+
+func TestBuildLeaderboardWeeklyExcludesOlderRuns(t *testing.T) {
+	d := setupTestDB(t)
+	linkChild(t, d, 1, 2, "Alice", "🐼")
+
+	// Use times relative to time.Now() so the test doesn't rely on the
+	// current wall-clock falling within a particular ISO week. Eight days
+	// ago is guaranteed to be before the Monday that starts the current
+	// week (at worst today is Monday, in which case the cutoff is today
+	// 00:00 UTC and a run 8 days ago is still excluded).
+	now := time.Now().UTC()
+	lastWeek := now.Add(-8 * 24 * time.Hour)
+	thisWeek := now.Add(-1 * time.Hour)
+	finishedMarathon(t, d, 2, 200000, 0, lastWeek) // excluded in weekly view
+	thisID := finishedMarathon(t, d, 2, 260000, 1, thisWeek)
+
+	svc := NewService(d)
+	// All-time: child entry reflects the faster, older run.
+	lbAll, err := svc.BuildLeaderboard(context.Background(), 1, ModeMarathon, PeriodAll)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard(all): %v", err)
+	}
+	childAll := findEntry(t, lbAll.Entries, 2)
+	if childAll.Score == nil || *childAll.Score != 200000 {
+		t.Errorf("all-time child score = %v, want 200000", childAll.Score)
+	}
+
+	// Weekly: old run is filtered out; the this-week run shows instead.
+	lbWeek, err := svc.BuildLeaderboard(context.Background(), 1, ModeMarathon, PeriodWeek)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard(week): %v", err)
+	}
+	childWeek := findEntry(t, lbWeek.Entries, 2)
+	if childWeek.Score == nil || *childWeek.Score != 260000 {
+		t.Errorf("weekly child score = %v, want 260000", childWeek.Score)
+	}
+	if childWeek.SessionID == nil || *childWeek.SessionID != thisID {
+		t.Errorf("weekly child session = %v, want %d", childWeek.SessionID, thisID)
+	}
+}
+
+func TestBuildLeaderboardExcludesPartialMarathon(t *testing.T) {
+	d := setupTestDB(t)
+	linkChild(t, d, 1, 2, "Alice", "🐼")
+	start := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	startStr := start.Format(time.RFC3339)
+	endStr := start.Add(5 * time.Minute).Format(time.RFC3339)
+	// A partial Marathon for the child (only 100 attempts recorded).
+	if _, err := d.Exec(`INSERT INTO math_sessions
+		(user_id, mode, started_at, ended_at, duration_ms, total_correct, total_wrong, score_num)
+		VALUES (2, ?, ?, ?, 100000, 100, 0, 100)`,
+		ModeMarathon, startStr, endStr); err != nil {
+		t.Fatalf("insert partial: %v", err)
+	}
+
+	svc := NewService(d)
+	lb, err := svc.BuildLeaderboard(context.Background(), 1, ModeMarathon, PeriodAll)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard: %v", err)
+	}
+	child := findEntry(t, lb.Entries, 2)
+	if child.Score != nil {
+		t.Errorf("partial marathon should not count: score=%v", child.Score)
+	}
+}
+
+func TestBuildLeaderboardScopedToCallerFamily(t *testing.T) {
+	d := setupTestDB(t)
+	// Insert a third user unrelated to the family and give them a fast run.
+	if _, err := d.Exec(`INSERT INTO users (id, email, name, picture, google_id, created_at) VALUES (3, 'outsider@example.com', 'Outsider', '', 'g3', '')`); err != nil {
+		t.Fatalf("insert outsider: %v", err)
+	}
+	start := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	finishedMarathon(t, d, 3, 100000, 0, start)
+	// Parent 1 has a slower run; no link exists to user 3.
+	finishedMarathon(t, d, 1, 280000, 0, start)
+
+	svc := NewService(d)
+	lb, err := svc.BuildLeaderboard(context.Background(), 1, ModeMarathon, PeriodAll)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard: %v", err)
+	}
+	for _, e := range lb.Entries {
+		if e.UserID == 3 {
+			t.Fatal("outsider leaked into family leaderboard")
+		}
+	}
+	if len(lb.Entries) != 1 || lb.Entries[0].UserID != 1 {
+		t.Errorf("expected single parent entry, got %+v", lb.Entries)
+	}
+}
+
+func TestBuildLeaderboardChildCallerSeesWholeFamily(t *testing.T) {
+	d := setupTestDB(t)
+	// Parent=1, Child=2. Child is the caller.
+	linkChild(t, d, 1, 2, "Alice", "🐼")
+
+	svc := NewService(d)
+	lb, err := svc.BuildLeaderboard(context.Background(), 2, ModeBlitz, PeriodAll)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard: %v", err)
+	}
+	if len(lb.Entries) != 2 {
+		t.Fatalf("expected child to see 2 entries (self + parent), got %d", len(lb.Entries))
+	}
+	ids := map[int64]bool{lb.Entries[0].UserID: true, lb.Entries[1].UserID: true}
+	if !ids[1] || !ids[2] {
+		t.Errorf("expected entries for both parent and child, got %v", ids)
+	}
+}
+
+func TestLeaderboardHandlerUnknownMode(t *testing.T) {
+	d := setupTestDB(t)
+	h := LeaderboardHandler(d)
+	r := withUser(httptest.NewRequest(http.MethodGet, "/api/math/leaderboard?mode=mixed&period=all", nil), testUser)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestLeaderboardHandlerReturnsEntries(t *testing.T) {
+	d := setupTestDB(t)
+	linkChild(t, d, 1, 2, "Alice", "🐼")
+	start := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	finishedBlitz(t, d, 2, 77, start)
+
+	h := LeaderboardHandler(d)
+	r := withUser(httptest.NewRequest(http.MethodGet, "/api/math/leaderboard?mode=blitz&period=all", nil), testUser)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var lb Leaderboard
+	if err := json.Unmarshal(w.Body.Bytes(), &lb); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if lb.Mode != ModeBlitz || lb.Period != PeriodAll {
+		t.Errorf("mode/period mismatch: %+v", lb)
+	}
+	if len(lb.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(lb.Entries))
+	}
+	top := lb.Entries[0]
+	if top.UserID != 2 || top.Score == nil || *top.Score != 77 {
+		t.Errorf("top entry %+v, want child with 77", top)
+	}
+}
+
+func TestLeaderboardHandlerDefaultsPeriodToAll(t *testing.T) {
+	d := setupTestDB(t)
+	h := LeaderboardHandler(d)
+	r := withUser(httptest.NewRequest(http.MethodGet, "/api/math/leaderboard?mode=marathon", nil), testUser)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var lb Leaderboard
+	if err := json.Unmarshal(w.Body.Bytes(), &lb); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if lb.Period != PeriodAll {
+		t.Errorf("default period = %q, want %q", lb.Period, PeriodAll)
+	}
+}
+
+func TestLeaderboardHandlerUnauthorized(t *testing.T) {
+	d := setupTestDB(t)
+	h := LeaderboardHandler(d)
+	// No auth context attached.
+	r := httptest.NewRequest(http.MethodGet, "/api/math/leaderboard?mode=marathon&period=all", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+// findEntry returns the leaderboard entry for the given user, or fails the
+// test if the user is absent.
+func findEntry(t *testing.T, entries []LeaderboardEntry, userID int64) LeaderboardEntry {
+	t.Helper()
+	for _, e := range entries {
+		if e.UserID == userID {
+			return e
+		}
+	}
+	t.Fatalf("entry for user %d not found in %+v", userID, entries)
+	return LeaderboardEntry{}
+}
+

--- a/internal/math/leaderboard_test.go
+++ b/internal/math/leaderboard_test.go
@@ -226,6 +226,36 @@ func TestBuildLeaderboardWeeklyExcludesOlderRuns(t *testing.T) {
 	}
 }
 
+// TestBuildLeaderboardWeeklyIncludesBoundaryRun verifies that a run whose
+// started_at falls before Monday 00:00 UTC but whose ended_at falls after is
+// still included in the weekly window. The old started_at filter would have
+// dropped it; the fix uses ended_at >= weekStart instead.
+func TestBuildLeaderboardWeeklyIncludesBoundaryRun(t *testing.T) {
+	d := setupTestDB(t)
+
+	now := time.Now().UTC()
+	weekStart := weekStartUTC(now)
+
+	// A run that starts 5 minutes before this week's Monday cutoff and
+	// finishes 5 minutes after it (duration = 10 minutes = 600 000 ms).
+	// started_at is before the cutoff; ended_at is after it.
+	crossStart := weekStart.Add(-5 * time.Minute)
+	crossID := finishedMarathon(t, d, 1, 600000, 0, crossStart)
+
+	svc := NewService(d)
+	lb, err := svc.BuildLeaderboard(context.Background(), 1, ModeMarathon, PeriodWeek)
+	if err != nil {
+		t.Fatalf("BuildLeaderboard(week): %v", err)
+	}
+	entry := findEntry(t, lb.Entries, 1)
+	if entry.Score == nil {
+		t.Fatal("boundary-crossing run should appear in weekly leaderboard")
+	}
+	if entry.SessionID == nil || *entry.SessionID != crossID {
+		t.Errorf("session = %v, want %d", entry.SessionID, crossID)
+	}
+}
+
 func TestBuildLeaderboardExcludesPartialMarathon(t *testing.T) {
 	d := setupTestDB(t)
 	linkChild(t, d, 1, 2, "Alice", "🐼")

--- a/web/public/locales/en/regnemester.json
+++ b/web/public/locales/en/regnemester.json
@@ -73,5 +73,28 @@
     "failedToStart": "Could not start the run. Try again.",
     "failedToRecord": "Could not record your answer. The run was stopped.",
     "failedToFinish": "Could not finish the run. Your progress was saved but the result could not be loaded."
+  },
+  "leaderboard": {
+    "title": "Leaderboard",
+    "viewLink": "View leaderboard",
+    "viewLinkShort": "View",
+    "modeMarathon": "Marathon",
+    "modeBlitz": "Blitz",
+    "modeTabsLabel": "Mode",
+    "periodAll": "All time",
+    "periodWeek": "This week",
+    "periodTabsLabel": "Time window",
+    "rank": "Rank",
+    "player": "Player",
+    "score": "Score",
+    "when": "When",
+    "empty": "Nobody has finished a run yet.",
+    "parentTag": "(parent)",
+    "anonymous": "Unknown",
+    "errorLoad": "Could not load the leaderboard.",
+    "yourRank": "Your rank",
+    "rankSummary": "{{all}} all time · {{week}} this week",
+    "unranked": "Unranked",
+    "loading": "Loading rank…"
   }
 }

--- a/web/public/locales/nb/regnemester.json
+++ b/web/public/locales/nb/regnemester.json
@@ -73,5 +73,28 @@
     "failedToStart": "Kunne ikke starte runden. Prøv igjen.",
     "failedToRecord": "Kunne ikke lagre svaret ditt. Runden ble stoppet.",
     "failedToFinish": "Kunne ikke fullføre runden. Fremgangen ble lagret, men resultatet kunne ikke lastes."
+  },
+  "leaderboard": {
+    "title": "Resultatliste",
+    "viewLink": "Se resultatliste",
+    "viewLinkShort": "Se",
+    "modeMarathon": "Maraton",
+    "modeBlitz": "Blitz",
+    "modeTabsLabel": "Modus",
+    "periodAll": "All tid",
+    "periodWeek": "Denne uken",
+    "periodTabsLabel": "Tidsvindu",
+    "rank": "Plass",
+    "player": "Spiller",
+    "score": "Poeng",
+    "when": "Når",
+    "empty": "Ingen har fullført en runde ennå.",
+    "parentTag": "(forelder)",
+    "anonymous": "Ukjent",
+    "errorLoad": "Kunne ikke laste resultatlisten.",
+    "yourRank": "Din plassering",
+    "rankSummary": "{{all}} all tid · {{week}} denne uken",
+    "unranked": "Uten plassering",
+    "loading": "Laster plassering…"
   }
 }

--- a/web/public/locales/th/regnemester.json
+++ b/web/public/locales/th/regnemester.json
@@ -73,5 +73,28 @@
     "failedToStart": "ไม่สามารถเริ่มรอบได้ กรุณาลองใหม่",
     "failedToRecord": "ไม่สามารถบันทึกคำตอบได้ การเล่นถูกหยุด",
     "failedToFinish": "ไม่สามารถจบรอบได้ ความคืบหน้าถูกบันทึกแล้วแต่โหลดผลไม่ได้"
+  },
+  "leaderboard": {
+    "title": "ตารางคะแนน",
+    "viewLink": "ดูตารางคะแนน",
+    "viewLinkShort": "ดู",
+    "modeMarathon": "มาราธอน",
+    "modeBlitz": "บลิตซ์",
+    "modeTabsLabel": "โหมด",
+    "periodAll": "ตลอดกาล",
+    "periodWeek": "สัปดาห์นี้",
+    "periodTabsLabel": "ช่วงเวลา",
+    "rank": "อันดับ",
+    "player": "ผู้เล่น",
+    "score": "คะแนน",
+    "when": "เมื่อ",
+    "empty": "ยังไม่มีใครทำสำเร็จ",
+    "parentTag": "(ผู้ปกครอง)",
+    "anonymous": "ไม่ทราบ",
+    "errorLoad": "โหลดตารางคะแนนไม่ได้",
+    "yourRank": "อันดับของคุณ",
+    "rankSummary": "{{all}} ตลอดกาล · {{week}} สัปดาห์นี้",
+    "unranked": "ไม่ติดอันดับ",
+    "loading": "กำลังโหลดอันดับ…"
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -69,6 +69,7 @@ import HomeworkParentReview from './pages/HomeworkParentReview'
 import MathLanding from './pages/Math'
 import MathMarathon from './pages/MathMarathon'
 import MathBlitz from './pages/MathBlitz'
+import MathLeaderboard from './pages/MathLeaderboard'
 
 function MainLayout() {
   const { user } = useAuth()
@@ -511,6 +512,14 @@ function MainLayout() {
             element={
               <FeatureRoute feature="regnemester">
                 <MathBlitz />
+              </FeatureRoute>
+            }
+          />
+          <Route
+            path="/math/leaderboard"
+            element={
+              <FeatureRoute feature="regnemester">
+                <MathLeaderboard />
               </FeatureRoute>
             }
           />

--- a/web/src/components/math/FinishRank.tsx
+++ b/web/src/components/math/FinishRank.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { Trophy } from 'lucide-react'
+import { useAuth } from '../../auth'
+
+type Mode = 'marathon' | 'blitz'
+
+interface LeaderboardEntry {
+  user_id: number
+  rank: number | null
+  score: number | null
+}
+
+interface LeaderboardResponse {
+  entries: LeaderboardEntry[]
+}
+
+interface Ranks {
+  all: number | null
+  week: number | null
+}
+
+async function fetchRank(mode: Mode, period: 'all' | 'week', userID: number): Promise<number | null> {
+  const res = await fetch(`/api/math/leaderboard?mode=${mode}&period=${period}`, { credentials: 'include' })
+  if (!res.ok) return null
+  const data = (await res.json()) as LeaderboardResponse
+  const me = data.entries.find(e => e.user_id === userID)
+  if (!me || me.rank == null) return null
+  return me.rank
+}
+
+// FinishRank renders the caller's current rank for the given mode across
+// both time windows and links to /math/leaderboard. The sessionId prop
+// forces a re-fetch each time a new run finishes so the shown rank reflects
+// the run just stored server-side.
+export function FinishRank({ mode, sessionId }: { mode: Mode; sessionId: number | null }) {
+  const { t } = useTranslation('regnemester')
+  const { user } = useAuth()
+  const [ranks, setRanks] = useState<Ranks | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!user || sessionId == null) return
+    const controller = new AbortController()
+    setLoading(true)
+    Promise.all([fetchRank(mode, 'all', user.id), fetchRank(mode, 'week', user.id)])
+      .then(([all, week]) => {
+        if (controller.signal.aborted) return
+        setRanks({ all, week })
+      })
+      .catch(() => { /* non-critical display */ })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+    return () => { controller.abort() }
+  }, [mode, sessionId, user])
+
+  if (!user) return null
+
+  const render = (r: number | null) => (r == null ? t('leaderboard.unranked') : `#${r}`)
+
+  return (
+    <div className="rounded-lg border border-gray-700 bg-gray-800 p-4 flex items-center gap-3">
+      <Trophy size={20} className="text-yellow-400 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <div className="text-xs uppercase tracking-wide text-gray-400">{t('leaderboard.yourRank')}</div>
+        {loading || !ranks ? (
+          <div className="text-gray-300 text-sm">{t('leaderboard.loading')}</div>
+        ) : (
+          <div className="text-white font-semibold tabular-nums">
+            {t('leaderboard.rankSummary', { all: render(ranks.all), week: render(ranks.week) })}
+          </div>
+        )}
+      </div>
+      <Link
+        to="/math/leaderboard"
+        className="text-sm font-medium text-blue-300 hover:text-blue-200 whitespace-nowrap"
+      >
+        {t('leaderboard.viewLinkShort')}
+      </Link>
+    </div>
+  )
+}

--- a/web/src/components/math/FinishRank.tsx
+++ b/web/src/components/math/FinishRank.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useReducer } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Trophy } from 'lucide-react'
@@ -19,6 +19,18 @@ interface LeaderboardResponse {
 interface Ranks {
   all: number | null
   week: number | null
+}
+
+type RankState = { ranks: Ranks | null; loading: boolean }
+type RankAction =
+  | { type: 'start' }
+  | { type: 'done'; ranks: Ranks }
+
+function rankReducer(_state: RankState, action: RankAction): RankState {
+  switch (action.type) {
+    case 'start': return { ranks: null, loading: true }
+    case 'done': return { ranks: action.ranks, loading: false }
+  }
 }
 
 async function fetchRank(
@@ -45,31 +57,27 @@ async function fetchRank(
 export function FinishRank({ mode, sessionId }: { mode: Mode; sessionId: number | null }) {
   const { t } = useTranslation('regnemester')
   const { user } = useAuth()
-  const [ranks, setRanks] = useState<Ranks | null>(null)
-  const [loading, setLoading] = useState(false)
+  const [{ ranks, loading }, dispatch] = useReducer(rankReducer, { ranks: null, loading: false })
 
   useEffect(() => {
     if (!user || sessionId == null) return
     const controller = new AbortController()
     const { signal } = controller
-    setLoading(true)
+    dispatch({ type: 'start' })
     Promise.all([
       fetchRank(mode, 'all', user.id, signal),
       fetchRank(mode, 'week', user.id, signal),
     ])
       .then(([all, week]) => {
         if (signal.aborted) return
-        setRanks({ all, week })
+        dispatch({ type: 'done', ranks: { all, week } })
       })
       .catch(err => {
         if (signal.aborted || (err instanceof DOMException && err.name === 'AbortError')) return
         // Surface unreachable leaderboard as Unranked instead of a permanent
         // loading spinner. Network errors on the finish screen are
         // non-critical — the run itself has already been recorded.
-        setRanks({ all: null, week: null })
-      })
-      .finally(() => {
-        if (!signal.aborted) setLoading(false)
+        dispatch({ type: 'done', ranks: { all: null, week: null } })
       })
     return () => { controller.abort() }
   }, [mode, sessionId, user])

--- a/web/src/components/math/FinishRank.tsx
+++ b/web/src/components/math/FinishRank.tsx
@@ -21,8 +21,16 @@ interface Ranks {
   week: number | null
 }
 
-async function fetchRank(mode: Mode, period: 'all' | 'week', userID: number): Promise<number | null> {
-  const res = await fetch(`/api/math/leaderboard?mode=${mode}&period=${period}`, { credentials: 'include' })
+async function fetchRank(
+  mode: Mode,
+  period: 'all' | 'week',
+  userID: number,
+  signal: AbortSignal,
+): Promise<number | null> {
+  const res = await fetch(`/api/math/leaderboard?mode=${mode}&period=${period}`, {
+    credentials: 'include',
+    signal,
+  })
   if (!res.ok) return null
   const data = (await res.json()) as LeaderboardResponse
   const me = data.entries.find(e => e.user_id === userID)
@@ -43,15 +51,25 @@ export function FinishRank({ mode, sessionId }: { mode: Mode; sessionId: number 
   useEffect(() => {
     if (!user || sessionId == null) return
     const controller = new AbortController()
+    const { signal } = controller
     setLoading(true)
-    Promise.all([fetchRank(mode, 'all', user.id), fetchRank(mode, 'week', user.id)])
+    Promise.all([
+      fetchRank(mode, 'all', user.id, signal),
+      fetchRank(mode, 'week', user.id, signal),
+    ])
       .then(([all, week]) => {
-        if (controller.signal.aborted) return
+        if (signal.aborted) return
         setRanks({ all, week })
       })
-      .catch(() => { /* non-critical display */ })
+      .catch(err => {
+        if (signal.aborted || (err instanceof DOMException && err.name === 'AbortError')) return
+        // Surface unreachable leaderboard as Unranked instead of a permanent
+        // loading spinner. Network errors on the finish screen are
+        // non-critical — the run itself has already been recorded.
+        setRanks({ all: null, week: null })
+      })
       .finally(() => {
-        if (!controller.signal.aborted) setLoading(false)
+        if (!signal.aborted) setLoading(false)
       })
     return () => { controller.abort() }
   }, [mode, sessionId, user])

--- a/web/src/pages/Math.tsx
+++ b/web/src/pages/Math.tsx
@@ -30,6 +30,16 @@ export default function MathLanding() {
         <p className="text-gray-400 text-sm sm:text-base">{t('tagline')}</p>
       </header>
 
+      <div className="mb-6">
+        <Link
+          to="/math/leaderboard"
+          className="inline-flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-800 hover:border-yellow-500/40 hover:bg-gray-800/80 px-4 py-2 text-sm font-medium text-yellow-300 transition-colors"
+        >
+          <Trophy size={18} />
+          {t('leaderboard.viewLink')}
+        </Link>
+      </div>
+
       <section aria-labelledby="modes-heading">
         <h2 id="modes-heading" className="sr-only">{t('modePickerHeading')}</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">

--- a/web/src/pages/MathBlitz.tsx
+++ b/web/src/pages/MathBlitz.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { ArrowLeft, Trophy, Zap } from 'lucide-react'
 import { MathAnswerPad } from '../components/math/MathAnswerPad'
 import { appendAnswerDigit } from '../components/math/mathUtils'
+import { FinishRank } from '../components/math/FinishRank'
 
 const DURATION_MS = 60_000
 
@@ -359,6 +360,10 @@ export default function MathBlitz() {
             })}
           </div>
         )}
+
+        <div className="mb-6">
+          <FinishRank mode="blitz" sessionId={summary.session_id} />
+        </div>
 
         <div className="flex flex-col sm:flex-row gap-3">
           <button

--- a/web/src/pages/MathLeaderboard.tsx
+++ b/web/src/pages/MathLeaderboard.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { ArrowLeft, Trophy } from 'lucide-react'
+import { useAuth } from '../auth'
+import { formatDate } from '../utils/formatDate'
+
+type Mode = 'marathon' | 'blitz'
+type Period = 'all' | 'week'
+
+interface LeaderboardEntry {
+  user_id: number
+  name: string
+  avatar_emoji: string
+  is_parent: boolean
+  score: number | null
+  session_id: number | null
+  achieved_at: string | null
+  rank: number | null
+}
+
+interface LeaderboardResponse {
+  mode: Mode
+  period: Period
+  entries: LeaderboardEntry[]
+}
+
+function formatMarathonScore(ms: number): string {
+  const totalSeconds = Math.max(0, ms) / 1000
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = Math.floor(totalSeconds - minutes * 60)
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}
+
+export default function MathLeaderboard() {
+  const { t } = useTranslation('regnemester')
+  const { user } = useAuth()
+
+  const [mode, setMode] = useState<Mode>('marathon')
+  const [period, setPeriod] = useState<Period>('all')
+  const [data, setData] = useState<LeaderboardResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setLoading(true)
+    setError('')
+    fetch(`/api/math/leaderboard?mode=${mode}&period=${period}`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
+      .then(res => {
+        if (!res.ok) throw new Error('fetch failed')
+        return res.json() as Promise<LeaderboardResponse>
+      })
+      .then(json => {
+        if (!controller.signal.aborted) setData(json)
+      })
+      .catch(err => {
+        if (controller.signal.aborted || (err instanceof DOMException && err.name === 'AbortError')) return
+        setError(t('leaderboard.errorLoad'))
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+    return () => { controller.abort() }
+  }, [mode, period, t])
+
+  const MODES: { key: Mode; label: string }[] = useMemo(() => ([
+    { key: 'marathon', label: t('leaderboard.modeMarathon') },
+    { key: 'blitz', label: t('leaderboard.modeBlitz') },
+  ]), [t])
+
+  const PERIODS: { key: Period; label: string }[] = useMemo(() => ([
+    { key: 'all', label: t('leaderboard.periodAll') },
+    { key: 'week', label: t('leaderboard.periodWeek') },
+  ]), [t])
+
+  const renderScore = (score: number | null): string => {
+    if (score == null) return '—'
+    if (mode === 'marathon') return formatMarathonScore(score)
+    return score.toLocaleString()
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 sm:p-6 space-y-5">
+      <div className="flex items-center gap-3">
+        <Link
+          to="/math"
+          aria-label={t('back')}
+          className="text-gray-400 hover:text-white transition-colors"
+        >
+          <ArrowLeft size={20} />
+        </Link>
+        <Trophy size={24} className="text-yellow-400 shrink-0" />
+        <h1 className="text-2xl sm:text-3xl font-bold text-white">
+          {t('leaderboard.title')}
+        </h1>
+      </div>
+
+      <div className="flex gap-1 bg-gray-800/60 rounded-lg border border-gray-700 p-1" role="tablist" aria-label={t('leaderboard.modeTabsLabel')}>
+        {MODES.map(({ key, label }) => (
+          <button
+            key={key}
+            type="button"
+            role="tab"
+            aria-selected={mode === key}
+            onClick={() => setMode(key)}
+            className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-colors ${
+              mode === key
+                ? 'bg-blue-500/20 text-blue-300 border border-blue-500/30'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex gap-1 bg-gray-800/60 rounded-lg border border-gray-700 p-1" role="tablist" aria-label={t('leaderboard.periodTabsLabel')}>
+        {PERIODS.map(({ key, label }) => (
+          <button
+            key={key}
+            type="button"
+            role="tab"
+            aria-selected={period === key}
+            onClick={() => setPeriod(key)}
+            className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-colors ${
+              period === key
+                ? 'bg-yellow-500/20 text-yellow-300 border border-yellow-500/30'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {loading && (
+        <div className="space-y-2">
+          {[0, 1, 2].map(i => (
+            <div key={i} className="h-14 rounded-lg bg-gray-800 animate-pulse" />
+          ))}
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="rounded border border-red-500/50 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && data && (
+        data.entries.length === 0 ? (
+          <div className="bg-gray-800/60 rounded-xl border border-gray-700 p-8 text-center">
+            <Trophy size={40} className="text-yellow-400/40 mx-auto mb-3" />
+            <p className="text-gray-400">{t('leaderboard.empty')}</p>
+          </div>
+        ) : (
+          <div className="bg-gray-800/60 rounded-xl border border-gray-700 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-700">
+                  <th className="w-14 text-left text-gray-400 font-medium px-3 sm:px-4 py-3 text-xs uppercase tracking-wide">
+                    {t('leaderboard.rank')}
+                  </th>
+                  <th className="text-left text-gray-400 font-medium px-3 sm:px-4 py-3 text-xs uppercase tracking-wide">
+                    {t('leaderboard.player')}
+                  </th>
+                  <th className="text-right text-gray-400 font-medium px-3 sm:px-4 py-3 text-xs uppercase tracking-wide">
+                    {t('leaderboard.score')}
+                  </th>
+                  <th className="hidden sm:table-cell text-right text-gray-400 font-medium px-4 py-3 text-xs uppercase tracking-wide">
+                    {t('leaderboard.when')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.entries.map(entry => {
+                  const isMe = user?.id === entry.user_id
+                  return (
+                    <tr
+                      key={entry.user_id}
+                      className={`border-b border-gray-700/50 last:border-0 ${
+                        isMe ? 'bg-yellow-500/10' : 'hover:bg-gray-700/30'
+                      }`}
+                    >
+                      <td className="px-3 sm:px-4 py-3 tabular-nums text-gray-300">
+                        {entry.rank == null ? '—' : `#${entry.rank}`}
+                      </td>
+                      <td className="px-3 sm:px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <span className="text-lg" role="img" aria-hidden="true">
+                            {entry.avatar_emoji || '👤'}
+                          </span>
+                          <span className={`font-medium ${isMe ? 'text-yellow-300' : 'text-white'}`}>
+                            {entry.name || t('leaderboard.anonymous')}
+                          </span>
+                          {entry.is_parent && (
+                            <span className="text-xs text-gray-400">
+                              {t('leaderboard.parentTag')}
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-3 sm:px-4 py-3 text-right text-white font-semibold tabular-nums">
+                        {renderScore(entry.score)}
+                      </td>
+                      <td className="hidden sm:table-cell px-4 py-3 text-right text-gray-400 tabular-nums">
+                        {entry.achieved_at
+                          ? formatDate(entry.achieved_at, { year: 'numeric', month: 'short', day: 'numeric' })
+                          : '—'}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/MathLeaderboard.tsx
+++ b/web/src/pages/MathLeaderboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useReducer, useState } from 'react'
+import React, { useEffect, useId, useMemo, useReducer, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ArrowLeft, Trophy } from 'lucide-react'
@@ -46,13 +46,49 @@ function formatMarathonScore(ms: number): string {
   return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
 }
 
+const MODE_KEYS: Mode[] = ['marathon', 'blitz']
+const PERIOD_KEYS: Period[] = ['all', 'week']
+
 export default function MathLeaderboard() {
   const { t } = useTranslation('regnemester')
   const { user } = useAuth()
+  const uid = useId()
 
   const [mode, setMode] = useState<Mode>('marathon')
   const [period, setPeriod] = useState<Period>('all')
   const [{ loading, data, error }, dispatch] = useReducer(fetchReducer, { loading: true, data: null, error: '' })
+
+  const modeRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const periodRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const panelId = `${uid}-panel`
+
+  const handleModeKeyDown = (e: React.KeyboardEvent, key: Mode) => {
+    const idx = MODE_KEYS.indexOf(key)
+    let next: number | null = null
+    if (e.key === 'ArrowRight') next = (idx + 1) % MODE_KEYS.length
+    else if (e.key === 'ArrowLeft') next = (idx - 1 + MODE_KEYS.length) % MODE_KEYS.length
+    else if (e.key === 'Home') next = 0
+    else if (e.key === 'End') next = MODE_KEYS.length - 1
+    if (next !== null) {
+      e.preventDefault()
+      setMode(MODE_KEYS[next])
+      modeRefs.current[next]?.focus()
+    }
+  }
+
+  const handlePeriodKeyDown = (e: React.KeyboardEvent, key: Period) => {
+    const idx = PERIOD_KEYS.indexOf(key)
+    let next: number | null = null
+    if (e.key === 'ArrowRight') next = (idx + 1) % PERIOD_KEYS.length
+    else if (e.key === 'ArrowLeft') next = (idx - 1 + PERIOD_KEYS.length) % PERIOD_KEYS.length
+    else if (e.key === 'Home') next = 0
+    else if (e.key === 'End') next = PERIOD_KEYS.length - 1
+    if (next !== null) {
+      e.preventDefault()
+      setPeriod(PERIOD_KEYS[next])
+      periodRefs.current[next]?.focus()
+    }
+  }
 
   useEffect(() => {
     const controller = new AbortController()
@@ -108,13 +144,18 @@ export default function MathLeaderboard() {
       </div>
 
       <div className="flex gap-1 bg-gray-800/60 rounded-lg border border-gray-700 p-1" role="tablist" aria-label={t('leaderboard.modeTabsLabel')}>
-        {MODES.map(({ key, label }) => (
+        {MODES.map(({ key, label }, i) => (
           <button
             key={key}
+            ref={el => { modeRefs.current[i] = el }}
             type="button"
             role="tab"
+            id={`${uid}-mode-${key}`}
             aria-selected={mode === key}
+            aria-controls={panelId}
+            tabIndex={mode === key ? 0 : -1}
             onClick={() => setMode(key)}
+            onKeyDown={e => handleModeKeyDown(e, key)}
             className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-colors ${
               mode === key
                 ? 'bg-blue-500/20 text-blue-300 border border-blue-500/30'
@@ -127,13 +168,18 @@ export default function MathLeaderboard() {
       </div>
 
       <div className="flex gap-1 bg-gray-800/60 rounded-lg border border-gray-700 p-1" role="tablist" aria-label={t('leaderboard.periodTabsLabel')}>
-        {PERIODS.map(({ key, label }) => (
+        {PERIODS.map(({ key, label }, i) => (
           <button
             key={key}
+            ref={el => { periodRefs.current[i] = el }}
             type="button"
             role="tab"
+            id={`${uid}-period-${key}`}
             aria-selected={period === key}
+            aria-controls={panelId}
+            tabIndex={period === key ? 0 : -1}
             onClick={() => setPeriod(key)}
+            onKeyDown={e => handlePeriodKeyDown(e, key)}
             className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-colors ${
               period === key
                 ? 'bg-yellow-500/20 text-yellow-300 border border-yellow-500/30'
@@ -145,89 +191,95 @@ export default function MathLeaderboard() {
         ))}
       </div>
 
-      {loading && (
-        <div className="space-y-2">
-          {[0, 1, 2].map(i => (
-            <div key={i} className="h-14 rounded-lg bg-gray-800 animate-pulse" />
-          ))}
-        </div>
-      )}
-
-      {!loading && error && (
-        <div className="rounded border border-red-500/50 bg-red-500/10 px-3 py-2 text-sm text-red-300">
-          {error}
-        </div>
-      )}
-
-      {!loading && !error && data && (
-        data.entries.length === 0 ? (
-          <div className="bg-gray-800/60 rounded-xl border border-gray-700 p-8 text-center">
-            <Trophy size={40} className="text-yellow-400/40 mx-auto mb-3" />
-            <p className="text-gray-400">{t('leaderboard.empty')}</p>
+      <div
+        id={panelId}
+        role="tabpanel"
+        aria-labelledby={`${uid}-mode-${mode} ${uid}-period-${period}`}
+      >
+        {loading && (
+          <div className="space-y-2">
+            {[0, 1, 2].map(i => (
+              <div key={i} className="h-14 rounded-lg bg-gray-800 animate-pulse" />
+            ))}
           </div>
-        ) : (
-          <div className="bg-gray-800/60 rounded-xl border border-gray-700 overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-gray-700">
-                  <th className="w-14 text-left text-gray-400 font-medium px-3 sm:px-4 py-3 text-xs uppercase tracking-wide">
-                    {t('leaderboard.rank')}
-                  </th>
-                  <th className="text-left text-gray-400 font-medium px-3 sm:px-4 py-3 text-xs uppercase tracking-wide">
-                    {t('leaderboard.player')}
-                  </th>
-                  <th className="text-right text-gray-400 font-medium px-3 sm:px-4 py-3 text-xs uppercase tracking-wide">
-                    {t('leaderboard.score')}
-                  </th>
-                  <th className="hidden sm:table-cell text-right text-gray-400 font-medium px-4 py-3 text-xs uppercase tracking-wide">
-                    {t('leaderboard.when')}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.entries.map(entry => {
-                  const isMe = user?.id === entry.user_id
-                  return (
-                    <tr
-                      key={entry.user_id}
-                      className={`border-b border-gray-700/50 last:border-0 ${
-                        isMe ? 'bg-yellow-500/10' : 'hover:bg-gray-700/30'
-                      }`}
-                    >
-                      <td className="px-3 sm:px-4 py-3 tabular-nums text-gray-300">
-                        {entry.rank == null ? '—' : `#${entry.rank}`}
-                      </td>
-                      <td className="px-3 sm:px-4 py-3">
-                        <div className="flex items-center gap-2">
-                          <span className="text-lg" role="img" aria-hidden="true">
-                            {entry.avatar_emoji || '👤'}
-                          </span>
-                          <span className={`font-medium ${isMe ? 'text-yellow-300' : 'text-white'}`}>
-                            {entry.name || t('leaderboard.anonymous')}
-                          </span>
-                          {entry.is_parent && (
-                            <span className="text-xs text-gray-400">
-                              {t('leaderboard.parentTag')}
+        )}
+
+        {!loading && error && (
+          <div className="rounded border border-red-500/50 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && data && (
+          data.entries.length === 0 ? (
+            <div className="bg-gray-800/60 rounded-xl border border-gray-700 p-8 text-center">
+              <Trophy size={40} className="text-yellow-400/40 mx-auto mb-3" />
+              <p className="text-gray-400">{t('leaderboard.empty')}</p>
+            </div>
+          ) : (
+            <div className="bg-gray-800/60 rounded-xl border border-gray-700 overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-700">
+                    <th className="w-14 text-left text-gray-400 font-medium px-3 sm:px-4 py-3 text-xs uppercase tracking-wide">
+                      {t('leaderboard.rank')}
+                    </th>
+                    <th className="text-left text-gray-400 font-medium px-3 sm:px-4 py-3 text-xs uppercase tracking-wide">
+                      {t('leaderboard.player')}
+                    </th>
+                    <th className="text-right text-gray-400 font-medium px-3 sm:px-4 py-3 text-xs uppercase tracking-wide">
+                      {t('leaderboard.score')}
+                    </th>
+                    <th className="hidden sm:table-cell text-right text-gray-400 font-medium px-4 py-3 text-xs uppercase tracking-wide">
+                      {t('leaderboard.when')}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.entries.map(entry => {
+                    const isMe = user?.id === entry.user_id
+                    return (
+                      <tr
+                        key={entry.user_id}
+                        className={`border-b border-gray-700/50 last:border-0 ${
+                          isMe ? 'bg-yellow-500/10' : 'hover:bg-gray-700/30'
+                        }`}
+                      >
+                        <td className="px-3 sm:px-4 py-3 tabular-nums text-gray-300">
+                          {entry.rank == null ? '—' : `#${entry.rank}`}
+                        </td>
+                        <td className="px-3 sm:px-4 py-3">
+                          <div className="flex items-center gap-2">
+                            <span className="text-lg" role="img" aria-hidden="true">
+                              {entry.avatar_emoji || '👤'}
                             </span>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-3 sm:px-4 py-3 text-right text-white font-semibold tabular-nums">
-                        {renderScore(entry.score)}
-                      </td>
-                      <td className="hidden sm:table-cell px-4 py-3 text-right text-gray-400 tabular-nums">
-                        {entry.achieved_at
-                          ? formatDate(entry.achieved_at, { year: 'numeric', month: 'short', day: 'numeric' })
-                          : '—'}
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
-        )
-      )}
+                            <span className={`font-medium ${isMe ? 'text-yellow-300' : 'text-white'}`}>
+                              {entry.name || t('leaderboard.anonymous')}
+                            </span>
+                            {entry.is_parent && (
+                              <span className="text-xs text-gray-400">
+                                {t('leaderboard.parentTag')}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-3 sm:px-4 py-3 text-right text-white font-semibold tabular-nums">
+                          {renderScore(entry.score)}
+                        </td>
+                        <td className="hidden sm:table-cell px-4 py-3 text-right text-gray-400 tabular-nums">
+                          {entry.achieved_at
+                            ? formatDate(entry.achieved_at, { year: 'numeric', month: 'short', day: 'numeric' })
+                            : '—'}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )
+        )}
+      </div>
     </div>
   )
 }

--- a/web/src/pages/MathLeaderboard.tsx
+++ b/web/src/pages/MathLeaderboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useReducer, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ArrowLeft, Trophy } from 'lucide-react'
@@ -25,6 +25,20 @@ interface LeaderboardResponse {
   entries: LeaderboardEntry[]
 }
 
+type FetchState = { loading: boolean; data: LeaderboardResponse | null; error: string }
+type FetchAction =
+  | { type: 'start' }
+  | { type: 'success'; data: LeaderboardResponse }
+  | { type: 'error'; message: string }
+
+function fetchReducer(_state: FetchState, action: FetchAction): FetchState {
+  switch (action.type) {
+    case 'start': return { loading: true, error: '', data: null }
+    case 'success': return { loading: false, error: '', data: action.data }
+    case 'error': return { loading: false, error: action.message, data: null }
+  }
+}
+
 function formatMarathonScore(ms: number): string {
   const totalSeconds = Math.max(0, ms) / 1000
   const minutes = Math.floor(totalSeconds / 60)
@@ -38,14 +52,11 @@ export default function MathLeaderboard() {
 
   const [mode, setMode] = useState<Mode>('marathon')
   const [period, setPeriod] = useState<Period>('all')
-  const [data, setData] = useState<LeaderboardResponse | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
+  const [{ loading, data, error }, dispatch] = useReducer(fetchReducer, { loading: true, data: null, error: '' })
 
   useEffect(() => {
     const controller = new AbortController()
-    setLoading(true)
-    setError('')
+    dispatch({ type: 'start' })
     fetch(`/api/math/leaderboard?mode=${mode}&period=${period}`, {
       credentials: 'include',
       signal: controller.signal,
@@ -55,14 +66,11 @@ export default function MathLeaderboard() {
         return res.json() as Promise<LeaderboardResponse>
       })
       .then(json => {
-        if (!controller.signal.aborted) setData(json)
+        if (!controller.signal.aborted) dispatch({ type: 'success', data: json })
       })
       .catch(err => {
         if (controller.signal.aborted || (err instanceof DOMException && err.name === 'AbortError')) return
-        setError(t('leaderboard.errorLoad'))
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false)
+        dispatch({ type: 'error', message: t('leaderboard.errorLoad') })
       })
     return () => { controller.abort() }
   }, [mode, period, t])

--- a/web/src/pages/MathLeaderboard.tsx
+++ b/web/src/pages/MathLeaderboard.tsx
@@ -62,32 +62,31 @@ export default function MathLeaderboard() {
   const periodRefs = useRef<(HTMLButtonElement | null)[]>([])
   const panelId = `${uid}-panel`
 
-  const handleModeKeyDown = (e: React.KeyboardEvent, key: Mode) => {
-    const idx = MODE_KEYS.indexOf(key)
+  const handleRovingTabKeyDown = <T extends string>(
+    e: React.KeyboardEvent,
+    key: T,
+    keys: readonly T[],
+    setValue: React.Dispatch<React.SetStateAction<T>>,
+    refs: React.RefObject<(HTMLButtonElement | null)[]>,
+  ) => {
+    const idx = keys.indexOf(key)
     let next: number | null = null
-    if (e.key === 'ArrowRight') next = (idx + 1) % MODE_KEYS.length
-    else if (e.key === 'ArrowLeft') next = (idx - 1 + MODE_KEYS.length) % MODE_KEYS.length
+    if (e.key === 'ArrowRight') next = (idx + 1) % keys.length
+    else if (e.key === 'ArrowLeft') next = (idx - 1 + keys.length) % keys.length
     else if (e.key === 'Home') next = 0
-    else if (e.key === 'End') next = MODE_KEYS.length - 1
-    if (next !== null) {
-      e.preventDefault()
-      setMode(MODE_KEYS[next])
-      modeRefs.current[next]?.focus()
-    }
+    else if (e.key === 'End') next = keys.length - 1
+    if (next === null) return
+    e.preventDefault()
+    setValue(keys[next])
+    refs.current[next]?.focus()
+  }
+
+  const handleModeKeyDown = (e: React.KeyboardEvent, key: Mode) => {
+    handleRovingTabKeyDown(e, key, MODE_KEYS, setMode, modeRefs)
   }
 
   const handlePeriodKeyDown = (e: React.KeyboardEvent, key: Period) => {
-    const idx = PERIOD_KEYS.indexOf(key)
-    let next: number | null = null
-    if (e.key === 'ArrowRight') next = (idx + 1) % PERIOD_KEYS.length
-    else if (e.key === 'ArrowLeft') next = (idx - 1 + PERIOD_KEYS.length) % PERIOD_KEYS.length
-    else if (e.key === 'Home') next = 0
-    else if (e.key === 'End') next = PERIOD_KEYS.length - 1
-    if (next !== null) {
-      e.preventDefault()
-      setPeriod(PERIOD_KEYS[next])
-      periodRefs.current[next]?.focus()
-    }
+    handleRovingTabKeyDown(e, key, PERIOD_KEYS, setPeriod, periodRefs)
   }
 
   useEffect(() => {

--- a/web/src/pages/MathMarathon.tsx
+++ b/web/src/pages/MathMarathon.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { ArrowLeft, Trophy } from 'lucide-react'
 import { MathAnswerPad } from '../components/math/MathAnswerPad'
 import { appendAnswerDigit } from '../components/math/mathUtils'
+import { FinishRank } from '../components/math/FinishRank'
 
 const TOTAL = 200
 
@@ -334,6 +335,10 @@ export default function MathMarathon() {
             })}
           </div>
         )}
+
+        <div className="mb-6">
+          <FinishRank mode="marathon" sessionId={summary.session_id} />
+        </div>
 
         <div className="flex flex-col sm:flex-row gap-3">
           <button


### PR DESCRIPTION
## Changes

- **Regnemester leaderboards** - Added family-scoped leaderboards for Marathon and Blitz with all-time and weekly (Monday 00:00 UTC) views at `/math/leaderboard`, plus a post-finish rank summary on both game-over screens. (Hytte-0p6m)

## Original Issue (feature): Regnemester: leaderboards (per mode, all-time + weekly)

Bead 4 of 7 for Regnemester. Depends on Blitz (Hytte-j3ll). Family-scoped leaderboards, per mode, two time windows.

Build:
- API: GET /api/math/leaderboard?mode=marathon|blitz&period=all|week
  - Returns array of { user_id, name, avatar_emoji, score, session_id, achieved_at } ordered by best score
  - Score sort: Marathon = ascending duration_ms; Blitz = descending score_num
  - One entry per user (their personal best in the window)
  - Scope: current user's family — parent_id + all child_ids from family_links, plus the parent themselves. Include family members with zero sessions (score shown as '—' in UI)
  - Weekly period starts Monday 00:00 UTC (ISO week)
- UI: /math/leaderboard route
  - Tabs: Marathon / Blitz
  - Subtabs: All time / This week
  - Table columns: rank, avatar, name, score (formatted as mm:ss for Marathon, plain int for Blitz), when
  - Highlight current user's row
  - Link to /math/leaderboard from /math landing page
- Post-finish screen in Marathon and Blitz: show user's current rank on both time windows and link to the leaderboard

Non-goals: achievement unlocks for leaderboard placement (that's the achievements bead).

---
Bead: Hytte-0p6m | Branch: forge/Hytte-0p6m
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)