### PR TITLE
Suggestions: bd create integration for Planned suggestions (Hytte-id25)

### DIFF
--- a/changelog.d/Hytte-id25.md
+++ b/changelog.d/Hytte-id25.md
@@ -1,0 +1,2 @@
+category: Added
+- **Suggestions: create bead from planned suggestions** - Wired the Planned-card "Create bead" button up to a new `POST /api/suggestions/{id}/bead` endpoint that shells out to `bd create` with the `forgeReady` label and links the resulting Hytte- bead back to the suggestion. The Planned tab now shows a "Created beads" section for suggestions that have already shipped. (Hytte-id25)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -203,6 +203,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/suggestions/run", suggestions.RunHandler(db))
 				r.Post("/suggestions/{id}/reject", suggestions.RejectHandler(db))
 				r.Post("/suggestions/{id}/plan", suggestions.PlanHandler(db))
+				r.Post("/suggestions/{id}/bead", suggestions.CreateBeadHandler(db))
 				r.Get("/suggestions/pages", suggestions.PagesHandler())
 
 				// Forge dashboard — admin only, registered only when FEATURE_FORGE_DASHBOARD=1.

--- a/internal/forge/handlers.go
+++ b/internal/forge/handlers.go
@@ -114,6 +114,19 @@ func resolveCommand(name string) string {
 	return name
 }
 
+// AnvilDirForBead is the exported wrapper around anvilDirForBead so other
+// packages (e.g. suggestions) can resolve the working directory for a bead.
+func AnvilDirForBead(beadID string) (string, error) {
+	return anvilDirForBead(beadID)
+}
+
+// ResolveCommand is the exported wrapper around resolveCommand so other
+// packages (e.g. suggestions) can find user-installed binaries when running
+// under systemd.
+func ResolveCommand(name string) string {
+	return resolveCommand(name)
+}
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/internal/suggestions/bead.go
+++ b/internal/suggestions/bead.go
@@ -1,0 +1,179 @@
+package suggestions
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/forge"
+	"github.com/go-chi/chi/v5"
+)
+
+// BeadCreateTimeout caps how long we wait for `bd create` to return. Declared
+// as var so tests do not have to wait the full 60s when exercising timeouts.
+var BeadCreateTimeout = 60 * time.Second
+
+// MaxBeadTitleLength caps the title we hand to bd create. bd has its own
+// limits and we don't want to surprise it with arbitrarily long titles.
+const MaxBeadTitleLength = 120
+
+// beadIDPattern matches the freshly-issued bead ID in `bd create` stdout.
+// The format is "✓ Created issue: <Anvil>-XXXX — ..." and we accept any anvil
+// prefix here so we don't have to rebuild this regex if we ever rename Hytte.
+var beadIDPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9_]*-[a-z0-9]+`)
+
+// bdCreateFn is the function used to invoke `bd create`. Replaced in tests,
+// mirroring the runPromptFn pattern in generate.go.
+var bdCreateFn = defaultBdCreate
+
+// defaultBdCreate runs `bd create` against the Hytte anvil. Title is passed
+// inline; the description body is streamed on stdin via --body-file -.
+func defaultBdCreate(ctx context.Context, cwd, title, body string) (stdout, stderr string, err error) {
+	args := []string{
+		"create", title,
+		"--type", "feature",
+		"--priority", "3",
+		"--labels", "forgeReady",
+		"--body-file", "-",
+	}
+	cmd := exec.CommandContext(ctx, forge.ResolveCommand("bd"), args...)
+	cmd.Dir = cwd
+	cmd.Stdin = strings.NewReader(body)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	runErr := cmd.Run()
+	return outBuf.String(), errBuf.String(), runErr
+}
+
+// CreateBeadHandler turns a planned suggestion into a real bead by shelling
+// out to `bd create` against the Hytte anvil with the forgeReady label set.
+// Admin-only — relies on auth.RequireAdmin upstream.
+//
+// POST /api/suggestions/{id}/bead
+// Response: 200 with the updated Suggestion (status=bead_created, bead_id set)
+func CreateBeadHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		idStr := chi.URLParam(r, "id")
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+			return
+		}
+
+		existing, err := GetByID(r.Context(), db, id)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "suggestion not found"})
+				return
+			}
+			log.Printf("suggestions: load %d for bead create: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load suggestion"})
+			return
+		}
+
+		// Cross-user enumeration guard, same as RejectHandler/PlanHandler.
+		if existing.UserID != user.ID {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "suggestion not found"})
+			return
+		}
+
+		if existing.Status != StatusPlanned {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "suggestion must be planned before creating a bead"})
+			return
+		}
+
+		cwd, err := forge.AnvilDirForBead("Hytte-x")
+		if err != nil {
+			log.Printf("suggestions: resolve Hytte anvil dir: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to resolve Hytte anvil directory"})
+			return
+		}
+
+		title := capTitle(existing.Title, MaxBeadTitleLength)
+		body := buildBeadBody(*existing)
+
+		ctx, cancel := context.WithTimeout(r.Context(), BeadCreateTimeout)
+		defer cancel()
+
+		stdout, stderr, runErr := bdCreateFn(ctx, cwd, title, body)
+		if runErr != nil {
+			trimmed := strings.TrimSpace(stderr)
+			if trimmed == "" {
+				trimmed = runErr.Error()
+			}
+			log.Printf("suggestions: bd create for suggestion %d failed: %v (stderr=%s)", id, runErr, trimmed)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("bd create failed: %s", trimmed)})
+			return
+		}
+
+		beadID := beadIDPattern.FindString(stdout)
+		if beadID == "" {
+			log.Printf("suggestions: bd create for suggestion %d succeeded but no bead ID in stdout: %q", id, stdout)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "bd create succeeded but no bead ID was returned"})
+			return
+		}
+
+		if err := MarkBeadCreated(r.Context(), db, id, beadID); err != nil {
+			log.Printf("suggestions: mark bead created %d: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to record bead creation"})
+			return
+		}
+
+		updated, err := GetByID(r.Context(), db, id)
+		if err != nil {
+			log.Printf("suggestions: reload bead-created %d: %v", id, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load suggestion"})
+			return
+		}
+		writeJSON(w, http.StatusOK, updated)
+	}
+}
+
+// capTitle returns the input trimmed and truncated at max characters. Truncation
+// happens on rune boundaries so we never split a multibyte character mid-codepoint.
+func capTitle(s string, max int) string {
+	s = strings.TrimSpace(s)
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return strings.TrimSpace(string(runes[:max]))
+}
+
+// buildBeadBody assembles the markdown description we hand to bd create.
+// It leads with the saved plan body, then appends footer sections so the
+// resulting bead is self-contained and traceable back to the suggestion.
+func buildBeadBody(s Suggestion) string {
+	var b strings.Builder
+	if plan := strings.TrimSpace(s.Plan); plan != "" {
+		b.WriteString(plan)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("## Source\n\n")
+	fmt.Fprintf(&b, "Created from Suggestions page (suggestion id %d, page slug %q, source=%s).\n", s.ID, s.PageSlug, s.Source)
+	if feedback := strings.TrimSpace(s.Feedback); feedback != "" {
+		b.WriteString("\n## User feedback when planning\n\n")
+		b.WriteString(feedback)
+		b.WriteString("\n")
+	}
+	if body := strings.TrimSpace(s.Body); body != "" {
+		b.WriteString("\n## Original suggestion\n\n")
+		b.WriteString(body)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/internal/suggestions/bead.go
+++ b/internal/suggestions/bead.go
@@ -96,6 +96,11 @@ func CreateBeadHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		if strings.TrimSpace(existing.Plan) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "suggestion has no plan body; edit and save a plan before creating a bead"})
+			return
+		}
+
 		cwd, err := forge.AnvilDirForBead("Hytte-x")
 		if err != nil {
 			log.Printf("suggestions: resolve Hytte anvil dir: %v", err)
@@ -115,6 +120,10 @@ func CreateBeadHandler(db *sql.DB) http.HandlerFunc {
 			if trimmed == "" {
 				trimmed = runErr.Error()
 			}
+			const maxStderrLen = 500
+			if len(trimmed) > maxStderrLen {
+				trimmed = trimmed[:maxStderrLen] + "…"
+			}
 			log.Printf("suggestions: bd create for suggestion %d failed: %v (stderr=%s)", id, runErr, trimmed)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("bd create failed: %s", trimmed)})
 			return
@@ -127,13 +136,18 @@ func CreateBeadHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		if err := MarkBeadCreated(r.Context(), db, id, beadID); err != nil {
+		// Use a fresh context for persistence so a client disconnect after bd create
+		// completes doesn't leave the bead unlinked in the DB.
+		persistCtx, persistCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer persistCancel()
+
+		if err := MarkBeadCreated(persistCtx, db, id, beadID); err != nil {
 			log.Printf("suggestions: mark bead created %d: %v", id, err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to record bead creation"})
 			return
 		}
 
-		updated, err := GetByID(r.Context(), db, id)
+		updated, err := GetByID(persistCtx, db, id)
 		if err != nil {
 			log.Printf("suggestions: reload bead-created %d: %v", id, err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load suggestion"})

--- a/internal/suggestions/bead_test.go
+++ b/internal/suggestions/bead_test.go
@@ -1,0 +1,366 @@
+package suggestions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// withBdCreate temporarily replaces bdCreateFn for the duration of a test and
+// returns a restore function to defer.
+func withBdCreate(fn func(ctx context.Context, cwd, title, body string) (string, string, error)) func() {
+	prev := bdCreateFn
+	bdCreateFn = fn
+	return func() { bdCreateFn = prev }
+}
+
+func TestCreateBeadHandlerRejectsNonAdmin(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/1/bead", nil), 99, false)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateBeadHandlerInvalidID(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/abc/bead", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestCreateBeadHandlerNotFound(t *testing.T) {
+	d := setupTestDB(t)
+	defer withBdCreate(func(ctx context.Context, cwd, title, body string) (string, string, error) {
+		t.Fatal("bdCreateFn should not be called for missing id")
+		return "", "", nil
+	})()
+
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/999/bead", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateBeadHandlerOtherUserSuggestionReturns404(t *testing.T) {
+	d := setupTestDB(t)
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Plan: "p", Status: StatusPlanned,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	defer withBdCreate(func(ctx context.Context, cwd, title, body string) (string, string, error) {
+		t.Fatal("bdCreateFn should not be called for cross-user lookup")
+		return "", "", nil
+	})()
+
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/bead", id), nil), 2, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-user bead create, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateBeadHandlerRejectsPendingStatus(t *testing.T) {
+	d := setupTestDB(t)
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	defer withBdCreate(func(ctx context.Context, cwd, title, body string) (string, string, error) {
+		t.Fatal("bdCreateFn should not be called for non-planned suggestion")
+		return "", "", nil
+	})()
+
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/bead", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for pending status, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateBeadHandlerRejectsRejectedStatus(t *testing.T) {
+	d := setupTestDB(t)
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Status: StatusRejected,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	defer withBdCreate(func(ctx context.Context, cwd, title, body string) (string, string, error) {
+		t.Fatal("bdCreateFn should not be called for rejected suggestion")
+		return "", "", nil
+	})()
+
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/bead", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for rejected status, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateBeadHandlerSuccess(t *testing.T) {
+	d := setupTestDB(t)
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS,
+		Title: "Cache forecasts", Body: "Original body content.",
+		Plan: "## Scope\nDo the cache thing.", Feedback: "Use Redis.",
+		Status: StatusPlanned,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	var capturedBody, capturedTitle string
+	defer withBdCreate(func(ctx context.Context, cwd, title, body string) (string, string, error) {
+		capturedBody = body
+		capturedTitle = title
+		return "✓ Created issue: Hytte-test1234 — Cache forecasts\n", "", nil
+	})()
+
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/bead", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got Suggestion
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != StatusBeadCreated {
+		t.Fatalf("status: got %q want %q", got.Status, StatusBeadCreated)
+	}
+	if got.BeadID != "Hytte-test1234" {
+		t.Fatalf("bead_id: got %q want Hytte-test1234", got.BeadID)
+	}
+	if got.BeadCreatedAt == nil {
+		t.Fatal("expected bead_created_at to be set")
+	}
+	if capturedTitle != "Cache forecasts" {
+		t.Fatalf("title passed to bd create: got %q want %q", capturedTitle, "Cache forecasts")
+	}
+	if !strings.Contains(capturedBody, "Do the cache thing.") {
+		t.Fatalf("expected plan body in bd create body, got:\n%s", capturedBody)
+	}
+	if !strings.Contains(capturedBody, "Original body content.") {
+		t.Fatalf("expected original suggestion body in bd create body, got:\n%s", capturedBody)
+	}
+	if !strings.Contains(capturedBody, "Use Redis.") {
+		t.Fatalf("expected feedback in bd create body, got:\n%s", capturedBody)
+	}
+	if !strings.Contains(capturedBody, "## Source") {
+		t.Fatalf("expected ## Source heading in body, got:\n%s", capturedBody)
+	}
+}
+
+func TestCreateBeadHandlerOmitsFeedbackWhenEmpty(t *testing.T) {
+	d := setupTestDB(t)
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS,
+		Title: "X", Body: "b",
+		Plan: "## Scope\nDo it.",
+		Status: StatusPlanned,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	var capturedBody string
+	defer withBdCreate(func(ctx context.Context, cwd, title, body string) (string, string, error) {
+		capturedBody = body
+		return "✓ Created issue: Hytte-abcd1234 — X\n", "", nil
+	})()
+
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/bead", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(capturedBody, "## User feedback when planning") {
+		t.Fatalf("expected no feedback section when feedback is empty, got:\n%s", capturedBody)
+	}
+}
+
+func TestCreateBeadHandlerBdFailureKeepsPlanned(t *testing.T) {
+	d := setupTestDB(t)
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Plan: "p",
+		Status: StatusPlanned,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	defer withBdCreate(func(ctx context.Context, cwd, title, body string) (string, string, error) {
+		return "", "bd: fatal error: database locked", errors.New("exit status 1")
+	})()
+
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/bead", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on bd failure, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var errResp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(errResp["error"], "database locked") {
+		t.Fatalf("expected error to include trimmed stderr, got %q", errResp["error"])
+	}
+
+	// Suggestion must remain in planned state, not bead_created.
+	got, err := GetByID(context.Background(), d, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != StatusPlanned {
+		t.Fatalf("status should remain planned after bd failure, got %q", got.Status)
+	}
+	if got.BeadID != "" {
+		t.Fatalf("bead_id should remain empty after bd failure, got %q", got.BeadID)
+	}
+	if got.BeadCreatedAt != nil {
+		t.Fatalf("bead_created_at should remain nil after bd failure, got %v", got.BeadCreatedAt)
+	}
+}
+
+func TestCreateBeadHandlerUnparsableStdoutReturns500(t *testing.T) {
+	d := setupTestDB(t)
+
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Plan: "p",
+		Status: StatusPlanned,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Successful exit but no bead ID anywhere in stdout.
+	defer withBdCreate(func(ctx context.Context, cwd, title, body string) (string, string, error) {
+		return "garbage with no recognisable id\n", "", nil
+	})()
+
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/bead", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when bead ID cannot be parsed, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got, err := GetByID(context.Background(), d, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != StatusPlanned {
+		t.Fatalf("status should remain planned when parse fails, got %q", got.Status)
+	}
+}
+
+func TestCreateBeadHandlerRejectsAlreadyBeadCreated(t *testing.T) {
+	d := setupTestDB(t)
+	id, err := Insert(context.Background(), d, Suggestion{
+		UserID: 1, PageSlug: "weather", Source: SourceClaude,
+		Type: TypeImprovement, Size: SizeS, Title: "X", Body: "b", Plan: "p",
+		Status: StatusBeadCreated,
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	defer withBdCreate(func(ctx context.Context, cwd, title, body string) (string, string, error) {
+		t.Fatal("bdCreateFn should not be called when status is already bead_created")
+		return "", "", nil
+	})()
+
+	router := mountAdmin(CreateBeadHandler(d), http.MethodPost, "/api/suggestions/{id}/bead")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/bead", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for already-bead_created, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Cap title to MaxBeadTitleLength.
+func TestCapTitleTruncatesLongInput(t *testing.T) {
+	long := strings.Repeat("a", MaxBeadTitleLength+50)
+	got := capTitle(long, MaxBeadTitleLength)
+	if len([]rune(got)) > MaxBeadTitleLength {
+		t.Fatalf("expected at most %d runes, got %d", MaxBeadTitleLength, len([]rune(got)))
+	}
+}
+
+func TestBuildBeadBodyOrdersSections(t *testing.T) {
+	body := buildBeadBody(Suggestion{
+		ID: 7, PageSlug: "weather", Source: SourceClaude,
+		Body: "ORIG", Plan: "PLAN", Feedback: "FB",
+	})
+	planIdx := strings.Index(body, "PLAN")
+	srcIdx := strings.Index(body, "## Source")
+	fbIdx := strings.Index(body, "## User feedback")
+	origIdx := strings.Index(body, "## Original suggestion")
+	if planIdx == -1 || srcIdx == -1 || fbIdx == -1 || origIdx == -1 {
+		t.Fatalf("missing section in body:\n%s", body)
+	}
+	if !(planIdx < srcIdx && srcIdx < fbIdx && fbIdx < origIdx) {
+		t.Fatalf("unexpected section order in body:\n%s", body)
+	}
+}
+

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -60,12 +60,13 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 }
 
 // listResponse is the shape returned by GET /api/suggestions: the caller gets
-// one bucket per actionable status. Suggestions in the bead_created status are
-// terminal and not surfaced here.
+// one bucket per status, including the terminal bead_created bucket so the UI
+// can surface what has already shipped.
 type listResponse struct {
-	Pending  []Suggestion `json:"pending"`
-	Planned  []Suggestion `json:"planned"`
-	Rejected []Suggestion `json:"rejected"`
+	Pending     []Suggestion `json:"pending"`
+	Planned     []Suggestion `json:"planned"`
+	Rejected    []Suggestion `json:"rejected"`
+	BeadCreated []Suggestion `json:"bead_created"`
 }
 
 // ListHandler returns the admin user's suggestions partitioned by status. Each
@@ -95,11 +96,18 @@ func ListHandler(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list suggestions"})
 			return
 		}
+		beadCreated, err := ListByStatus(r.Context(), db, user.ID, StatusBeadCreated)
+		if err != nil {
+			log.Printf("suggestions: list bead_created for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list suggestions"})
+			return
+		}
 
 		writeJSON(w, http.StatusOK, listResponse{
-			Pending:  nilToEmpty(pending),
-			Planned:  nilToEmpty(planned),
-			Rejected: nilToEmpty(rejected),
+			Pending:     nilToEmpty(pending),
+			Planned:     nilToEmpty(planned),
+			Rejected:    nilToEmpty(rejected),
+			BeadCreated: nilToEmpty(beadCreated),
 		})
 	}
 }

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -163,7 +163,7 @@ func TestListHandlerPartitionsByStatus(t *testing.T) {
 	insert(StatusPending, "P2")
 	insert(StatusPlanned, "PL1")
 	insert(StatusRejected, "R1")
-	insert(StatusBeadCreated, "BC1") // should not appear in any bucket
+	insert(StatusBeadCreated, "BC1")
 
 	router := mountAdmin(ListHandler(d), http.MethodGet, "/api/suggestions")
 	req := adminContext(httptest.NewRequest(http.MethodGet, "/api/suggestions", nil), 1, true)
@@ -186,6 +186,9 @@ func TestListHandlerPartitionsByStatus(t *testing.T) {
 	if len(got.Rejected) != 1 || got.Rejected[0].Title != "R1" {
 		t.Fatalf("rejected mismatch: %+v", got.Rejected)
 	}
+	if len(got.BeadCreated) != 1 || got.BeadCreated[0].Title != "BC1" {
+		t.Fatalf("bead_created mismatch: %+v", got.BeadCreated)
+	}
 }
 
 func TestListHandlerEmptyBucketsAreArrays(t *testing.T) {
@@ -199,7 +202,7 @@ func TestListHandlerEmptyBucketsAreArrays(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 	body := rec.Body.String()
-	for _, key := range []string{`"pending":[]`, `"planned":[]`, `"rejected":[]`} {
+	for _, key := range []string{`"pending":[]`, `"planned":[]`, `"rejected":[]`, `"bead_created":[]`} {
 		if !strings.Contains(body, key) {
 			t.Fatalf("expected empty array for %s, body=%s", key, body)
 		}

--- a/web/public/locales/en/suggestions.json
+++ b/web/public/locales/en/suggestions.json
@@ -16,7 +16,18 @@
     "feedbackPlaceholder": "Add context for the planner…",
     "noPlanYet": "No plan saved yet.",
     "createBead": "Create bead",
-    "createBeadDisabledTooltip": "Bead creation lands in the next bead."
+    "createBeadInProgress": "Creating bead…",
+    "createBeadRetry": "Retry create bead",
+    "createBeadError": "Failed to create bead: {{message}}"
+  },
+  "status": {
+    "beadCreated": "Bead created"
+  },
+  "meta": {
+    "beadId": "Bead: {{id}}"
+  },
+  "headings": {
+    "beadCreated": "Created beads"
   },
   "tabs": {
     "pending": "Pending",
@@ -32,7 +43,8 @@
     "failedToLoad": "Failed to load suggestions",
     "runFailed": "Failed to run suggestions",
     "rejectFailed": "Failed to reject suggestion",
-    "planFailed": "Failed to plan suggestion"
+    "planFailed": "Failed to plan suggestion",
+    "unknown": "unknown error"
   },
   "form": {
     "title": "New suggestion",

--- a/web/public/locales/nb/suggestions.json
+++ b/web/public/locales/nb/suggestions.json
@@ -16,7 +16,18 @@
     "feedbackPlaceholder": "Legg til kontekst for planleggeren…",
     "noPlanYet": "Ingen plan lagret ennå.",
     "createBead": "Opprett bead",
-    "createBeadDisabledTooltip": "Bead-opprettelse kommer i neste bead."
+    "createBeadInProgress": "Oppretter bead…",
+    "createBeadRetry": "Prøv å opprette bead igjen",
+    "createBeadError": "Kunne ikke opprette bead: {{message}}"
+  },
+  "status": {
+    "beadCreated": "Bead opprettet"
+  },
+  "meta": {
+    "beadId": "Bead: {{id}}"
+  },
+  "headings": {
+    "beadCreated": "Opprettede beads"
   },
   "tabs": {
     "pending": "Avventer",
@@ -32,7 +43,8 @@
     "failedToLoad": "Kunne ikke laste forslag",
     "runFailed": "Kunne ikke kjøre forslag",
     "rejectFailed": "Kunne ikke avvise forslag",
-    "planFailed": "Kunne ikke planlegge forslag"
+    "planFailed": "Kunne ikke planlegge forslag",
+    "unknown": "ukjent feil"
   },
   "form": {
     "title": "Nytt forslag",

--- a/web/public/locales/th/suggestions.json
+++ b/web/public/locales/th/suggestions.json
@@ -16,7 +16,18 @@
     "feedbackPlaceholder": "เพิ่มบริบทสำหรับผู้วางแผน…",
     "noPlanYet": "ยังไม่มีการบันทึกแผน",
     "createBead": "สร้าง bead",
-    "createBeadDisabledTooltip": "การสร้าง bead จะมาในงานถัดไป"
+    "createBeadInProgress": "กำลังสร้าง bead…",
+    "createBeadRetry": "ลองสร้าง bead อีกครั้ง",
+    "createBeadError": "สร้าง bead ไม่สำเร็จ: {{message}}"
+  },
+  "status": {
+    "beadCreated": "สร้าง bead แล้ว"
+  },
+  "meta": {
+    "beadId": "Bead: {{id}}"
+  },
+  "headings": {
+    "beadCreated": "Bead ที่สร้างแล้ว"
   },
   "tabs": {
     "pending": "รอดำเนินการ",
@@ -32,7 +43,8 @@
     "failedToLoad": "โหลดข้อเสนอแนะไม่สำเร็จ",
     "runFailed": "เรียกใช้ข้อเสนอแนะไม่สำเร็จ",
     "rejectFailed": "ปฏิเสธข้อเสนอแนะไม่สำเร็จ",
-    "planFailed": "วางแผนข้อเสนอแนะไม่สำเร็จ"
+    "planFailed": "วางแผนข้อเสนอแนะไม่สำเร็จ",
+    "unknown": "ข้อผิดพลาดที่ไม่รู้จัก"
   },
   "form": {
     "title": "ข้อเสนอแนะใหม่",

--- a/web/src/components/suggestions/SuggestionActions.tsx
+++ b/web/src/components/suggestions/SuggestionActions.tsx
@@ -9,6 +9,7 @@ export interface SuggestionActionsProps {
   suggestion: Suggestion
   onPlanned?: (updated: Suggestion) => void
   onRejected?: () => void
+  onBeadCreated?: (updated: Suggestion) => void
 }
 
 const SAFE_URL_PROTOCOLS = ['http:', 'https:', 'mailto:', 'tel:'] as const
@@ -41,12 +42,15 @@ const markdownComponents = {
   },
 }
 
-export function SuggestionActions({ suggestion, onPlanned, onRejected }: SuggestionActionsProps) {
+export function SuggestionActions({ suggestion, onPlanned, onRejected, onBeadCreated }: SuggestionActionsProps) {
   if (suggestion.status === 'pending') {
     return <PendingActions suggestion={suggestion} onPlanned={onPlanned} onRejected={onRejected} />
   }
   if (suggestion.status === 'planned') {
-    return <PlannedActions suggestion={suggestion} />
+    return <PlannedActions suggestion={suggestion} onBeadCreated={onBeadCreated} />
+  }
+  if (suggestion.status === 'bead_created') {
+    return <BeadCreatedActions suggestion={suggestion} />
   }
   return null
 }
@@ -176,10 +180,46 @@ function PendingActions({
   )
 }
 
-function PlannedActions({ suggestion }: { suggestion: Suggestion }) {
+function PlannedActions({
+  suggestion,
+  onBeadCreated,
+}: {
+  suggestion: Suggestion
+  onBeadCreated?: (updated: Suggestion) => void
+}) {
   const { t } = useTranslation('suggestions')
   const plan = suggestion.plan ?? ''
-  const beadDescId = `suggestion-${suggestion.id}-bead-desc`
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleCreateBead() {
+    if (submitting) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/suggestions/${suggestion.id}/bead`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        let msg = ''
+        try {
+          const body = await res.json() as { error?: string }
+          if (body?.error) msg = body.error
+        } catch {
+          // keep generic fallback
+        }
+        throw new Error(msg)
+      }
+      const updated = await res.json() as Suggestion
+      onBeadCreated?.(updated)
+    } catch (err) {
+      const detail = err instanceof Error && err.message ? err.message : ''
+      setError(t('actions.createBeadError', { message: detail || t('errors.unknown') }))
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   return (
     <div className="w-full space-y-3">
@@ -197,19 +237,65 @@ function PlannedActions({ suggestion }: { suggestion: Suggestion }) {
           {t('actions.noPlanYet')}
         </p>
       )}
-      <div className="space-y-1">
+      {error && (
+        <p
+          role="alert"
+          data-testid={`suggestion-${suggestion.id}-bead-error`}
+          className="text-xs text-red-300"
+        >
+          {error}
+        </p>
+      )}
+      <div>
         <button
           type="button"
-          aria-disabled="true"
-          aria-describedby={beadDescId}
-          onClick={e => e.preventDefault()}
-          className="inline-flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-1.5 text-xs font-medium text-gray-400 cursor-not-allowed opacity-70"
+          onClick={handleCreateBead}
+          disabled={submitting}
+          className="inline-flex items-center gap-2 rounded-lg border border-blue-500/40 bg-blue-500/20 px-3 py-1.5 text-xs font-medium text-blue-300 hover:bg-blue-500/30 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {t('actions.createBead')}
+          {submitting && (
+            <Loader2 size={14} className="animate-spin" aria-hidden={true} />
+          )}
+          <span>
+            {submitting
+              ? t('actions.createBeadInProgress')
+              : error
+                ? t('actions.createBeadRetry')
+                : t('actions.createBead')}
+          </span>
         </button>
-        <p id={beadDescId} className="text-xs text-gray-500">
-          {t('actions.createBeadDisabledTooltip')}
-        </p>
+      </div>
+    </div>
+  )
+}
+
+function BeadCreatedActions({ suggestion }: { suggestion: Suggestion }) {
+  const { t } = useTranslation('suggestions')
+  const plan = suggestion.plan ?? ''
+  const beadID = suggestion.bead_id ?? ''
+
+  return (
+    <div className="w-full space-y-3">
+      {plan && (
+        <div
+          className="prose prose-invert prose-sm max-w-none rounded-md border border-gray-700/60 bg-gray-900/40 px-3 py-2"
+          data-testid={`suggestion-${suggestion.id}-plan`}
+        >
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+            {plan}
+          </ReactMarkdown>
+        </div>
+      )}
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-200">
+        <p className="font-medium">{t('status.beadCreated')}</p>
+        {beadID && (
+          <p
+            className="mt-1 font-mono text-emerald-300"
+            data-testid={`suggestion-${suggestion.id}-bead-id`}
+          >
+            {t('meta.beadId', { id: beadID })}
+          </p>
+        )}
       </div>
     </div>
   )

--- a/web/src/pages/Suggestions.test.tsx
+++ b/web/src/pages/Suggestions.test.tsx
@@ -809,9 +809,9 @@ describe('Suggestions – planned tab', () => {
     })
   })
 
-  it('Create bead button is keyboard-focusable and shows its description', async () => {
+  it('Create bead button is enabled on planned suggestions', async () => {
     const plannedSuggestion = makeSuggestion({ id: 4, title: 'Has plan', status: 'planned', plan: 'A plan' })
-    const list = { pending: [], planned: [plannedSuggestion], rejected: [] }
+    const list = { pending: [], planned: [plannedSuggestion], rejected: [], bead_created: [] }
 
     vi.stubGlobal('fetch', vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve(list) }),
@@ -826,14 +826,168 @@ describe('Suggestions – planned tab', () => {
     fireEvent.click(screen.getByRole('tab', { name: /Planned/ }))
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Create bead/ })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^Create bead$/ })).toBeInTheDocument()
     })
 
-    const btn = screen.getByRole('button', { name: /Create bead/ })
-    // Must not be natively disabled (so keyboard can reach it)
+    const btn = screen.getByRole('button', { name: /^Create bead$/ })
     expect(btn).not.toBeDisabled()
-    expect(btn).toHaveAttribute('aria-disabled', 'true')
-    // Visible description text must be present
-    expect(screen.getByText('Bead creation lands in the next bead.')).toBeInTheDocument()
+    expect(btn).not.toHaveAttribute('aria-disabled', 'true')
+  })
+})
+
+describe('Suggestions – create bead action', () => {
+  it('create bead succeeds: surfaces bead id in a Created beads section', async () => {
+    const plannedSuggestion = makeSuggestion({
+      id: 5,
+      title: 'Plan ready',
+      status: 'planned',
+      plan: '## Plan\n\nDo it',
+    })
+    const updatedSuggestion: Suggestion = {
+      ...plannedSuggestion,
+      status: 'bead_created',
+      bead_id: 'Hytte-abcd',
+      bead_created_at: '2026-05-06T10:00:00Z',
+    }
+    const initial = { pending: [], planned: [plannedSuggestion], rejected: [], bead_created: [] }
+    const refreshed = { pending: [], planned: [], rejected: [], bead_created: [updatedSuggestion] }
+
+    let listCalls = 0
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/5/bead' && init?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(updatedSuggestion) })
+      }
+      if (url === '/api/suggestions') {
+        listCalls += 1
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(listCalls === 1 ? initial : refreshed) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /Planned \(1\)/ })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('tab', { name: /Planned/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Create bead$/ })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Create bead$/ }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggestion-5-bead-id')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('suggestion-5-bead-id')).toHaveTextContent('Hytte-abcd')
+    expect(screen.getByTestId('bead-created-section')).toBeInTheDocument()
+    expect(listCalls).toBeGreaterThanOrEqual(2)
+  })
+
+  it('create bead loading state: shows spinner and disables button', async () => {
+    const plannedSuggestion = makeSuggestion({
+      id: 6,
+      title: 'Plan ready',
+      status: 'planned',
+      plan: 'A plan',
+    })
+    const updatedSuggestion: Suggestion = {
+      ...plannedSuggestion,
+      status: 'bead_created',
+      bead_id: 'Hytte-xyz9',
+    }
+    const initial = { pending: [], planned: [plannedSuggestion], rejected: [], bead_created: [] }
+    const refreshed = { pending: [], planned: [], rejected: [], bead_created: [updatedSuggestion] }
+
+    let resolveBead: ((v: { ok: boolean; json: () => Promise<unknown> }) => void) | null = null
+    let listCalls = 0
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/6/bead' && init?.method === 'POST') {
+        return new Promise<{ ok: boolean; json: () => Promise<unknown> }>(resolve => {
+          resolveBead = resolve
+        })
+      }
+      if (url === '/api/suggestions') {
+        listCalls += 1
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(listCalls === 1 ? initial : refreshed),
+        })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /Planned/ })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('tab', { name: /Planned/ }))
+
+    const idleBtn = await screen.findByRole('button', { name: /^Create bead$/ })
+    expect(idleBtn).not.toBeDisabled()
+    fireEvent.click(idleBtn)
+
+    await waitFor(() => {
+      const inFlight = screen.getByRole('button', { name: /Creating bead…/ })
+      expect(inFlight).toBeDisabled()
+      expect(inFlight.querySelector('.animate-spin')).not.toBeNull()
+    })
+
+    resolveBead!({ ok: true, json: () => Promise.resolve(updatedSuggestion) })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggestion-6-bead-id')).toBeInTheDocument()
+    })
+  })
+
+  it('create bead fails: shows error and keeps card in Planned', async () => {
+    const plannedSuggestion = makeSuggestion({
+      id: 7,
+      title: 'Stays planned',
+      status: 'planned',
+      plan: 'A plan',
+    })
+    const initial = { pending: [], planned: [plannedSuggestion], rejected: [], bead_created: [] }
+
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/7/bead' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({ error: 'bd create failed: database locked' }),
+        })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(initial) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /Planned/ })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('tab', { name: /Planned/ }))
+
+    const btn = await screen.findByRole('button', { name: /^Create bead$/ })
+    fireEvent.click(btn)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggestion-7-bead-error')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('suggestion-7-bead-error')).toHaveTextContent('database locked')
+    // Card must remain in Planned — the planned-card title is still visible.
+    expect(screen.getByText('Stays planned')).toBeInTheDocument()
+    // No bead-created section because nothing has been created yet.
+    expect(screen.queryByTestId('bead-created-section')).not.toBeInTheDocument()
+    // Button label flips to retry.
+    expect(screen.getByRole('button', { name: /Retry create bead/ })).toBeInTheDocument()
   })
 })

--- a/web/src/pages/Suggestions.tsx
+++ b/web/src/pages/Suggestions.tsx
@@ -13,6 +13,7 @@ interface ListResponse {
   pending: Suggestion[]
   planned: Suggestion[]
   rejected: Suggestion[]
+  bead_created?: Suggestion[]
 }
 
 export default function Suggestions() {
@@ -21,6 +22,7 @@ export default function Suggestions() {
   const [pending, setPending] = useState<Suggestion[]>([])
   const [planned, setPlanned] = useState<Suggestion[]>([])
   const [rejected, setRejected] = useState<Suggestion[]>([])
+  const [beadCreated, setBeadCreated] = useState<Suggestion[]>([])
   const [loading, setLoading] = useState(true)
   const [hasData, setHasData] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -37,6 +39,12 @@ export default function Suggestions() {
   const handlePlanned = useCallback((updated: Suggestion) => {
     setPending(prev => prev.filter(s => s.id !== updated.id))
     setPlanned(prev => [updated, ...prev])
+    refetch()
+  }, [refetch])
+
+  const handleBeadCreated = useCallback((updated: Suggestion) => {
+    setPlanned(prev => prev.filter(s => s.id !== updated.id))
+    setBeadCreated(prev => [updated, ...prev])
     refetch()
   }, [refetch])
 
@@ -59,6 +67,7 @@ export default function Suggestions() {
         setPending(data.pending ?? [])
         setPlanned(data.planned ?? [])
         setRejected(data.rejected ?? [])
+        setBeadCreated(data.bead_created ?? [])
         setHasData(true)
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') return
@@ -73,10 +82,10 @@ export default function Suggestions() {
   const counts = useMemo(
     () => ({
       pending: pending.length,
-      planned: planned.length,
+      planned: planned.length + beadCreated.length,
       rejected: rejected.length,
     }),
-    [pending, planned, rejected],
+    [pending, planned, rejected, beadCreated],
   )
 
   async function handleRunNow() {
@@ -109,7 +118,59 @@ export default function Suggestions() {
     refetch()
   }, [refetch])
 
+  function renderCard(s: Suggestion) {
+    return (
+      <SuggestionCard
+        key={s.id}
+        suggestion={s}
+        actionsSlot={
+          s.status === 'rejected' ? null : (
+            <SuggestionActions
+              suggestion={s}
+              onPlanned={handlePlanned}
+              onRejected={refetch}
+              onBeadCreated={handleBeadCreated}
+            />
+          )
+        }
+      />
+    )
+  }
+
   function renderPanel(tab: TabKey, list: Suggestion[]) {
+    if (tab === 'planned') {
+      if (list.length === 0 && beadCreated.length === 0) {
+        return (
+          <p className="px-4 py-10 text-center text-sm text-gray-400">
+            {t('empty.planned')}
+          </p>
+        )
+      }
+      return (
+        <div className="space-y-6">
+          {list.length > 0 && (
+            <div className="space-y-3">
+              {list.map(renderCard)}
+            </div>
+          )}
+          {beadCreated.length > 0 && (
+            <section
+              aria-labelledby="bead-created-heading"
+              data-testid="bead-created-section"
+              className="space-y-3"
+            >
+              <h2
+                id="bead-created-heading"
+                className="text-sm font-semibold uppercase tracking-wide text-emerald-300"
+              >
+                {t('headings.beadCreated')}
+              </h2>
+              {beadCreated.map(renderCard)}
+            </section>
+          )}
+        </div>
+      )
+    }
     if (list.length === 0) {
       return (
         <p className="px-4 py-10 text-center text-sm text-gray-400">
@@ -119,21 +180,7 @@ export default function Suggestions() {
     }
     return (
       <div className="space-y-3">
-        {list.map(s => (
-          <SuggestionCard
-            key={s.id}
-            suggestion={s}
-            actionsSlot={
-              s.status === 'rejected' ? null : (
-                <SuggestionActions
-                  suggestion={s}
-                  onPlanned={handlePlanned}
-                  onRejected={refetch}
-                />
-              )
-            }
-          />
-        ))}
+        {list.map(renderCard)}
       </div>
     )
   }


### PR DESCRIPTION
## Changes

- **Suggestions: create bead from planned suggestions** - Wired the Planned-card "Create bead" button up to a new `POST /api/suggestions/{id}/bead` endpoint that shells out to `bd create` with the `forgeReady` label and links the resulting Hytte- bead back to the suggestion. The Planned tab now shows a "Created beads" section for suggestions that have already shipped. (Hytte-id25)

## Original Issue (feature): Suggestions: bd create integration for Planned suggestions

Third slice of Suggestions. Wires up the "Create bead" button on Planned cards (currently disabled per Hytte-30ko) so it shells out to `bd create` against the Hytte anvil, applies the `forgeReady` label, and links the resulting bead in the UI.

## Context

Planned suggestions today have a disabled "Create bead" button with a tooltip explaining the wiring lands later. This bead does that wiring. After this bead, a typical flow is: Claude generates a suggestion → user clicks Plan it → user reviews the plan → user clicks Create bead → Forge picks up the new forgeReady bead and dispatches it.

## Backend

### New endpoint

`POST /api/suggestions/{id}/bead` (admin-only, inside the existing is_admin block in internal/api/router.go).

Behaviour:

1. Load the suggestion via store.GetByID. 404 if not found.
2. Reject (400) if status is not "planned" — there must be a plan to use as the bead description. Suggesting "auto-plan first" is tempting but explicit two-step is what we agreed on.
3. Construct the bd create invocation:
   - cwd: resolve via `anvilDirForBead("Hytte-x")` from internal/forge/handlers.go (we just want the Hytte anvil path; an alternative is to just use `repoRoot()` from forge/handlers.go — pick whichever is simpler). The intent: `bd create` runs from the Hytte anvil so the issued bead gets the Hytte- prefix.
   - command: `bd create <title> --type feature --priority 3 --labels forgeReady --body-file -`
   - title: the suggestion's title, capped at ~120 chars.
   - description on stdin: the plan body, with a footer that includes:
     - "## Source"
     - "Created from Suggestions page (suggestion id N, page slug, source=claude|user)."
     - If feedback is non-empty: "## User feedback when planning" then the feedback text.
     - The original suggestion body under "## Original suggestion".
   - Use `exec.CommandContext` with a 60-second timeout, mirroring the patterns in internal/forge/handlers.go (AddLabelHandler, BeadDetailHandler).
4. Parse the bead ID from bd create's stdout. The output starts with `✓ Created issue: Hytte-XXXX — ...`. A simple regex `Hytte-[a-z0-9]+` against stdout is sufficient. If parsing fails but the command succeeded, log loudly and return 500 — we cannot link a bead we cannot identify.
5. On success, call store.MarkBeadCreated(ctx, db, id, beadID) and return the updated Suggestion (decrypted) in the response.
6. On bd create failure (non-zero exit), return 500 with the trimmed stderr in the error message. Do NOT mark the suggestion as bead_created.
7. The handler must be admin-only, follow the same auth gating pattern as the other suggestions handlers.

### Resolution of the bd binary

Use `resolveCommand("bd")` from internal/forge/handlers.go (or the equivalent helper there). This is important because forge runs under systemd which can strip user paths — the existing helper handles that.

### Tests

In internal/suggestions/handlers_test.go:

- Add a test for the new endpoint that mocks the bd invocation. The simplest approach: introduce a package-level `bdCreateFn` variable in handlers.go (or a small new file) that defaults to the real exec call and can be replaced in tests, mirroring the runPromptFn pattern. The test substitutes a stub that returns canned stdout containing "Hytte-test1234".
- Cover: 404 on missing id, 400 on non-planned status, success path returns updated Suggestion with bead_id set, bd failure returns 500 and does not move the row to bead_created.
- Confirm the description body assembled on stdin contains the plan body, the suggestion body, and the feedback when present.

### What NOT to do

- Do NOT actually call `bd label add forgeReady` as a follow-up command — the `--labels forgeReady` flag on `bd create` already does this. (We confirmed this in the earlier filing of Hytte-ipyx.)
- Do NOT support new_page suggestions specially yet — they go through the same flow with the same Hytte- prefix; the new_page treatment lives in a later bead.

## Frontend

### Suggestion actions

In web/src/components/suggestions/SuggestionActions.tsx (or wherever the Planned actions are rendered today, per Hytte-k8tl):

- Replace the disabled Create bead button with an enabled button.
- On click, POST to `/api/suggestions/{id}/bead` with credentials.
- Show a loading spinner while the call is in flight (typical 2–10s; cap UX expectations at 60s).
- On success, replace the card's display with a Planned → bead-created variant: the card stays in the Planned tab visually for the rest of this bead OR moves to a new "Created" subsection — pick whichever is simpler given the current code structure. The minimum: surface the new bead ID prominently with a link to `/forge/anvils/Hytte/<bead-id>` if that route exists today; otherwise just plaintext like `Hytte-abcd` is fine.
- On error, show the error inline beneath the button with a retry option. Do NOT remove the suggestion from Planned on error.

### Status filtering

The list endpoint already returns suggestions partitioned by status. Suggestions in `bead_created` status currently come back in the `planned` array (per the existing list handler) only if the handler doesn't filter them out — verify this and update either backend (add a 4th array key "createdBead" to the response) or frontend (filter client-side and render bead_created cards as a sub-list under Planned with a small visual distinction). Pick whichever is simpler. Either way: bead_created cards should still be visible somewhere in the UI so the user can see what they have shipped.

### i18n

Add new keys to web/public/locales/{en,nb,th}/suggestions.json:
- `actions.createBead` already exists from Hytte-30ko — reuse.
- `actions.createBeadInProgress` — "Creating bead…" / "Oppretter bead…" / Thai equivalent
- `actions.createBeadError` — "Failed to create bead: {{message}}"
- `status.beadCreated` — "Bead created"
- `meta.beadId` — "Bead: {{id}}"

### Frontend tests

Update web/src/pages/Suggestions.test.tsx:

- Add a test for the Create bead happy path (mock fetch returning the updated suggestion with bead_id set), assert the resulting card shows the bead ID.
- Add a test for the failure path (mock fetch returning 500), assert the error is shown and the card stays Planned.

## Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build` all pass.
- Backend: hitting `POST /api/suggestions/{id}/bead` against a planned suggestion creates a real Hytte- bead labelled `forgeReady` and updates the row to status=bead_created with the bead id stored.
- Backend: hitting it against a pending or rejected suggestion returns 400.
- Backend: non-admin returns 403/401.
- Frontend: clicking Create bead on a planned card kicks off the call, shows a loading state, and on success surfaces the bead id. On failure, shows an error and keeps the card in Planned.
- The created bead's description includes the plan body, the original suggestion body, and the feedback (when provided).
- Changelog fragment in changelog.d/ (category: Added).

## Reference

- internal/forge/handlers.go — `anvilDirForBead`, `resolveCommand`, AddLabelHandler / BeadDetailHandler for the exec pattern.
- internal/suggestions/handlers.go — admin handler pattern; runPromptFn-style mock pattern.
- internal/suggestions/store.go — MarkBeadCreated already exists.
- web/src/components/suggestions/SuggestionActions.tsx — current Planned actions.


---
Bead: Hytte-id25 | Branch: forge/Hytte-id25
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)