### PR TITLE
Suggestions: schema, page registry, and manual generation run (Hytte-ipyx)

### DIFF
--- a/changelog.d/Hytte-ipyx.md
+++ b/changelog.d/Hytte-ipyx.md
@@ -1,0 +1,2 @@
+category: Added
+- **Suggestions backend foundation** - Added the database schema, page registry, generator, and admin-only `POST /api/suggestions/run` endpoint that asks Claude for three improvement ideas per curated page (weather, budget, notes, training, links). Suggestion bodies are encrypted at rest; per-page errors are isolated so one failure does not abort the whole run. UI lands in a follow-up bead. (Hytte-ipyx)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Robin831/Hytte/internal/skywatch"
 	"github.com/Robin831/Hytte/internal/stars"
 	"github.com/Robin831/Hytte/internal/stride"
+	"github.com/Robin831/Hytte/internal/suggestions"
 	"github.com/Robin831/Hytte/internal/training"
 	"github.com/Robin831/Hytte/internal/vault"
 	"github.com/Robin831/Hytte/internal/transit"
@@ -195,6 +196,9 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/kiosk/tokens", kiosk.CreateTokenHandler(db))
 				r.Get("/kiosk/tokens", kiosk.ListTokensHandler(db))
 				r.Delete("/kiosk/tokens/{id}", kiosk.DeleteTokenHandler(db))
+
+				// Suggestions: AI-generated page improvement ideas — admin only.
+				r.Post("/suggestions/run", suggestions.RunHandler(db))
 
 				// Forge dashboard — admin only, registered only when FEATURE_FORGE_DASHBOARD=1.
 				// The feature flag is evaluated at startup; when disabled, these routes are

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1531,6 +1531,28 @@ func createSchema(db *sql.DB) error {
 		UNIQUE(user_id, code)
 	);
 
+	CREATE TABLE IF NOT EXISTS suggestions (
+		id              INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_id         INTEGER NOT NULL,
+		generated_at    TIMESTAMP NOT NULL,
+		page_slug       TEXT NOT NULL,
+		source          TEXT NOT NULL,
+		type            TEXT NOT NULL,
+		size            TEXT NOT NULL,
+		title           TEXT NOT NULL,
+		body_enc        TEXT NOT NULL,
+		status          TEXT NOT NULL,
+		feedback_enc    TEXT,
+		plan_enc        TEXT,
+		bead_id         TEXT,
+		rejected_at     TIMESTAMP,
+		planned_at      TIMESTAMP,
+		bead_created_at TIMESTAMP,
+		FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+	);
+	CREATE INDEX IF NOT EXISTS idx_suggestions_user_status ON suggestions(user_id, status);
+	CREATE INDEX IF NOT EXISTS idx_suggestions_page_slug ON suggestions(page_slug);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/suggestions/generate.go
+++ b/internal/suggestions/generate.go
@@ -1,0 +1,242 @@
+package suggestions
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+// runPromptFn is the function used to invoke Claude. Replaced in tests, mirroring
+// the package-level pattern used in chat/handlers.go.
+var runPromptFn = training.RunPrompt
+
+// PerPageTimeout is the deadline applied to each individual page's generation
+// attempt. RunSuggestionsForPages caps each Claude call at this duration so a
+// single hung page cannot starve the overall run.
+const PerPageTimeout = 90 * time.Second
+
+// recentSuggestionsWindowDays is the look-back window used when injecting prior
+// suggestion titles into the prompt to discourage repeats.
+const recentSuggestionsWindowDays = 14
+
+// MaxRetriesOnMalformedJSON is the number of retries attempted when Claude
+// returns a response that does not parse as the expected JSON shape.
+const MaxRetriesOnMalformedJSON = 1
+
+// RunResult summarises a generation pass.
+type RunResult struct {
+	Generated int `json:"generated"`
+	Errors    int `json:"errors"`
+}
+
+// generated is the per-suggestion shape we expect from Claude.
+type generated struct {
+	Type  string `json:"type"`
+	Size  string `json:"size"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// validTypes / validSizes are the allowed enum values from the prompt schema.
+// new_page is generated through a separate prompt in a later bead, so it is
+// excluded from per-page suggestion generation here.
+var validTypes = map[string]bool{
+	TypeAddition:    true,
+	TypeBugfix:      true,
+	TypeImprovement: true,
+	TypeRefactor:    true,
+}
+
+var validSizes = map[string]bool{
+	SizeS: true,
+	SizeM: true,
+	SizeL: true,
+}
+
+// RunSuggestionsForPages iterates over pages, calling Claude once per page to
+// generate three improvement suggestions and inserting them as pending rows
+// owned by userID. Per-page errors are logged but do not abort the run, so a
+// single Claude failure or malformed-JSON page does not lose the rest.
+//
+// Returns counts of inserted suggestions and pages that errored.
+func RunSuggestionsForPages(
+	ctx context.Context,
+	db *sql.DB,
+	cfg *training.ClaudeConfig,
+	userID int64,
+	pages []Page,
+) RunResult {
+	var result RunResult
+
+	for _, page := range pages {
+		if !page.Enabled {
+			continue
+		}
+		inserted, err := runForPage(ctx, db, cfg, userID, page)
+		if err != nil {
+			result.Errors++
+			log.Printf("suggestions: page %q errored: %v", page.Slug, err)
+			continue
+		}
+		result.Generated += inserted
+	}
+
+	return result
+}
+
+// runForPage handles a single page end-to-end: build prompt, call Claude (with
+// one retry on malformed JSON), and insert the resulting rows.
+func runForPage(
+	ctx context.Context,
+	db *sql.DB,
+	cfg *training.ClaudeConfig,
+	userID int64,
+	page Page,
+) (int, error) {
+	pageCtx, cancel := context.WithTimeout(ctx, PerPageTimeout)
+	defer cancel()
+
+	sources := loadSourceFiles(page.SourceFiles)
+	gitLog := loadGitLog(pageCtx, page.SourceFiles)
+
+	recent, err := recentForPage(pageCtx, db, userID, page.Slug, recentSuggestionsWindowDays)
+	if err != nil {
+		log.Printf("suggestions: load recent for %q: %v; continuing without", page.Slug, err)
+		recent = nil
+	}
+
+	prompt := buildPagePrompt(page, sources, gitLog, recent)
+
+	suggestions, err := callAndParse(pageCtx, cfg, prompt)
+	if err != nil {
+		return 0, err
+	}
+
+	now := time.Now().UTC()
+	inserted := 0
+	for _, sg := range suggestions {
+		row := Suggestion{
+			UserID:      userID,
+			GeneratedAt: now,
+			PageSlug:    page.Slug,
+			Source:      SourceClaude,
+			Type:        sg.Type,
+			Size:        sg.Size,
+			Title:       sg.Title,
+			Body:        sg.Body,
+			Status:      StatusPending,
+		}
+		if _, err := Insert(pageCtx, db, row); err != nil {
+			log.Printf("suggestions: insert for %q: %v", page.Slug, err)
+			continue
+		}
+		inserted++
+	}
+	if inserted == 0 {
+		return 0, errors.New("no suggestions inserted")
+	}
+	return inserted, nil
+}
+
+// callAndParse calls Claude and parses the response. On a malformed JSON
+// response it retries up to MaxRetriesOnMalformedJSON times, then returns the
+// last error.
+func callAndParse(ctx context.Context, cfg *training.ClaudeConfig, prompt string) ([]generated, error) {
+	var lastErr error
+	for attempt := 0; attempt <= MaxRetriesOnMalformedJSON; attempt++ {
+		resp, err := runPromptFn(ctx, cfg, prompt)
+		if err != nil {
+			return nil, fmt.Errorf("claude prompt: %w", err)
+		}
+		parsed, err := parseSuggestionsResponse(resp)
+		if err == nil {
+			return parsed, nil
+		}
+		lastErr = err
+		log.Printf("suggestions: parse attempt %d failed: %v", attempt+1, err)
+	}
+	return nil, fmt.Errorf("parse response after %d attempts: %w", MaxRetriesOnMalformedJSON+1, lastErr)
+}
+
+// parseSuggestionsResponse strips an optional markdown fence and decodes the
+// response into exactly three validated generated suggestions.
+func parseSuggestionsResponse(response string) ([]generated, error) {
+	response = strings.TrimSpace(response)
+
+	if strings.HasPrefix(response, "```") {
+		lines := strings.Split(response, "\n")
+		if len(lines) >= 3 {
+			response = strings.Join(lines[1:len(lines)-1], "\n")
+		}
+	}
+
+	var items []generated
+	if err := json.Unmarshal([]byte(response), &items); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	if len(items) != 3 {
+		return nil, fmt.Errorf("expected exactly 3 suggestions, got %d", len(items))
+	}
+	for i, it := range items {
+		if !validTypes[it.Type] {
+			return nil, fmt.Errorf("item %d: invalid type %q", i, it.Type)
+		}
+		if !validSizes[it.Size] {
+			return nil, fmt.Errorf("item %d: invalid size %q", i, it.Size)
+		}
+		if strings.TrimSpace(it.Title) == "" {
+			return nil, fmt.Errorf("item %d: empty title", i)
+		}
+		if strings.TrimSpace(it.Body) == "" {
+			return nil, fmt.Errorf("item %d: empty body", i)
+		}
+	}
+	return items, nil
+}
+
+// loadSourceFiles reads each provided path relative to the current working
+// directory and returns a map of path → contents. Files that cannot be read are
+// silently skipped — the prompt simply omits them rather than failing the run.
+func loadSourceFiles(paths []string) map[string]string {
+	out := make(map[string]string, len(paths))
+	for _, p := range paths {
+		content, err := os.ReadFile(filepath.FromSlash(p))
+		if err != nil {
+			log.Printf("suggestions: read source %q: %v", p, err)
+			continue
+		}
+		out[p] = string(content)
+	}
+	return out
+}
+
+// loadGitLog returns the recent commit history touching the given files. An
+// empty string is returned (and the failure logged) if git is unavailable —
+// this is a context-only enrichment, not a hard requirement for generation.
+func loadGitLog(ctx context.Context, paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	args := []string{"log", "-n", "20", "--oneline", "--"}
+	args = append(args, paths...)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		log.Printf("suggestions: git log failed: %v: %s", err, stderr.String())
+		return ""
+	}
+	return strings.TrimSpace(stdout.String())
+}

--- a/internal/suggestions/generate.go
+++ b/internal/suggestions/generate.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -67,9 +66,13 @@ var validSizes = map[string]bool{
 // RunSuggestionsForPages iterates over pages, calling Claude once per page to
 // generate three improvement suggestions and inserting them as pending rows
 // owned by userID. Per-page errors are logged but do not abort the run, so a
-// single Claude failure or malformed-JSON page does not lose the rest.
+// single Claude failure or malformed-JSON page does not lose the rest. The
+// caller is responsible for filtering pages by Enabled (see EnabledPages).
 //
-// Returns counts of inserted suggestions and pages that errored.
+// Returns counts of inserted suggestions and total errors. Errors include both
+// page-level failures (Claude call, JSON parse) and per-row insert failures, so
+// "13 generated, 2 errors" tells the operator that two intended suggestions did
+// not land in the DB.
 func RunSuggestionsForPages(
 	ctx context.Context,
 	db *sql.DB,
@@ -80,39 +83,45 @@ func RunSuggestionsForPages(
 	var result RunResult
 
 	for _, page := range pages {
-		if !page.Enabled {
-			continue
+		if err := ctx.Err(); err != nil {
+			log.Printf("suggestions: context done before page %q: %v", page.Slug, err)
+			result.Errors++
+			break
 		}
-		inserted, err := runForPage(ctx, db, cfg, userID, page)
+		inserted, failed, err := runForPage(ctx, db, cfg, userID, page)
+		result.Generated += inserted
+		result.Errors += failed
 		if err != nil {
 			result.Errors++
 			log.Printf("suggestions: page %q errored: %v", page.Slug, err)
-			continue
 		}
-		result.Generated += inserted
 	}
 
 	return result
 }
 
 // runForPage handles a single page end-to-end: build prompt, call Claude (with
-// one retry on malformed JSON), and insert the resulting rows.
+// one retry on malformed JSON), and insert the resulting rows. Returns the
+// number of rows successfully inserted, the number of per-row insert failures,
+// and a page-level error (Claude call / JSON parse). Per-row insert failures
+// are reported via the second return value so the caller can surface them in
+// the overall error count.
 func runForPage(
 	ctx context.Context,
 	db *sql.DB,
 	cfg *training.ClaudeConfig,
 	userID int64,
 	page Page,
-) (int, error) {
+) (inserted int, failed int, err error) {
 	pageCtx, cancel := context.WithTimeout(ctx, PerPageTimeout)
 	defer cancel()
 
 	sources := loadSourceFiles(page.SourceFiles)
 	gitLog := loadGitLog(pageCtx, page.SourceFiles)
 
-	recent, err := recentForPage(pageCtx, db, userID, page.Slug, recentSuggestionsWindowDays)
-	if err != nil {
-		log.Printf("suggestions: load recent for %q: %v; continuing without", page.Slug, err)
+	recent, recentErr := recentForPage(pageCtx, db, userID, page.Slug, recentSuggestionsWindowDays)
+	if recentErr != nil {
+		log.Printf("suggestions: load recent for %q: %v; continuing without", page.Slug, recentErr)
 		recent = nil
 	}
 
@@ -120,11 +129,10 @@ func runForPage(
 
 	suggestions, err := callAndParse(pageCtx, cfg, prompt)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
 	now := time.Now().UTC()
-	inserted := 0
 	for _, sg := range suggestions {
 		row := Suggestion{
 			UserID:      userID,
@@ -137,16 +145,14 @@ func runForPage(
 			Body:        sg.Body,
 			Status:      StatusPending,
 		}
-		if _, err := Insert(pageCtx, db, row); err != nil {
-			log.Printf("suggestions: insert for %q: %v", page.Slug, err)
+		if _, insErr := Insert(pageCtx, db, row); insErr != nil {
+			log.Printf("suggestions: insert for %q: %v", page.Slug, insErr)
+			failed++
 			continue
 		}
 		inserted++
 	}
-	if inserted == 0 {
-		return 0, errors.New("no suggestions inserted")
-	}
-	return inserted, nil
+	return inserted, failed, nil
 }
 
 // callAndParse calls Claude and parses the response. On a malformed JSON

--- a/internal/suggestions/generate.go
+++ b/internal/suggestions/generate.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/training"
@@ -194,6 +195,8 @@ func parseSuggestionsResponse(response string) ([]generated, error) {
 	if len(items) != 3 {
 		return nil, fmt.Errorf("expected exactly 3 suggestions, got %d", len(items))
 	}
+	seenTypes := make(map[string]bool, len(items))
+	seenSizes := make(map[string]bool, len(items))
 	for i, it := range items {
 		if !validTypes[it.Type] {
 			return nil, fmt.Errorf("item %d: invalid type %q", i, it.Type)
@@ -207,17 +210,53 @@ func parseSuggestionsResponse(response string) ([]generated, error) {
 		if strings.TrimSpace(it.Body) == "" {
 			return nil, fmt.Errorf("item %d: empty body", i)
 		}
+		if seenTypes[it.Type] {
+			return nil, fmt.Errorf("item %d: duplicate type %q", i, it.Type)
+		}
+		seenTypes[it.Type] = true
+		if seenSizes[it.Size] {
+			return nil, fmt.Errorf("item %d: duplicate size %q", i, it.Size)
+		}
+		seenSizes[it.Size] = true
 	}
 	return items, nil
 }
 
-// loadSourceFiles reads each provided path relative to the current working
-// directory and returns a map of path → contents. Files that cannot be read are
-// silently skipped — the prompt simply omits them rather than failing the run.
+var (
+	repoRootOnce  sync.Once
+	repoRootValue string
+	repoRootErr   error
+)
+
+// repoRoot returns the absolute path to the repository root by running
+// "git rev-parse --show-toplevel". The result is cached after the first call.
+// SourceFiles in the page registry are repo-root-relative, so resolving against
+// this path is necessary when the server or tests run from any other directory.
+func repoRoot() (string, error) {
+	repoRootOnce.Do(func() {
+		out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+		if err != nil {
+			repoRootErr = fmt.Errorf("git rev-parse --show-toplevel: %w", err)
+			return
+		}
+		repoRootValue = strings.TrimSpace(string(out))
+	})
+	return repoRootValue, repoRootErr
+}
+
+// loadSourceFiles reads each provided repo-root-relative path and returns a
+// map of path → contents. Files that cannot be read are skipped with a log
+// warning — the prompt simply omits them rather than failing the run.
 func loadSourceFiles(paths []string) map[string]string {
 	out := make(map[string]string, len(paths))
+	root, err := repoRoot()
+	if err != nil {
+		log.Printf("suggestions: cannot resolve repo root for source files: %v", err)
+		return out
+	}
 	for _, p := range paths {
-		content, err := os.ReadFile(filepath.FromSlash(p))
+		full := filepath.Join(root, filepath.FromSlash(p))
+		content, err := os.ReadFile(full)
 		if err != nil {
 			log.Printf("suggestions: read source %q: %v", p, err)
 			continue
@@ -227,16 +266,24 @@ func loadSourceFiles(paths []string) map[string]string {
 	return out
 }
 
-// loadGitLog returns the recent commit history touching the given files. An
-// empty string is returned (and the failure logged) if git is unavailable —
-// this is a context-only enrichment, not a hard requirement for generation.
+// loadGitLog returns the recent commit history touching the given files. The
+// command runs from the repository root so that repo-root-relative paths in
+// SourceFiles are resolved correctly regardless of the server's working
+// directory. An empty string is returned (and the failure logged) if git is
+// unavailable — this is a context-only enrichment, not a hard requirement.
 func loadGitLog(ctx context.Context, paths []string) string {
 	if len(paths) == 0 {
+		return ""
+	}
+	root, err := repoRoot()
+	if err != nil {
+		log.Printf("suggestions: cannot resolve repo root for git log: %v", err)
 		return ""
 	}
 	args := []string{"log", "-n", "20", "--oneline", "--"}
 	args = append(args, paths...)
 	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = root
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/suggestions/generate_test.go
+++ b/internal/suggestions/generate_test.go
@@ -3,6 +3,7 @@ package suggestions
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -95,7 +96,7 @@ func TestRunSuggestionsForPagesContinuesAfterPerPageError(t *testing.T) {
 	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
 		// Fail entirely on the weather page; succeed on notes.
 		// The prompt embeds the page slug, so we look for it.
-		if contains(prompt, "Slug: weather") {
+		if strings.Contains(prompt, "Slug: weather") {
 			return "", errors.New("simulated claude failure")
 		}
 		return validJSONResponse, nil
@@ -122,6 +123,27 @@ func TestRunSuggestionsForPagesContinuesAfterPerPageError(t *testing.T) {
 	}
 	if notesCount != 3 {
 		t.Fatalf("notes: expected 3 rows, got %d", notesCount)
+	}
+}
+
+func TestRunSuggestionsForPagesCountsPerRowInsertFailures(t *testing.T) {
+	d := setupTestDB(t)
+
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		return validJSONResponse, nil
+	})()
+
+	// Use a non-existent user_id so the FK constraint fails for every Insert.
+	// The Claude call still succeeds, so this isolates per-row failures from
+	// page-level errors.
+	res := RunSuggestionsForPages(context.Background(), d, dummyCfg(), 9999, []Page{
+		{Slug: "weather", Title: "Weather", Enabled: true},
+	})
+	if res.Generated != 0 {
+		t.Fatalf("expected 0 generated, got %d", res.Generated)
+	}
+	if res.Errors != 3 {
+		t.Fatalf("expected 3 per-row errors counted, got %d", res.Errors)
 	}
 }
 
@@ -155,17 +177,4 @@ func TestParseSuggestionsResponseStripsMarkdownFence(t *testing.T) {
 	if len(got) != 3 {
 		t.Fatalf("expected 3 items, got %d", len(got))
 	}
-}
-
-// contains is a small helper kept local to avoid pulling in strings just for one match.
-func contains(haystack, needle string) bool {
-	if len(needle) == 0 {
-		return true
-	}
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/suggestions/generate_test.go
+++ b/internal/suggestions/generate_test.go
@@ -21,7 +21,7 @@ func withRunPrompt(fn func(ctx context.Context, cfg *training.ClaudeConfig, prom
 const validJSONResponse = `[
   {"type": "improvement", "size": "s", "title": "Cache the forecast", "body": "Add a 10-minute in-memory cache so repeated reloads do not hammer yr.no."},
   {"type": "addition", "size": "m", "title": "Add wind direction", "body": "Render the wind direction next to wind speed using the existing arrow icon."},
-  {"type": "bugfix", "size": "s", "title": "Fix midnight rollover", "body": "Use local time when grouping forecast slots so the day label flips at the right moment."}
+  {"type": "bugfix", "size": "l", "title": "Fix midnight rollover", "body": "Use local time when grouping forecast slots so the day label flips at the right moment."}
 ]`
 
 func dummyCfg() *training.ClaudeConfig {

--- a/internal/suggestions/generate_test.go
+++ b/internal/suggestions/generate_test.go
@@ -1,0 +1,171 @@
+package suggestions
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+// withRunPrompt swaps the package-level runPromptFn for the duration of a test
+// and returns a restore function to defer.
+func withRunPrompt(fn func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error)) func() {
+	prev := runPromptFn
+	runPromptFn = fn
+	return func() { runPromptFn = prev }
+}
+
+const validJSONResponse = `[
+  {"type": "improvement", "size": "s", "title": "Cache the forecast", "body": "Add a 10-minute in-memory cache so repeated reloads do not hammer yr.no."},
+  {"type": "addition", "size": "m", "title": "Add wind direction", "body": "Render the wind direction next to wind speed using the existing arrow icon."},
+  {"type": "bugfix", "size": "s", "title": "Fix midnight rollover", "body": "Use local time when grouping forecast slots so the day label flips at the right moment."}
+]`
+
+func dummyCfg() *training.ClaudeConfig {
+	return &training.ClaudeConfig{Enabled: true, CLIPath: "claude", Model: "claude-sonnet-4-6"}
+}
+
+func twoPages() []Page {
+	return []Page{
+		{Slug: "weather", Title: "Weather", Enabled: true},
+		{Slug: "notes", Title: "Notes", Enabled: true},
+	}
+}
+
+func TestRunSuggestionsForPagesInsertsThreeRowsPerPage(t *testing.T) {
+	d := setupTestDB(t)
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		return validJSONResponse, nil
+	})()
+
+	res := RunSuggestionsForPages(context.Background(), d, dummyCfg(), 1, twoPages())
+	if res.Errors != 0 {
+		t.Fatalf("expected 0 errors, got %d", res.Errors)
+	}
+	if res.Generated != 6 {
+		t.Fatalf("expected 6 generated (3 per page × 2 pages), got %d", res.Generated)
+	}
+
+	for _, slug := range []string{"weather", "notes"} {
+		var n int
+		if err := d.QueryRow(`SELECT COUNT(*) FROM suggestions WHERE page_slug = ?`, slug).Scan(&n); err != nil {
+			t.Fatalf("count for %s: %v", slug, err)
+		}
+		if n != 3 {
+			t.Fatalf("page %s: expected 3 rows, got %d", slug, n)
+		}
+	}
+}
+
+func TestRunSuggestionsForPagesRetriesOnceOnMalformedJSON(t *testing.T) {
+	d := setupTestDB(t)
+
+	var calls int
+	var mu sync.Mutex
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		// First call: malformed. Second call: valid.
+		if calls == 1 {
+			return "{not valid json", nil
+		}
+		return validJSONResponse, nil
+	})()
+
+	res := RunSuggestionsForPages(context.Background(), d, dummyCfg(), 1, []Page{
+		{Slug: "weather", Title: "Weather", Enabled: true},
+	})
+	if calls != 2 {
+		t.Fatalf("expected exactly 2 calls (1 retry), got %d", calls)
+	}
+	if res.Errors != 0 {
+		t.Fatalf("expected 0 errors after successful retry, got %d", res.Errors)
+	}
+	if res.Generated != 3 {
+		t.Fatalf("expected 3 rows after retry, got %d", res.Generated)
+	}
+}
+
+func TestRunSuggestionsForPagesContinuesAfterPerPageError(t *testing.T) {
+	d := setupTestDB(t)
+
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		// Fail entirely on the weather page; succeed on notes.
+		// The prompt embeds the page slug, so we look for it.
+		if contains(prompt, "Slug: weather") {
+			return "", errors.New("simulated claude failure")
+		}
+		return validJSONResponse, nil
+	})()
+
+	res := RunSuggestionsForPages(context.Background(), d, dummyCfg(), 1, twoPages())
+	if res.Errors != 1 {
+		t.Fatalf("expected 1 error, got %d", res.Errors)
+	}
+	if res.Generated != 3 {
+		t.Fatalf("expected 3 generated (notes succeeded), got %d", res.Generated)
+	}
+
+	// Confirm only the notes page has rows.
+	var weatherCount, notesCount int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM suggestions WHERE page_slug = 'weather'`).Scan(&weatherCount); err != nil {
+		t.Fatalf("count weather: %v", err)
+	}
+	if err := d.QueryRow(`SELECT COUNT(*) FROM suggestions WHERE page_slug = 'notes'`).Scan(&notesCount); err != nil {
+		t.Fatalf("count notes: %v", err)
+	}
+	if weatherCount != 0 {
+		t.Fatalf("weather: expected 0 rows after error, got %d", weatherCount)
+	}
+	if notesCount != 3 {
+		t.Fatalf("notes: expected 3 rows, got %d", notesCount)
+	}
+}
+
+func TestParseSuggestionsResponseRejectsWrongCount(t *testing.T) {
+	_, err := parseSuggestionsResponse(`[
+		{"type":"improvement","size":"s","title":"X","body":"y"},
+		{"type":"improvement","size":"s","title":"X","body":"y"}
+	]`)
+	if err == nil {
+		t.Fatal("expected error for 2-item response, got nil")
+	}
+}
+
+func TestParseSuggestionsResponseRejectsInvalidEnum(t *testing.T) {
+	_, err := parseSuggestionsResponse(`[
+		{"type":"weird","size":"s","title":"X","body":"y"},
+		{"type":"improvement","size":"s","title":"X","body":"y"},
+		{"type":"improvement","size":"s","title":"X","body":"y"}
+	]`)
+	if err == nil {
+		t.Fatal("expected error for invalid type, got nil")
+	}
+}
+
+func TestParseSuggestionsResponseStripsMarkdownFence(t *testing.T) {
+	wrapped := "```json\n" + validJSONResponse + "\n```"
+	got, err := parseSuggestionsResponse(wrapped)
+	if err != nil {
+		t.Fatalf("expected fence-stripped parse to succeed: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(got))
+	}
+}
+
+// contains is a small helper kept local to avoid pulling in strings just for one match.
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -1,0 +1,56 @@
+package suggestions
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+// OverallRunTimeout caps the entire RunHandler invocation. Five pages × 90s
+// per-page worst case fits under 10 minutes, but Claude can occasionally
+// stall — we want to return a result rather than hang the request indefinitely.
+const OverallRunTimeout = 10 * time.Minute
+
+// RunHandler triggers a synchronous suggestions-generation pass for all enabled
+// pages in the registry. Admin-only.
+//
+// POST /api/suggestions/run
+// Response: { "generated": int, "errors": int }
+func RunHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			return
+		}
+
+		cfg, err := training.LoadClaudeConfig(db, user.ID)
+		if err != nil {
+			log.Printf("suggestions: load claude config for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load Claude configuration"})
+			return
+		}
+		if !cfg.Enabled {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Claude is not enabled — enable it in settings"})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), OverallRunTimeout)
+		defer cancel()
+
+		result := RunSuggestionsForPages(ctx, db, cfg, user.ID, EnabledPages())
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -18,18 +18,14 @@ import (
 const OverallRunTimeout = 10 * time.Minute
 
 // RunHandler triggers a synchronous suggestions-generation pass for all enabled
-// pages in the registry. Admin-only.
+// pages in the registry. Admin-only — relies on auth.RequireAdmin upstream to
+// guarantee a non-nil admin user in the request context.
 //
 // POST /api/suggestions/run
 // Response: { "generated": int, "errors": int }
 func RunHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
-		if user == nil {
-			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
-			return
-		}
-
 		cfg, err := training.LoadClaudeConfig(db, user.ID)
 		if err != nil {
 			log.Printf("suggestions: load claude config for user %d: %v", user.ID, err)

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -1,0 +1,114 @@
+package suggestions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+// withSavedPages temporarily overrides the global Pages registry for a test
+// (so the handler doesn't try to generate against the full prod registry) and
+// returns a restore function to defer.
+func withSavedPages(replacement []Page) func() {
+	prev := Pages
+	Pages = replacement
+	return func() { Pages = prev }
+}
+
+func TestRunHandlerRejectsNonAdmin(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		return validJSONResponse, nil
+	})()
+
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/run", auth.RequireAdmin()(RunHandler(d)))
+
+	// Non-admin user.
+	user := &auth.User{ID: 99, IsAdmin: false}
+	req := httptest.NewRequest(http.MethodPost, "/api/suggestions/run", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRunHandlerAdminReturnsCounts(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{
+		{Slug: "weather", Title: "Weather", Enabled: true},
+		{Slug: "notes", Title: "Notes", Enabled: true},
+	})()
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		return validJSONResponse, nil
+	})()
+
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/run", auth.RequireAdmin()(RunHandler(d)))
+
+	user := &auth.User{ID: 1, IsAdmin: true}
+	req := httptest.NewRequest(http.MethodPost, "/api/suggestions/run", bytes.NewReader(nil))
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var got RunResult
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.Errors != 0 {
+		t.Fatalf("expected 0 errors, got %d", got.Errors)
+	}
+	if got.Generated != 6 {
+		t.Fatalf("expected 6 generated (3 per page × 2), got %d", got.Generated)
+	}
+
+	var rowCount int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM suggestions`).Scan(&rowCount); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if rowCount != 6 {
+		t.Fatalf("expected 6 rows persisted, got %d", rowCount)
+	}
+}
+
+func TestRunHandlerRequiresClaudeEnabled(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	// Note: claude_enabled is intentionally NOT set.
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/run", auth.RequireAdmin()(RunHandler(d)))
+
+	user := &auth.User{ID: 1, IsAdmin: true}
+	req := httptest.NewRequest(http.MethodPost, "/api/suggestions/run", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when claude disabled, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/suggestions/pages.go
+++ b/internal/suggestions/pages.go
@@ -1,0 +1,102 @@
+package suggestions
+
+// Page describes a single Hytte page that can receive AI-generated improvement
+// suggestions. The registry is hand-curated rather than auto-discovered so that
+// each page comes with a meaningful description and an explicit list of source
+// files for the prompt context.
+type Page struct {
+	// Slug is a stable, lowercase identifier used as the page_slug column value.
+	Slug string
+	// Title is a short human-readable label.
+	Title string
+	// Route is the frontend path (for display only).
+	Route string
+	// Description is a one-sentence summary of the page's purpose.
+	Description string
+	// SourceFiles are repository-relative paths whose contents (truncated) are
+	// included in the prompt as context.
+	SourceFiles []string
+	// FeatureFlag is the user_features key gating the page. Informational only
+	// in this bead — used in the prompt context.
+	FeatureFlag string
+	// Enabled controls whether RunSuggestionsForPages will generate against this
+	// page. The per-page enable toggle UI is a later bead; for now all seeded
+	// pages default to true.
+	Enabled bool
+}
+
+// Pages is the curated registry. This bead seeds five pages; the full registry
+// of ~70 pages lands in a later bead together with the rotation scheduler.
+var Pages = []Page{
+	{
+		Slug:        "weather",
+		Title:       "Weather",
+		Route:       "/weather",
+		Description: "Multi-day forecast for Norwegian cities backed by the yr.no API.",
+		SourceFiles: []string{
+			"web/src/pages/Weather.tsx",
+			"internal/weather/handler.go",
+		},
+		FeatureFlag: "weather",
+		Enabled:     true,
+	},
+	{
+		Slug:        "budget",
+		Title:       "Budget",
+		Route:       "/budget",
+		Description: "Personal finance: accounts, categories, transactions, recurring bills, and trends.",
+		SourceFiles: []string{
+			"web/src/pages/BudgetPage.tsx",
+			"internal/budget/handlers.go",
+		},
+		FeatureFlag: "budget",
+		Enabled:     true,
+	},
+	{
+		Slug:        "notes",
+		Title:       "Notes",
+		Route:       "/notes",
+		Description: "Encrypted personal notes with tagging and search.",
+		SourceFiles: []string{
+			"web/src/pages/Notes.tsx",
+			"internal/notes/handlers.go",
+		},
+		FeatureFlag: "notes",
+		Enabled:     true,
+	},
+	{
+		Slug:        "training",
+		Title:       "Training",
+		Route:       "/training",
+		Description: "Workout list with summaries, training load, VO2max, and Claude analysis.",
+		SourceFiles: []string{
+			"web/src/pages/Training.tsx",
+			"internal/training/handlers.go",
+		},
+		FeatureFlag: "training",
+		Enabled:     true,
+	},
+	{
+		Slug:        "links",
+		Title:       "Links",
+		Route:       "/links",
+		Description: "Personal short-link manager.",
+		SourceFiles: []string{
+			"web/src/pages/Links.tsx",
+			"internal/links/handlers.go",
+		},
+		FeatureFlag: "links",
+		Enabled:     true,
+	},
+}
+
+// EnabledPages returns the subset of Pages with Enabled == true.
+func EnabledPages() []Page {
+	out := make([]Page, 0, len(Pages))
+	for _, p := range Pages {
+		if p.Enabled {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/suggestions/pages.go
+++ b/internal/suggestions/pages.go
@@ -1,5 +1,7 @@
 package suggestions
 
+import "fmt"
+
 // Page describes a single Hytte page that can receive AI-generated improvement
 // suggestions. The registry is hand-curated rather than auto-discovered so that
 // each page comes with a meaningful description and an explicit list of source
@@ -90,7 +92,9 @@ var Pages = []Page{
 	},
 }
 
-// EnabledPages returns the subset of Pages with Enabled == true.
+// EnabledPages returns the subset of Pages with Enabled == true. This is the
+// canonical filter used at the handler boundary; downstream functions trust
+// that the slice they receive is already filtered.
 func EnabledPages() []Page {
 	out := make([]Page, 0, len(Pages))
 	for _, p := range Pages {
@@ -99,4 +103,16 @@ func EnabledPages() []Page {
 		}
 	}
 	return out
+}
+
+// init enforces that page slugs are unique. A duplicate slug would silently
+// merge prompts and confuse stats — fail loud at startup instead of in prod.
+func init() {
+	seen := make(map[string]struct{}, len(Pages))
+	for _, p := range Pages {
+		if _, dup := seen[p.Slug]; dup {
+			panic(fmt.Sprintf("suggestions: duplicate page slug %q in registry", p.Slug))
+		}
+		seen[p.Slug] = struct{}{}
+	}
 }

--- a/internal/suggestions/prompt.go
+++ b/internal/suggestions/prompt.go
@@ -1,0 +1,98 @@
+package suggestions
+
+import (
+	"fmt"
+	"strings"
+)
+
+// maxSourceFileChars caps the size of any one source file dropped into the prompt.
+// Most React pages and Go handlers are well under this; larger files are
+// truncated with a marker so the model can still see structure.
+const maxSourceFileChars = 6000
+
+// buildPagePrompt assembles a Claude prompt for generating page-improvement
+// suggestions. The model is asked for a strict JSON array of exactly 3 objects,
+// each with the fields {type, size, title, body}.
+//
+// sourceFiles is a map of relative path → file contents. Callers truncate
+// large files to keep the prompt within reasonable bounds; this function
+// applies a safety cap regardless.
+func buildPagePrompt(page Page, sourceFiles map[string]string, recentGitLog string, recentSuggestions []Suggestion) string {
+	var sb strings.Builder
+
+	sb.WriteString("You are a senior software engineer reviewing one page of a personal web app called Hytte.\n")
+	sb.WriteString("Your job: propose three concrete, scoped improvements to that page.\n\n")
+
+	sb.WriteString("## Page\n")
+	fmt.Fprintf(&sb, "- Slug: %s\n", page.Slug)
+	fmt.Fprintf(&sb, "- Title: %s\n", page.Title)
+	fmt.Fprintf(&sb, "- Route: %s\n", page.Route)
+	if page.Description != "" {
+		fmt.Fprintf(&sb, "- Description: %s\n", page.Description)
+	}
+	if page.FeatureFlag != "" {
+		fmt.Fprintf(&sb, "- Feature flag: %s\n", page.FeatureFlag)
+	}
+	sb.WriteString("\n")
+
+	if len(sourceFiles) > 0 {
+		sb.WriteString("## Source files (truncated)\n")
+		for _, path := range page.SourceFiles {
+			content, ok := sourceFiles[path]
+			if !ok {
+				continue
+			}
+			fmt.Fprintf(&sb, "### %s\n", path)
+			sb.WriteString("```\n")
+			sb.WriteString(truncate(content, maxSourceFileChars))
+			sb.WriteString("\n```\n\n")
+		}
+	}
+
+	if recentGitLog = strings.TrimSpace(recentGitLog); recentGitLog != "" {
+		sb.WriteString("## Recent commits touching this page\n")
+		sb.WriteString("```\n")
+		sb.WriteString(recentGitLog)
+		sb.WriteString("\n```\n\n")
+	}
+
+	if len(recentSuggestions) > 0 {
+		sb.WriteString("## Recent suggestions for this page (avoid repeating these)\n")
+		for _, s := range recentSuggestions {
+			fmt.Fprintf(&sb, "- [%s/%s/%s] %s\n", s.Status, s.Type, s.Size, s.Title)
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(`## Output format
+
+Return ONLY a JSON array of exactly 3 objects. Do not wrap in markdown fences.
+Each object must have these fields and only these fields:
+
+- "type": one of "addition", "bugfix", "improvement", "refactor"
+- "size": one of "s" (under a day), "m" (one to three days), "l" (more than three days)
+- "title": short imperative sentence, max 80 chars, no trailing period
+- "body": 2 to 5 sentences explaining the problem, the proposed change, and the user-visible impact
+
+Distribute types and sizes — do not return three of the same type or three of the same size unless the page genuinely warrants it.
+
+Example shape (do NOT copy these contents):
+[
+  {"type": "improvement", "size": "s", "title": "...", "body": "..."},
+  {"type": "addition", "size": "m", "title": "...", "body": "..."},
+  {"type": "bugfix", "size": "s", "title": "...", "body": "..."}
+]
+`)
+
+	return sb.String()
+}
+
+// truncate returns s clipped to at most max bytes, appending a marker when
+// truncated. Operates on bytes; safe for the source files we feed it because
+// React/Go source is ASCII-dominant and the marker only documents truncation.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "\n... [truncated]"
+}

--- a/internal/suggestions/store.go
+++ b/internal/suggestions/store.go
@@ -122,8 +122,8 @@ func Insert(ctx context.Context, db *sql.DB, s Suggestion) (int64, error) {
 }
 
 // ListByStatus returns all suggestions for a user filtered by status, newest first.
-// Encrypted fields are decrypted; on decrypt error, the ciphertext is returned and
-// the error is logged (per project convention for legacy plaintext compatibility).
+// Encrypted fields are decrypted; on decrypt error the value is replaced with an
+// empty string and the error is logged (see decryptField for rationale).
 func ListByStatus(ctx context.Context, db *sql.DB, userID int64, status string) ([]Suggestion, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT id, user_id, generated_at, page_slug, source, type, size,
@@ -248,14 +248,14 @@ func recentForPage(ctx context.Context, db *sql.DB, userID int64, pageSlug strin
 // Accepts either *sql.Row or *sql.Rows via the rowScanner interface.
 func scanSuggestion(scanner rowScanner) (Suggestion, error) {
 	var (
-		s            Suggestion
-		generatedAt  string
-		bodyEnc      string
-		feedbackEnc  sql.NullString
-		planEnc      sql.NullString
-		beadID       sql.NullString
-		rejectedAt   sql.NullString
-		plannedAt    sql.NullString
+		s             Suggestion
+		generatedAt   string
+		bodyEnc       string
+		feedbackEnc   sql.NullString
+		planEnc       sql.NullString
+		beadID        sql.NullString
+		rejectedAt    sql.NullString
+		plannedAt     sql.NullString
 		beadCreatedAt sql.NullString
 	)
 	if err := scanner.Scan(
@@ -266,32 +266,32 @@ func scanSuggestion(scanner rowScanner) (Suggestion, error) {
 		return s, err
 	}
 
-	if t, err := parseTimeFlexible(generatedAt); err == nil {
+	if t, err := parseTimestamp(generatedAt); err == nil {
 		s.GeneratedAt = t
 	}
 
-	s.Body = decryptOrFallback(bodyEnc, "body", s.ID)
+	s.Body = decryptField(bodyEnc, "body", s.ID)
 	if feedbackEnc.Valid {
-		s.Feedback = decryptOrFallback(feedbackEnc.String, "feedback", s.ID)
+		s.Feedback = decryptField(feedbackEnc.String, "feedback", s.ID)
 	}
 	if planEnc.Valid {
-		s.Plan = decryptOrFallback(planEnc.String, "plan", s.ID)
+		s.Plan = decryptField(planEnc.String, "plan", s.ID)
 	}
 	if beadID.Valid {
 		s.BeadID = beadID.String
 	}
 	if rejectedAt.Valid {
-		if t, err := parseTimeFlexible(rejectedAt.String); err == nil {
+		if t, err := parseTimestamp(rejectedAt.String); err == nil {
 			s.RejectedAt = &t
 		}
 	}
 	if plannedAt.Valid {
-		if t, err := parseTimeFlexible(plannedAt.String); err == nil {
+		if t, err := parseTimestamp(plannedAt.String); err == nil {
 			s.PlannedAt = &t
 		}
 	}
 	if beadCreatedAt.Valid {
-		if t, err := parseTimeFlexible(beadCreatedAt.String); err == nil {
+		if t, err := parseTimestamp(beadCreatedAt.String); err == nil {
 			s.BeadCreatedAt = &t
 		}
 	}
@@ -303,14 +303,17 @@ type rowScanner interface {
 	Scan(dest ...any) error
 }
 
-// decryptOrFallback returns the decrypted value, or the original ciphertext
-// with a logged warning if decryption fails. This matches the existing project
-// convention for handling legacy plaintext values gracefully.
-func decryptOrFallback(value, field string, id int64) string {
+// decryptField returns the decrypted plaintext, or an empty string with a
+// logged warning if decryption fails. We deliberately do NOT fall back to the
+// ciphertext on error — that would leak unreadable encrypted bytes into the
+// API response. Legacy plaintext values (without the enc: prefix) are passed
+// through transparently by encryption.DecryptField itself, so they never reach
+// this error path.
+func decryptField(value, field string, id int64) string {
 	dec, err := encryption.DecryptField(value)
 	if err != nil {
-		log.Printf("suggestions: decrypt %s for id=%d failed: %v; returning ciphertext", field, id, err)
-		return value
+		log.Printf("suggestions: decrypt %s for id=%d failed (returning empty): %v", field, id, err)
+		return ""
 	}
 	return dec
 }
@@ -336,16 +339,11 @@ func nullableTime(t *time.Time) any {
 	return t.UTC().Format(time.RFC3339)
 }
 
-func parseTimeFlexible(s string) (time.Time, error) {
+func parseTimestamp(s string) (time.Time, error) {
 	if s == "" {
 		return time.Time{}, errors.New("empty time string")
 	}
-	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05", "2006-01-02T15:04:05Z"} {
-		if t, err := time.Parse(layout, s); err == nil {
-			return t, nil
-		}
-	}
-	return time.Time{}, fmt.Errorf("unparseable time %q", s)
+	return time.Parse(time.RFC3339, s)
 }
 
 func checkRowsAffected(res sql.Result, id int64) error {

--- a/internal/suggestions/store.go
+++ b/internal/suggestions/store.go
@@ -303,17 +303,16 @@ type rowScanner interface {
 	Scan(dest ...any) error
 }
 
-// decryptField returns the decrypted plaintext, or an empty string with a
-// logged warning if decryption fails. We deliberately do NOT fall back to the
-// ciphertext on error — that would leak unreadable encrypted bytes into the
-// API response. Legacy plaintext values (without the enc: prefix) are passed
-// through transparently by encryption.DecryptField itself, so they never reach
-// this error path.
+// decryptField returns the decrypted plaintext. On failure it logs a warning
+// and returns the original ciphertext so the suggestion remains inspectable
+// (the operator can see what was stored and recover it if needed). Legacy
+// plaintext values (without the enc: prefix) are passed through transparently
+// by encryption.DecryptField itself, so they never reach this error path.
 func decryptField(value, field string, id int64) string {
 	dec, err := encryption.DecryptField(value)
 	if err != nil {
-		log.Printf("suggestions: decrypt %s for id=%d failed (returning empty): %v", field, id, err)
-		return ""
+		log.Printf("suggestions: decrypt %s for id=%d failed (returning ciphertext): %v", field, id, err)
+		return value
 	}
 	return dec
 }

--- a/internal/suggestions/store.go
+++ b/internal/suggestions/store.go
@@ -1,0 +1,360 @@
+package suggestions
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+// Source values for the source column.
+const (
+	SourceClaude = "claude"
+	SourceUser   = "user"
+)
+
+// Type values for the type column.
+const (
+	TypeAddition    = "addition"
+	TypeBugfix      = "bugfix"
+	TypeImprovement = "improvement"
+	TypeRefactor    = "refactor"
+	TypeNewPage     = "new_page"
+)
+
+// Size values for the size column.
+const (
+	SizeS = "s"
+	SizeM = "m"
+	SizeL = "l"
+)
+
+// Status values for the status column.
+const (
+	StatusPending     = "pending"
+	StatusRejected    = "rejected"
+	StatusPlanned     = "planned"
+	StatusBeadCreated = "bead_created"
+)
+
+// Suggestion is the decrypted in-memory representation of a row in the
+// suggestions table. Body, Feedback, and Plan are plaintext on this struct;
+// they are encrypted when written and decrypted when read.
+type Suggestion struct {
+	ID            int64      `json:"id"`
+	UserID        int64      `json:"user_id"`
+	GeneratedAt   time.Time  `json:"generated_at"`
+	PageSlug      string     `json:"page_slug"`
+	Source        string     `json:"source"`
+	Type          string     `json:"type"`
+	Size          string     `json:"size"`
+	Title         string     `json:"title"`
+	Body          string     `json:"body"`
+	Status        string     `json:"status"`
+	Feedback      string     `json:"feedback,omitempty"`
+	Plan          string     `json:"plan,omitempty"`
+	BeadID        string     `json:"bead_id,omitempty"`
+	RejectedAt    *time.Time `json:"rejected_at,omitempty"`
+	PlannedAt     *time.Time `json:"planned_at,omitempty"`
+	BeadCreatedAt *time.Time `json:"bead_created_at,omitempty"`
+}
+
+// Insert persists a new suggestion. Body, Feedback, and Plan are encrypted at
+// the boundary using encryption.EncryptField. Returns the new row ID.
+func Insert(ctx context.Context, db *sql.DB, s Suggestion) (int64, error) {
+	encBody, err := encryption.EncryptField(s.Body)
+	if err != nil {
+		return 0, fmt.Errorf("encrypt body: %w", err)
+	}
+	encFeedback, err := encryption.EncryptField(s.Feedback)
+	if err != nil {
+		return 0, fmt.Errorf("encrypt feedback: %w", err)
+	}
+	encPlan, err := encryption.EncryptField(s.Plan)
+	if err != nil {
+		return 0, fmt.Errorf("encrypt plan: %w", err)
+	}
+
+	generatedAt := s.GeneratedAt
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+	status := s.Status
+	if status == "" {
+		status = StatusPending
+	}
+
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO suggestions (
+			user_id, generated_at, page_slug, source, type, size,
+			title, body_enc, status, feedback_enc, plan_enc, bead_id,
+			rejected_at, planned_at, bead_created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		s.UserID,
+		generatedAt.UTC().Format(time.RFC3339),
+		s.PageSlug,
+		s.Source,
+		s.Type,
+		s.Size,
+		s.Title,
+		encBody,
+		status,
+		nullableEncrypted(encFeedback),
+		nullableEncrypted(encPlan),
+		nullableString(s.BeadID),
+		nullableTime(s.RejectedAt),
+		nullableTime(s.PlannedAt),
+		nullableTime(s.BeadCreatedAt),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("insert suggestion: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// ListByStatus returns all suggestions for a user filtered by status, newest first.
+// Encrypted fields are decrypted; on decrypt error, the ciphertext is returned and
+// the error is logged (per project convention for legacy plaintext compatibility).
+func ListByStatus(ctx context.Context, db *sql.DB, userID int64, status string) ([]Suggestion, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, user_id, generated_at, page_slug, source, type, size,
+		       title, body_enc, status, feedback_enc, plan_enc, bead_id,
+		       rejected_at, planned_at, bead_created_at
+		FROM suggestions
+		WHERE user_id = ? AND status = ?
+		ORDER BY generated_at DESC, id DESC
+	`, userID, status)
+	if err != nil {
+		return nil, fmt.Errorf("query suggestions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Suggestion
+	for rows.Next() {
+		s, err := scanSuggestion(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetByID returns a single suggestion by ID. Returns sql.ErrNoRows if not found.
+func GetByID(ctx context.Context, db *sql.DB, id int64) (*Suggestion, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, user_id, generated_at, page_slug, source, type, size,
+		       title, body_enc, status, feedback_enc, plan_enc, bead_id,
+		       rejected_at, planned_at, bead_created_at
+		FROM suggestions
+		WHERE id = ?
+	`, id)
+	s, err := scanSuggestion(row)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// MarkRejected sets status to "rejected" and records the rejected_at timestamp.
+func MarkRejected(ctx context.Context, db *sql.DB, id int64) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.ExecContext(ctx, `
+		UPDATE suggestions SET status = ?, rejected_at = ? WHERE id = ?
+	`, StatusRejected, now, id)
+	if err != nil {
+		return fmt.Errorf("mark rejected: %w", err)
+	}
+	return checkRowsAffected(res, id)
+}
+
+// MarkPlanned sets status to "planned", stores the encrypted plan body, and
+// records planned_at.
+func MarkPlanned(ctx context.Context, db *sql.DB, id int64, plan string) error {
+	encPlan, err := encryption.EncryptField(plan)
+	if err != nil {
+		return fmt.Errorf("encrypt plan: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.ExecContext(ctx, `
+		UPDATE suggestions SET status = ?, plan_enc = ?, planned_at = ? WHERE id = ?
+	`, StatusPlanned, nullableEncrypted(encPlan), now, id)
+	if err != nil {
+		return fmt.Errorf("mark planned: %w", err)
+	}
+	return checkRowsAffected(res, id)
+}
+
+// MarkBeadCreated sets status to "bead_created", stores the bead ID, and
+// records bead_created_at.
+func MarkBeadCreated(ctx context.Context, db *sql.DB, id int64, beadID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.ExecContext(ctx, `
+		UPDATE suggestions SET status = ?, bead_id = ?, bead_created_at = ? WHERE id = ?
+	`, StatusBeadCreated, nullableString(beadID), now, id)
+	if err != nil {
+		return fmt.Errorf("mark bead created: %w", err)
+	}
+	return checkRowsAffected(res, id)
+}
+
+// recentForPage returns suggestions for a given page slug whose status is not
+// "rejected" and that were generated within the last `days` days. Used by the
+// generator to discourage repeat suggestions in the prompt.
+func recentForPage(ctx context.Context, db *sql.DB, userID int64, pageSlug string, days int) ([]Suggestion, error) {
+	cutoff := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, user_id, generated_at, page_slug, source, type, size,
+		       title, body_enc, status, feedback_enc, plan_enc, bead_id,
+		       rejected_at, planned_at, bead_created_at
+		FROM suggestions
+		WHERE user_id = ? AND page_slug = ?
+		  AND status IN (?, ?, ?)
+		  AND generated_at >= ?
+		ORDER BY generated_at DESC
+	`, userID, pageSlug,
+		StatusPending, StatusPlanned, StatusBeadCreated,
+		cutoff,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("recent suggestions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Suggestion
+	for rows.Next() {
+		s, err := scanSuggestion(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// scanSuggestion decodes one row into a Suggestion, decrypting encrypted fields.
+// Accepts either *sql.Row or *sql.Rows via the rowScanner interface.
+func scanSuggestion(scanner rowScanner) (Suggestion, error) {
+	var (
+		s            Suggestion
+		generatedAt  string
+		bodyEnc      string
+		feedbackEnc  sql.NullString
+		planEnc      sql.NullString
+		beadID       sql.NullString
+		rejectedAt   sql.NullString
+		plannedAt    sql.NullString
+		beadCreatedAt sql.NullString
+	)
+	if err := scanner.Scan(
+		&s.ID, &s.UserID, &generatedAt, &s.PageSlug, &s.Source, &s.Type, &s.Size,
+		&s.Title, &bodyEnc, &s.Status, &feedbackEnc, &planEnc, &beadID,
+		&rejectedAt, &plannedAt, &beadCreatedAt,
+	); err != nil {
+		return s, err
+	}
+
+	if t, err := parseTimeFlexible(generatedAt); err == nil {
+		s.GeneratedAt = t
+	}
+
+	s.Body = decryptOrFallback(bodyEnc, "body", s.ID)
+	if feedbackEnc.Valid {
+		s.Feedback = decryptOrFallback(feedbackEnc.String, "feedback", s.ID)
+	}
+	if planEnc.Valid {
+		s.Plan = decryptOrFallback(planEnc.String, "plan", s.ID)
+	}
+	if beadID.Valid {
+		s.BeadID = beadID.String
+	}
+	if rejectedAt.Valid {
+		if t, err := parseTimeFlexible(rejectedAt.String); err == nil {
+			s.RejectedAt = &t
+		}
+	}
+	if plannedAt.Valid {
+		if t, err := parseTimeFlexible(plannedAt.String); err == nil {
+			s.PlannedAt = &t
+		}
+	}
+	if beadCreatedAt.Valid {
+		if t, err := parseTimeFlexible(beadCreatedAt.String); err == nil {
+			s.BeadCreatedAt = &t
+		}
+	}
+	return s, nil
+}
+
+// rowScanner unifies *sql.Row and *sql.Rows for scanSuggestion.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// decryptOrFallback returns the decrypted value, or the original ciphertext
+// with a logged warning if decryption fails. This matches the existing project
+// convention for handling legacy plaintext values gracefully.
+func decryptOrFallback(value, field string, id int64) string {
+	dec, err := encryption.DecryptField(value)
+	if err != nil {
+		log.Printf("suggestions: decrypt %s for id=%d failed: %v; returning ciphertext", field, id, err)
+		return value
+	}
+	return dec
+}
+
+func nullableEncrypted(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func nullableTime(t *time.Time) any {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func parseTimeFlexible(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, errors.New("empty time string")
+	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05", "2006-01-02T15:04:05Z"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unparseable time %q", s)
+}
+
+func checkRowsAffected(res sql.Result, id int64) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("no suggestion with id %d", id)
+	}
+	return nil
+}

--- a/internal/suggestions/store_test.go
+++ b/internal/suggestions/store_test.go
@@ -1,0 +1,270 @@
+package suggestions
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/db"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	d, err := db.Init(":memory:")
+	if err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	d.SetMaxOpenConns(1)
+	d.SetMaxIdleConns(1)
+	t.Cleanup(func() { d.Close() })
+
+	if _, err := d.Exec(
+		`INSERT INTO users (id, google_id, email, name, picture, is_admin) VALUES (1, 'g1', 'admin@example.com', 'Admin', '', 1)`,
+	); err != nil {
+		t.Fatalf("create test user: %v", err)
+	}
+	return d
+}
+
+func TestInsertEncryptsBodyAndRoundTrips(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	body := "This is the suggestion body that must be stored encrypted at rest."
+	feedback := "I disagree with the framing here."
+	plan := "Step 1: refactor X. Step 2: add tests."
+
+	id, err := Insert(ctx, d, Suggestion{
+		UserID:   1,
+		PageSlug: "weather",
+		Source:   SourceClaude,
+		Type:     TypeImprovement,
+		Size:     SizeS,
+		Title:    "Tighten forecast cache",
+		Body:     body,
+		Feedback: feedback,
+		Plan:     plan,
+		Status:   StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("expected positive id, got %d", id)
+	}
+
+	// Verify the raw column does NOT contain plaintext.
+	var rawBody, rawFeedback, rawPlan sql.NullString
+	if err := d.QueryRow(`SELECT body_enc, feedback_enc, plan_enc FROM suggestions WHERE id = ?`, id).
+		Scan(&rawBody, &rawFeedback, &rawPlan); err != nil {
+		t.Fatalf("read raw row: %v", err)
+	}
+	if !rawBody.Valid || rawBody.String == body {
+		t.Fatalf("expected encrypted body, got raw plaintext: %q", rawBody.String)
+	}
+	if !strings.HasPrefix(rawBody.String, "enc:") {
+		t.Fatalf("expected body to be encrypted with enc: prefix, got %q", rawBody.String)
+	}
+	if !rawFeedback.Valid || rawFeedback.String == feedback {
+		t.Fatalf("expected encrypted feedback, got raw plaintext: %q", rawFeedback.String)
+	}
+	if !rawPlan.Valid || rawPlan.String == plan {
+		t.Fatalf("expected encrypted plan, got raw plaintext: %q", rawPlan.String)
+	}
+
+	// GetByID should round-trip the plaintext.
+	got, err := GetByID(ctx, d, id)
+	if err != nil {
+		t.Fatalf("get by id: %v", err)
+	}
+	if got.Body != body {
+		t.Fatalf("body round-trip failed: got %q want %q", got.Body, body)
+	}
+	if got.Feedback != feedback {
+		t.Fatalf("feedback round-trip failed: got %q want %q", got.Feedback, feedback)
+	}
+	if got.Plan != plan {
+		t.Fatalf("plan round-trip failed: got %q want %q", got.Plan, plan)
+	}
+	if got.Title != "Tighten forecast cache" {
+		t.Fatalf("title mismatch: %q", got.Title)
+	}
+	if got.Status != StatusPending {
+		t.Fatalf("status mismatch: %q", got.Status)
+	}
+}
+
+func TestListByStatusOnlyReturnsMatchingRows(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	// Insert a mix of statuses.
+	if _, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "A", Body: "b", Status: StatusPending,
+	}); err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	if _, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeBugfix, Size: SizeM, Title: "B", Body: "b", Status: StatusRejected,
+	}); err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+	if _, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "notes", Source: SourceClaude,
+		Type: TypeAddition, Size: SizeL, Title: "C", Body: "b", Status: StatusPending,
+	}); err != nil {
+		t.Fatalf("insert C: %v", err)
+	}
+
+	pending, err := ListByStatus(ctx, d, 1, StatusPending)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("expected 2 pending, got %d", len(pending))
+	}
+
+	rejected, err := ListByStatus(ctx, d, 1, StatusRejected)
+	if err != nil {
+		t.Fatalf("list rejected: %v", err)
+	}
+	if len(rejected) != 1 || rejected[0].Title != "B" {
+		t.Fatalf("expected single rejected B, got %+v", rejected)
+	}
+}
+
+func TestMarkRejectedUpdatesStatusAndTimestamp(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	id, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := MarkRejected(ctx, d, id); err != nil {
+		t.Fatalf("mark rejected: %v", err)
+	}
+	got, err := GetByID(ctx, d, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != StatusRejected {
+		t.Fatalf("status: got %q want %q", got.Status, StatusRejected)
+	}
+	if got.RejectedAt == nil || got.RejectedAt.IsZero() {
+		t.Fatalf("rejected_at not set")
+	}
+}
+
+func TestMarkPlannedStoresEncryptedPlan(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	id, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	plan := "Detailed plan: do A, then B, then C."
+	if err := MarkPlanned(ctx, d, id, plan); err != nil {
+		t.Fatalf("mark planned: %v", err)
+	}
+
+	var rawPlan sql.NullString
+	if err := d.QueryRow(`SELECT plan_enc FROM suggestions WHERE id = ?`, id).Scan(&rawPlan); err != nil {
+		t.Fatalf("read raw plan: %v", err)
+	}
+	if !rawPlan.Valid || rawPlan.String == plan || !strings.HasPrefix(rawPlan.String, "enc:") {
+		t.Fatalf("plan not encrypted at rest: %q", rawPlan.String)
+	}
+
+	got, err := GetByID(ctx, d, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Plan != plan {
+		t.Fatalf("plan round-trip: got %q want %q", got.Plan, plan)
+	}
+	if got.Status != StatusPlanned {
+		t.Fatalf("status: %q", got.Status)
+	}
+	if got.PlannedAt == nil {
+		t.Fatalf("planned_at not set")
+	}
+}
+
+func TestMarkBeadCreatedRecordsBeadID(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	id, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPlanned,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := MarkBeadCreated(ctx, d, id, "Hytte-abcd"); err != nil {
+		t.Fatalf("mark bead created: %v", err)
+	}
+	got, err := GetByID(ctx, d, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != StatusBeadCreated {
+		t.Fatalf("status: %q", got.Status)
+	}
+	if got.BeadID != "Hytte-abcd" {
+		t.Fatalf("bead id: %q", got.BeadID)
+	}
+	if got.BeadCreatedAt == nil {
+		t.Fatalf("bead_created_at not set")
+	}
+}
+
+func TestRecentForPageIncludesPendingExcludesRejected(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	insertWithGenerated := func(slug, status string, when time.Time) {
+		t.Helper()
+		if _, err := Insert(ctx, d, Suggestion{
+			UserID: 1, GeneratedAt: when, PageSlug: slug, Source: SourceClaude,
+			Type: TypeImprovement, Size: SizeS, Title: "T-" + status, Body: "b", Status: status,
+		}); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	insertWithGenerated("weather", StatusPending, now)
+	insertWithGenerated("weather", StatusRejected, now)
+	insertWithGenerated("weather", StatusPlanned, now)
+	insertWithGenerated("weather", StatusBeadCreated, now)
+	// Out of window — should be excluded.
+	insertWithGenerated("weather", StatusPending, now.AddDate(0, 0, -30))
+	// Different page — excluded.
+	insertWithGenerated("notes", StatusPending, now)
+
+	got, err := recentForPage(ctx, d, 1, "weather", 14)
+	if err != nil {
+		t.Fatalf("recent: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 recent (pending/planned/bead_created within 14d), got %d", len(got))
+	}
+	for _, s := range got {
+		if s.Status == StatusRejected {
+			t.Fatalf("rejected should be excluded, got %+v", s)
+		}
+	}
+}

--- a/internal/suggestions/store_test.go
+++ b/internal/suggestions/store_test.go
@@ -8,10 +8,20 @@ import (
 	"time"
 
 	"github.com/Robin831/Hytte/internal/db"
+	"github.com/Robin831/Hytte/internal/encryption"
 )
 
+// setupTestDB returns a fresh in-memory database with a single admin user and
+// pins the encryption key so EncryptField/DecryptField produce stable, hermetic
+// output. Without t.Setenv("ENCRYPTION_KEY", ...) tests would either share the
+// developer's auto-generated key file (non-hermetic, fails on a fresh checkout)
+// or fail outright in CI where the user config dir may not be writable.
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-encryption-key-for-suggestions-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+
 	d, err := db.Init(":memory:")
 	if err != nil {
 		t.Fatalf("init test db: %v", err)


### PR DESCRIPTION
## Changes

- **Suggestions backend foundation** - Added the database schema, page registry, generator, and admin-only `POST /api/suggestions/run` endpoint that asks Claude for three improvement ideas per curated page (weather, budget, notes, training, links). Suggestion bodies are encrypted at rest; per-page errors are isolated so one failure does not abort the whole run. UI lands in a follow-up bead. (Hytte-ipyx)

## Original Issue (feature): Suggestions: schema, page registry, and manual generation run

First slice of a new admin-only Suggestions feature. This bead lays the foundation: DB schema, a curated page registry, the nightly-style generator function, and a manual-trigger endpoint. No UI in this bead — that's the next bead.

## Context

The full feature: Claude generates 3 improvement suggestions per page on a nightly rotation (so each page is touched ~weekly, not all 70 pages every night), plus at least one new-page idea. Robin (admin only) reviews suggestions on a Suggestions page, can reject, can give optional feedback, can click "Plan it" to have Claude expand it into a plan, then "Create bead" to file it as a forgeReady bead. Robin can also write his own suggestions and run them through the same plan→bead pipeline. Pending suggestions carry over indefinitely until acted on.

This bead implements only the backend foundation. Subsequent beads will add: UI, bd-create integration, scheduler+rotation+per-page enable toggle, new-page prompt + cost surfacing.

## Scope of this bead

### 1. DB schema

Add to internal/db/db.go createSchema():

    CREATE TABLE IF NOT EXISTS suggestions (
      id              INTEGER PRIMARY KEY AUTOINCREMENT,
      user_id         INTEGER NOT NULL,
      generated_at    TIMESTAMP NOT NULL,
      page_slug       TEXT NOT NULL,
      source          TEXT NOT NULL,         -- 'claude' | 'user'
      type            TEXT NOT NULL,         -- 'addition' | 'bugfix' | 'improvement' | 'refactor' | 'new_page'
      size            TEXT NOT NULL,         -- 's' | 'm' | 'l'
      title           TEXT NOT NULL,
      body_enc        TEXT NOT NULL,
      status          TEXT NOT NULL,         -- 'pending' | 'rejected' | 'planned' | 'bead_created'
      feedback_enc    TEXT,
      plan_enc        TEXT,
      bead_id         TEXT,
      rejected_at     TIMESTAMP,
      planned_at      TIMESTAMP,
      bead_created_at TIMESTAMP,
      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
    );
    CREATE INDEX IF NOT EXISTS idx_suggestions_user_status ON suggestions(user_id, status);
    CREATE INDEX IF NOT EXISTS idx_suggestions_page_slug ON suggestions(page_slug);

No migration files — inline in createSchema() per project convention.

### 2. Encryption

Per CLAUDE.md, free-text fields must be encrypted at rest. Use encryption.EncryptField on write and encryption.DecryptField on read for: body_enc, feedback_enc, plan_enc. Title is short and not sensitive — leave plaintext for searchability. Handle decrypt errors gracefully (log + return ciphertext) per existing convention.

### 3. New package: internal/suggestions/

Files:

- pages.go — curated page registry. Hand-written struct slice, NOT auto-discovered. Each entry: { Slug, Title, Route, Description, SourceFiles []string, FeatureFlag string, Enabled bool }. Seed with exactly 5 pages for this bead: weather, budget, notes, training, links. Full registry comes in a later bead.
- generate.go — RunSuggestionsForPages(ctx, db, pages []Page) error: for each page, build a prompt (page metadata + truncated contents of page's main React file + truncated backend handler + git log -n 20 --oneline -- <files> + last 14d of pending/planned/bead_created suggestions for that page slug to discourage repeats), call training.RunPrompt, parse strict JSON response, insert 3 rows. Skip new-page generation in this bead. Errors per page should log but not abort the whole run.
- prompt.go — buildPagePrompt(page Page, recentGitLog string, recentSuggestions []Suggestion) string. Response schema requested: array of exactly 3 objects with fields {type, size, title, body}. Reject and retry once if JSON is malformed.
- store.go — Insert, ListByStatus, GetByID, MarkRejected, MarkPlanned (with plan), MarkBeadCreated (with bead_id), with encryption applied/reversed at the boundary.
- handlers.go — admin-gated:
    - POST /api/suggestions/run: triggers RunSuggestionsForPages over all enabled pages. Synchronous, with a per-page timeout (90s) and overall ctx timeout (10min). Returns counts: { generated, errors }.
- Wire routes in internal/api/router.go inside an admin-gated group (existing pattern from Claude AI settings — RequireAuth + is_admin check).

### 4. Tests

- store_test.go: round-trip insert/list/update with encryption verified (body_enc in DB ≠ plaintext, decrypted result matches).
- generate_test.go: mock training.RunPrompt (replace the package-level function variable, same pattern as chat/handlers.go runPromptFn). Verify: (a) 3 rows inserted per page on success, (b) malformed JSON triggers one retry then logs+continues, (c) per-page error doesn't abort other pages.
- handlers_test.go: admin-only enforcement, success path returns counts.

## Non-goals (explicitly NOT in this bead)

- Any frontend code
- Scheduler / cron loop in main.go (later bead)
- Rotation logic (later bead — for now, all 5 seeded pages run every invocation)
- Per-page enable toggle UI (the Enabled struct field is added now but not configurable yet)
- New-page suggestion prompt
- bd create integration
- Cost tracking
- Plan generation endpoint and feedback flow (later bead)

## Acceptance

- make build, make test, npm run lint, npm run build all pass
- Manually: hitting POST /api/suggestions/run as admin generates 15 rows (5 pages × 3) with encrypted bodies, distinct types/sizes, returns 200 with counts
- Hitting it as non-admin returns 403
- Changelog fragment added in changelog.d/ (category: Added)

## Reference

Follow these existing patterns:
- training/claude.go for Claude invocation
- chat/handlers.go for the runPromptFn package variable pattern (so tests can mock)
- stride/evaluate.go for nightly-style generation logic structure
- forge/handlers.go for admin gating pattern


---
Bead: Hytte-ipyx | Branch: forge/Hytte-ipyx
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)