### PR TITLE
Backend: plan endpoint + plan prompt (Hytte-phzn)

### DIFF
--- a/changelog.d/Hytte-phzn.md
+++ b/changelog.d/Hytte-phzn.md
@@ -1,0 +1,2 @@
+category: Added
+- **Suggestions: plan endpoint** - New `POST /api/suggestions/{id}/plan` admin endpoint asks Claude for a concrete implementation plan (scope, files, acceptance criteria, non-goals) and persists it on the suggestion. Supports an optional feedback string for re-planning. (Hytte-phzn)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -202,6 +202,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/suggestions", suggestions.CreateHandler(db))
 				r.Post("/suggestions/run", suggestions.RunHandler(db))
 				r.Post("/suggestions/{id}/reject", suggestions.RejectHandler(db))
+				r.Post("/suggestions/{id}/plan", suggestions.PlanHandler(db))
 				r.Get("/suggestions/pages", suggestions.PagesHandler())
 
 				// Forge dashboard — admin only, registered only when FEATURE_FORGE_DASHBOARD=1.

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -310,6 +310,14 @@ func PlanHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		// bead_created is terminal — a linked bead already exists. Flipping
+		// status back to planned would leave bead_id/bead_created_at behind and
+		// produce an inconsistent row.
+		if existing.Status == StatusBeadCreated {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "cannot plan a suggestion with a linked bead"})
+			return
+		}
+
 		cfg, err := training.LoadClaudeConfig(db, user.ID)
 		if err != nil {
 			log.Printf("suggestions: load claude config for user %d: %v", user.ID, err)

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -20,6 +21,11 @@ import (
 // per-page worst case fits under 10 minutes, but Claude can occasionally
 // stall — we want to return a result rather than hang the request indefinitely.
 const OverallRunTimeout = 10 * time.Minute
+
+// PlanTimeout caps a single PlanHandler Claude invocation. Declared as var so
+// tests can shrink it to verify timeout handling without hanging for two
+// minutes per run. Production callers must not mutate it.
+var PlanTimeout = 120 * time.Second
 
 // NewPageSlug is the synthetic page_slug used for "new page" suggestions that
 // do not target an existing page in the registry.
@@ -253,6 +259,122 @@ func RejectHandler(db *sql.DB) http.HandlerFunc {
 		}
 		writeJSON(w, http.StatusOK, updated)
 	}
+}
+
+// PlanHandler asks Claude to produce a concrete implementation plan for a
+// suggestion and persists the result. Synchronous: blocks until Claude returns
+// or PlanTimeout elapses. Not idempotent — re-planning replaces the previous
+// plan and resets planned_at.
+//
+// POST /api/suggestions/{id}/plan
+// Request:  { "feedback"?: string }
+// Response: 200 with the updated Suggestion (status=planned, plan populated).
+func PlanHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		idStr := chi.URLParam(r, "id")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+			return
+		}
+
+		// Body is optional — an empty/missing body is valid for a fresh plan.
+		var body struct {
+			Feedback string `json:"feedback"`
+		}
+		if r.Body != nil && r.ContentLength != 0 {
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+				return
+			}
+		}
+		body.Feedback = strings.TrimSpace(body.Feedback)
+
+		existing, err := GetByID(r.Context(), db, id)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "suggestion not found"})
+				return
+			}
+			log.Printf("suggestions: load %d for plan: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load suggestion"})
+			return
+		}
+
+		// Same enumeration-resistance pattern as RejectHandler: cross-user access
+		// returns 404 so other users' suggestion IDs are not discoverable.
+		if existing.UserID != user.ID {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "suggestion not found"})
+			return
+		}
+
+		cfg, err := training.LoadClaudeConfig(db, user.ID)
+		if err != nil {
+			log.Printf("suggestions: load claude config for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load Claude configuration"})
+			return
+		}
+		if !cfg.Enabled {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Claude is not enabled — enable it in settings"})
+			return
+		}
+
+		page := findPageBySlug(existing.PageSlug)
+		prompt := buildPlanPrompt(*existing, page, body.Feedback)
+
+		ctx, cancel := context.WithTimeout(r.Context(), PlanTimeout)
+		defer cancel()
+
+		plan, err := runPromptFn(ctx, cfg, prompt)
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				log.Printf("suggestions: plan %d timed out after %s", id, PlanTimeout)
+				writeJSON(w, http.StatusGatewayTimeout, map[string]string{"error": "Claude timed out generating the plan"})
+				return
+			}
+			log.Printf("suggestions: plan %d claude error: %v", id, err)
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to generate plan"})
+			return
+		}
+
+		plan = strings.TrimSpace(plan)
+		if plan == "" {
+			log.Printf("suggestions: plan %d: empty response from Claude", id)
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "Claude returned an empty plan"})
+			return
+		}
+
+		if err := MarkPlanned(r.Context(), db, id, plan); err != nil {
+			log.Printf("suggestions: mark planned %d: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save plan"})
+			return
+		}
+
+		updated, err := GetByID(r.Context(), db, id)
+		if err != nil {
+			log.Printf("suggestions: reload planned %d: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load suggestion"})
+			return
+		}
+		writeJSON(w, http.StatusOK, updated)
+	}
+}
+
+// findPageBySlug returns the registry entry matching slug, or nil if the slug
+// is the synthetic new-page sentinel or no longer present in the registry.
+// buildPlanPrompt handles a nil result.
+func findPageBySlug(slug string) *Page {
+	if slug == NewPageSlug {
+		return nil
+	}
+	for i := range Pages {
+		if Pages[i].Slug == slug {
+			return &Pages[i]
+		}
+	}
+	return nil
 }
 
 // pageSummary is the lightweight page descriptor returned to the UI.

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -777,6 +777,71 @@ func TestPlanHandlerReplacesPriorPlan(t *testing.T) {
 	}
 }
 
+func TestPlanHandlerCannotPlanBeadCreated(t *testing.T) {
+	d := setupTestDB(t)
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusBeadCreated,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for bead_created suggestion, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPlanHandlerCanPlanRejectedSuggestion(t *testing.T) {
+	d := setupTestDB(t)
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		return "recovery plan", nil
+	})()
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := MarkRejected(context.Background(), d, id); err != nil {
+		t.Fatalf("mark rejected: %v", err)
+	}
+
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 when re-planning rejected suggestion, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got Suggestion
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != StatusPlanned {
+		t.Fatalf("status: got %q want %q", got.Status, StatusPlanned)
+	}
+	if got.RejectedAt != nil {
+		t.Fatalf("expected rejected_at to be cleared after re-planning, got %v", got.RejectedAt)
+	}
+	if got.Plan != "recovery plan" {
+		t.Fatalf("plan: got %q want %q", got.Plan, "recovery plan")
+	}
+}
+
 func TestPlanHandlerRequiresClaudeEnabled(t *testing.T) {
 	d := setupTestDB(t)
 	// claude_enabled intentionally NOT set.

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/training"
@@ -483,6 +484,318 @@ func TestRejectHandlerIsIdempotent(t *testing.T) {
 	}
 	if got.Status != StatusRejected {
 		t.Fatalf("status: %q", got.Status)
+	}
+}
+
+// --- PlanHandler -------------------------------------------------------------
+
+// withPlanTimeout temporarily shrinks PlanTimeout so the timeout-path test can
+// run in milliseconds rather than the production 120s. Returns a restore fn.
+func withPlanTimeout(d time.Duration) func() {
+	prev := PlanTimeout
+	PlanTimeout = d
+	return func() { PlanTimeout = prev }
+}
+
+func TestPlanHandlerRejectsNonAdmin(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/1/plan", nil), 99, false)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPlanHandlerSuccess(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	const cannedPlan = "### Scope\nDo the thing.\n\n### Files to touch\n- foo.go\n\n### Acceptance criteria\n- It works.\n\n### Non-goals\n- Anything else."
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		return cannedPlan, nil
+	})()
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got Suggestion
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != StatusPlanned {
+		t.Fatalf("status: got %q want %q", got.Status, StatusPlanned)
+	}
+	if got.Plan != cannedPlan {
+		t.Fatalf("plan round-trip: got %q want %q", got.Plan, cannedPlan)
+	}
+	if got.PlannedAt == nil {
+		t.Fatal("expected planned_at to be set")
+	}
+}
+
+func TestPlanHandlerPassesFeedbackIntoPrompt(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	const feedback = "Use Redis instead of an in-memory map; we already run Redis."
+	var capturedPrompt string
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		capturedPrompt = prompt
+		return "ok plan", nil
+	})()
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	payload := fmt.Sprintf(`{"feedback":%q}`, feedback)
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), strings.NewReader(payload)), 1, true)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(capturedPrompt, feedback) {
+		t.Fatalf("expected captured prompt to contain feedback verbatim, got:\n%s", capturedPrompt)
+	}
+}
+
+func TestPlanHandlerNotFound(t *testing.T) {
+	d := setupTestDB(t)
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	// runPromptFn must NOT be called on the not-found path, but defining it
+	// keeps the test hermetic if the handler ever changes.
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		t.Fatal("runPromptFn should not be called for missing id")
+		return "", nil
+	})()
+
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/999/plan", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPlanHandlerInvalidID(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/abc/plan", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestPlanHandlerOtherUserSuggestionReturns404(t *testing.T) {
+	d := setupTestDB(t)
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	// User 2 (a different admin) tries to plan user 1's suggestion.
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 2, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-user plan, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPlanHandlerTimeoutDoesNotMarkPlanned(t *testing.T) {
+	d := setupTestDB(t)
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	defer withPlanTimeout(50 * time.Millisecond)()
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	})()
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504 on timeout, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify the suggestion was NOT marked planned.
+	got, err := GetByID(context.Background(), d, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != StatusPending {
+		t.Fatalf("status should remain pending after timeout, got %q", got.Status)
+	}
+	if got.PlannedAt != nil {
+		t.Fatalf("planned_at should remain nil after timeout, got %v", got.PlannedAt)
+	}
+	if got.Plan != "" {
+		t.Fatalf("plan should remain empty after timeout, got %q", got.Plan)
+	}
+}
+
+func TestPlanHandlerNewPageSlugProducesValidPrompt(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	var capturedPrompt string
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		capturedPrompt = prompt
+		return "plan body", nil
+	})()
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: NewPageSlug, Source: SourceUser,
+		Type: TypeNewPage, Size: SizeL, Title: "Brand new page", Body: "details", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(capturedPrompt, NewPageSlug) {
+		t.Fatalf("expected prompt to acknowledge __new_page__, got:\n%s", capturedPrompt)
+	}
+}
+
+func TestPlanHandlerReplacesPriorPlan(t *testing.T) {
+	d := setupTestDB(t)
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// First plan.
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		return "first plan", nil
+	})()
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first plan: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Second plan replaces the first.
+	runPromptFn = func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		return "second plan", nil
+	}
+	req = adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 1, true)
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second plan: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got Suggestion
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Plan != "second plan" {
+		t.Fatalf("expected re-plan to replace plan, got %q", got.Plan)
+	}
+}
+
+func TestPlanHandlerRequiresClaudeEnabled(t *testing.T) {
+	d := setupTestDB(t)
+	// claude_enabled intentionally NOT set.
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	router := mountAdmin(PlanHandler(d), http.MethodPost, "/api/suggestions/{id}/plan")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when claude disabled, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/suggestions/plan_prompt.go
+++ b/internal/suggestions/plan_prompt.go
@@ -1,0 +1,109 @@
+package suggestions
+
+import (
+	"fmt"
+	"strings"
+)
+
+// maxPlanResponseChars caps the requested plan size in the prompt so Claude
+// returns something the admin UI can render without truncation. The handler
+// still trusts whatever comes back, but a hard size limit in the prompt keeps
+// responses focused on essentials.
+const maxPlanResponseChars = 3000
+
+// buildPlanPrompt assembles a Claude prompt asking for a concrete
+// implementation plan for one suggestion. The output is plain markdown — not
+// JSON — and source files are intentionally NOT included: the planning step
+// produces a high-level plan the operator (or another Claude session) will
+// then execute, so feeding source bytes here would just bloat the prompt.
+//
+// page may be nil when the suggestion targets the synthetic "__new_page__"
+// slug or when the original page slug is no longer in the registry; in both
+// cases the prompt notes that page context is unavailable rather than
+// fabricating it.
+//
+// feedback, if non-empty, is appended verbatim under a dedicated section so
+// the admin can steer a re-plan without us re-interpreting their words.
+func buildPlanPrompt(suggestion Suggestion, page *Page, feedback string) string {
+	var sb strings.Builder
+
+	sb.WriteString("You are a senior software engineer writing an implementation plan for a single Hytte suggestion.\n")
+	sb.WriteString("The plan will be reviewed by the project owner and then handed to a coding agent that will execute it.\n\n")
+
+	sb.WriteString("## Suggestion\n")
+	fmt.Fprintf(&sb, "- Type: %s\n", suggestion.Type)
+	fmt.Fprintf(&sb, "- Size: %s\n", suggestion.Size)
+	fmt.Fprintf(&sb, "- Title: %s\n", suggestion.Title)
+	if body := strings.TrimSpace(suggestion.Body); body != "" {
+		sb.WriteString("- Body:\n")
+		sb.WriteString(indentBlock(body, "  "))
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Page context\n")
+	if page == nil {
+		if suggestion.PageSlug == NewPageSlug {
+			sb.WriteString("This suggestion proposes a brand-new page (slug \"__new_page__\"). No existing page registry entry applies — design the plan as a greenfield addition.\n")
+		} else {
+			fmt.Fprintf(&sb, "Page slug %q is not in the registry; treat the page context as unavailable and base the plan on the suggestion body alone.\n", suggestion.PageSlug)
+		}
+	} else {
+		fmt.Fprintf(&sb, "- Slug: %s\n", page.Slug)
+		fmt.Fprintf(&sb, "- Title: %s\n", page.Title)
+		if page.Route != "" {
+			fmt.Fprintf(&sb, "- Route: %s\n", page.Route)
+		}
+		if page.Description != "" {
+			fmt.Fprintf(&sb, "- Description: %s\n", page.Description)
+		}
+		if page.FeatureFlag != "" {
+			fmt.Fprintf(&sb, "- Feature flag: %s\n", page.FeatureFlag)
+		}
+		if len(page.SourceFiles) > 0 {
+			sb.WriteString("- Likely source files (for reference — do not assume contents):\n")
+			for _, p := range page.SourceFiles {
+				fmt.Fprintf(&sb, "  - %s\n", p)
+			}
+		}
+	}
+	sb.WriteString("\n")
+
+	if trimmed := strings.TrimSpace(feedback); trimmed != "" {
+		sb.WriteString("## User feedback\n")
+		sb.WriteString("Treat the following feedback as guidance from the project owner. It overrides your default judgement where they conflict.\n\n")
+		sb.WriteString(trimmed)
+		sb.WriteString("\n\n")
+	}
+
+	fmt.Fprintf(&sb, `## Output format
+
+Return plain GitHub-flavored markdown — NOT JSON, NOT wrapped in a code fence. Keep the entire response under %d characters; be concise and concrete. Use these sections in order:
+
+### Scope
+One short paragraph describing what this plan covers.
+
+### Files to touch
+A bulleted list of the specific files (or new files) you expect to add or modify. Mark new files with "(new)".
+
+### Acceptance criteria
+A bulleted list of observable conditions that must all be true for the work to be considered done. Each bullet should be testable from the user's or maintainer's perspective.
+
+### Non-goals
+A bulleted list of things this plan deliberately does NOT cover, to prevent scope creep.
+
+Do not include source code, large diff blocks, or speculation about contents you have not been shown.
+`, maxPlanResponseChars)
+
+	return sb.String()
+}
+
+// indentBlock prefixes every line of s with prefix. Used to nest a multi-line
+// suggestion body under a bullet without breaking markdown rendering.
+func indentBlock(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/suggestions/plan_prompt_test.go
+++ b/internal/suggestions/plan_prompt_test.go
@@ -1,0 +1,120 @@
+package suggestions
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPlanPromptIncludesSuggestionFields(t *testing.T) {
+	s := Suggestion{
+		PageSlug: "weather",
+		Type:     TypeImprovement,
+		Size:     SizeM,
+		Title:    "Cache the forecast",
+		Body:     "Add a 10-minute in-memory cache.",
+	}
+	page := &Page{
+		Slug:        "weather",
+		Title:       "Weather",
+		Route:       "/weather",
+		Description: "Multi-day forecast.",
+		FeatureFlag: "weather",
+		SourceFiles: []string{"web/src/pages/Weather.tsx"},
+	}
+
+	prompt := buildPlanPrompt(s, page, "")
+
+	for _, want := range []string{
+		"Cache the forecast",
+		"Add a 10-minute in-memory cache.",
+		"Slug: weather",
+		"Route: /weather",
+		"Feature flag: weather",
+		"web/src/pages/Weather.tsx",
+		"### Scope",
+		"### Files to touch",
+		"### Acceptance criteria",
+		"### Non-goals",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("expected prompt to contain %q, missing.\nFull prompt:\n%s", want, prompt)
+		}
+	}
+
+	if strings.Contains(prompt, "## User feedback") {
+		t.Errorf("did not expect a User feedback section when feedback is empty")
+	}
+	if strings.Contains(prompt, "JSON") && !strings.Contains(prompt, "NOT JSON") {
+		t.Errorf("plan prompt should explicitly forbid JSON output")
+	}
+}
+
+func TestBuildPlanPromptHandlesNilPageForNewPageSlug(t *testing.T) {
+	s := Suggestion{
+		PageSlug: NewPageSlug,
+		Type:     TypeNewPage,
+		Size:     SizeL,
+		Title:    "Add expense tracker",
+		Body:     "A new page that tracks expenses.",
+	}
+
+	prompt := buildPlanPrompt(s, nil, "")
+
+	if !strings.Contains(prompt, "__new_page__") {
+		t.Errorf("expected greenfield notice referencing __new_page__, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "greenfield") && !strings.Contains(prompt, "brand-new page") {
+		t.Errorf("expected the prompt to indicate this is a brand-new page, got:\n%s", prompt)
+	}
+}
+
+func TestBuildPlanPromptHandlesNilPageForUnknownSlug(t *testing.T) {
+	s := Suggestion{
+		PageSlug: "deprecated-page",
+		Type:     TypeImprovement,
+		Size:     SizeS,
+		Title:    "Tweak something",
+		Body:     "Detail.",
+	}
+
+	prompt := buildPlanPrompt(s, nil, "")
+
+	if !strings.Contains(prompt, "deprecated-page") {
+		t.Errorf("expected the unknown slug to appear in the prompt, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "not in the registry") {
+		t.Errorf("expected the prompt to note the page is missing from the registry, got:\n%s", prompt)
+	}
+}
+
+func TestBuildPlanPromptIncludesFeedbackVerbatim(t *testing.T) {
+	s := Suggestion{
+		PageSlug: "weather",
+		Type:     TypeImprovement,
+		Size:     SizeS,
+		Title:    "Cache the forecast",
+		Body:     "Add caching.",
+	}
+	page := &Page{Slug: "weather", Title: "Weather"}
+	feedback := "Please use Redis instead of an in-memory map; we already run Redis for sessions."
+
+	prompt := buildPlanPrompt(s, page, feedback)
+
+	if !strings.Contains(prompt, "## User feedback") {
+		t.Errorf("expected a User feedback section, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, feedback) {
+		t.Errorf("expected feedback %q to appear verbatim in prompt, got:\n%s", feedback, prompt)
+	}
+}
+
+func TestBuildPlanPromptIgnoresWhitespaceOnlyFeedback(t *testing.T) {
+	s := Suggestion{PageSlug: "weather", Type: TypeImprovement, Size: SizeS, Title: "T", Body: "B"}
+	page := &Page{Slug: "weather", Title: "Weather"}
+
+	prompt := buildPlanPrompt(s, page, "   \n\t  ")
+
+	if strings.Contains(prompt, "## User feedback") {
+		t.Errorf("whitespace-only feedback should not produce a feedback section, got:\n%s", prompt)
+	}
+}

--- a/internal/suggestions/store.go
+++ b/internal/suggestions/store.go
@@ -189,7 +189,7 @@ func MarkPlanned(ctx context.Context, db *sql.DB, id int64, plan string) error {
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := db.ExecContext(ctx, `
-		UPDATE suggestions SET status = ?, plan_enc = ?, planned_at = ? WHERE id = ?
+		UPDATE suggestions SET status = ?, plan_enc = ?, planned_at = ?, rejected_at = NULL WHERE id = ?
 	`, StatusPlanned, nullableEncrypted(encPlan), now, id)
 	if err != nil {
 		return fmt.Errorf("mark planned: %w", err)


### PR DESCRIPTION
## Changes

- **Suggestions: plan endpoint** - New `POST /api/suggestions/{id}/plan` admin endpoint asks Claude for a concrete implementation plan (scope, files, acceptance criteria, non-goals) and persists it on the suggestion. Supports an optional feedback string for re-planning. (Hytte-phzn)

## Original Issue (task): Backend: plan endpoint + plan prompt

Add internal/suggestions/plan_prompt.go exposing buildPlanPrompt(suggestion Suggestion, page *Page, feedback string) string — prompt asks Claude for a concrete implementation plan (scope, files to touch, acceptance criteria, non-goals) as plain markdown (NOT JSON), under ~3KB, no source files included; handle page=nil gracefully when page_slug is "__new_page__" or no longer in registry. Add POST /api/suggestions/{id}/plan handler accepting { feedback?: string }, invoking Claude via the runPromptFn package-variable pattern (mirror generate.go), synchronous with a 120s timeout, calling store.MarkPlanned to persist plan + planned_at and set status=planned; not idempotent (re-planning replaces). Returns updated Suggestion. Tests in handlers_test.go: admin gating, success path with mocked runPromptFn, feedback round-trip into prompt, 404 on missing id, timeout behaviour. Depends on sub-task 1 for the suggestion store/data shape; consumed by the frontend in sub-task 3.

---
Bead: Hytte-phzn | Branch: forge/Hytte-phzn
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)