### PR TITLE
Suggestions: keep distinct types but drop distinct-sizes constraint (Hytte-4qbd)

### DIFF
--- a/changelog.d/Hytte-4qbd.md
+++ b/changelog.d/Hytte-4qbd.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Suggestions parser no longer requires distinct sizes per page** - Per-page suggestion responses still need three distinct types, but two or three suggestions may now share the same size. The prompt is updated to make sizes a soft preference, reducing wasted retries on otherwise-valid Claude responses. (Hytte-4qbd)

--- a/internal/suggestions/generate.go
+++ b/internal/suggestions/generate.go
@@ -196,7 +196,6 @@ func parseSuggestionsResponse(response string) ([]generated, error) {
 		return nil, fmt.Errorf("expected exactly 3 suggestions, got %d", len(items))
 	}
 	seenTypes := make(map[string]bool, len(items))
-	seenSizes := make(map[string]bool, len(items))
 	for i, it := range items {
 		if !validTypes[it.Type] {
 			return nil, fmt.Errorf("item %d: invalid type %q", i, it.Type)
@@ -214,10 +213,6 @@ func parseSuggestionsResponse(response string) ([]generated, error) {
 			return nil, fmt.Errorf("item %d: duplicate type %q", i, it.Type)
 		}
 		seenTypes[it.Type] = true
-		if seenSizes[it.Size] {
-			return nil, fmt.Errorf("item %d: duplicate size %q", i, it.Size)
-		}
-		seenSizes[it.Size] = true
 	}
 	return items, nil
 }

--- a/internal/suggestions/generate_test.go
+++ b/internal/suggestions/generate_test.go
@@ -18,10 +18,13 @@ func withRunPrompt(fn func(ctx context.Context, cfg *training.ClaudeConfig, prom
 	return func() { runPromptFn = prev }
 }
 
+// validJSONResponse intentionally repeats size "s" twice to exercise the
+// loosened parser: distinct types are still required, but distinct sizes are
+// not.
 const validJSONResponse = `[
   {"type": "improvement", "size": "s", "title": "Cache the forecast", "body": "Add a 10-minute in-memory cache so repeated reloads do not hammer yr.no."},
   {"type": "addition", "size": "m", "title": "Add wind direction", "body": "Render the wind direction next to wind speed using the existing arrow icon."},
-  {"type": "bugfix", "size": "l", "title": "Fix midnight rollover", "body": "Use local time when grouping forecast slots so the day label flips at the right moment."}
+  {"type": "bugfix", "size": "s", "title": "Fix midnight rollover", "body": "Use local time when grouping forecast slots so the day label flips at the right moment."}
 ]`
 
 func dummyCfg() *training.ClaudeConfig {
@@ -165,6 +168,34 @@ func TestParseSuggestionsResponseRejectsInvalidEnum(t *testing.T) {
 	]`)
 	if err == nil {
 		t.Fatal("expected error for invalid type, got nil")
+	}
+}
+
+func TestParseSuggestionsResponseAllowsDuplicateSizes(t *testing.T) {
+	got, err := parseSuggestionsResponse(`[
+		{"type":"improvement","size":"s","title":"A","body":"a"},
+		{"type":"addition","size":"s","title":"B","body":"b"},
+		{"type":"bugfix","size":"s","title":"C","body":"c"}
+	]`)
+	if err != nil {
+		t.Fatalf("expected three same-size suggestions to parse, got error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(got))
+	}
+}
+
+func TestParseSuggestionsResponseRejectsDuplicateTypes(t *testing.T) {
+	_, err := parseSuggestionsResponse(`[
+		{"type":"improvement","size":"s","title":"A","body":"a"},
+		{"type":"improvement","size":"m","title":"B","body":"b"},
+		{"type":"bugfix","size":"l","title":"C","body":"c"}
+	]`)
+	if err == nil {
+		t.Fatal("expected error for duplicate type, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate type") {
+		t.Fatalf("expected duplicate-type error, got: %v", err)
 	}
 }
 

--- a/internal/suggestions/prompt.go
+++ b/internal/suggestions/prompt.go
@@ -74,7 +74,7 @@ Each object must have these fields and only these fields:
 - "title": short imperative sentence, max 80 chars, no trailing period
 - "body": 2 to 5 sentences explaining the problem, the proposed change, and the user-visible impact
 
-Use a distinct type for each suggestion — do not return three of the same type. Use a mix of sizes when the work genuinely varies, but it is fine to return three small or three medium suggestions if that reflects the page.
+Each suggestion must have a unique type — all three types must be different. Sizes may repeat freely: returning all three the same size is fine if that reflects the page.
 
 Example shape (do NOT copy these contents):
 [

--- a/internal/suggestions/prompt.go
+++ b/internal/suggestions/prompt.go
@@ -74,7 +74,7 @@ Each object must have these fields and only these fields:
 - "title": short imperative sentence, max 80 chars, no trailing period
 - "body": 2 to 5 sentences explaining the problem, the proposed change, and the user-visible impact
 
-Distribute types and sizes — do not return three of the same type or three of the same size unless the page genuinely warrants it.
+Use a distinct type for each suggestion — do not return three of the same type. Use a mix of sizes when the work genuinely varies, but it is fine to return three small or three medium suggestions if that reflects the page.
 
 Example shape (do NOT copy these contents):
 [


### PR DESCRIPTION
## Changes

- **Suggestions parser no longer requires distinct sizes per page** - Per-page suggestion responses still need three distinct types, but two or three suggestions may now share the same size. The prompt is updated to make sizes a soft preference, reducing wasted retries on otherwise-valid Claude responses. (Hytte-4qbd)

## Original Issue (task): Suggestions: keep distinct types but drop distinct-sizes constraint

Small follow-up to Hytte-ipyx. The current parser hard-enforces both distinct types and distinct sizes across the three suggestions per page. Distinct types is useful (avoids getting three refactors). Distinct sizes is too rigid — a page may legitimately have three small bug fixes, and forcing one s/m/l every time is artificial. The prompt itself only says "unless the page genuinely warrants it", so the hard size check causes wasted retries on otherwise-valid Claude responses.

## Changes

In `internal/suggestions/generate.go`, function `parseSuggestionsResponse`:

- Keep the distinct-type check (`seenTypes`).
- Remove the distinct-size check (`seenSizes` and the duplicate-size error branch).

In `internal/suggestions/prompt.go`, function `buildPagePrompt`:

- Update the "Distribute types and sizes" sentence to talk only about types. Keep the encouragement to vary sizes but make it clearly soft: e.g. "Use a mix of sizes when the work genuinely varies, but it is fine to return three small or three medium suggestions if that reflects the page."

## Tests

In `internal/suggestions/generate_test.go`:

- Update `validJSONResponse` (or whichever fixture currently uses three distinct sizes) so one size is repeated. Confirm parsing succeeds.
- Keep an existing case (or add one) where two suggestions share a type and assert it still fails with the duplicate-type error.
- Remove or invert the test that asserts duplicate sizes fail.

## Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build` all pass.
- A response with three suggestions where two share `size: "s"` parses successfully.
- A response with two suggestions sharing a `type` still fails parsing (one retry, then the page reports an error).
- No changes outside `internal/suggestions/` and `changelog.d/`.
- Changelog fragment in `changelog.d/` (category: Changed).


---
Bead: Hytte-4qbd | Branch: forge/Hytte-4qbd
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)