### PR TITLE
Backend: suggestion CRUD + pages endpoints (Hytte-tdui)

### DIFF
--- a/changelog.d/Hytte-tdui.md
+++ b/changelog.d/Hytte-tdui.md
@@ -1,0 +1,2 @@
+category: Added
+- **Suggestion CRUD endpoints** - Added admin-only `GET /api/suggestions` (partitioned by status with decrypted bodies), `POST /api/suggestions` (user-authored pending suggestions, validated against the type/size/page registry), `POST /api/suggestions/{id}/reject` (idempotent), and `GET /api/suggestions/pages` (registry plus the synthetic `__new_page__` entry). (Hytte-tdui)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -198,7 +198,11 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Delete("/kiosk/tokens/{id}", kiosk.DeleteTokenHandler(db))
 
 				// Suggestions: AI-generated page improvement ideas — admin only.
+				r.Get("/suggestions", suggestions.ListHandler(db))
+				r.Post("/suggestions", suggestions.CreateHandler(db))
 				r.Post("/suggestions/run", suggestions.RunHandler(db))
+				r.Post("/suggestions/{id}/reject", suggestions.RejectHandler(db))
+				r.Get("/suggestions/pages", suggestions.PagesHandler())
 
 				// Forge dashboard — admin only, registered only when FEATURE_FORGE_DASHBOARD=1.
 				// The feature flag is evaluated at startup; when disabled, these routes are

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -4,18 +4,26 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/training"
+	"github.com/go-chi/chi/v5"
 )
 
 // OverallRunTimeout caps the entire RunHandler invocation. Five pages × 90s
 // per-page worst case fits under 10 minutes, but Claude can occasionally
 // stall — we want to return a result rather than hang the request indefinitely.
 const OverallRunTimeout = 10 * time.Minute
+
+// NewPageSlug is the synthetic page_slug used for "new page" suggestions that
+// do not target an existing page in the registry.
+const NewPageSlug = "__new_page__"
 
 // RunHandler triggers a synchronous suggestions-generation pass for all enabled
 // pages in the registry. Admin-only — relies on auth.RequireAdmin upstream to
@@ -43,6 +51,232 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 		result := RunSuggestionsForPages(ctx, db, cfg, user.ID, EnabledPages())
 		writeJSON(w, http.StatusOK, result)
 	}
+}
+
+// listResponse is the shape returned by GET /api/suggestions: the caller gets
+// one bucket per actionable status. Suggestions in the bead_created status are
+// terminal and not surfaced here.
+type listResponse struct {
+	Pending  []Suggestion `json:"pending"`
+	Planned  []Suggestion `json:"planned"`
+	Rejected []Suggestion `json:"rejected"`
+}
+
+// ListHandler returns the admin user's suggestions partitioned by status. Each
+// bucket is decrypted at the boundary by the store layer so the response body
+// holds plaintext title/body/feedback/plan.
+//
+// GET /api/suggestions
+func ListHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		pending, err := ListByStatus(r.Context(), db, user.ID, StatusPending)
+		if err != nil {
+			log.Printf("suggestions: list pending for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list suggestions"})
+			return
+		}
+		planned, err := ListByStatus(r.Context(), db, user.ID, StatusPlanned)
+		if err != nil {
+			log.Printf("suggestions: list planned for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list suggestions"})
+			return
+		}
+		rejected, err := ListByStatus(r.Context(), db, user.ID, StatusRejected)
+		if err != nil {
+			log.Printf("suggestions: list rejected for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list suggestions"})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, listResponse{
+			Pending:  nilToEmpty(pending),
+			Planned:  nilToEmpty(planned),
+			Rejected: nilToEmpty(rejected),
+		})
+	}
+}
+
+// validUserSuggestionTypes mirrors validTypes from generate.go but additionally
+// allows "new_page" — a user can author a new-page suggestion explicitly,
+// whereas Claude generation does not produce them per-page.
+var validUserSuggestionTypes = map[string]bool{
+	TypeAddition:    true,
+	TypeBugfix:      true,
+	TypeImprovement: true,
+	TypeRefactor:    true,
+	TypeNewPage:     true,
+}
+
+// CreateHandler accepts a user-authored suggestion. The row is written with
+// source="user" and status="pending"; type, size, and page_slug are validated
+// against the same enums Claude is held to plus the synthetic "__new_page__"
+// slug. Body/title are encrypted at rest by Insert.
+//
+// POST /api/suggestions
+// Request:  {"type": "...", "size": "...", "page_slug": "...", "title": "...", "body": "..."}
+// Response: 201 with the inserted Suggestion (decrypted).
+func CreateHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		var body struct {
+			Type     string `json:"type"`
+			Size     string `json:"size"`
+			PageSlug string `json:"page_slug"`
+			Title    string `json:"title"`
+			Body     string `json:"body"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+
+		body.Type = strings.TrimSpace(body.Type)
+		body.Size = strings.TrimSpace(body.Size)
+		body.PageSlug = strings.TrimSpace(body.PageSlug)
+		body.Title = strings.TrimSpace(body.Title)
+		body.Body = strings.TrimSpace(body.Body)
+
+		if !validUserSuggestionTypes[body.Type] {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid type"})
+			return
+		}
+		if !validSizes[body.Size] {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid size"})
+			return
+		}
+		if !isValidPageSlug(body.PageSlug) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown page_slug"})
+			return
+		}
+		if body.Title == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "title is required"})
+			return
+		}
+		if body.Body == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body is required"})
+			return
+		}
+
+		row := Suggestion{
+			UserID:      user.ID,
+			GeneratedAt: time.Now().UTC(),
+			PageSlug:    body.PageSlug,
+			Source:      SourceUser,
+			Type:        body.Type,
+			Size:        body.Size,
+			Title:       body.Title,
+			Body:        body.Body,
+			Status:      StatusPending,
+		}
+		id, err := Insert(r.Context(), db, row)
+		if err != nil {
+			log.Printf("suggestions: create for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create suggestion"})
+			return
+		}
+
+		created, err := GetByID(r.Context(), db, id)
+		if err != nil {
+			log.Printf("suggestions: load created suggestion %d: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load created suggestion"})
+			return
+		}
+		writeJSON(w, http.StatusCreated, created)
+	}
+}
+
+// RejectHandler marks a suggestion as rejected. Idempotent: re-rejecting an
+// already-rejected suggestion returns 200 with the existing row instead of
+// erroring, so the UI does not have to special-case duplicate clicks.
+//
+// POST /api/suggestions/{id}/reject
+func RejectHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idStr := chi.URLParam(r, "id")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+			return
+		}
+
+		existing, err := GetByID(r.Context(), db, id)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "suggestion not found"})
+				return
+			}
+			log.Printf("suggestions: load %d for reject: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load suggestion"})
+			return
+		}
+
+		if existing.Status == StatusRejected {
+			writeJSON(w, http.StatusOK, existing)
+			return
+		}
+
+		if err := MarkRejected(r.Context(), db, id); err != nil {
+			log.Printf("suggestions: mark rejected %d: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to reject suggestion"})
+			return
+		}
+		updated, err := GetByID(r.Context(), db, id)
+		if err != nil {
+			log.Printf("suggestions: reload rejected %d: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load suggestion"})
+			return
+		}
+		writeJSON(w, http.StatusOK, updated)
+	}
+}
+
+// pageSummary is the lightweight page descriptor returned to the UI.
+type pageSummary struct {
+	Slug  string `json:"slug"`
+	Title string `json:"title"`
+}
+
+// PagesHandler returns the registry of pages a user-authored suggestion can
+// target, plus the synthetic "__new_page__" entry for proposing brand-new
+// pages. Order is stable: registry order followed by the new-page sentinel.
+//
+// GET /api/suggestions/pages
+func PagesHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		pages := EnabledPages()
+		out := make([]pageSummary, 0, len(pages)+1)
+		for _, p := range pages {
+			out = append(out, pageSummary{Slug: p.Slug, Title: p.Title})
+		}
+		out = append(out, pageSummary{Slug: NewPageSlug, Title: "New page"})
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// isValidPageSlug returns true if slug is the synthetic new-page sentinel or a
+// slug from the enabled-pages registry.
+func isValidPageSlug(slug string) bool {
+	if slug == NewPageSlug {
+		return true
+	}
+	for _, p := range EnabledPages() {
+		if p.Slug == slug {
+			return true
+		}
+	}
+	return false
+}
+
+// nilToEmpty returns an empty slice when given nil so JSON encoding produces
+// `[]` rather than `null` — easier for the frontend to consume unconditionally.
+func nilToEmpty(s []Suggestion) []Suggestion {
+	if s == nil {
+		return []Suggestion{}
+	}
+	return s
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -98,15 +98,12 @@ func ListHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
-// validUserSuggestionTypes mirrors validTypes from generate.go but additionally
-// allows "new_page" — a user can author a new-page suggestion explicitly,
-// whereas Claude generation does not produce them per-page.
-var validUserSuggestionTypes = map[string]bool{
-	TypeAddition:    true,
-	TypeBugfix:      true,
-	TypeImprovement: true,
-	TypeRefactor:    true,
-	TypeNewPage:     true,
+// isValidUserSuggestionType reports whether t is valid for user-authored
+// suggestions. It delegates to validTypes from generate.go as the single enum
+// source of truth, extending it with TypeNewPage, which users can propose
+// explicitly but Claude generation does not produce per-page.
+func isValidUserSuggestionType(t string) bool {
+	return validTypes[t] || t == TypeNewPage
 }
 
 // CreateHandler accepts a user-authored suggestion. The row is written with
@@ -139,7 +136,7 @@ func CreateHandler(db *sql.DB) http.HandlerFunc {
 		body.Title = strings.TrimSpace(body.Title)
 		body.Body = strings.TrimSpace(body.Body)
 
-		if !validUserSuggestionTypes[body.Type] {
+		if !isValidUserSuggestionType(body.Type) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid type"})
 			return
 		}
@@ -149,6 +146,14 @@ func CreateHandler(db *sql.DB) http.HandlerFunc {
 		}
 		if !isValidPageSlug(body.PageSlug) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown page_slug"})
+			return
+		}
+		// new_page type and __new_page__ slug are exclusive to each other: one
+		// implies the other. Accepting them independently would produce rows whose
+		// type and target contradict each other (e.g. a "bugfix" aimed at no page,
+		// or a "new_page" targeting an existing page).
+		if (body.Type == TypeNewPage) != (body.PageSlug == NewPageSlug) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "type new_page requires page_slug __new_page__ and vice versa"})
 			return
 		}
 		if body.Title == "" {
@@ -195,6 +200,8 @@ func CreateHandler(db *sql.DB) http.HandlerFunc {
 // POST /api/suggestions/{id}/reject
 func RejectHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
 		idStr := chi.URLParam(r, "id")
 		id, err := strconv.ParseInt(idStr, 10, 64)
 		if err != nil {
@@ -213,8 +220,23 @@ func RejectHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		// Return 404 rather than 403 so that other users' suggestion IDs are
+		// not discoverable by enumeration.
+		if existing.UserID != user.ID {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "suggestion not found"})
+			return
+		}
+
 		if existing.Status == StatusRejected {
 			writeJSON(w, http.StatusOK, existing)
+			return
+		}
+
+		// bead_created is terminal — a linked bead already exists. Allowing a
+		// reject here would silently drop the suggestion from the admin UI while
+		// leaving the bead metadata behind in the row.
+		if existing.Status == StatusBeadCreated {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "cannot reject a suggestion with a linked bead"})
 			return
 		}
 

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -280,6 +280,9 @@ func TestCreateHandlerValidationRejections(t *testing.T) {
 		{"empty title", `{"type":"improvement","size":"s","page_slug":"weather","title":"  ","body":"b"}`},
 		{"empty body", `{"type":"improvement","size":"s","page_slug":"weather","title":"t","body":""}`},
 		{"invalid json", `{not json`},
+		// Cross-validation: new_page type must pair with __new_page__ slug and vice versa.
+		{"new_page type with registered slug", `{"type":"new_page","size":"s","page_slug":"weather","title":"t","body":"b"}`},
+		{"bugfix type with __new_page__ slug", fmt.Sprintf(`{"type":"bugfix","size":"s","page_slug":%q,"title":"t","body":"b"}`, NewPageSlug)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -396,6 +399,52 @@ func TestRejectHandlerInvalidID(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestRejectHandlerOtherUserSuggestionReturns404(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	// Suggestion owned by user 1.
+	id, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(RejectHandler(d), http.MethodPost, "/api/suggestions/{id}/reject")
+	// Different admin (user 2) tries to reject user 1's suggestion.
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/reject", id), nil), 2, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-user reject, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRejectHandlerCannotRejectBeadCreated(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	id, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusBeadCreated,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(RejectHandler(d), http.MethodPost, "/api/suggestions/{id}/reject")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/reject", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for bead_created suggestion, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/training"
+	"github.com/go-chi/chi/v5"
 )
 
 // withSavedPages temporarily overrides the global Pages registry for a test
@@ -110,5 +113,370 @@ func TestRunHandlerRequiresClaudeEnabled(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 when claude disabled, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// mountAdmin wraps a single handler in RequireAdmin, mounted on a chi router
+// so that URL params are populated as they are at runtime.
+func mountAdmin(handler http.Handler, method, pattern string) chi.Router {
+	r := chi.NewRouter()
+	r.Method(method, pattern, auth.RequireAdmin()(handler))
+	return r
+}
+
+func adminContext(r *http.Request, userID int64, isAdmin bool) *http.Request {
+	user := &auth.User{ID: userID, IsAdmin: isAdmin}
+	return r.WithContext(auth.ContextWithUser(r.Context(), user))
+}
+
+// --- ListHandler -------------------------------------------------------------
+
+func TestListHandlerRejectsNonAdmin(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(ListHandler(d), http.MethodGet, "/api/suggestions")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/suggestions", nil)
+	req = adminContext(req, 99, false)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestListHandlerPartitionsByStatus(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	insert := func(status, title string) {
+		t.Helper()
+		if _, err := Insert(ctx, d, Suggestion{
+			UserID: 1, PageSlug: "weather", Source: SourceClaude,
+			Type: TypeImprovement, Size: SizeS, Title: title, Body: "b", Status: status,
+		}); err != nil {
+			t.Fatalf("insert %s: %v", status, err)
+		}
+	}
+	insert(StatusPending, "P1")
+	insert(StatusPending, "P2")
+	insert(StatusPlanned, "PL1")
+	insert(StatusRejected, "R1")
+	insert(StatusBeadCreated, "BC1") // should not appear in any bucket
+
+	router := mountAdmin(ListHandler(d), http.MethodGet, "/api/suggestions")
+	req := adminContext(httptest.NewRequest(http.MethodGet, "/api/suggestions", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got listResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Pending) != 2 {
+		t.Fatalf("pending: expected 2, got %d", len(got.Pending))
+	}
+	if len(got.Planned) != 1 || got.Planned[0].Title != "PL1" {
+		t.Fatalf("planned mismatch: %+v", got.Planned)
+	}
+	if len(got.Rejected) != 1 || got.Rejected[0].Title != "R1" {
+		t.Fatalf("rejected mismatch: %+v", got.Rejected)
+	}
+}
+
+func TestListHandlerEmptyBucketsAreArrays(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(ListHandler(d), http.MethodGet, "/api/suggestions")
+	req := adminContext(httptest.NewRequest(http.MethodGet, "/api/suggestions", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, key := range []string{`"pending":[]`, `"planned":[]`, `"rejected":[]`} {
+		if !strings.Contains(body, key) {
+			t.Fatalf("expected empty array for %s, body=%s", key, body)
+		}
+	}
+}
+
+// --- CreateHandler -----------------------------------------------------------
+
+func TestCreateHandlerRejectsNonAdmin(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(CreateHandler(d), http.MethodPost, "/api/suggestions")
+	body := `{"type":"improvement","size":"s","page_slug":"weather","title":"t","body":"b"}`
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions", strings.NewReader(body)), 99, false)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d", rec.Code)
+	}
+}
+
+func TestCreateHandlerSuccess(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+
+	router := mountAdmin(CreateHandler(d), http.MethodPost, "/api/suggestions")
+	payload := `{"type":"improvement","size":"m","page_slug":"weather","title":"Cache forecasts","body":"Cache yr.no for 10 minutes."}`
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions", strings.NewReader(payload)), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got Suggestion
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID <= 0 {
+		t.Fatalf("expected positive id, got %d", got.ID)
+	}
+	if got.Source != SourceUser {
+		t.Fatalf("expected source=user, got %q", got.Source)
+	}
+	if got.Status != StatusPending {
+		t.Fatalf("expected status=pending, got %q", got.Status)
+	}
+	if got.Title != "Cache forecasts" || got.Body != "Cache yr.no for 10 minutes." {
+		t.Fatalf("title/body round-trip failed: %+v", got)
+	}
+}
+
+func TestCreateHandlerAllowsNewPageSlug(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+
+	router := mountAdmin(CreateHandler(d), http.MethodPost, "/api/suggestions")
+	payload := fmt.Sprintf(`{"type":"new_page","size":"l","page_slug":%q,"title":"Add expense tracker","body":"A page that..."}`, NewPageSlug)
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions", strings.NewReader(payload)), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for __new_page__, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateHandlerValidationRejections(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"bad type", `{"type":"weird","size":"s","page_slug":"weather","title":"t","body":"b"}`},
+		{"bad size", `{"type":"improvement","size":"xl","page_slug":"weather","title":"t","body":"b"}`},
+		{"unknown slug", `{"type":"improvement","size":"s","page_slug":"nope","title":"t","body":"b"}`},
+		{"empty title", `{"type":"improvement","size":"s","page_slug":"weather","title":"  ","body":"b"}`},
+		{"empty body", `{"type":"improvement","size":"s","page_slug":"weather","title":"t","body":""}`},
+		{"invalid json", `{not json`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := mountAdmin(CreateHandler(d), http.MethodPost, "/api/suggestions")
+			req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions", strings.NewReader(tc.payload)), 1, true)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("%s: expected 400, got %d: %s", tc.name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestCreateThenListRoundTripsDecryptedBody(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+
+	const plaintext = "Encrypted at rest, decrypted at the boundary."
+	create := mountAdmin(CreateHandler(d), http.MethodPost, "/api/suggestions")
+	payload := fmt.Sprintf(`{"type":"improvement","size":"s","page_slug":"weather","title":"Round trip","body":%q}`, plaintext)
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions", strings.NewReader(payload)), 1, true)
+	rec := httptest.NewRecorder()
+	create.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	list := mountAdmin(ListHandler(d), http.MethodGet, "/api/suggestions")
+	req = adminContext(httptest.NewRequest(http.MethodGet, "/api/suggestions", nil), 1, true)
+	rec = httptest.NewRecorder()
+	list.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got listResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Pending) != 1 {
+		t.Fatalf("expected 1 pending, got %d", len(got.Pending))
+	}
+	if got.Pending[0].Body != plaintext {
+		t.Fatalf("body round-trip failed: got %q want %q", got.Pending[0].Body, plaintext)
+	}
+}
+
+// --- RejectHandler -----------------------------------------------------------
+
+func TestRejectHandlerRejectsNonAdmin(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(RejectHandler(d), http.MethodPost, "/api/suggestions/{id}/reject")
+
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/1/reject", nil), 99, false)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestRejectHandlerSuccess(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	id, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(RejectHandler(d), http.MethodPost, "/api/suggestions/{id}/reject")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/reject", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got Suggestion
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != StatusRejected {
+		t.Fatalf("status: got %q want %q", got.Status, StatusRejected)
+	}
+	if got.RejectedAt == nil {
+		t.Fatal("expected rejected_at to be set")
+	}
+}
+
+func TestRejectHandlerNotFound(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(RejectHandler(d), http.MethodPost, "/api/suggestions/{id}/reject")
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/999/reject", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRejectHandlerInvalidID(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(RejectHandler(d), http.MethodPost, "/api/suggestions/{id}/reject")
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/abc/reject", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestRejectHandlerIsIdempotent(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	id, err := Insert(ctx, d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(RejectHandler(d), http.MethodPost, "/api/suggestions/{id}/reject")
+
+	// First reject — should succeed.
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/reject", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first reject: expected 200, got %d", rec.Code)
+	}
+
+	// Second reject — must also return 200 with the existing row.
+	req = adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/reject", id), nil), 1, true)
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second reject: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got Suggestion
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != StatusRejected {
+		t.Fatalf("status: %q", got.Status)
+	}
+}
+
+// --- PagesHandler ------------------------------------------------------------
+
+func TestPagesHandlerRejectsNonAdmin(t *testing.T) {
+	router := mountAdmin(PagesHandler(), http.MethodGet, "/api/suggestions/pages")
+	req := adminContext(httptest.NewRequest(http.MethodGet, "/api/suggestions/pages", nil), 99, false)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestPagesHandlerReturnsRegistryPlusNewPage(t *testing.T) {
+	defer withSavedPages([]Page{
+		{Slug: "weather", Title: "Weather", Enabled: true},
+		{Slug: "notes", Title: "Notes", Enabled: true},
+		{Slug: "disabled", Title: "Disabled", Enabled: false},
+	})()
+
+	router := mountAdmin(PagesHandler(), http.MethodGet, "/api/suggestions/pages")
+	req := adminContext(httptest.NewRequest(http.MethodGet, "/api/suggestions/pages", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []pageSummary
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Expect 2 enabled pages + 1 synthetic.
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries (2 enabled + new_page), got %d: %+v", len(got), got)
+	}
+	if got[0].Slug != "weather" || got[1].Slug != "notes" {
+		t.Fatalf("registry order broken: %+v", got)
+	}
+	if got[2].Slug != NewPageSlug {
+		t.Fatalf("expected last entry to be %q, got %q", NewPageSlug, got[2].Slug)
 	}
 }


### PR DESCRIPTION
## Changes

- **Suggestion CRUD endpoints** - Added admin-only `GET /api/suggestions` (partitioned by status with decrypted bodies), `POST /api/suggestions` (user-authored pending suggestions, validated against the type/size/page registry), `POST /api/suggestions/{id}/reject` (idempotent), and `GET /api/suggestions/pages` (registry plus the synthetic `__new_page__` entry). (Hytte-tdui)

## Original Issue (task): Backend: suggestion CRUD + pages endpoints

Add admin-only endpoints in internal/api/router.go (inside the existing is_admin block): GET /api/suggestions (returns {pending, planned, rejected} with decrypted body/feedback/plan at the boundary), POST /api/suggestions (user-authored creation with source="user", status="pending"; validates type ∈ {addition,bugfix,improvement,refactor,new_page}, size ∈ {s,m,l}, page_slug equal to "__new_page__" or matching registry), POST /api/suggestions/{id}/reject (idempotent — re-rejecting returns 200 with existing row), and GET /api/suggestions/pages (returns [{slug,title}] from EnabledPages() plus synthetic "__new_page__"). Add handlers in internal/suggestions/handlers.go following the existing admin handler pattern. Extend handlers_test.go with admin-gating, success, validation rejection (bad type/size/unknown slug), 404 on missing id, and a round-trip test that GET returns properly decrypted bodies after POST insert. No Claude calls in this sub-task — sets up the data plane the other sub-tasks build on.

---
Bead: Hytte-tdui | Branch: forge/Hytte-tdui
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)