### PR TITLE
Suggestion card component: chips, badges, body, metadata (Hytte-iyg9)

### DIFF
--- a/changelog.d/Hytte-iyg9.md
+++ b/changelog.d/Hytte-iyg9.md
@@ -1,0 +1,2 @@
+category: Added
+- **Suggestion card component** - Filled in the `SuggestionCard` placeholder with a page-slug chip, color-coded type badge (addition/bugfix/improvement/refactor/new_page), S/M/L size pill, title, expandable body (collapsed by default with show more/less), source indicator (by Claude/by you), and a formatted generated date. The card accepts an `actionsSlot` prop so a follow-up sub-task can inject status-specific actions without coupling the card to mutations. (Hytte-iyg9)

--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -56,6 +56,26 @@
     "errors": {
       "failedToLoad": "Failed to load suggestions",
       "runFailed": "Failed to run suggestions"
+    },
+    "card": {
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "types": {
+        "addition": "Addition",
+        "bugfix": "Bugfix",
+        "improvement": "Improvement",
+        "refactor": "Refactor",
+        "new_page": "New page"
+      },
+      "sizes": {
+        "s": "S",
+        "m": "M",
+        "l": "L"
+      },
+      "source": {
+        "claude": "by Claude",
+        "user": "by you"
+      }
     }
   },
   "actions": {

--- a/web/public/locales/nb/common.json
+++ b/web/public/locales/nb/common.json
@@ -56,6 +56,26 @@
     "errors": {
       "failedToLoad": "Kunne ikke laste forslag",
       "runFailed": "Kunne ikke kjøre forslag"
+    },
+    "card": {
+      "showMore": "Vis mer",
+      "showLess": "Vis mindre",
+      "types": {
+        "addition": "Tillegg",
+        "bugfix": "Feilretting",
+        "improvement": "Forbedring",
+        "refactor": "Refaktorering",
+        "new_page": "Ny side"
+      },
+      "sizes": {
+        "s": "S",
+        "m": "M",
+        "l": "L"
+      },
+      "source": {
+        "claude": "av Claude",
+        "user": "av deg"
+      }
     }
   },
   "actions": {

--- a/web/public/locales/th/common.json
+++ b/web/public/locales/th/common.json
@@ -56,6 +56,26 @@
     "errors": {
       "failedToLoad": "โหลดข้อเสนอแนะไม่สำเร็จ",
       "runFailed": "เรียกใช้ข้อเสนอแนะไม่สำเร็จ"
+    },
+    "card": {
+      "showMore": "แสดงเพิ่มเติม",
+      "showLess": "แสดงน้อยลง",
+      "types": {
+        "addition": "เพิ่มเติม",
+        "bugfix": "แก้บั๊ก",
+        "improvement": "ปรับปรุง",
+        "refactor": "ปรับโครงสร้าง",
+        "new_page": "หน้าใหม่"
+      },
+      "sizes": {
+        "s": "S",
+        "m": "M",
+        "l": "L"
+      },
+      "source": {
+        "claude": "โดย Claude",
+        "user": "โดยคุณ"
+      }
     }
   },
   "actions": {

--- a/web/src/components/suggestions/SuggestionCard.tsx
+++ b/web/src/components/suggestions/SuggestionCard.tsx
@@ -1,3 +1,8 @@
+import { useState, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { formatDate } from '../../utils/formatDate'
+
 export type SuggestionStatus = 'pending' | 'planned' | 'rejected' | 'bead_created'
 
 export type SuggestionSource = 'claude' | 'user'
@@ -27,17 +32,98 @@ export interface Suggestion {
 
 export interface SuggestionCardProps {
   suggestion: Suggestion
-  onPlan: (id: number) => void
-  onReject: (id: number) => void
+  actionsSlot?: ReactNode
 }
 
-export function SuggestionCard({ suggestion }: SuggestionCardProps) {
+export function typeBadgeClass(type: SuggestionType): string {
+  switch (type) {
+    case 'addition':
+      return 'border-green-500/40 bg-green-500/15 text-green-300'
+    case 'bugfix':
+      return 'border-red-500/40 bg-red-500/15 text-red-300'
+    case 'improvement':
+      return 'border-blue-500/40 bg-blue-500/15 text-blue-300'
+    case 'refactor':
+      return 'border-amber-500/40 bg-amber-500/15 text-amber-300'
+    case 'new_page':
+      return 'border-purple-500/40 bg-purple-500/15 text-purple-300'
+  }
+}
+
+const COLLAPSED_BODY_LIMIT = 240
+
+export function SuggestionCard({ suggestion, actionsSlot }: SuggestionCardProps) {
+  const { t } = useTranslation('common')
+  const [expanded, setExpanded] = useState(false)
+
+  const body = suggestion.body ?? ''
+  const isLong = body.length > COLLAPSED_BODY_LIMIT
+  const visibleBody = isLong && !expanded
+    ? `${body.slice(0, COLLAPSED_BODY_LIMIT).trimEnd()}…`
+    : body
+
+  const typeLabel = t(`suggestions.card.types.${suggestion.type}`)
+  const sizeLabel = t(`suggestions.card.sizes.${suggestion.size}`)
+  const sourceLabel = t(`suggestions.card.source.${suggestion.source}`)
+  const generatedDate = formatDate(suggestion.generated_at, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+
   return (
     <article
       data-suggestion-id={suggestion.id}
       className="rounded-lg border border-gray-700 bg-gray-800 p-4 text-sm text-gray-200"
     >
-      <h3 className="font-medium text-white break-words">{suggestion.title}</h3>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="inline-flex max-w-full items-center rounded-full border border-gray-600 bg-gray-700/60 px-2 py-0.5 text-xs font-medium text-gray-300 break-all">
+          {suggestion.page_slug}
+        </span>
+        <span
+          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${typeBadgeClass(suggestion.type)}`}
+        >
+          {typeLabel}
+        </span>
+        <span className="inline-flex items-center rounded-full border border-gray-600 bg-gray-700/60 px-2 py-0.5 text-xs font-semibold text-gray-200">
+          {sizeLabel}
+        </span>
+      </div>
+
+      <h3 className="mt-3 font-medium text-white break-words">{suggestion.title}</h3>
+
+      {body && (
+        <div className="mt-2">
+          <p className="whitespace-pre-wrap break-words text-sm text-gray-300">
+            {visibleBody}
+          </p>
+          {isLong && (
+            <button
+              type="button"
+              onClick={() => setExpanded(prev => !prev)}
+              aria-expanded={expanded}
+              className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-blue-300 hover:text-blue-200"
+            >
+              {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+              <span>
+                {expanded ? t('suggestions.card.showLess') : t('suggestions.card.showMore')}
+              </span>
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-400">
+        <span>{sourceLabel}</span>
+        <span aria-hidden="true">·</span>
+        <time dateTime={suggestion.generated_at}>{generatedDate}</time>
+      </div>
+
+      {actionsSlot && (
+        <div className="mt-3 flex flex-wrap gap-2 border-t border-gray-700/60 pt-3">
+          {actionsSlot}
+        </div>
+      )}
     </article>
   )
 }

--- a/web/src/components/suggestions/SuggestionCard.tsx
+++ b/web/src/components/suggestions/SuggestionCard.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronDown, ChevronUp } from 'lucide-react'
-import { formatDate } from '../../utils/formatDate'
 
 export type SuggestionStatus = 'pending' | 'planned' | 'rejected' | 'bead_created'
 
@@ -52,8 +51,17 @@ function typeBadgeClass(type: SuggestionType): string {
 
 const COLLAPSED_BODY_LIMIT = 240
 
+function formatLocalDate(dateStr: string, language: string, options?: Intl.DateTimeFormatOptions): string {
+  const d = new Date(dateStr)
+  const opts: Intl.DateTimeFormatOptions = { ...options }
+  if (language === 'th' || language.startsWith('th-')) {
+    opts.calendar = 'gregory'
+  }
+  return d.toLocaleDateString(language, opts)
+}
+
 export function SuggestionCard({ suggestion, actionsSlot }: SuggestionCardProps) {
-  const { t } = useTranslation('common')
+  const { t, i18n } = useTranslation('common')
   const [expanded, setExpanded] = useState(false)
 
   const body = suggestion.body ?? ''
@@ -62,10 +70,12 @@ export function SuggestionCard({ suggestion, actionsSlot }: SuggestionCardProps)
     ? `${body.slice(0, COLLAPSED_BODY_LIMIT).trimEnd()}…`
     : body
 
+  const bodyId = `suggestion-body-${suggestion.id}`
+
   const typeLabel = t(`suggestions.card.types.${suggestion.type}`)
   const sizeLabel = t(`suggestions.card.sizes.${suggestion.size}`)
   const sourceLabel = t(`suggestions.card.source.${suggestion.source}`)
-  const generatedDate = formatDate(suggestion.generated_at, {
+  const generatedDate = formatLocalDate(suggestion.generated_at, i18n.language, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -94,7 +104,7 @@ export function SuggestionCard({ suggestion, actionsSlot }: SuggestionCardProps)
 
       {body && (
         <div className="mt-2">
-          <p className="whitespace-pre-wrap break-words text-sm text-gray-300">
+          <p id={bodyId} className="whitespace-pre-wrap break-words text-sm text-gray-300">
             {visibleBody}
           </p>
           {isLong && (
@@ -102,9 +112,10 @@ export function SuggestionCard({ suggestion, actionsSlot }: SuggestionCardProps)
               type="button"
               onClick={() => setExpanded(prev => !prev)}
               aria-expanded={expanded}
+              aria-controls={bodyId}
               className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-blue-300 hover:text-blue-200"
             >
-              {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+              {expanded ? <ChevronUp size={14} aria-hidden={true} /> : <ChevronDown size={14} aria-hidden={true} />}
               <span>
                 {expanded ? t('suggestions.card.showLess') : t('suggestions.card.showMore')}
               </span>

--- a/web/src/components/suggestions/SuggestionCard.tsx
+++ b/web/src/components/suggestions/SuggestionCard.tsx
@@ -35,7 +35,7 @@ export interface SuggestionCardProps {
   actionsSlot?: ReactNode
 }
 
-export function typeBadgeClass(type: SuggestionType): string {
+function typeBadgeClass(type: SuggestionType): string {
   switch (type) {
     case 'addition':
       return 'border-green-500/40 bg-green-500/15 text-green-300'

--- a/web/src/pages/Suggestions.tsx
+++ b/web/src/pages/Suggestions.tsx
@@ -93,20 +93,6 @@ export default function Suggestions() {
     // Wired up by a follow-up sub-task that adds the create-suggestion form.
   }
 
-  const handlePlan = useCallback(
-    (_id: number) => {
-      refetch()
-    },
-    [refetch],
-  )
-
-  const handleReject = useCallback(
-    (_id: number) => {
-      refetch()
-    },
-    [refetch],
-  )
-
   function renderPanel(tab: TabKey, list: Suggestion[]) {
     if (list.length === 0) {
       return (
@@ -118,12 +104,7 @@ export default function Suggestions() {
     return (
       <div className="space-y-3">
         {list.map(s => (
-          <SuggestionCard
-            key={s.id}
-            suggestion={s}
-            onPlan={handlePlan}
-            onReject={handleReject}
-          />
+          <SuggestionCard key={s.id} suggestion={s} />
         ))}
       </div>
     )


### PR DESCRIPTION
## Changes

- **Suggestion card component** - Filled in the `SuggestionCard` placeholder with a page-slug chip, color-coded type badge (addition/bugfix/improvement/refactor/new_page), S/M/L size pill, title, expandable body (collapsed by default with show more/less), source indicator (by Claude/by you), and a formatted generated date. The card accepts an `actionsSlot` prop so a follow-up sub-task can inject status-specific actions without coupling the card to mutations. (Hytte-iyg9)

## Original Issue (task): Suggestion card component: chips, badges, body, metadata

Create web/src/components/SuggestionCard.tsx rendering one suggestion: page-slug chip, color-coded type badge (addition=green, bugfix=red, improvement=blue, refactor=amber, new_page=purple) via a small typeBadgeClass(type) helper, S/M/L size pill, title, expandable body (toggle with local useState; collapsed by default with show more/less), source indicator ('by Claude' vs 'by you' from suggestion.source), generated date (formatted). Tailwind dark theme, mobile-first 375px with wrapping badges and no fixed widths. Accept props { suggestion, actionsSlot?: ReactNode } so sub-task 3 can inject status-specific action UI without coupling card to mutations. Consumed by Suggestions.tsx (sub-task 1).

---
Bead: Hytte-iyg9 | Branch: forge/Hytte-iyg9
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)