### PR TITLE
Backend: per-page settings table + RotationEligible refactor (Hytte-5aq6)

### DIFF
--- a/changelog.d/Hytte-5aq6.md
+++ b/changelog.d/Hytte-5aq6.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Suggestions: rotation eligibility moved to the database** - The page registry no longer carries an in-code `Enabled` flag; rotation eligibility is read from a new `suggestion_page_settings` table instead. The synchronous run endpoint now consults `RotationEligible`, defaulting every registered page to eligible until an admin row says otherwise. Foundation for the upcoming per-page admin toggle and rotation scheduler. (Hytte-5aq6)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1553,6 +1553,12 @@ func createSchema(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_suggestions_user_status ON suggestions(user_id, status);
 	CREATE INDEX IF NOT EXISTS idx_suggestions_page_slug ON suggestions(page_slug);
 
+	CREATE TABLE IF NOT EXISTS suggestion_page_settings (
+		page_slug        TEXT PRIMARY KEY,
+		rotation_enabled INTEGER NOT NULL DEFAULT 1,
+		updated_at       TIMESTAMP NOT NULL
+	);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/suggestions/generate.go
+++ b/internal/suggestions/generate.go
@@ -68,7 +68,7 @@ var validSizes = map[string]bool{
 // generate three improvement suggestions and inserting them as pending rows
 // owned by userID. Per-page errors are logged but do not abort the run, so a
 // single Claude failure or malformed-JSON page does not lose the rest. The
-// caller is responsible for filtering pages by Enabled (see EnabledPages).
+// caller is responsible for filtering pages (see RotationEligible).
 //
 // Returns counts of inserted suggestions and total errors. Errors include both
 // page-level failures (Claude call, JSON parse) and per-row insert failures, so

--- a/internal/suggestions/generate_test.go
+++ b/internal/suggestions/generate_test.go
@@ -33,8 +33,8 @@ func dummyCfg() *training.ClaudeConfig {
 
 func twoPages() []Page {
 	return []Page{
-		{Slug: "weather", Title: "Weather", Enabled: true},
-		{Slug: "notes", Title: "Notes", Enabled: true},
+		{Slug: "weather", Title: "Weather"},
+		{Slug: "notes", Title: "Notes"},
 	}
 }
 
@@ -80,7 +80,7 @@ func TestRunSuggestionsForPagesRetriesOnceOnMalformedJSON(t *testing.T) {
 	})()
 
 	res := RunSuggestionsForPages(context.Background(), d, dummyCfg(), 1, []Page{
-		{Slug: "weather", Title: "Weather", Enabled: true},
+		{Slug: "weather", Title: "Weather"},
 	})
 	if calls != 2 {
 		t.Fatalf("expected exactly 2 calls (1 retry), got %d", calls)
@@ -140,7 +140,7 @@ func TestRunSuggestionsForPagesCountsPerRowInsertFailures(t *testing.T) {
 	// The Claude call still succeeds, so this isolates per-row failures from
 	// page-level errors.
 	res := RunSuggestionsForPages(context.Background(), d, dummyCfg(), 9999, []Page{
-		{Slug: "weather", Title: "Weather", Enabled: true},
+		{Slug: "weather", Title: "Weather"},
 	})
 	if res.Generated != 0 {
 		t.Fatalf("expected 0 generated, got %d", res.Generated)

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -54,7 +54,14 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 		ctx, cancel := context.WithTimeout(r.Context(), OverallRunTimeout)
 		defer cancel()
 
-		result := RunSuggestionsForPages(ctx, db, cfg, user.ID, EnabledPages())
+		pages, err := RotationEligible(ctx, db)
+		if err != nil {
+			log.Printf("suggestions: load rotation-eligible pages for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load page settings"})
+			return
+		}
+
+		result := RunSuggestionsForPages(ctx, db, cfg, user.ID, pages)
 		writeJSON(w, http.StatusOK, result)
 	}
 }
@@ -402,11 +409,13 @@ type pageSummary struct {
 // PagesHandler returns the registry of pages a user-authored suggestion can
 // target, plus the synthetic "__new_page__" entry for proposing brand-new
 // pages. Order is stable: registry order followed by the new-page sentinel.
+// Rotation eligibility controls auto-generation, not which pages a user can
+// target manually, so this endpoint serves the full registry.
 //
 // GET /api/suggestions/pages
 func PagesHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		pages := EnabledPages()
+		pages := AllRegistered()
 		out := make([]pageSummary, 0, len(pages)+1)
 		for _, p := range pages {
 			out = append(out, pageSummary{Slug: p.Slug, Title: p.Title})
@@ -417,12 +426,13 @@ func PagesHandler() http.HandlerFunc {
 }
 
 // isValidPageSlug returns true if slug is the synthetic new-page sentinel or a
-// slug from the enabled-pages registry.
+// slug from the registry. Users can target any registered page regardless of
+// rotation state.
 func isValidPageSlug(slug string) bool {
 	if slug == NewPageSlug {
 		return true
 	}
-	for _, p := range EnabledPages() {
+	for _, p := range AllRegistered() {
 		if p.Slug == slug {
 			return true
 		}

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -27,7 +27,7 @@ func withSavedPages(replacement []Page) func() {
 
 func TestRunHandlerRejectsNonAdmin(t *testing.T) {
 	d := setupTestDB(t)
-	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
 	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
 		return validJSONResponse, nil
 	})()
@@ -54,8 +54,8 @@ func TestRunHandlerRejectsNonAdmin(t *testing.T) {
 func TestRunHandlerAdminReturnsCounts(t *testing.T) {
 	d := setupTestDB(t)
 	defer withSavedPages([]Page{
-		{Slug: "weather", Title: "Weather", Enabled: true},
-		{Slug: "notes", Title: "Notes", Enabled: true},
+		{Slug: "weather", Title: "Weather"},
+		{Slug: "notes", Title: "Notes"},
 	})()
 	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
 		return validJSONResponse, nil
@@ -100,7 +100,7 @@ func TestRunHandlerAdminReturnsCounts(t *testing.T) {
 
 func TestRunHandlerRequiresClaudeEnabled(t *testing.T) {
 	d := setupTestDB(t)
-	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
 	// Note: claude_enabled is intentionally NOT set.
 
 	mux := http.NewServeMux()
@@ -226,7 +226,7 @@ func TestCreateHandlerRejectsNonAdmin(t *testing.T) {
 
 func TestCreateHandlerSuccess(t *testing.T) {
 	d := setupTestDB(t)
-	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
 
 	router := mountAdmin(CreateHandler(d), http.MethodPost, "/api/suggestions")
 	payload := `{"type":"improvement","size":"m","page_slug":"weather","title":"Cache forecasts","body":"Cache yr.no for 10 minutes."}`
@@ -257,7 +257,7 @@ func TestCreateHandlerSuccess(t *testing.T) {
 
 func TestCreateHandlerAllowsNewPageSlug(t *testing.T) {
 	d := setupTestDB(t)
-	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
 
 	router := mountAdmin(CreateHandler(d), http.MethodPost, "/api/suggestions")
 	payload := fmt.Sprintf(`{"type":"new_page","size":"l","page_slug":%q,"title":"Add expense tracker","body":"A page that..."}`, NewPageSlug)
@@ -272,7 +272,7 @@ func TestCreateHandlerAllowsNewPageSlug(t *testing.T) {
 
 func TestCreateHandlerValidationRejections(t *testing.T) {
 	d := setupTestDB(t)
-	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
 
 	cases := []struct {
 		name    string
@@ -304,7 +304,7 @@ func TestCreateHandlerValidationRejections(t *testing.T) {
 
 func TestCreateThenListRoundTripsDecryptedBody(t *testing.T) {
 	d := setupTestDB(t)
-	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
 
 	const plaintext = "Encrypted at rest, decrypted at the boundary."
 	create := mountAdmin(CreateHandler(d), http.MethodPost, "/api/suggestions")
@@ -515,7 +515,7 @@ func TestPlanHandlerRejectsNonAdmin(t *testing.T) {
 
 func TestPlanHandlerSuccess(t *testing.T) {
 	d := setupTestDB(t)
-	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
 
 	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
 		t.Fatalf("set preference: %v", err)
@@ -559,7 +559,7 @@ func TestPlanHandlerSuccess(t *testing.T) {
 
 func TestPlanHandlerPassesFeedbackIntoPrompt(t *testing.T) {
 	d := setupTestDB(t)
-	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
 
 	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
 		t.Fatalf("set preference: %v", err)
@@ -702,7 +702,7 @@ func TestPlanHandlerTimeoutDoesNotMarkPlanned(t *testing.T) {
 
 func TestPlanHandlerNewPageSlugProducesValidPrompt(t *testing.T) {
 	d := setupTestDB(t)
-	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather", Enabled: true}})()
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
 
 	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
 		t.Fatalf("set preference: %v", err)
@@ -882,9 +882,8 @@ func TestPagesHandlerRejectsNonAdmin(t *testing.T) {
 
 func TestPagesHandlerReturnsRegistryPlusNewPage(t *testing.T) {
 	defer withSavedPages([]Page{
-		{Slug: "weather", Title: "Weather", Enabled: true},
-		{Slug: "notes", Title: "Notes", Enabled: true},
-		{Slug: "disabled", Title: "Disabled", Enabled: false},
+		{Slug: "weather", Title: "Weather"},
+		{Slug: "notes", Title: "Notes"},
 	})()
 
 	router := mountAdmin(PagesHandler(), http.MethodGet, "/api/suggestions/pages")
@@ -899,9 +898,9 @@ func TestPagesHandlerReturnsRegistryPlusNewPage(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	// Expect 2 enabled pages + 1 synthetic.
+	// Expect 2 registered pages + 1 synthetic.
 	if len(got) != 3 {
-		t.Fatalf("expected 3 entries (2 enabled + new_page), got %d: %+v", len(got), got)
+		t.Fatalf("expected 3 entries (2 registered + new_page), got %d: %+v", len(got), got)
 	}
 	if got[0].Slug != "weather" || got[1].Slug != "notes" {
 		t.Fatalf("registry order broken: %+v", got)

--- a/internal/suggestions/pages.go
+++ b/internal/suggestions/pages.go
@@ -91,7 +91,12 @@ var Pages = []Page{
 // rotation-aware view should use RotationEligible instead.
 func AllRegistered() []Page {
 	out := make([]Page, len(Pages))
-	copy(out, Pages)
+	for i, p := range Pages {
+		out[i] = p
+		if p.SourceFiles != nil {
+			out[i].SourceFiles = append([]string(nil), p.SourceFiles...)
+		}
+	}
 	return out
 }
 
@@ -123,7 +128,11 @@ func RotationEligible(ctx context.Context, db *sql.DB) ([]Page, error) {
 	for _, p := range Pages {
 		enabled, ok := settings[p.Slug]
 		if !ok || enabled {
-			out = append(out, p)
+			cp := p
+			if p.SourceFiles != nil {
+				cp.SourceFiles = append([]string(nil), p.SourceFiles...)
+			}
+			out = append(out, cp)
 		}
 	}
 	return out, nil

--- a/internal/suggestions/pages.go
+++ b/internal/suggestions/pages.go
@@ -1,6 +1,10 @@
 package suggestions
 
-import "fmt"
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
 
 // Page describes a single Hytte page that can receive AI-generated improvement
 // suggestions. The registry is hand-curated rather than auto-discovered so that
@@ -21,10 +25,6 @@ type Page struct {
 	// FeatureFlag is the user_features key gating the page. Informational only
 	// in this bead — used in the prompt context.
 	FeatureFlag string
-	// Enabled controls whether RunSuggestionsForPages will generate against this
-	// page. The per-page enable toggle UI is a later bead; for now all seeded
-	// pages default to true.
-	Enabled bool
 }
 
 // Pages is the curated registry. This bead seeds five pages; the full registry
@@ -40,7 +40,6 @@ var Pages = []Page{
 			"internal/weather/handler.go",
 		},
 		FeatureFlag: "weather",
-		Enabled:     true,
 	},
 	{
 		Slug:        "budget",
@@ -52,7 +51,6 @@ var Pages = []Page{
 			"internal/budget/handlers.go",
 		},
 		FeatureFlag: "budget",
-		Enabled:     true,
 	},
 	{
 		Slug:        "notes",
@@ -64,7 +62,6 @@ var Pages = []Page{
 			"internal/notes/handlers.go",
 		},
 		FeatureFlag: "notes",
-		Enabled:     true,
 	},
 	{
 		Slug:        "training",
@@ -76,7 +73,6 @@ var Pages = []Page{
 			"internal/training/handlers.go",
 		},
 		FeatureFlag: "training",
-		Enabled:     true,
 	},
 	{
 		Slug:        "links",
@@ -88,21 +84,49 @@ var Pages = []Page{
 			"internal/links/handlers.go",
 		},
 		FeatureFlag: "links",
-		Enabled:     true,
 	},
 }
 
-// EnabledPages returns the subset of Pages with Enabled == true. This is the
-// canonical filter used at the handler boundary; downstream functions trust
-// that the slice they receive is already filtered.
-func EnabledPages() []Page {
+// AllRegistered returns the unfiltered registry slice. Callers that need a
+// rotation-aware view should use RotationEligible instead.
+func AllRegistered() []Page {
+	out := make([]Page, len(Pages))
+	copy(out, Pages)
+	return out
+}
+
+// RotationEligible returns the subset of Pages that should participate in the
+// rotation scheduler. A page is eligible when no row exists in
+// suggestion_page_settings (the default) or when its rotation_enabled column
+// is 1. The DB is the sole source of truth for rotation state.
+func RotationEligible(ctx context.Context, db *sql.DB) ([]Page, error) {
+	rows, err := db.QueryContext(ctx, `SELECT page_slug, rotation_enabled FROM suggestion_page_settings`)
+	if err != nil {
+		return nil, fmt.Errorf("query suggestion_page_settings: %w", err)
+	}
+	defer rows.Close()
+
+	settings := make(map[string]bool)
+	for rows.Next() {
+		var slug string
+		var enabled int
+		if err := rows.Scan(&slug, &enabled); err != nil {
+			return nil, fmt.Errorf("scan suggestion_page_settings: %w", err)
+		}
+		settings[slug] = enabled == 1
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate suggestion_page_settings: %w", err)
+	}
+
 	out := make([]Page, 0, len(Pages))
 	for _, p := range Pages {
-		if p.Enabled {
+		enabled, ok := settings[p.Slug]
+		if !ok || enabled {
 			out = append(out, p)
 		}
 	}
-	return out
+	return out, nil
 }
 
 // init enforces that page slugs are unique. A duplicate slug would silently

--- a/internal/suggestions/pages_test.go
+++ b/internal/suggestions/pages_test.go
@@ -3,7 +3,6 @@ package suggestions
 import (
 	"context"
 	"database/sql"
-	"sort"
 	"testing"
 	"time"
 )
@@ -98,19 +97,10 @@ func TestRotationEligibleMixedSettings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RotationEligible: %v", err)
 	}
+	// Registry order must be preserved regardless of DB row insertion order.
 	want := []string{"weather", "training"}
-	if diff := slugs(got); !equalStrings(diff, want) {
-		t.Fatalf("expected %v, got %v", want, diff)
-	}
-
-	// Make sure the order of returned pages matches registry order even when
-	// settings rows arrived in a different sequence.
-	wantSorted := append([]string{}, want...)
-	sort.Strings(wantSorted)
-	gotSorted := append([]string{}, slugs(got)...)
-	sort.Strings(gotSorted)
-	if !equalStrings(wantSorted, gotSorted) {
-		t.Fatalf("set mismatch: want %v got %v", wantSorted, gotSorted)
+	if got := slugs(got); !equalStrings(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
 	}
 }
 
@@ -132,16 +122,23 @@ func TestRotationEligibleIgnoresUnknownSlug(t *testing.T) {
 }
 
 func TestAllRegisteredReturnsCopy(t *testing.T) {
-	defer pinTestRegistry()()
+	defer withSavedPages([]Page{
+		{Slug: "weather", Title: "Weather", SourceFiles: []string{"a.go", "b.go"}},
+	})()
 
 	got := AllRegistered()
-	if len(got) != 3 {
-		t.Fatalf("expected 3 pages, got %d", len(got))
+	if len(got) != 1 {
+		t.Fatalf("expected 1 page, got %d", len(got))
 	}
 	// Mutating the returned slice must not affect the package-level registry.
 	got[0].Slug = "tampered"
 	if Pages[0].Slug == "tampered" {
 		t.Fatalf("AllRegistered returned a slice that aliases Pages")
+	}
+	// Mutating a nested SourceFiles slice must not affect the registry.
+	got[0].SourceFiles[0] = "tampered.go"
+	if Pages[0].SourceFiles[0] == "tampered.go" {
+		t.Fatalf("AllRegistered returned SourceFiles that aliases the registry entry")
 	}
 }
 

--- a/internal/suggestions/pages_test.go
+++ b/internal/suggestions/pages_test.go
@@ -1,0 +1,158 @@
+package suggestions
+
+import (
+	"context"
+	"database/sql"
+	"sort"
+	"testing"
+	"time"
+)
+
+// insertPageSetting writes a row into suggestion_page_settings for a given slug
+// and rotation_enabled value. Helper kept local to the test file rather than
+// exported from the package — production writes happen through the admin API,
+// which is built in a sibling bead.
+func insertPageSetting(t *testing.T, d *sql.DB, slug string, enabled int) {
+	t.Helper()
+	_, err := d.Exec(
+		`INSERT INTO suggestion_page_settings (page_slug, rotation_enabled, updated_at) VALUES (?, ?, ?)`,
+		slug, enabled, time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatalf("insert page setting %q=%d: %v", slug, enabled, err)
+	}
+}
+
+// slugs extracts page slugs in order from a slice of pages.
+func slugs(pages []Page) []string {
+	out := make([]string, len(pages))
+	for i, p := range pages {
+		out[i] = p.Slug
+	}
+	return out
+}
+
+// pinTestRegistry replaces the package-level Pages slice for the duration of a
+// test so RotationEligible runs against a known, small registry rather than
+// the production list.
+func pinTestRegistry() func() {
+	return withSavedPages([]Page{
+		{Slug: "weather", Title: "Weather"},
+		{Slug: "notes", Title: "Notes"},
+		{Slug: "training", Title: "Training"},
+	})
+}
+
+func TestRotationEligibleEmptySettingsReturnsAll(t *testing.T) {
+	d := setupTestDB(t)
+	defer pinTestRegistry()()
+
+	got, err := RotationEligible(context.Background(), d)
+	if err != nil {
+		t.Fatalf("RotationEligible: %v", err)
+	}
+	want := []string{"weather", "notes", "training"}
+	if diff := slugs(got); !equalStrings(diff, want) {
+		t.Fatalf("expected %v, got %v", want, diff)
+	}
+}
+
+func TestRotationEligibleExplicitEnableIncludesPage(t *testing.T) {
+	d := setupTestDB(t)
+	defer pinTestRegistry()()
+	insertPageSetting(t, d, "weather", 1)
+
+	got, err := RotationEligible(context.Background(), d)
+	if err != nil {
+		t.Fatalf("RotationEligible: %v", err)
+	}
+	want := []string{"weather", "notes", "training"}
+	if diff := slugs(got); !equalStrings(diff, want) {
+		t.Fatalf("expected %v, got %v", want, diff)
+	}
+}
+
+func TestRotationEligibleExplicitDisableExcludesPage(t *testing.T) {
+	d := setupTestDB(t)
+	defer pinTestRegistry()()
+	insertPageSetting(t, d, "weather", 0)
+
+	got, err := RotationEligible(context.Background(), d)
+	if err != nil {
+		t.Fatalf("RotationEligible: %v", err)
+	}
+	want := []string{"notes", "training"}
+	if diff := slugs(got); !equalStrings(diff, want) {
+		t.Fatalf("expected %v, got %v", want, diff)
+	}
+}
+
+func TestRotationEligibleMixedSettings(t *testing.T) {
+	d := setupTestDB(t)
+	defer pinTestRegistry()()
+	insertPageSetting(t, d, "weather", 1) // explicit on
+	insertPageSetting(t, d, "notes", 0)   // explicit off
+	// "training" has no row → defaults to eligible.
+
+	got, err := RotationEligible(context.Background(), d)
+	if err != nil {
+		t.Fatalf("RotationEligible: %v", err)
+	}
+	want := []string{"weather", "training"}
+	if diff := slugs(got); !equalStrings(diff, want) {
+		t.Fatalf("expected %v, got %v", want, diff)
+	}
+
+	// Make sure the order of returned pages matches registry order even when
+	// settings rows arrived in a different sequence.
+	wantSorted := append([]string{}, want...)
+	sort.Strings(wantSorted)
+	gotSorted := append([]string{}, slugs(got)...)
+	sort.Strings(gotSorted)
+	if !equalStrings(wantSorted, gotSorted) {
+		t.Fatalf("set mismatch: want %v got %v", wantSorted, gotSorted)
+	}
+}
+
+func TestRotationEligibleIgnoresUnknownSlug(t *testing.T) {
+	d := setupTestDB(t)
+	defer pinTestRegistry()()
+	// A row for a slug that is not in the current registry should not affect
+	// the output: registry membership drives the result, settings only filter.
+	insertPageSetting(t, d, "ghost-page", 0)
+
+	got, err := RotationEligible(context.Background(), d)
+	if err != nil {
+		t.Fatalf("RotationEligible: %v", err)
+	}
+	want := []string{"weather", "notes", "training"}
+	if diff := slugs(got); !equalStrings(diff, want) {
+		t.Fatalf("expected %v, got %v", want, diff)
+	}
+}
+
+func TestAllRegisteredReturnsCopy(t *testing.T) {
+	defer pinTestRegistry()()
+
+	got := AllRegistered()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 pages, got %d", len(got))
+	}
+	// Mutating the returned slice must not affect the package-level registry.
+	got[0].Slug = "tampered"
+	if Pages[0].Slug == "tampered" {
+		t.Fatalf("AllRegistered returned a slice that aliases Pages")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Changes

- **Suggestions: rotation eligibility moved to the database** - The page registry no longer carries an in-code `Enabled` flag; rotation eligibility is read from a new `suggestion_page_settings` table instead. The synchronous run endpoint now consults `RotationEligible`, defaulting every registered page to eligible until an admin row says otherwise. Foundation for the upcoming per-page admin toggle and rotation scheduler. (Hytte-5aq6)

## Original Issue (task): Backend: per-page settings table + RotationEligible refactor

Foundation work that all other sub-tasks depend on.

Files to modify:
- internal/db/db.go: add `suggestion_page_settings` table to createSchema() with columns (page_slug TEXT PRIMARY KEY, rotation_enabled INTEGER NOT NULL DEFAULT 1, updated_at TIMESTAMP NOT NULL).
- internal/suggestions/pages.go: replace EnabledPages() with two functions:
  - `func AllRegistered() []Page` — returns the unfiltered registry slice.
  - `func RotationEligible(ctx context.Context, db *sql.DB) ([]Page, error)` — left-joins registry with suggestion_page_settings; a page is eligible if no DB row exists OR rotation_enabled = 1.
  - Remove the in-code `Enabled` field from Page struct (DB is sole source of truth).
- internal/suggestions/handlers.go (and any callers): update the existing POST /api/suggestions/run endpoint to use RotationEligible (no quota slicing).
- Update existing call sites that referenced EnabledPages or the Enabled field.

Tests: pages_test.go covering RotationEligible with: empty settings table (all eligible), explicit enable=1, explicit enable=0, mix.

Connects to siblings: provides AllRegistered, RotationEligible, and the schema that PickRotation, the scheduler, and the admin endpoints all rely on. Must merge first.

---
Bead: Hytte-5aq6 | Branch: forge/Hytte-5aq6
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)