### PR TITLE
Backend: PickRotation + nightly scheduler (Hytte-ira9)

### DIFF
--- a/changelog.d/Hytte-ira9.md
+++ b/changelog.d/Hytte-ira9.md
@@ -1,0 +1,2 @@
+category: Added
+- **Nightly suggestion rotation scheduler** - A new background job runs at 03:00 Europe/Oslo for each admin with Claude enabled, picking the most stale eligible pages from the registry and generating fresh improvement suggestions. (Hytte-ira9)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -214,6 +214,27 @@ func main() {
 				}
 				rows.Close()
 
+				eligibleCtx, eligibleCancel := context.WithTimeout(notifCtx, 30*time.Second)
+				eligible, err := suggestions.RotationEligible(eligibleCtx, database)
+				eligibleCancel()
+				if err != nil {
+					log.Printf("suggestions: rotation eligible: %v", err)
+					continue
+				}
+
+				pickCtx, pickCancel := context.WithTimeout(notifCtx, 30*time.Second)
+				rotation, err := suggestions.PickRotation(pickCtx, database, eligible, suggestions.RotationDefaultN)
+				pickCancel()
+				if err != nil {
+					log.Printf("suggestions: pick rotation: %v", err)
+					continue
+				}
+
+				pageSlugs := make([]string, len(rotation))
+				for i, p := range rotation {
+					pageSlugs[i] = p.Slug
+				}
+
 				for _, adminID := range adminIDs {
 					if notifCtx.Err() != nil {
 						break
@@ -226,27 +247,6 @@ func main() {
 					if !cfg.Enabled {
 						log.Printf("suggestions: skip admin=%d (claude disabled)", adminID)
 						continue
-					}
-
-					eligibleCtx, eligibleCancel := context.WithTimeout(notifCtx, 30*time.Second)
-					eligible, err := suggestions.RotationEligible(eligibleCtx, database)
-					eligibleCancel()
-					if err != nil {
-						log.Printf("suggestions: rotation eligible for admin=%d: %v", adminID, err)
-						continue
-					}
-
-					pickCtx, pickCancel := context.WithTimeout(notifCtx, 30*time.Second)
-					rotation, err := suggestions.PickRotation(pickCtx, database, eligible, suggestions.RotationDefaultN)
-					pickCancel()
-					if err != nil {
-						log.Printf("suggestions: pick rotation for admin=%d: %v", adminID, err)
-						continue
-					}
-
-					pageSlugs := make([]string, len(rotation))
-					for i, p := range rotation {
-						pageSlugs[i] = p.Slug
 					}
 
 					runCtx, runCancel := context.WithTimeout(notifCtx, 30*time.Minute)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/Robin831/Hytte/internal/push"
 	"github.com/Robin831/Hytte/internal/stars"
 	"github.com/Robin831/Hytte/internal/stride"
+	"github.com/Robin831/Hytte/internal/suggestions"
+	"github.com/Robin831/Hytte/internal/training"
 )
 
 func main() {
@@ -170,6 +172,90 @@ func main() {
 					log.Println("stride eval: nightly evaluation complete")
 				}
 				evalCancel()
+			}
+		}
+	}()
+
+	// Schedule nightly suggestion rotation at 03:00 Europe/Oslo.
+	// For each admin user with Claude enabled, pick a rotation slice from the
+	// eligible page registry and run RunSuggestionsForPages with a 30-minute
+	// per-admin timeout derived from notifCtx.
+	go func() {
+		oslo, err := time.LoadLocation("Europe/Oslo")
+		if err != nil {
+			log.Printf("suggestions: failed to load Europe/Oslo timezone: %v", err)
+			return
+		}
+		for {
+			next := suggestions.NextScheduledRun(time.Now(), oslo)
+			timer := time.NewTimer(time.Until(next))
+			select {
+			case <-notifCtx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+				rows, err := database.QueryContext(notifCtx,
+					`SELECT id FROM users WHERE is_admin = 1 ORDER BY id`)
+				if err != nil {
+					log.Printf("suggestions: query admin users: %v", err)
+					continue
+				}
+				var adminIDs []int64
+				for rows.Next() {
+					var id int64
+					if err := rows.Scan(&id); err != nil {
+						log.Printf("suggestions: scan admin id: %v", err)
+						continue
+					}
+					adminIDs = append(adminIDs, id)
+				}
+				if err := rows.Err(); err != nil {
+					log.Printf("suggestions: rows iteration error: %v", err)
+				}
+				rows.Close()
+
+				for _, adminID := range adminIDs {
+					if notifCtx.Err() != nil {
+						break
+					}
+					cfg, err := training.LoadClaudeConfig(database, adminID)
+					if err != nil {
+						log.Printf("suggestions: load claude config for admin=%d: %v", adminID, err)
+						continue
+					}
+					if !cfg.Enabled {
+						log.Printf("suggestions: skip admin=%d (claude disabled)", adminID)
+						continue
+					}
+
+					eligibleCtx, eligibleCancel := context.WithTimeout(notifCtx, 30*time.Second)
+					eligible, err := suggestions.RotationEligible(eligibleCtx, database)
+					eligibleCancel()
+					if err != nil {
+						log.Printf("suggestions: rotation eligible for admin=%d: %v", adminID, err)
+						continue
+					}
+
+					pickCtx, pickCancel := context.WithTimeout(notifCtx, 30*time.Second)
+					rotation, err := suggestions.PickRotation(pickCtx, database, eligible, suggestions.RotationDefaultN)
+					pickCancel()
+					if err != nil {
+						log.Printf("suggestions: pick rotation for admin=%d: %v", adminID, err)
+						continue
+					}
+
+					pageSlugs := make([]string, len(rotation))
+					for i, p := range rotation {
+						pageSlugs[i] = p.Slug
+					}
+
+					runCtx, runCancel := context.WithTimeout(notifCtx, 30*time.Minute)
+					result := suggestions.RunSuggestionsForPages(runCtx, database, cfg, adminID, rotation)
+					runCancel()
+
+					log.Printf("suggestions: nightly run for admin=%d generated=%d errors=%d pages=%v",
+						adminID, result.Generated, result.Errors, pageSlugs)
+				}
 			}
 		}
 	}()

--- a/internal/suggestions/rotation.go
+++ b/internal/suggestions/rotation.go
@@ -1,0 +1,95 @@
+package suggestions
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// RotationDefaultN is the default number of pages selected per nightly
+// rotation. Picked to keep one nightly run well under the per-admin time
+// budget while still cycling through the full registry within a couple of
+// weeks.
+const RotationDefaultN = 10
+
+// PickRotation selects up to n pages from eligible, ordered so that the most
+// stale pages run first. The ordering is:
+//  1. Pages with no prior suggestions, alphabetical by slug.
+//  2. Remaining pages ascending by their most recent generated_at (oldest
+//     first), tie-broken by slug.
+//
+// If n <= 0 or n >= len(eligible), the full sorted slice is returned. The
+// returned slice is a fresh copy; the caller may mutate it freely.
+func PickRotation(ctx context.Context, db *sql.DB, eligible []Page, n int) ([]Page, error) {
+	if len(eligible) == 0 {
+		return []Page{}, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `SELECT page_slug, MAX(generated_at) FROM suggestions GROUP BY page_slug`)
+	if err != nil {
+		return nil, fmt.Errorf("query suggestions max generated_at: %w", err)
+	}
+	defer rows.Close()
+
+	lastBySlug := make(map[string]time.Time)
+	for rows.Next() {
+		var slug string
+		var maxGen sql.NullString
+		if err := rows.Scan(&slug, &maxGen); err != nil {
+			return nil, fmt.Errorf("scan suggestions max generated_at: %w", err)
+		}
+		if !maxGen.Valid {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, maxGen.String)
+		if err != nil {
+			// Fall through with zero time so the slug is still treated as
+			// "no prior suggestion" rather than dropping it silently.
+			continue
+		}
+		lastBySlug[slug] = t
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate suggestions max generated_at: %w", err)
+	}
+
+	type entry struct {
+		page    Page
+		last    time.Time
+		hasPast bool
+	}
+	entries := make([]entry, len(eligible))
+	for i, p := range eligible {
+		t, ok := lastBySlug[p.Slug]
+		entries[i] = entry{page: p, last: t, hasPast: ok}
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if a.hasPast != b.hasPast {
+			return !a.hasPast
+		}
+		if !a.hasPast {
+			return a.page.Slug < b.page.Slug
+		}
+		if !a.last.Equal(b.last) {
+			return a.last.Before(b.last)
+		}
+		return a.page.Slug < b.page.Slug
+	})
+
+	out := make([]Page, len(entries))
+	for i, e := range entries {
+		out[i] = e.page
+		if e.page.SourceFiles != nil {
+			out[i].SourceFiles = append([]string(nil), e.page.SourceFiles...)
+		}
+	}
+
+	if n <= 0 || n >= len(out) {
+		return out, nil
+	}
+	return out[:n], nil
+}

--- a/internal/suggestions/rotation_test.go
+++ b/internal/suggestions/rotation_test.go
@@ -1,0 +1,165 @@
+package suggestions
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// rotationFixturePages returns five eligible pages with deterministic slugs.
+// Using a local fixture rather than the package-level Pages registry means the
+// tests stay valid even if the registry is reordered or extended.
+func rotationFixturePages() []Page {
+	return []Page{
+		{Slug: "alpha", Title: "Alpha", Route: "/alpha"},
+		{Slug: "bravo", Title: "Bravo", Route: "/bravo"},
+		{Slug: "charlie", Title: "Charlie", Route: "/charlie"},
+		{Slug: "delta", Title: "Delta", Route: "/delta"},
+		{Slug: "echo", Title: "Echo", Route: "/echo"},
+	}
+}
+
+// seedSuggestion inserts a minimal suggestion row with the supplied page slug
+// and generated_at timestamp.
+func seedSuggestion(t *testing.T, db *sql.DB, slug string, generatedAt time.Time) {
+	t.Helper()
+	if _, err := Insert(context.Background(), db, Suggestion{
+		UserID:      1,
+		PageSlug:    slug,
+		GeneratedAt: generatedAt,
+		Source:      SourceClaude,
+		Type:        TypeImprovement,
+		Size:        SizeS,
+		Title:       "seed",
+		Body:        "seed body",
+		Status:      StatusPending,
+	}); err != nil {
+		t.Fatalf("seed suggestion for %q: %v", slug, err)
+	}
+}
+
+func slugs(pages []Page) []string {
+	out := make([]string, len(pages))
+	for i, p := range pages {
+		out[i] = p.Slug
+	}
+	return out
+}
+
+func TestPickRotation_SelectsLeastRecentlyRun(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// All five pages have prior suggestions with distinct timestamps.
+	// "echo" is oldest, "alpha" is newest.
+	seedSuggestion(t, d, "alpha", base.Add(4*time.Hour))
+	seedSuggestion(t, d, "bravo", base.Add(3*time.Hour))
+	seedSuggestion(t, d, "charlie", base.Add(2*time.Hour))
+	seedSuggestion(t, d, "delta", base.Add(1*time.Hour))
+	seedSuggestion(t, d, "echo", base)
+
+	got, err := PickRotation(ctx, d, rotationFixturePages(), 2)
+	if err != nil {
+		t.Fatalf("PickRotation: %v", err)
+	}
+	want := []string{"echo", "delta"}
+	if !reflect.DeepEqual(slugs(got), want) {
+		t.Fatalf("slugs mismatch: got %v want %v", slugs(got), want)
+	}
+}
+
+func TestPickRotation_PagesWithoutPriorSuggestionsComeFirst(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// Only alpha and bravo have prior suggestions; charlie/delta/echo do not.
+	// Among the new pages the ordering must be alphabetical.
+	seedSuggestion(t, d, "alpha", base.Add(2*time.Hour))
+	seedSuggestion(t, d, "bravo", base.Add(1*time.Hour))
+
+	got, err := PickRotation(ctx, d, rotationFixturePages(), 0)
+	if err != nil {
+		t.Fatalf("PickRotation: %v", err)
+	}
+	want := []string{"charlie", "delta", "echo", "bravo", "alpha"}
+	if !reflect.DeepEqual(slugs(got), want) {
+		t.Fatalf("slugs mismatch: got %v want %v", slugs(got), want)
+	}
+}
+
+func TestPickRotation_TieBreaksAlphabetically(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// All five pages have the same generated_at — they should be returned in
+	// alphabetical order by slug to keep ordering deterministic.
+	for _, s := range []string{"alpha", "bravo", "charlie", "delta", "echo"} {
+		seedSuggestion(t, d, s, ts)
+	}
+
+	got, err := PickRotation(ctx, d, rotationFixturePages(), 5)
+	if err != nil {
+		t.Fatalf("PickRotation: %v", err)
+	}
+	want := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	if !reflect.DeepEqual(slugs(got), want) {
+		t.Fatalf("slugs mismatch: got %v want %v", slugs(got), want)
+	}
+}
+
+func TestPickRotation_NReturnsAllWhenOutOfBounds(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+	pages := rotationFixturePages()
+
+	for _, n := range []int{-1, 0, len(pages), len(pages) + 5} {
+		got, err := PickRotation(ctx, d, pages, n)
+		if err != nil {
+			t.Fatalf("PickRotation n=%d: %v", n, err)
+		}
+		if len(got) != len(pages) {
+			t.Fatalf("n=%d: expected %d pages, got %d", n, len(pages), len(got))
+		}
+	}
+}
+
+func TestPickRotation_EmptyEligibleReturnsEmpty(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	got, err := PickRotation(ctx, d, []Page{}, RotationDefaultN)
+	if err != nil {
+		t.Fatalf("PickRotation: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", slugs(got))
+	}
+}
+
+func TestPickRotation_ReturnedSliceIsACopy(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+	pages := rotationFixturePages()
+	pages[0].SourceFiles = []string{"a/b.go"}
+
+	got, err := PickRotation(ctx, d, pages, 0)
+	if err != nil {
+		t.Fatalf("PickRotation: %v", err)
+	}
+	// Find alpha in the result and mutate its SourceFiles — the input slice
+	// must not be affected. (PickRotation is allowed to reorder, so we look
+	// the page up by slug rather than by index.)
+	for i := range got {
+		if got[i].Slug == "alpha" {
+			got[i].SourceFiles[0] = "MUTATED"
+		}
+	}
+	if pages[0].SourceFiles[0] == "MUTATED" {
+		t.Fatalf("expected PickRotation to copy SourceFiles; input was mutated")
+	}
+}

--- a/internal/suggestions/rotation_test.go
+++ b/internal/suggestions/rotation_test.go
@@ -40,14 +40,6 @@ func seedSuggestion(t *testing.T, db *sql.DB, slug string, generatedAt time.Time
 	}
 }
 
-func slugs(pages []Page) []string {
-	out := make([]string, len(pages))
-	for i, p := range pages {
-		out[i] = p.Slug
-	}
-	return out
-}
-
 func TestPickRotation_SelectsLeastRecentlyRun(t *testing.T) {
 	d := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/suggestions/scheduler.go
+++ b/internal/suggestions/scheduler.go
@@ -1,0 +1,21 @@
+package suggestions
+
+import "time"
+
+// NextScheduledRun returns the next time the nightly suggestion-rotation cron
+// should fire (daily at 03:00 in the given location). If today's 03:00 is
+// still in the future, today's run is returned; otherwise the next day's run
+// is returned. The result is constructed via time.Date in loc on every call so
+// DST transitions in the target zone are handled correctly.
+func NextScheduledRun(now time.Time, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = time.UTC
+	}
+	now = now.In(loc)
+	todayRun := time.Date(now.Year(), now.Month(), now.Day(), 3, 0, 0, 0, loc)
+	if now.Before(todayRun) {
+		return todayRun
+	}
+	tomorrow := now.AddDate(0, 0, 1)
+	return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 3, 0, 0, 0, loc)
+}

--- a/internal/suggestions/scheduler_test.go
+++ b/internal/suggestions/scheduler_test.go
@@ -59,8 +59,10 @@ func TestNextScheduledRun_BasicSameAndNextDay(t *testing.T) {
 			if !got.After(tc.now) {
 				t.Errorf("result %v is not after now %v", got, tc.now)
 			}
-			if h := got.In(loc).Hour(); loc != nil && h != 3 {
-				t.Errorf("expected hour 3 in loc, got %d", h)
+			if loc != nil {
+				if h := got.In(loc).Hour(); h != 3 {
+					t.Errorf("expected hour 3 in loc, got %d", h)
+				}
 			}
 		})
 	}

--- a/internal/suggestions/scheduler_test.go
+++ b/internal/suggestions/scheduler_test.go
@@ -1,0 +1,145 @@
+package suggestions
+
+import (
+	"testing"
+	"time"
+)
+
+func mustLoadOslo(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("Europe/Oslo")
+	if err != nil {
+		t.Fatalf("load Europe/Oslo: %v", err)
+	}
+	return loc
+}
+
+func TestNextScheduledRun_BasicSameAndNextDay(t *testing.T) {
+	oslo := mustLoadOslo(t)
+
+	tests := []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "before 03:00 returns same day 03:00",
+			now:  time.Date(2026, 4, 6, 1, 0, 0, 0, oslo),
+			want: time.Date(2026, 4, 6, 3, 0, 0, 0, oslo),
+		},
+		{
+			name: "after 03:00 returns next day 03:00",
+			now:  time.Date(2026, 4, 6, 4, 0, 0, 0, oslo),
+			want: time.Date(2026, 4, 7, 3, 0, 0, 0, oslo),
+		},
+		{
+			name: "exactly 03:00 returns next day",
+			now:  time.Date(2026, 4, 6, 3, 0, 0, 0, oslo),
+			want: time.Date(2026, 4, 7, 3, 0, 0, 0, oslo),
+		},
+		{
+			name: "nil location defaults to UTC",
+			now:  time.Date(2026, 4, 6, 1, 0, 0, 0, time.UTC),
+			want: time.Date(2026, 4, 6, 3, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var loc *time.Location
+			if tc.name == "nil location defaults to UTC" {
+				loc = nil
+			} else {
+				loc = oslo
+			}
+			got := NextScheduledRun(tc.now, loc)
+			if !got.Equal(tc.want) {
+				t.Errorf("NextScheduledRun(%v) = %v, want %v", tc.now, got, tc.want)
+			}
+			if !got.After(tc.now) {
+				t.Errorf("result %v is not after now %v", got, tc.now)
+			}
+			if h := got.In(loc).Hour(); loc != nil && h != 3 {
+				t.Errorf("expected hour 3 in loc, got %d", h)
+			}
+		})
+	}
+}
+
+// TestNextScheduledRun_SpringForward verifies behaviour around the European
+// spring-forward DST transition (last Sunday of March). On 2026-03-29 the
+// Oslo clock jumps from 01:59:59 CET (UTC+1) to 03:00:00 CEST (UTC+2).
+func TestNextScheduledRun_SpringForward(t *testing.T) {
+	oslo := mustLoadOslo(t)
+
+	t.Run("before 03:00 on transition day returns today 03:00 CEST", func(t *testing.T) {
+		now := time.Date(2026, 3, 29, 1, 0, 0, 0, oslo) // 01:00 CET (UTC+1)
+		got := NextScheduledRun(now, oslo)
+		want := time.Date(2026, 3, 29, 3, 0, 0, 0, oslo) // 03:00 CEST (UTC+2)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if h := got.In(oslo).Hour(); h != 3 {
+			t.Errorf("expected wall-clock hour 3, got %d", h)
+		}
+		if _, off := got.Zone(); off != 2*3600 {
+			t.Errorf("expected UTC offset +7200 (CEST), got %d", off)
+		}
+	})
+
+	t.Run("after transition returns next day 03:00 CEST", func(t *testing.T) {
+		now := time.Date(2026, 3, 29, 4, 0, 0, 0, oslo) // 04:00 CEST
+		got := NextScheduledRun(now, oslo)
+		want := time.Date(2026, 3, 30, 3, 0, 0, 0, oslo)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if h := got.In(oslo).Hour(); h != 3 {
+			t.Errorf("expected wall-clock hour 3, got %d", h)
+		}
+		if _, off := got.Zone(); off != 2*3600 {
+			t.Errorf("expected UTC offset +7200 (CEST), got %d", off)
+		}
+	})
+}
+
+// TestNextScheduledRun_FallBack verifies behaviour around the European
+// fall-back DST transition (last Sunday of October). On 2026-10-25 the Oslo
+// clock turns back from 02:59:59 CEST (UTC+2) to 02:00:00 CET (UTC+1); the
+// 03:00 wall-clock instant on that day is CET.
+func TestNextScheduledRun_FallBack(t *testing.T) {
+	oslo := mustLoadOslo(t)
+
+	t.Run("before 03:00 on transition day returns today 03:00 CET", func(t *testing.T) {
+		now := time.Date(2026, 10, 25, 1, 0, 0, 0, oslo) // 01:00 CEST (UTC+2)
+		got := NextScheduledRun(now, oslo)
+		want := time.Date(2026, 10, 25, 3, 0, 0, 0, oslo) // 03:00 CET (UTC+1)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if h := got.In(oslo).Hour(); h != 3 {
+			t.Errorf("expected wall-clock hour 3, got %d", h)
+		}
+		if _, off := got.Zone(); off != 1*3600 {
+			t.Errorf("expected UTC offset +3600 (CET), got %d", off)
+		}
+		if !got.After(now) {
+			t.Errorf("result %v not after now %v", got, now)
+		}
+	})
+
+	t.Run("after 03:00 on transition day returns next day 03:00 CET", func(t *testing.T) {
+		now := time.Date(2026, 10, 25, 4, 0, 0, 0, oslo) // 04:00 CET (UTC+1)
+		got := NextScheduledRun(now, oslo)
+		want := time.Date(2026, 10, 26, 3, 0, 0, 0, oslo)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if h := got.In(oslo).Hour(); h != 3 {
+			t.Errorf("expected wall-clock hour 3, got %d", h)
+		}
+		if _, off := got.Zone(); off != 1*3600 {
+			t.Errorf("expected UTC offset +3600 (CET), got %d", off)
+		}
+	})
+}


### PR DESCRIPTION
## Changes

- **Nightly suggestion rotation scheduler** - A new background job runs at 03:00 Europe/Oslo for each admin with Claude enabled, picking the most stale eligible pages from the registry and generating fresh improvement suggestions. (Hytte-ira9)

## Original Issue (task): Backend: PickRotation + nightly scheduler

Depends on sub-task 1 (RotationEligible + schema).

Files to create/modify:
- internal/suggestions/rotation.go (new): `func PickRotation(ctx, db, eligible []Page, n int) ([]Page, error)`. Single SQL query: `SELECT page_slug, MAX(generated_at) FROM suggestions GROUP BY page_slug`. Join in Go with eligible registry. Sort: pages with no prior suggestions first (alphabetical by slug among themselves), then ascending most-recent generated_at. If n<=0 or n>=len(eligible), return all. Const `RotationDefaultN = 10`.
- internal/suggestions/scheduler.go (new): `func NextScheduledRun(now time.Time, loc *time.Location) time.Time` mirroring stride.NextNightlyEvaluationRun — if before 03:00 today in Europe/Oslo, today 03:00; else tomorrow 03:00. Handle DST.
- cmd/server/main.go: add nightly goroutine mirroring the Stride pattern around line 148. On each 03:00 tick: enumerate admin users, for each load training.LoadClaudeConfig(db, adminID) — skip if !cfg.Enabled with a log line; compute eligible := RotationEligible; rotation := PickRotation(eligible, RotationDefaultN); call RunSuggestionsForPages with a 30-minute timeout context derived from notifCtx. Log one-line summary per admin: `suggestions: nightly run for admin=%d generated=%d errors=%d pages=%v`.

Tests:
- internal/suggestions/rotation_test.go: N=2 of 5 picks two least-recently-run; pages with no prior suggestions come first alphabetically; n<=0 and n>=len return all.
- internal/suggestions/scheduler_test.go: NextScheduledRun before/after 03:00 same day, DST spring-forward and fall-back transitions in Europe/Oslo.

Connects: consumes RotationEligible from sub-task 1; produces the runtime behaviour the admin UI in sub-task 4 controls. Independent from sub-task 3 except both depend on sub-task 1.

---
Bead: Hytte-ira9 | Branch: forge/Hytte-ira9
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)