### PR TITLE
Status-specific actions: Pending plan/reject form and Planned markdown view (Hytte-k8tl)

### DIFF
--- a/changelog.d/Hytte-k8tl.md
+++ b/changelog.d/Hytte-k8tl.md
@@ -1,0 +1,2 @@
+category: Added
+- **Suggestion actions: plan & reject** - Pending suggestions now offer a Reject button and an inline Plan-it form (with optional feedback) that calls the synchronous plan endpoint and refreshes the list on success. Planned suggestions render the saved plan as markdown next to a disabled Create-bead button. (Hytte-k8tl)

--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -41,7 +41,17 @@
     "actions": {
       "runNow": "Run now",
       "running": "Running…",
-      "newSuggestion": "New suggestion"
+      "newSuggestion": "New suggestion",
+      "reject": "Reject",
+      "rejecting": "Rejecting…",
+      "planIt": "Plan it",
+      "planning": "Planning…",
+      "planHint": "Planning may take up to two minutes.",
+      "feedbackLabel": "Feedback (optional)",
+      "feedbackPlaceholder": "Add context for the planner…",
+      "noPlanYet": "No plan saved yet.",
+      "createBead": "Create bead",
+      "createBeadDisabledTooltip": "Bead creation lands in the next bead."
     },
     "tabs": {
       "pending": "Pending",
@@ -55,7 +65,9 @@
     },
     "errors": {
       "failedToLoad": "Failed to load suggestions",
-      "runFailed": "Failed to run suggestions"
+      "runFailed": "Failed to run suggestions",
+      "rejectFailed": "Failed to reject suggestion",
+      "planFailed": "Failed to plan suggestion"
     },
     "card": {
       "showMore": "Show more",

--- a/web/public/locales/nb/common.json
+++ b/web/public/locales/nb/common.json
@@ -41,7 +41,17 @@
     "actions": {
       "runNow": "Kjør nå",
       "running": "Kjører…",
-      "newSuggestion": "Nytt forslag"
+      "newSuggestion": "Nytt forslag",
+      "reject": "Avvis",
+      "rejecting": "Avviser…",
+      "planIt": "Planlegg",
+      "planning": "Planlegger…",
+      "planHint": "Planlegging kan ta opptil to minutter.",
+      "feedbackLabel": "Tilbakemelding (valgfritt)",
+      "feedbackPlaceholder": "Legg til kontekst for planleggeren…",
+      "noPlanYet": "Ingen plan lagret ennå.",
+      "createBead": "Opprett bead",
+      "createBeadDisabledTooltip": "Bead-opprettelse kommer i neste bead."
     },
     "tabs": {
       "pending": "Avventer",
@@ -55,7 +65,9 @@
     },
     "errors": {
       "failedToLoad": "Kunne ikke laste forslag",
-      "runFailed": "Kunne ikke kjøre forslag"
+      "runFailed": "Kunne ikke kjøre forslag",
+      "rejectFailed": "Kunne ikke avvise forslag",
+      "planFailed": "Kunne ikke planlegge forslag"
     },
     "card": {
       "showMore": "Vis mer",

--- a/web/public/locales/th/common.json
+++ b/web/public/locales/th/common.json
@@ -41,7 +41,17 @@
     "actions": {
       "runNow": "ทำงานเดี๋ยวนี้",
       "running": "กำลังทำงาน…",
-      "newSuggestion": "ข้อเสนอแนะใหม่"
+      "newSuggestion": "ข้อเสนอแนะใหม่",
+      "reject": "ปฏิเสธ",
+      "rejecting": "กำลังปฏิเสธ…",
+      "planIt": "วางแผน",
+      "planning": "กำลังวางแผน…",
+      "planHint": "การวางแผนอาจใช้เวลานานถึงสองนาที",
+      "feedbackLabel": "ข้อคิดเห็น (ไม่บังคับ)",
+      "feedbackPlaceholder": "เพิ่มบริบทสำหรับผู้วางแผน…",
+      "noPlanYet": "ยังไม่มีการบันทึกแผน",
+      "createBead": "สร้าง bead",
+      "createBeadDisabledTooltip": "การสร้าง bead จะมาในงานถัดไป"
     },
     "tabs": {
       "pending": "รอดำเนินการ",
@@ -55,7 +65,9 @@
     },
     "errors": {
       "failedToLoad": "โหลดข้อเสนอแนะไม่สำเร็จ",
-      "runFailed": "เรียกใช้ข้อเสนอแนะไม่สำเร็จ"
+      "runFailed": "เรียกใช้ข้อเสนอแนะไม่สำเร็จ",
+      "rejectFailed": "ปฏิเสธข้อเสนอแนะไม่สำเร็จ",
+      "planFailed": "วางแผนข้อเสนอแนะไม่สำเร็จ"
     },
     "card": {
       "showMore": "แสดงเพิ่มเติม",

--- a/web/src/components/suggestions/SuggestionActions.tsx
+++ b/web/src/components/suggestions/SuggestionActions.tsx
@@ -7,7 +7,7 @@ import type { Suggestion } from './SuggestionCard'
 
 export interface SuggestionActionsProps {
   suggestion: Suggestion
-  onPlanned?: () => void
+  onPlanned?: (updated: Suggestion) => void
   onRejected?: () => void
 }
 
@@ -98,10 +98,18 @@ function PendingActions({
         body: JSON.stringify(trimmed ? { feedback: trimmed } : {}),
       })
       if (!res.ok) {
-        throw new Error(t('suggestions.errors.planFailed'))
+        let msg = t('suggestions.errors.planFailed')
+        try {
+          const body = await res.json() as { error?: string }
+          if (body?.error) msg = body.error
+        } catch {
+          // keep generic message if body parse fails
+        }
+        throw new Error(msg)
       }
+      const updated = await res.json() as Suggestion
       setFeedback('')
-      onPlanned?.()
+      onPlanned?.(updated)
     } catch (err) {
       setError(err instanceof Error ? err.message : t('suggestions.errors.planFailed'))
     } finally {
@@ -171,7 +179,7 @@ function PendingActions({
 function PlannedActions({ suggestion }: { suggestion: Suggestion }) {
   const { t } = useTranslation('common')
   const plan = suggestion.plan ?? ''
-  const tooltip = t('suggestions.actions.createBeadDisabledTooltip')
+  const beadDescId = `suggestion-${suggestion.id}-bead-desc`
 
   return (
     <div className="w-full space-y-3">
@@ -189,15 +197,20 @@ function PlannedActions({ suggestion }: { suggestion: Suggestion }) {
           {t('suggestions.actions.noPlanYet')}
         </p>
       )}
-      <button
-        type="button"
-        disabled
-        title={tooltip}
-        aria-label={tooltip}
-        className="inline-flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-1.5 text-xs font-medium text-gray-400 cursor-not-allowed opacity-70"
-      >
-        {t('suggestions.actions.createBead')}
-      </button>
+      <div className="space-y-1">
+        <button
+          type="button"
+          aria-disabled="true"
+          aria-describedby={beadDescId}
+          onClick={e => e.preventDefault()}
+          className="inline-flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-1.5 text-xs font-medium text-gray-400 cursor-not-allowed opacity-70"
+        >
+          {t('suggestions.actions.createBead')}
+        </button>
+        <p id={beadDescId} className="text-xs text-gray-500">
+          {t('suggestions.actions.createBeadDisabledTooltip')}
+        </p>
+      </div>
     </div>
   )
 }

--- a/web/src/components/suggestions/SuggestionActions.tsx
+++ b/web/src/components/suggestions/SuggestionActions.tsx
@@ -1,0 +1,203 @@
+import { useState, type AnchorHTMLAttributes, type FormEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2 } from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import type { Suggestion } from './SuggestionCard'
+
+export interface SuggestionActionsProps {
+  suggestion: Suggestion
+  onPlanned?: () => void
+  onRejected?: () => void
+}
+
+const SAFE_URL_PROTOCOLS = ['http:', 'https:', 'mailto:', 'tel:'] as const
+
+function getSafeHref(href?: string): string | undefined {
+  if (!href) return undefined
+  if (href.startsWith('/') || href.startsWith('#')) return href
+  try {
+    const url = new URL(href, window.location.origin)
+    if (SAFE_URL_PROTOCOLS.includes(url.protocol as (typeof SAFE_URL_PROTOCOLS)[number])) {
+      return href
+    }
+  } catch {
+    // If parsing fails, treat as unsafe
+  }
+  return undefined
+}
+
+const markdownComponents = {
+  a: ({ children, href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) => {
+    const safeHref = getSafeHref(typeof href === 'string' ? href : undefined)
+    if (!safeHref) {
+      return <span>{children}</span>
+    }
+    return (
+      <a {...props} href={safeHref} target="_blank" rel="noopener noreferrer">
+        {children}
+      </a>
+    )
+  },
+}
+
+export function SuggestionActions({ suggestion, onPlanned, onRejected }: SuggestionActionsProps) {
+  if (suggestion.status === 'pending') {
+    return <PendingActions suggestion={suggestion} onPlanned={onPlanned} onRejected={onRejected} />
+  }
+  if (suggestion.status === 'planned') {
+    return <PlannedActions suggestion={suggestion} />
+  }
+  return null
+}
+
+function PendingActions({
+  suggestion,
+  onPlanned,
+  onRejected,
+}: SuggestionActionsProps) {
+  const { t } = useTranslation('common')
+  const [feedback, setFeedback] = useState('')
+  const [submitting, setSubmitting] = useState<'plan' | 'reject' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const isBusy = submitting !== null
+  const feedbackId = `suggestion-feedback-${suggestion.id}`
+
+  async function handleReject() {
+    if (isBusy) return
+    setSubmitting('reject')
+    setError(null)
+    try {
+      const res = await fetch(`/api/suggestions/${suggestion.id}/reject`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        throw new Error(t('suggestions.errors.rejectFailed'))
+      }
+      onRejected?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('suggestions.errors.rejectFailed'))
+    } finally {
+      setSubmitting(null)
+    }
+  }
+
+  async function handlePlan(e: FormEvent) {
+    e.preventDefault()
+    if (isBusy) return
+    setSubmitting('plan')
+    setError(null)
+    try {
+      const trimmed = feedback.trim()
+      const res = await fetch(`/api/suggestions/${suggestion.id}/plan`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(trimmed ? { feedback: trimmed } : {}),
+      })
+      if (!res.ok) {
+        throw new Error(t('suggestions.errors.planFailed'))
+      }
+      setFeedback('')
+      onPlanned?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('suggestions.errors.planFailed'))
+    } finally {
+      setSubmitting(null)
+    }
+  }
+
+  return (
+    <form onSubmit={handlePlan} className="w-full space-y-2">
+      <label htmlFor={feedbackId} className="block text-xs font-medium text-gray-400">
+        {t('suggestions.actions.feedbackLabel')}
+      </label>
+      <textarea
+        id={feedbackId}
+        value={feedback}
+        onChange={e => setFeedback(e.target.value)}
+        disabled={isBusy}
+        placeholder={t('suggestions.actions.feedbackPlaceholder')}
+        rows={3}
+        className="w-full rounded-md border border-gray-700 bg-gray-900/60 px-3 py-2 text-sm text-gray-200 placeholder:text-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50"
+      />
+      <p className="text-xs text-gray-500">{t('suggestions.actions.planHint')}</p>
+      {error && (
+        <p
+          role="alert"
+          data-testid={`suggestion-${suggestion.id}-action-error`}
+          className="text-xs text-red-300"
+        >
+          {error}
+        </p>
+      )}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="submit"
+          disabled={isBusy}
+          className="inline-flex items-center gap-2 rounded-lg border border-blue-500/40 bg-blue-500/20 px-3 py-1.5 text-xs font-medium text-blue-300 hover:bg-blue-500/30 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting === 'plan' && (
+            <Loader2 size={14} className="animate-spin" aria-hidden={true} />
+          )}
+          <span>
+            {submitting === 'plan'
+              ? t('suggestions.actions.planning')
+              : t('suggestions.actions.planIt')}
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={handleReject}
+          disabled={isBusy}
+          className="inline-flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-300 hover:bg-red-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting === 'reject' && (
+            <Loader2 size={14} className="animate-spin" aria-hidden={true} />
+          )}
+          <span>
+            {submitting === 'reject'
+              ? t('suggestions.actions.rejecting')
+              : t('suggestions.actions.reject')}
+          </span>
+        </button>
+      </div>
+    </form>
+  )
+}
+
+function PlannedActions({ suggestion }: { suggestion: Suggestion }) {
+  const { t } = useTranslation('common')
+  const plan = suggestion.plan ?? ''
+  const tooltip = t('suggestions.actions.createBeadDisabledTooltip')
+
+  return (
+    <div className="w-full space-y-3">
+      {plan ? (
+        <div
+          className="prose prose-invert prose-sm max-w-none rounded-md border border-gray-700/60 bg-gray-900/40 px-3 py-2"
+          data-testid={`suggestion-${suggestion.id}-plan`}
+        >
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+            {plan}
+          </ReactMarkdown>
+        </div>
+      ) : (
+        <p className="text-xs italic text-gray-500">
+          {t('suggestions.actions.noPlanYet')}
+        </p>
+      )}
+      <button
+        type="button"
+        disabled
+        title={tooltip}
+        aria-label={tooltip}
+        className="inline-flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-1.5 text-xs font-medium text-gray-400 cursor-not-allowed opacity-70"
+      >
+        {t('suggestions.actions.createBead')}
+      </button>
+    </div>
+  )
+}

--- a/web/src/pages/Suggestions.test.tsx
+++ b/web/src/pages/Suggestions.test.tsx
@@ -6,6 +6,11 @@ import Suggestions from './Suggestions'
 import enCommon from '../../public/locales/en/common.json'
 import type { Suggestion } from '../components/suggestions/SuggestionCard'
 
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <span data-testid="markdown">{children}</span>,
+}))
+vi.mock('remark-gfm', () => ({ default: () => {} }))
+
 type JsonValue = string | number | boolean | null | JsonObject | JsonValue[]
 interface JsonObject { [key: string]: JsonValue }
 
@@ -310,5 +315,260 @@ describe('Suggestions – header', () => {
     expect(await screen.findByRole('heading', { level: 1, name: 'Suggestions' })).toBeInTheDocument()
     expect(screen.getByText('Next run: tonight 03:00')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /New suggestion/ })).toBeInTheDocument()
+  })
+})
+
+describe('Suggestions – plan action', () => {
+  it('plan it succeeds: moves card from pending to planned optimistically and refetches', async () => {
+    const pendingSuggestion = makeSuggestion({ id: 1, title: 'Plan me' })
+    const updatedSuggestion: Suggestion = { ...pendingSuggestion, status: 'planned', plan: '## Plan\n\nDo stuff' }
+    const initial = { pending: [pendingSuggestion], planned: [], rejected: [] }
+    const refreshed = { pending: [], planned: [updatedSuggestion], rejected: [] }
+
+    let listCalls = 0
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/1/plan' && init?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(updatedSuggestion) })
+      }
+      if (url === '/api/suggestions') {
+        listCalls += 1
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(listCalls === 1 ? initial : refreshed) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Plan me')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Plan it/ }))
+
+    await waitFor(() => {
+      // Card is optimistically removed from pending; empty state appears
+      expect(
+        screen.getByText('No pending suggestions yet — try Run now.'),
+      ).toBeInTheDocument()
+    })
+    expect(listCalls).toBeGreaterThanOrEqual(2)
+    expect(screen.queryByTestId('suggestion-1-action-error')).not.toBeInTheDocument()
+  })
+
+  it('plan it fails: surfaces actionable error from backend instead of generic message', async () => {
+    const pendingSuggestion = makeSuggestion({ id: 1, title: 'Plan me' })
+    const initial = { pending: [pendingSuggestion], planned: [], rejected: [] }
+
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/1/plan' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ error: 'Claude is not enabled' }),
+        })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(initial) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Plan me')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Plan it/ }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggestion-1-action-error')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('suggestion-1-action-error')).toHaveTextContent('Claude is not enabled')
+    // Card must remain in the pending list
+    expect(screen.getByText('Plan me')).toBeInTheDocument()
+  })
+
+  it('plan it fails without error body: shows generic fallback message', async () => {
+    const pendingSuggestion = makeSuggestion({ id: 1, title: 'Plan me' })
+    const initial = { pending: [pendingSuggestion], planned: [], rejected: [] }
+
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/1/plan' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: () => Promise.reject(new Error('no body')),
+        })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(initial) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Plan me')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Plan it/ }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggestion-1-action-error')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('suggestion-1-action-error')).toHaveTextContent('Failed to plan suggestion')
+  })
+})
+
+describe('Suggestions – reject action', () => {
+  it('reject succeeds: removes card from pending and refetches', async () => {
+    const pendingSuggestion = makeSuggestion({ id: 1, title: 'Reject me' })
+    const initial = { pending: [pendingSuggestion], planned: [], rejected: [] }
+    const refreshed = { pending: [], planned: [], rejected: [{ ...pendingSuggestion, status: 'rejected' as const }] }
+
+    let listCalls = 0
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/1/reject' && init?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+      }
+      if (url === '/api/suggestions') {
+        listCalls += 1
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(listCalls === 1 ? initial : refreshed) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Reject me')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Reject$/ }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No pending suggestions yet — try Run now.'),
+      ).toBeInTheDocument()
+    })
+    expect(listCalls).toBe(2)
+  })
+
+  it('reject fails: shows error message and keeps card visible', async () => {
+    const pendingSuggestion = makeSuggestion({ id: 1, title: 'Reject me' })
+    const initial = { pending: [pendingSuggestion], planned: [], rejected: [] }
+
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/1/reject' && init?.method === 'POST') {
+        return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(initial) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Reject me')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Reject$/ }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggestion-1-action-error')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('suggestion-1-action-error')).toHaveTextContent('Failed to reject suggestion')
+    expect(screen.getByText('Reject me')).toBeInTheDocument()
+  })
+})
+
+describe('Suggestions – planned tab', () => {
+  it('renders saved plan markdown for planned suggestions', async () => {
+    const plannedSuggestion = makeSuggestion({
+      id: 2,
+      title: 'My planned item',
+      status: 'planned',
+      plan: '## Implementation plan\n\nStep 1: do the thing',
+    })
+    const list = { pending: [], planned: [plannedSuggestion], rejected: [] }
+
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(list) }),
+    ))
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /Planned \(1\)/ })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('tab', { name: /Planned/ }))
+
+    await waitFor(() => {
+      const panel = screen.getByRole('tabpanel')
+      expect(within(panel).getByTestId('suggestion-2-plan')).toBeInTheDocument()
+    })
+
+    const planEl = screen.getByTestId('suggestion-2-plan')
+    expect(planEl).toHaveTextContent('## Implementation plan')
+    expect(planEl).toHaveTextContent('Step 1: do the thing')
+  })
+
+  it('shows "no plan yet" when planned suggestion has no plan text', async () => {
+    const plannedSuggestion = makeSuggestion({ id: 3, title: 'No plan yet', status: 'planned' })
+    const list = { pending: [], planned: [plannedSuggestion], rejected: [] }
+
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(list) }),
+    ))
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /Planned \(1\)/ })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('tab', { name: /Planned/ }))
+
+    await waitFor(() => {
+      expect(screen.getByText('No plan saved yet.')).toBeInTheDocument()
+    })
+  })
+
+  it('Create bead button is keyboard-focusable and shows its description', async () => {
+    const plannedSuggestion = makeSuggestion({ id: 4, title: 'Has plan', status: 'planned', plan: 'A plan' })
+    const list = { pending: [], planned: [plannedSuggestion], rejected: [] }
+
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(list) }),
+    ))
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /Planned/ })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('tab', { name: /Planned/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Create bead/ })).toBeInTheDocument()
+    })
+
+    const btn = screen.getByRole('button', { name: /Create bead/ })
+    // Must not be natively disabled (so keyboard can reach it)
+    expect(btn).not.toBeDisabled()
+    expect(btn).toHaveAttribute('aria-disabled', 'true')
+    // Visible description text must be present
+    expect(screen.getByText('Bead creation lands in the next bead.')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/Suggestions.tsx
+++ b/web/src/pages/Suggestions.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../components/ui/skeleton'
 import { Tabs, TabList, TabTrigger, TabPanel } from '../components/ui/tabs'
 import { SuggestionCard, type Suggestion } from '../components/suggestions/SuggestionCard'
+import { SuggestionActions } from '../components/suggestions/SuggestionActions'
 
 type TabKey = 'pending' | 'planned' | 'rejected'
 
@@ -104,7 +105,19 @@ export default function Suggestions() {
     return (
       <div className="space-y-3">
         {list.map(s => (
-          <SuggestionCard key={s.id} suggestion={s} />
+          <SuggestionCard
+            key={s.id}
+            suggestion={s}
+            actionsSlot={
+              s.status === 'rejected' ? null : (
+                <SuggestionActions
+                  suggestion={s}
+                  onPlanned={refetch}
+                  onRejected={refetch}
+                />
+              )
+            }
+          />
         ))}
       </div>
     )

--- a/web/src/pages/Suggestions.tsx
+++ b/web/src/pages/Suggestions.tsx
@@ -31,6 +31,12 @@ export default function Suggestions() {
     setReloadKey(k => k + 1)
   }, [])
 
+  const handlePlanned = useCallback((updated: Suggestion) => {
+    setPending(prev => prev.filter(s => s.id !== updated.id))
+    setPlanned(prev => [updated, ...prev])
+    refetch()
+  }, [refetch])
+
   const failedToLoadMsg = t('suggestions.errors.failedToLoad')
 
   useEffect(() => {
@@ -112,7 +118,7 @@ export default function Suggestions() {
               s.status === 'rejected' ? null : (
                 <SuggestionActions
                   suggestion={s}
-                  onPlanned={refetch}
+                  onPlanned={handlePlanned}
                   onRejected={refetch}
                 />
               )


### PR DESCRIPTION
## Changes

- **Suggestion actions: plan & reject** - Pending suggestions now offer a Reject button and an inline Plan-it form (with optional feedback) that calls the synchronous plan endpoint and refreshes the list on success. Planned suggestions render the saved plan as markdown next to a disabled Create-bead button. (Hytte-k8tl)

## Original Issue (task): Status-specific actions: Pending plan/reject form and Planned markdown view

Implement action panels rendered inside SuggestionCard's actionsSlot based on status. Pending: Reject button (POST /api/suggestions/{id}/reject or equivalent — use whatever endpoint convention the sibling fetcher uses; if undefined, stub with TODO and surface via callback to parent) and inline 'Plan it' form with optional feedback <textarea> + submit triggering POST /api/suggestions/{id}/plan; show loading spinner and disable inputs during the up-to-2-minute sync wait; on success, refresh the list (callback up to sub-task 1). Planned: render suggestion.plan markdown (use existing markdown renderer if present, else a minimal safe renderer) and a DISABLED 'Create bead' button with tooltip 'Bead creation lands in the next bead.' Rejected: render nothing in actions. Place in web/src/components/SuggestionActions.tsx. Wire mutation callbacks back to Suggestions.tsx (sub-task 1) so list state updates after plan/reject.

---
Bead: Hytte-k8tl | Branch: forge/Hytte-k8tl
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)