### PR TITLE
'+ New suggestion' modal/form with validation and submit (Hytte-ym34)

### DIFF
--- a/changelog.d/Hytte-ym34.md
+++ b/changelog.d/Hytte-ym34.md
@@ -1,0 +1,2 @@
+category: Added
+- **New suggestion form** - The Suggestions page can now author user suggestions via a modal opened from the "+ New suggestion" button: page picker (loaded from `/api/suggestions/pages`), title (≤120 chars), body (≤4 KB), type, and size dropdowns with inline validation. Successful submission posts to `/api/suggestions` and refreshes the list. (Hytte-ym34)

--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -69,6 +69,42 @@
       "rejectFailed": "Failed to reject suggestion",
       "planFailed": "Failed to plan suggestion"
     },
+    "form": {
+      "title": "New suggestion",
+      "fields": {
+        "page": "Page",
+        "title": "Title",
+        "body": "Body",
+        "type": "Type",
+        "size": "Size"
+      },
+      "placeholders": {
+        "page": "Select a page",
+        "title": "Short summary…",
+        "body": "Describe what you'd like to see",
+        "type": "Select a type",
+        "size": "Select a size"
+      },
+      "charCount": "{{count}}/{{max}}",
+      "byteCount": "{{count}} / {{max}} bytes",
+      "actions": {
+        "submit": "Create suggestion",
+        "submitting": "Creating…",
+        "cancel": "Cancel"
+      },
+      "errors": {
+        "titleRequired": "Title is required",
+        "titleTooLong": "Title must be at most {{max}} characters",
+        "bodyRequired": "Body is required",
+        "bodyTooLong": "Body must be at most {{max}} bytes",
+        "pageRequired": "Page is required",
+        "typeRequired": "Type is required",
+        "sizeRequired": "Size is required",
+        "newPageMismatch": "New page type can only target the New page entry",
+        "failedToCreate": "Failed to create suggestion",
+        "failedToLoadPages": "Failed to load pages"
+      }
+    },
     "card": {
       "showMore": "Show more",
       "showLess": "Show less",

--- a/web/public/locales/nb/common.json
+++ b/web/public/locales/nb/common.json
@@ -69,6 +69,42 @@
       "rejectFailed": "Kunne ikke avvise forslag",
       "planFailed": "Kunne ikke planlegge forslag"
     },
+    "form": {
+      "title": "Nytt forslag",
+      "fields": {
+        "page": "Side",
+        "title": "Tittel",
+        "body": "Innhold",
+        "type": "Type",
+        "size": "Størrelse"
+      },
+      "placeholders": {
+        "page": "Velg en side",
+        "title": "Kort sammendrag…",
+        "body": "Beskriv hva du ønsker å se",
+        "type": "Velg en type",
+        "size": "Velg en størrelse"
+      },
+      "charCount": "{{count}}/{{max}}",
+      "byteCount": "{{count}} / {{max}} byte",
+      "actions": {
+        "submit": "Opprett forslag",
+        "submitting": "Oppretter…",
+        "cancel": "Avbryt"
+      },
+      "errors": {
+        "titleRequired": "Tittel er påkrevd",
+        "titleTooLong": "Tittelen kan være maks {{max}} tegn",
+        "bodyRequired": "Innhold er påkrevd",
+        "bodyTooLong": "Innhold kan være maks {{max}} byte",
+        "pageRequired": "Side er påkrevd",
+        "typeRequired": "Type er påkrevd",
+        "sizeRequired": "Størrelse er påkrevd",
+        "newPageMismatch": "Type «Ny side» kan bare peke på oppføringen «Ny side»",
+        "failedToCreate": "Kunne ikke opprette forslag",
+        "failedToLoadPages": "Kunne ikke laste sider"
+      }
+    },
     "card": {
       "showMore": "Vis mer",
       "showLess": "Vis mindre",

--- a/web/public/locales/th/common.json
+++ b/web/public/locales/th/common.json
@@ -69,6 +69,42 @@
       "rejectFailed": "ปฏิเสธข้อเสนอแนะไม่สำเร็จ",
       "planFailed": "วางแผนข้อเสนอแนะไม่สำเร็จ"
     },
+    "form": {
+      "title": "ข้อเสนอแนะใหม่",
+      "fields": {
+        "page": "หน้า",
+        "title": "หัวข้อ",
+        "body": "เนื้อหา",
+        "type": "ประเภท",
+        "size": "ขนาด"
+      },
+      "placeholders": {
+        "page": "เลือกหน้า",
+        "title": "สรุปสั้น ๆ…",
+        "body": "อธิบายสิ่งที่คุณอยากเห็น",
+        "type": "เลือกประเภท",
+        "size": "เลือกขนาด"
+      },
+      "charCount": "{{count}}/{{max}}",
+      "byteCount": "{{count}} / {{max}} ไบต์",
+      "actions": {
+        "submit": "สร้างข้อเสนอแนะ",
+        "submitting": "กำลังสร้าง…",
+        "cancel": "ยกเลิก"
+      },
+      "errors": {
+        "titleRequired": "ต้องระบุหัวข้อ",
+        "titleTooLong": "หัวข้อต้องมีความยาวไม่เกิน {{max}} ตัวอักษร",
+        "bodyRequired": "ต้องระบุเนื้อหา",
+        "bodyTooLong": "เนื้อหาต้องมีขนาดไม่เกิน {{max}} ไบต์",
+        "pageRequired": "ต้องระบุหน้า",
+        "typeRequired": "ต้องระบุประเภท",
+        "sizeRequired": "ต้องระบุขนาด",
+        "newPageMismatch": "ประเภทหน้าใหม่สามารถเลือกได้เฉพาะรายการหน้าใหม่เท่านั้น",
+        "failedToCreate": "สร้างข้อเสนอแนะไม่สำเร็จ",
+        "failedToLoadPages": "โหลดรายการหน้าไม่สำเร็จ"
+      }
+    },
     "card": {
       "showMore": "แสดงเพิ่มเติม",
       "showLess": "แสดงน้อยลง",

--- a/web/src/components/suggestions/NewSuggestionForm.test.tsx
+++ b/web/src/components/suggestions/NewSuggestionForm.test.tsx
@@ -1,0 +1,256 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { NewSuggestionForm } from './NewSuggestionForm'
+import enCommon from '../../../public/locales/en/common.json'
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[]
+interface JsonObject { [key: string]: JsonValue }
+
+function resolveKey(obj: JsonObject, parts: string[]): JsonValue | undefined {
+  const [head, ...rest] = parts
+  const val = obj[head]
+  if (rest.length === 0) return val
+  if (val && typeof val === 'object' && !Array.isArray(val)) {
+    return resolveKey(val as JsonObject, rest)
+  }
+  return undefined
+}
+
+function format(template: string, vars?: Record<string, unknown>): string {
+  if (!vars) return template
+  return template.replace(/\{\{(\w+)\}\}/g, (_, k) => String(vars[k] ?? ''))
+}
+
+function makeT(translations: JsonObject) {
+  return function t(key: string, vars?: Record<string, unknown>): string {
+    const val = resolveKey(translations, key.split('.'))
+    return typeof val === 'string' ? format(val, vars) : key
+  }
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: makeT(enCommon as unknown as JsonObject),
+    i18n: { language: 'en' },
+  }),
+  Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+const PAGES = [
+  { slug: 'weather', title: 'Weather' },
+  { slug: 'budget', title: 'Budget' },
+  { slug: '__new_page__', title: 'New page' },
+]
+
+function pagesFetch() {
+  return vi.fn((url: string) => {
+    if (url === '/api/suggestions/pages') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGES) })
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('NewSuggestionForm', () => {
+  it('does not render when closed', () => {
+    vi.stubGlobal('fetch', pagesFetch())
+    render(<NewSuggestionForm open={false} onClose={() => {}} onCreated={() => {}} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('loads pages on open and populates the page dropdown', async () => {
+    vi.stubGlobal('fetch', pagesFetch())
+    render(<NewSuggestionForm open={true} onClose={() => {}} onCreated={() => {}} />)
+
+    const pageSelect = await screen.findByLabelText('Page') as HTMLSelectElement
+    await waitFor(() => {
+      const slugs = Array.from(pageSelect.options).map(o => o.value)
+      expect(slugs).toContain('weather')
+      expect(slugs).toContain('budget')
+    })
+  })
+
+  it('shows inline validation errors when fields are missing', async () => {
+    vi.stubGlobal('fetch', pagesFetch())
+    render(<NewSuggestionForm open={true} onClose={() => {}} onCreated={() => {}} />)
+
+    await screen.findByLabelText('Page')
+
+    fireEvent.click(screen.getByRole('button', { name: /Create suggestion/ }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Type is required')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Size is required')).toBeInTheDocument()
+    expect(screen.getByText('Page is required')).toBeInTheDocument()
+    expect(screen.getByText('Title is required')).toBeInTheDocument()
+    expect(screen.getByText('Body is required')).toBeInTheDocument()
+  })
+
+  it('rejects body that exceeds the 4096-byte cap', async () => {
+    vi.stubGlobal('fetch', pagesFetch())
+    render(<NewSuggestionForm open={true} onClose={() => {}} onCreated={() => {}} />)
+
+    const pageSelect = (await screen.findByLabelText('Page')) as HTMLSelectElement
+    await waitFor(() => {
+      expect(Array.from(pageSelect.options).map(o => o.value)).toContain('weather')
+    })
+
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'addition' } })
+    fireEvent.change(screen.getByLabelText('Size'), { target: { value: 's' } })
+    fireEvent.change(pageSelect, { target: { value: 'weather' } })
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Hi' } })
+    fireEvent.change(screen.getByLabelText('Body'), { target: { value: 'x'.repeat(5000) } })
+
+    fireEvent.click(screen.getByRole('button', { name: /Create suggestion/ }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Body must be at most 4096 bytes')).toBeInTheDocument()
+    })
+  })
+
+  it('forces page to __new_page__ when type=new_page is selected', async () => {
+    vi.stubGlobal('fetch', pagesFetch())
+    render(<NewSuggestionForm open={true} onClose={() => {}} onCreated={() => {}} />)
+
+    const pageSelect = (await screen.findByLabelText('Page')) as HTMLSelectElement
+    await waitFor(() => {
+      expect(Array.from(pageSelect.options).map(o => o.value)).toContain('__new_page__')
+    })
+
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'new_page' } })
+
+    await waitFor(() => {
+      expect(pageSelect.value).toBe('__new_page__')
+    })
+    expect(pageSelect).toBeDisabled()
+  })
+
+  it('submits valid form, posts to /api/suggestions and calls onCreated', async () => {
+    const created = {
+      id: 99,
+      user_id: 1,
+      generated_at: '2026-05-01T00:00:00Z',
+      page_slug: 'weather',
+      source: 'user',
+      type: 'addition',
+      size: 's',
+      title: 'My idea',
+      body: 'A body',
+      status: 'pending',
+    }
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/pages') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGES) })
+      }
+      if (url === '/api/suggestions' && init?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(created) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const onCreated = vi.fn()
+    render(<NewSuggestionForm open={true} onClose={() => {}} onCreated={onCreated} />)
+
+    const pageSelect = (await screen.findByLabelText('Page')) as HTMLSelectElement
+    await waitFor(() => {
+      expect(Array.from(pageSelect.options).map(o => o.value)).toContain('weather')
+    })
+
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'addition' } })
+    fireEvent.change(screen.getByLabelText('Size'), { target: { value: 's' } })
+    fireEvent.change(pageSelect, { target: { value: 'weather' } })
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: '  My idea  ' } })
+    fireEvent.change(screen.getByLabelText('Body'), { target: { value: '  A body  ' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /Create suggestion/ }))
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith(created)
+    })
+
+    const postCall = fetchMock.mock.calls.find(([url, init]) =>
+      url === '/api/suggestions' && (init as RequestInit | undefined)?.method === 'POST',
+    )
+    expect(postCall).toBeDefined()
+    const body = JSON.parse((postCall![1] as RequestInit).body as string)
+    expect(body).toEqual({
+      type: 'addition',
+      size: 's',
+      page_slug: 'weather',
+      title: 'My idea',
+      body: 'A body',
+    })
+  })
+
+  it('surfaces the backend error message on submit failure', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/pages') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGES) })
+      }
+      if (url === '/api/suggestions' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ error: 'invalid type' }),
+        })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<NewSuggestionForm open={true} onClose={() => {}} onCreated={() => {}} />)
+
+    const pageSelect = (await screen.findByLabelText('Page')) as HTMLSelectElement
+    await waitFor(() => {
+      expect(Array.from(pageSelect.options).map(o => o.value)).toContain('weather')
+    })
+
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'addition' } })
+    fireEvent.change(screen.getByLabelText('Size'), { target: { value: 's' } })
+    fireEvent.change(pageSelect, { target: { value: 'weather' } })
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'A title' } })
+    fireEvent.change(screen.getByLabelText('Body'), { target: { value: 'A body' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /Create suggestion/ }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('new-suggestion-submit-error')).toHaveTextContent('invalid type')
+    })
+  })
+
+  it('shows a load error if pages fetch fails', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/suggestions/pages') {
+        return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<NewSuggestionForm open={true} onClose={() => {}} onCreated={() => {}} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load pages')).toBeInTheDocument()
+    })
+  })
+
+  it('cancel button calls onClose', async () => {
+    vi.stubGlobal('fetch', pagesFetch())
+    const onClose = vi.fn()
+    render(<NewSuggestionForm open={true} onClose={onClose} onCreated={() => {}} />)
+
+    await screen.findByLabelText('Page')
+
+    fireEvent.click(screen.getByRole('button', { name: /^Cancel$/ }))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/web/src/components/suggestions/NewSuggestionForm.tsx
+++ b/web/src/components/suggestions/NewSuggestionForm.tsx
@@ -1,0 +1,425 @@
+import { useEffect, useId, useMemo, useState, type FormEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2 } from 'lucide-react'
+import { Dialog, DialogBody, DialogFooter, DialogHeader } from '../ui/dialog'
+import type {
+  Suggestion,
+  SuggestionSize,
+  SuggestionType,
+} from './SuggestionCard'
+
+export const NEW_PAGE_SLUG = '__new_page__'
+export const TITLE_MAX = 120
+export const BODY_MAX_BYTES = 4096
+
+const TYPE_OPTIONS: SuggestionType[] = [
+  'addition',
+  'bugfix',
+  'improvement',
+  'refactor',
+  'new_page',
+]
+
+const SIZE_OPTIONS: SuggestionSize[] = ['s', 'm', 'l']
+
+interface PageOption {
+  slug: string
+  title: string
+}
+
+export interface NewSuggestionFormProps {
+  open: boolean
+  onClose: () => void
+  onCreated: (created: Suggestion) => void
+}
+
+interface FieldErrors {
+  page?: string
+  title?: string
+  body?: string
+  type?: string
+  size?: string
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).length
+}
+
+export function NewSuggestionForm({ open, onClose, onCreated }: NewSuggestionFormProps) {
+  const { t } = useTranslation('common')
+  const titleId = useId()
+  const pageId = useId()
+  const titleFieldId = useId()
+  const bodyFieldId = useId()
+  const typeId = useId()
+  const sizeId = useId()
+
+  const [pages, setPages] = useState<PageOption[]>([])
+  const [pagesLoading, setPagesLoading] = useState(false)
+  const [pagesError, setPagesError] = useState<string | null>(null)
+
+  const [pageSlug, setPageSlug] = useState('')
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [type, setType] = useState<SuggestionType | ''>('')
+  const [size, setSize] = useState<SuggestionSize | ''>('')
+
+  const [errors, setErrors] = useState<FieldErrors>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Reset form state and reload pages whenever the dialog opens. setState in
+  // an effect is the established pattern in this repo for dialogs that need to
+  // re-initialize on each open without unmounting the form (matches
+  // TokenCreateDialog).
+  useEffect(() => {
+    if (!open) return
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setPageSlug('')
+    setTitle('')
+    setBody('')
+    setType('')
+    setSize('')
+    setErrors({})
+    setSubmitError(null)
+    setSubmitting(false)
+    setPagesLoading(true)
+    setPagesError(null)
+    /* eslint-enable react-hooks/set-state-in-effect */
+
+    const controller = new AbortController()
+    ;(async () => {
+      try {
+        const res = await fetch('/api/suggestions/pages', {
+          credentials: 'include',
+          signal: controller.signal,
+        })
+        if (!res.ok) {
+          throw new Error(t('suggestions.form.errors.failedToLoadPages'))
+        }
+        const data = (await res.json()) as PageOption[]
+        setPages(Array.isArray(data) ? data : [])
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        setPagesError(
+          err instanceof Error ? err.message : t('suggestions.form.errors.failedToLoadPages'),
+        )
+      } finally {
+        if (!controller.signal.aborted) setPagesLoading(false)
+      }
+    })()
+    return () => controller.abort()
+  }, [open, t])
+
+  function handleTypeChange(value: string) {
+    const next = value as SuggestionType | ''
+    setType(next)
+    // The backend rejects type=new_page unless page_slug=__new_page__ (and vice
+    // versa); keep the slug aligned automatically so the user cannot land in an
+    // invalid combination.
+    if (next === 'new_page') {
+      setPageSlug(NEW_PAGE_SLUG)
+    } else if (pageSlug === NEW_PAGE_SLUG) {
+      setPageSlug('')
+    }
+  }
+
+  const visiblePages = useMemo(() => {
+    if (type === 'new_page') {
+      return pages.filter(p => p.slug === NEW_PAGE_SLUG)
+    }
+    if (type === '') {
+      return pages
+    }
+    return pages.filter(p => p.slug !== NEW_PAGE_SLUG)
+  }, [pages, type])
+
+  const titleLen = title.length
+  const bodyBytes = byteLength(body)
+
+  function validate(): FieldErrors {
+    const next: FieldErrors = {}
+    if (!type) {
+      next.type = t('suggestions.form.errors.typeRequired')
+    }
+    if (!size) {
+      next.size = t('suggestions.form.errors.sizeRequired')
+    }
+    if (!pageSlug) {
+      next.page = t('suggestions.form.errors.pageRequired')
+    } else if ((type === 'new_page') !== (pageSlug === NEW_PAGE_SLUG)) {
+      next.page = t('suggestions.form.errors.newPageMismatch')
+    }
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle) {
+      next.title = t('suggestions.form.errors.titleRequired')
+    } else if (trimmedTitle.length > TITLE_MAX) {
+      next.title = t('suggestions.form.errors.titleTooLong', { max: TITLE_MAX })
+    }
+    const trimmedBody = body.trim()
+    if (!trimmedBody) {
+      next.body = t('suggestions.form.errors.bodyRequired')
+    } else if (byteLength(trimmedBody) > BODY_MAX_BYTES) {
+      next.body = t('suggestions.form.errors.bodyTooLong', { max: BODY_MAX_BYTES })
+    }
+    return next
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (submitting) return
+    const next = validate()
+    setErrors(next)
+    setSubmitError(null)
+    if (Object.keys(next).length > 0) return
+
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/suggestions', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type,
+          size,
+          page_slug: pageSlug,
+          title: title.trim(),
+          body: body.trim(),
+        }),
+      })
+      if (!res.ok) {
+        let msg = t('suggestions.form.errors.failedToCreate')
+        try {
+          const data = (await res.json()) as { error?: string }
+          if (data?.error) msg = data.error
+        } catch {
+          // fall back to generic message
+        }
+        throw new Error(msg)
+      }
+      const created = (await res.json()) as Suggestion
+      onCreated(created)
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err.message : t('suggestions.form.errors.failedToCreate'),
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const titleErrId = `${titleFieldId}-error`
+  const bodyErrId = `${bodyFieldId}-error`
+  const pageErrId = `${pageId}-error`
+  const typeErrId = `${typeId}-error`
+  const sizeErrId = `${sizeId}-error`
+
+  return (
+    <Dialog
+      open={open}
+      onClose={submitting ? () => {} : onClose}
+      maxWidth="max-w-lg"
+      aria-labelledby={titleId}
+    >
+      <DialogHeader
+        id={titleId}
+        title={t('suggestions.form.title')}
+        onClose={submitting ? () => {} : onClose}
+      />
+      <form onSubmit={handleSubmit} noValidate>
+        <DialogBody>
+          <div className="space-y-4">
+            <div>
+              <label htmlFor={typeId} className="block text-sm font-medium text-gray-300 mb-1">
+                {t('suggestions.form.fields.type')}
+              </label>
+              <select
+                id={typeId}
+                value={type}
+                onChange={e => handleTypeChange(e.target.value)}
+                disabled={submitting}
+                aria-invalid={errors.type ? true : undefined}
+                aria-describedby={errors.type ? typeErrId : undefined}
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50 [color-scheme:dark]"
+              >
+                <option value="">{t('suggestions.form.placeholders.type')}</option>
+                {TYPE_OPTIONS.map(opt => (
+                  <option key={opt} value={opt}>
+                    {t(`suggestions.card.types.${opt}`)}
+                  </option>
+                ))}
+              </select>
+              {errors.type && (
+                <p id={typeErrId} role="alert" className="mt-1 text-xs text-red-300">
+                  {errors.type}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor={pageId} className="block text-sm font-medium text-gray-300 mb-1">
+                {t('suggestions.form.fields.page')}
+              </label>
+              <select
+                id={pageId}
+                value={pageSlug}
+                onChange={e => setPageSlug(e.target.value)}
+                disabled={submitting || pagesLoading || type === 'new_page'}
+                aria-invalid={errors.page ? true : undefined}
+                aria-describedby={errors.page ? pageErrId : undefined}
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50 [color-scheme:dark]"
+              >
+                <option value="">
+                  {pagesLoading
+                    ? t('status.loading')
+                    : t('suggestions.form.placeholders.page')}
+                </option>
+                {visiblePages.map(p => (
+                  <option key={p.slug} value={p.slug}>
+                    {p.title}
+                  </option>
+                ))}
+              </select>
+              {pagesError && (
+                <p role="alert" className="mt-1 text-xs text-red-300">
+                  {pagesError}
+                </p>
+              )}
+              {errors.page && (
+                <p id={pageErrId} role="alert" className="mt-1 text-xs text-red-300">
+                  {errors.page}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor={sizeId} className="block text-sm font-medium text-gray-300 mb-1">
+                {t('suggestions.form.fields.size')}
+              </label>
+              <select
+                id={sizeId}
+                value={size}
+                onChange={e => setSize(e.target.value as SuggestionSize | '')}
+                disabled={submitting}
+                aria-invalid={errors.size ? true : undefined}
+                aria-describedby={errors.size ? sizeErrId : undefined}
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50 [color-scheme:dark]"
+              >
+                <option value="">{t('suggestions.form.placeholders.size')}</option>
+                {SIZE_OPTIONS.map(opt => (
+                  <option key={opt} value={opt}>
+                    {t(`suggestions.card.sizes.${opt}`)}
+                  </option>
+                ))}
+              </select>
+              {errors.size && (
+                <p id={sizeErrId} role="alert" className="mt-1 text-xs text-red-300">
+                  {errors.size}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor={titleFieldId} className="block text-sm font-medium text-gray-300 mb-1">
+                {t('suggestions.form.fields.title')}
+              </label>
+              <input
+                id={titleFieldId}
+                type="text"
+                value={title}
+                onChange={e => setTitle(e.target.value)}
+                placeholder={t('suggestions.form.placeholders.title')}
+                maxLength={TITLE_MAX}
+                disabled={submitting}
+                aria-invalid={errors.title ? true : undefined}
+                aria-describedby={errors.title ? titleErrId : undefined}
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white placeholder:text-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50"
+              />
+              <div className="mt-1 flex items-start justify-between gap-2">
+                {errors.title ? (
+                  <p id={titleErrId} role="alert" className="text-xs text-red-300">
+                    {errors.title}
+                  </p>
+                ) : (
+                  <span className="text-xs text-gray-500" />
+                )}
+                <span
+                  className={`text-xs shrink-0 ${
+                    titleLen > TITLE_MAX ? 'text-red-300' : 'text-gray-500'
+                  }`}
+                >
+                  {t('suggestions.form.charCount', { count: titleLen, max: TITLE_MAX })}
+                </span>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor={bodyFieldId} className="block text-sm font-medium text-gray-300 mb-1">
+                {t('suggestions.form.fields.body')}
+              </label>
+              <textarea
+                id={bodyFieldId}
+                value={body}
+                onChange={e => setBody(e.target.value)}
+                placeholder={t('suggestions.form.placeholders.body')}
+                rows={6}
+                disabled={submitting}
+                aria-invalid={errors.body ? true : undefined}
+                aria-describedby={errors.body ? bodyErrId : undefined}
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white placeholder:text-gray-500 focus:outline-none focus:border-blue-500 disabled:opacity-50"
+              />
+              <div className="mt-1 flex items-start justify-between gap-2">
+                {errors.body ? (
+                  <p id={bodyErrId} role="alert" className="text-xs text-red-300">
+                    {errors.body}
+                  </p>
+                ) : (
+                  <span className="text-xs text-gray-500" />
+                )}
+                <span
+                  className={`text-xs shrink-0 ${
+                    bodyBytes > BODY_MAX_BYTES ? 'text-red-300' : 'text-gray-500'
+                  }`}
+                >
+                  {t('suggestions.form.byteCount', { count: bodyBytes, max: BODY_MAX_BYTES })}
+                </span>
+              </div>
+            </div>
+
+            {submitError && (
+              <p
+                role="alert"
+                data-testid="new-suggestion-submit-error"
+                className="text-sm text-red-300"
+              >
+                {submitError}
+              </p>
+            )}
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-4 py-2 text-sm text-gray-300 hover:text-white transition-colors disabled:opacity-50"
+          >
+            {t('suggestions.form.actions.cancel')}
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex items-center gap-2 rounded-lg border border-blue-500/40 bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting && <Loader2 size={14} className="animate-spin" aria-hidden={true} />}
+            <span>
+              {submitting
+                ? t('suggestions.form.actions.submitting')
+                : t('suggestions.form.actions.submit')}
+            </span>
+          </button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  )
+}

--- a/web/src/pages/Suggestions.test.tsx
+++ b/web/src/pages/Suggestions.test.tsx
@@ -302,7 +302,7 @@ describe('Suggestions – Run now flow', () => {
 })
 
 describe('Suggestions – header', () => {
-  it('renders title, next-run hint and the New suggestion stub', async () => {
+  it('renders title, next-run hint and the New suggestion button', async () => {
     vi.stubGlobal('fetch', vi.fn(() =>
       Promise.resolve({
         ok: true,
@@ -315,6 +315,38 @@ describe('Suggestions – header', () => {
     expect(await screen.findByRole('heading', { level: 1, name: 'Suggestions' })).toBeInTheDocument()
     expect(screen.getByText('Next run: tonight 03:00')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /New suggestion/ })).toBeInTheDocument()
+  })
+
+  it('opens the new-suggestion form when the New suggestion button is clicked', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/suggestions/pages') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            { slug: 'weather', title: 'Weather' },
+            { slug: '__new_page__', title: 'New page' },
+          ]),
+        })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ pending: [], planned: [], rejected: [] }),
+        })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    const button = await screen.findByRole('button', { name: /New suggestion/ })
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('heading', { name: 'New suggestion' })).toBeInTheDocument()
   })
 })
 

--- a/web/src/pages/Suggestions.tsx
+++ b/web/src/pages/Suggestions.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from '../components/ui/skeleton'
 import { Tabs, TabList, TabTrigger, TabPanel } from '../components/ui/tabs'
 import { SuggestionCard, type Suggestion } from '../components/suggestions/SuggestionCard'
 import { SuggestionActions } from '../components/suggestions/SuggestionActions'
+import { NewSuggestionForm } from '../components/suggestions/NewSuggestionForm'
 
 type TabKey = 'pending' | 'planned' | 'rejected'
 
@@ -26,6 +27,7 @@ export default function Suggestions() {
   const [running, setRunning] = useState(false)
   const [activeTab, setActiveTab] = useState<TabKey>('pending')
   const [reloadKey, setReloadKey] = useState(0)
+  const [newOpen, setNewOpen] = useState(false)
 
   const refetch = useCallback(() => {
     setReloadKey(k => k + 1)
@@ -97,8 +99,14 @@ export default function Suggestions() {
   }
 
   function handleNewSuggestion() {
-    // Wired up by a follow-up sub-task that adds the create-suggestion form.
+    setNewOpen(true)
   }
+
+  const handleCreated = useCallback(() => {
+    setNewOpen(false)
+    setActiveTab('pending')
+    refetch()
+  }, [refetch])
 
   function renderPanel(tab: TabKey, list: Suggestion[]) {
     if (list.length === 0) {
@@ -221,6 +229,11 @@ export default function Suggestions() {
           )}
         </Tabs>
       </div>
+      <NewSuggestionForm
+        open={newOpen}
+        onClose={() => setNewOpen(false)}
+        onCreated={handleCreated}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Changes

- **New suggestion form** - The Suggestions page can now author user suggestions via a modal opened from the "+ New suggestion" button: page picker (loaded from `/api/suggestions/pages`), title (≤120 chars), body (≤4 KB), type, and size dropdowns with inline validation. Successful submission posts to `/api/suggestions` and refreshes the list. (Hytte-ym34)

## Original Issue (task): '+ New suggestion' modal/form with validation and submit

Add a NewSuggestionForm component (e.g. web/src/pages/Suggestions/NewSuggestionForm.tsx) opened by the '+ New suggestion' button from sub-task 2. Fields: page dropdown populated from GET /api/suggestions/pages, title (max 120 chars), body textarea (max 4KB), type dropdown (addition/bugfix/improvement/refactor/new_page), size dropdown (S/M/L). Client-side validation with inline errors. On submit POST /api/suggestions and refresh the parent list (lift state or callback). Tailwind dark theme, mobile-first. Connects to sub-task 2 by being mounted from its header button and triggering its list refresh.

---
Bead: Hytte-ym34 | Branch: forge/Hytte-ym34
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)