### PR TITLE
Backend: admin endpoints for page settings (Hytte-1waa)

### DIFF
--- a/changelog.d/Hytte-1waa.md
+++ b/changelog.d/Hytte-1waa.md
@@ -1,0 +1,2 @@
+category: Added
+- **Admin endpoints for suggestion page rotation settings** - `GET /api/suggestions/pages` now includes the per-page `rotation_enabled` override (null when no override exists, defaulting to on), and a new `PATCH /api/suggestions/pages/{slug}` upserts the override. Both are admin-only. (Hytte-1waa)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -204,7 +204,8 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/suggestions/{id}/reject", suggestions.RejectHandler(db))
 				r.Post("/suggestions/{id}/plan", suggestions.PlanHandler(db))
 				r.Post("/suggestions/{id}/bead", suggestions.CreateBeadHandler(db))
-				r.Get("/suggestions/pages", suggestions.PagesHandler())
+				r.Get("/suggestions/pages", suggestions.PagesHandler(db))
+				r.Patch("/suggestions/pages/{slug}", suggestions.UpdatePageSettingsHandler(db))
 
 				// Forge dashboard — admin only, registered only when FEATURE_FORGE_DASHBOARD=1.
 				// The feature flag is evaluated at startup; when disabled, these routes are

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -401,28 +401,142 @@ func findPageBySlug(slug string) *Page {
 }
 
 // pageSummary is the lightweight page descriptor returned to the UI.
+// RotationEnabled is a pointer so it serializes as JSON null when no row
+// exists in suggestion_page_settings (the default-enabled case) and as a
+// bool when the admin has explicitly opted in or out. The synthetic
+// "__new_page__" entry is also rendered with null since rotation does not
+// apply to it.
 type pageSummary struct {
-	Slug  string `json:"slug"`
-	Title string `json:"title"`
+	Slug            string `json:"slug"`
+	Title           string `json:"title"`
+	RotationEnabled *bool  `json:"rotation_enabled"`
 }
 
 // PagesHandler returns the registry of pages a user-authored suggestion can
 // target, plus the synthetic "__new_page__" entry for proposing brand-new
 // pages. Order is stable: registry order followed by the new-page sentinel.
 // Rotation eligibility controls auto-generation, not which pages a user can
-// target manually, so this endpoint serves the full registry.
+// target manually, so this endpoint serves the full registry. Each registered
+// page also carries its current rotation_enabled override (null when no row
+// exists in suggestion_page_settings — the default is on).
 //
 // GET /api/suggestions/pages
-func PagesHandler() http.HandlerFunc {
+func PagesHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		settings, err := loadPageRotationSettings(r.Context(), db)
+		if err != nil {
+			log.Printf("suggestions: load page rotation settings: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load page settings"})
+			return
+		}
+
 		pages := AllRegistered()
 		out := make([]pageSummary, 0, len(pages)+1)
 		for _, p := range pages {
-			out = append(out, pageSummary{Slug: p.Slug, Title: p.Title})
+			summary := pageSummary{Slug: p.Slug, Title: p.Title}
+			if v, ok := settings[p.Slug]; ok {
+				enabled := v
+				summary.RotationEnabled = &enabled
+			}
+			out = append(out, summary)
 		}
 		out = append(out, pageSummary{Slug: NewPageSlug, Title: "New page"})
 		writeJSON(w, http.StatusOK, out)
 	}
+}
+
+// UpdatePageSettingsHandler upserts the rotation_enabled flag for a single
+// registered page. The slug must be in the curated registry (AllRegistered);
+// the synthetic "__new_page__" sentinel is rejected because rotation does
+// not apply to it. Returns the updated pageSummary on success.
+//
+// PATCH /api/suggestions/pages/{slug}
+// Request:  { "rotation_enabled": bool }
+// Response: 200 with the updated pageSummary.
+func UpdatePageSettingsHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := strings.TrimSpace(chi.URLParam(r, "slug"))
+		if slug == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "slug is required"})
+			return
+		}
+
+		// Look up the page in the curated registry. Unknown slugs (including
+		// the synthetic __new_page__) return 404 — rotation only applies to
+		// real registered pages.
+		var page *Page
+		for _, p := range AllRegistered() {
+			if p.Slug == slug {
+				cp := p
+				page = &cp
+				break
+			}
+		}
+		if page == nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "unknown page slug"})
+			return
+		}
+
+		// Use a *bool so a missing field is distinguishable from an explicit
+		// false. Either case where the field is absent is a 400.
+		var body struct {
+			RotationEnabled *bool `json:"rotation_enabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+		if body.RotationEnabled == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "rotation_enabled is required"})
+			return
+		}
+
+		enabled := 0
+		if *body.RotationEnabled {
+			enabled = 1
+		}
+		now := time.Now().UTC().Format(time.RFC3339)
+		if _, err := db.ExecContext(r.Context(), `
+			INSERT INTO suggestion_page_settings (page_slug, rotation_enabled, updated_at)
+			VALUES (?, ?, ?)
+			ON CONFLICT(page_slug) DO UPDATE SET
+				rotation_enabled = excluded.rotation_enabled,
+				updated_at = excluded.updated_at
+		`, slug, enabled, now); err != nil {
+			log.Printf("suggestions: upsert page settings %q: %v", slug, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save page settings"})
+			return
+		}
+
+		updated := *body.RotationEnabled
+		writeJSON(w, http.StatusOK, pageSummary{
+			Slug:            page.Slug,
+			Title:           page.Title,
+			RotationEnabled: &updated,
+		})
+	}
+}
+
+// loadPageRotationSettings returns the current per-page rotation_enabled
+// overrides keyed by page_slug. A missing slug means no override exists and
+// the page defaults to enabled.
+func loadPageRotationSettings(ctx context.Context, db *sql.DB) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, `SELECT page_slug, rotation_enabled FROM suggestion_page_settings`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]bool)
+	for rows.Next() {
+		var slug string
+		var enabled int
+		if err := rows.Scan(&slug, &enabled); err != nil {
+			return nil, err
+		}
+		out[slug] = enabled == 1
+	}
+	return out, rows.Err()
 }
 
 // isValidPageSlug returns true if slug is the synthetic new-page sentinel or a

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -464,14 +464,7 @@ func UpdatePageSettingsHandler(db *sql.DB) http.HandlerFunc {
 		// Look up the page in the curated registry. Unknown slugs (including
 		// the synthetic __new_page__) return 404 — rotation only applies to
 		// real registered pages.
-		var page *Page
-		for _, p := range AllRegistered() {
-			if p.Slug == slug {
-				cp := p
-				page = &cp
-				break
-			}
-		}
+		page := findPageBySlug(slug)
 		if page == nil {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "unknown page slug"})
 			return

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -870,7 +870,8 @@ func TestPlanHandlerRequiresClaudeEnabled(t *testing.T) {
 // --- PagesHandler ------------------------------------------------------------
 
 func TestPagesHandlerRejectsNonAdmin(t *testing.T) {
-	router := mountAdmin(PagesHandler(), http.MethodGet, "/api/suggestions/pages")
+	d := setupTestDB(t)
+	router := mountAdmin(PagesHandler(d), http.MethodGet, "/api/suggestions/pages")
 	req := adminContext(httptest.NewRequest(http.MethodGet, "/api/suggestions/pages", nil), 99, false)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
@@ -881,12 +882,13 @@ func TestPagesHandlerRejectsNonAdmin(t *testing.T) {
 }
 
 func TestPagesHandlerReturnsRegistryPlusNewPage(t *testing.T) {
+	d := setupTestDB(t)
 	defer withSavedPages([]Page{
 		{Slug: "weather", Title: "Weather"},
 		{Slug: "notes", Title: "Notes"},
 	})()
 
-	router := mountAdmin(PagesHandler(), http.MethodGet, "/api/suggestions/pages")
+	router := mountAdmin(PagesHandler(d), http.MethodGet, "/api/suggestions/pages")
 	req := adminContext(httptest.NewRequest(http.MethodGet, "/api/suggestions/pages", nil), 1, true)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
@@ -907,5 +909,189 @@ func TestPagesHandlerReturnsRegistryPlusNewPage(t *testing.T) {
 	}
 	if got[2].Slug != NewPageSlug {
 		t.Fatalf("expected last entry to be %q, got %q", NewPageSlug, got[2].Slug)
+	}
+	// With no rows in suggestion_page_settings, every entry should report
+	// rotation_enabled=null so the frontend can render the default-on state.
+	for _, p := range got {
+		if p.RotationEnabled != nil {
+			t.Fatalf("expected rotation_enabled=nil for %q with no settings row, got %v", p.Slug, *p.RotationEnabled)
+		}
+	}
+}
+
+func TestPagesHandlerIncludesRotationEnabledFromSettings(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{
+		{Slug: "weather", Title: "Weather"},
+		{Slug: "notes", Title: "Notes"},
+		{Slug: "training", Title: "Training"},
+	})()
+
+	// weather has an explicit on row, notes has an explicit off row, training
+	// has no row (default null).
+	insertPageSetting(t, d, "weather", 1)
+	insertPageSetting(t, d, "notes", 0)
+
+	router := mountAdmin(PagesHandler(d), http.MethodGet, "/api/suggestions/pages")
+	req := adminContext(httptest.NewRequest(http.MethodGet, "/api/suggestions/pages", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []pageSummary
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	bySlug := make(map[string]pageSummary, len(got))
+	for _, p := range got {
+		bySlug[p.Slug] = p
+	}
+
+	w := bySlug["weather"]
+	if w.RotationEnabled == nil || !*w.RotationEnabled {
+		t.Fatalf("weather: expected rotation_enabled=true, got %v", w.RotationEnabled)
+	}
+	n := bySlug["notes"]
+	if n.RotationEnabled == nil || *n.RotationEnabled {
+		t.Fatalf("notes: expected rotation_enabled=false, got %v", n.RotationEnabled)
+	}
+	tr := bySlug["training"]
+	if tr.RotationEnabled != nil {
+		t.Fatalf("training: expected rotation_enabled=nil (default), got %v", *tr.RotationEnabled)
+	}
+	// Synthetic new-page entry never carries a rotation flag.
+	np := bySlug[NewPageSlug]
+	if np.RotationEnabled != nil {
+		t.Fatalf("%s: expected rotation_enabled=nil, got %v", NewPageSlug, *np.RotationEnabled)
+	}
+}
+
+// --- UpdatePageSettingsHandler -----------------------------------------------
+
+func TestUpdatePageSettingsHandlerRejectsNonAdmin(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
+	router := mountAdmin(UpdatePageSettingsHandler(d), http.MethodPatch, "/api/suggestions/pages/{slug}")
+
+	req := adminContext(httptest.NewRequest(http.MethodPatch, "/api/suggestions/pages/weather", strings.NewReader(`{"rotation_enabled":true}`)), 99, false)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdatePageSettingsHandlerInsertsAndUpdates(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
+	router := mountAdmin(UpdatePageSettingsHandler(d), http.MethodPatch, "/api/suggestions/pages/{slug}")
+
+	// First call inserts a row with rotation_enabled=false.
+	req := adminContext(httptest.NewRequest(http.MethodPatch, "/api/suggestions/pages/weather", strings.NewReader(`{"rotation_enabled":false}`)), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first patch: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got pageSummary
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Slug != "weather" || got.Title != "Weather" {
+		t.Fatalf("unexpected page summary: %+v", got)
+	}
+	if got.RotationEnabled == nil || *got.RotationEnabled {
+		t.Fatalf("expected rotation_enabled=false, got %v", got.RotationEnabled)
+	}
+
+	// Verify the row landed in the DB with the expected value.
+	var enabled int
+	if err := d.QueryRow(`SELECT rotation_enabled FROM suggestion_page_settings WHERE page_slug = ?`, "weather").Scan(&enabled); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if enabled != 0 {
+		t.Fatalf("expected rotation_enabled=0 in DB, got %d", enabled)
+	}
+
+	// Second call flips it back to true via the upsert path.
+	req = adminContext(httptest.NewRequest(http.MethodPatch, "/api/suggestions/pages/weather", strings.NewReader(`{"rotation_enabled":true}`)), 1, true)
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second patch: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := d.QueryRow(`SELECT rotation_enabled FROM suggestion_page_settings WHERE page_slug = ?`, "weather").Scan(&enabled); err != nil {
+		t.Fatalf("read row after upsert: %v", err)
+	}
+	if enabled != 1 {
+		t.Fatalf("expected rotation_enabled=1 after upsert, got %d", enabled)
+	}
+
+	// Only one row should exist for the slug — confirms the upsert path.
+	var count int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM suggestion_page_settings WHERE page_slug = ?`, "weather").Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 row for weather, got %d", count)
+	}
+}
+
+func TestUpdatePageSettingsHandlerUnknownSlugReturns404(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
+	router := mountAdmin(UpdatePageSettingsHandler(d), http.MethodPatch, "/api/suggestions/pages/{slug}")
+
+	req := adminContext(httptest.NewRequest(http.MethodPatch, "/api/suggestions/pages/nope", strings.NewReader(`{"rotation_enabled":true}`)), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown slug, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdatePageSettingsHandlerNewPageSlugReturns404(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
+	router := mountAdmin(UpdatePageSettingsHandler(d), http.MethodPatch, "/api/suggestions/pages/{slug}")
+
+	// The synthetic __new_page__ sentinel is not a registered page; rotation
+	// does not apply to it, so the endpoint must reject it as unknown.
+	req := adminContext(httptest.NewRequest(http.MethodPatch, "/api/suggestions/pages/"+NewPageSlug, strings.NewReader(`{"rotation_enabled":true}`)), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for synthetic slug, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdatePageSettingsHandlerInvalidBody(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
+	router := mountAdmin(UpdatePageSettingsHandler(d), http.MethodPatch, "/api/suggestions/pages/{slug}")
+
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"malformed json", `{not json`},
+		{"missing field", `{}`},
+		{"wrong type", `{"rotation_enabled":"yes"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := adminContext(httptest.NewRequest(http.MethodPatch, "/api/suggestions/pages/weather", strings.NewReader(tc.payload)), 1, true)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("%s: expected 400, got %d: %s", tc.name, rec.Code, rec.Body.String())
+			}
+		})
 	}
 }

--- a/internal/suggestions/pages.go
+++ b/internal/suggestions/pages.go
@@ -105,23 +105,9 @@ func AllRegistered() []Page {
 // suggestion_page_settings (the default) or when its rotation_enabled column
 // is 1. The DB is the sole source of truth for rotation state.
 func RotationEligible(ctx context.Context, db *sql.DB) ([]Page, error) {
-	rows, err := db.QueryContext(ctx, `SELECT page_slug, rotation_enabled FROM suggestion_page_settings`)
+	settings, err := loadPageRotationSettings(ctx, db)
 	if err != nil {
-		return nil, fmt.Errorf("query suggestion_page_settings: %w", err)
-	}
-	defer rows.Close()
-
-	settings := make(map[string]bool)
-	for rows.Next() {
-		var slug string
-		var enabled int
-		if err := rows.Scan(&slug, &enabled); err != nil {
-			return nil, fmt.Errorf("scan suggestion_page_settings: %w", err)
-		}
-		settings[slug] = enabled == 1
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate suggestion_page_settings: %w", err)
+		return nil, fmt.Errorf("load page rotation settings: %w", err)
 	}
 
 	out := make([]Page, 0, len(Pages))


### PR DESCRIPTION
## Changes

- **Admin endpoints for suggestion page rotation settings** - `GET /api/suggestions/pages` now includes the per-page `rotation_enabled` override (null when no override exists, defaulting to on), and a new `PATCH /api/suggestions/pages/{slug}` upserts the override. Both are admin-only. (Hytte-1waa)

## Original Issue (task): Backend: admin endpoints for page settings

Depends on sub-task 1 (schema + RotationEligible).

Files to modify:
- internal/api/router.go: register inside the existing is_admin block:
  - GET /api/suggestions/pages — extend existing handler to include `rotation_enabled` per page (nullable; null means default true).
  - PATCH /api/suggestions/pages/{slug} — body `{ rotation_enabled: bool }`. Upserts a row in suggestion_page_settings with updated_at = now. 404 if slug not in registry (validate against AllRegistered()). Returns the updated record.
- internal/suggestions/handlers.go: implement the two handlers. Use AllRegistered() + a lookup against suggestion_page_settings for the GET; INSERT ... ON CONFLICT(page_slug) DO UPDATE for PATCH.

Tests: internal/suggestions/handlers_test.go covering for each endpoint: success path; validation (PATCH bad body, unknown slug → 404); admin-only enforcement (non-admin → 403).

Connects: produces the HTTP API the frontend in sub-task 4 calls. Can be developed in parallel with sub-task 2 once sub-task 1 is in.

---
Bead: Hytte-1waa | Branch: forge/Hytte-1waa
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)