### PR TITLE
New-page suggestion prompt and wiring (Hytte-1qag)

### DIFF
--- a/changelog.d/Hytte-1qag.md
+++ b/changelog.d/Hytte-1qag.md
@@ -1,0 +1,2 @@
+category: Added
+- **New-page suggestion pass** - The suggestions engine now runs a separate Claude pass per nightly rotation (and per Run-now click) that proposes one entirely new page idea. Generated rows use page_slug `__new_page__`, type `new_page`, and surface in the Suggestions UI with a distinct "New page idea" chip. (Hytte-1qag)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -258,6 +258,7 @@ func main() {
 					newPageResult, err := suggestions.RunNewPageSuggestion(runCtx, database, cfg, adminID)
 					if err != nil {
 						log.Printf("suggestions: new_page run for admin=%d: %v", adminID, err)
+						result.Errors++
 					}
 					result.Generated += newPageResult.Generated
 					result.Errors += newPageResult.Errors

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -251,6 +251,16 @@ func main() {
 
 					runCtx, runCancel := context.WithTimeout(notifCtx, 30*time.Minute)
 					result := suggestions.RunSuggestionsForPages(runCtx, database, cfg, adminID, rotation)
+
+					// Run a separate Claude pass that proposes one new page idea.
+					// Failures are logged and folded into the same RunResult; we
+					// do not abort the rest of the schedule when this pass fails.
+					newPageResult, err := suggestions.RunNewPageSuggestion(runCtx, database, cfg, adminID)
+					if err != nil {
+						log.Printf("suggestions: new_page run for admin=%d: %v", adminID, err)
+					}
+					result.Generated += newPageResult.Generated
+					result.Errors += newPageResult.Errors
 					runCancel()
 
 					log.Printf("suggestions: nightly run for admin=%d generated=%d errors=%d pages=%v",

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -62,6 +62,17 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		result := RunSuggestionsForPages(ctx, db, cfg, user.ID, pages)
+
+		// Also run the separate new-page idea pass. Errors are logged and
+		// counted in the aggregated RunResult so a single failure here cannot
+		// hide the per-page totals from the operator.
+		newPageResult, err := RunNewPageSuggestion(ctx, db, cfg, user.ID)
+		if err != nil {
+			log.Printf("suggestions: new_page run for user %d: %v", user.ID, err)
+		}
+		result.Generated += newPageResult.Generated
+		result.Errors += newPageResult.Errors
+
 		writeJSON(w, http.StatusOK, result)
 	}
 }

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -69,6 +69,7 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 		newPageResult, err := RunNewPageSuggestion(ctx, db, cfg, user.ID)
 		if err != nil {
 			log.Printf("suggestions: new_page run for user %d: %v", user.ID, err)
+			result.Errors++
 		}
 		result.Generated += newPageResult.Generated
 		result.Errors += newPageResult.Errors

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -61,7 +61,7 @@ func TestRunHandlerAdminReturnsCounts(t *testing.T) {
 	// separate new-page pass; respond with the right shape based on the
 	// prompt's distinguishing phrase so both passes succeed.
 	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
-		if strings.Contains(prompt, "brainstorming new pages") {
+		if strings.Contains(prompt, "Return ONLY a single JSON object") {
 			return validNewPageJSON, nil
 		}
 		return validJSONResponse, nil

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -57,7 +57,13 @@ func TestRunHandlerAdminReturnsCounts(t *testing.T) {
 		{Slug: "weather", Title: "Weather"},
 		{Slug: "notes", Title: "Notes"},
 	})()
+	// The run handler now calls both the per-page rotation pass and the
+	// separate new-page pass; respond with the right shape based on the
+	// prompt's distinguishing phrase so both passes succeed.
 	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		if strings.Contains(prompt, "brainstorming new pages") {
+			return validNewPageJSON, nil
+		}
 		return validJSONResponse, nil
 	})()
 
@@ -85,16 +91,26 @@ func TestRunHandlerAdminReturnsCounts(t *testing.T) {
 	if got.Errors != 0 {
 		t.Fatalf("expected 0 errors, got %d", got.Errors)
 	}
-	if got.Generated != 6 {
-		t.Fatalf("expected 6 generated (3 per page × 2), got %d", got.Generated)
+	// 3 per page × 2 pages = 6 from per-page rotation, plus 1 from the
+	// new-page pass = 7 total.
+	if got.Generated != 7 {
+		t.Fatalf("expected 7 generated (3 per page × 2 + 1 new_page), got %d", got.Generated)
 	}
 
 	var rowCount int
 	if err := d.QueryRow(`SELECT COUNT(*) FROM suggestions`).Scan(&rowCount); err != nil {
 		t.Fatalf("count rows: %v", err)
 	}
-	if rowCount != 6 {
-		t.Fatalf("expected 6 rows persisted, got %d", rowCount)
+	if rowCount != 7 {
+		t.Fatalf("expected 7 rows persisted, got %d", rowCount)
+	}
+
+	var newPageCount int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM suggestions WHERE page_slug = ?`, NewPageSlug).Scan(&newPageCount); err != nil {
+		t.Fatalf("count new_page rows: %v", err)
+	}
+	if newPageCount != 1 {
+		t.Fatalf("expected exactly 1 new_page row, got %d", newPageCount)
 	}
 }
 

--- a/internal/suggestions/new_page.go
+++ b/internal/suggestions/new_page.go
@@ -1,0 +1,226 @@
+package suggestions
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+// NewPageWindowDays is the look-back window for prior new_page suggestions
+// embedded in the prompt for de-duplication. The window matches the bead
+// specification (last 30 days).
+const NewPageWindowDays = 30
+
+// NewPageTimeout caps the single Claude call (plus one retry on malformed
+// JSON). Mirrors PerPageTimeout in shape but is set independently so the
+// new-page pass can be tuned without affecting per-page generation.
+const NewPageTimeout = 90 * time.Second
+
+// newPageGenerated is the JSON shape we expect for a single new-page
+// suggestion. Type is fixed to TypeNewPage on insert and is therefore not
+// included in the schema sent to Claude.
+type newPageGenerated struct {
+	Size  string `json:"size"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// RunNewPageSuggestion runs a separate Claude pass that proposes one entirely
+// new page idea. On success it inserts a single row with page_slug set to the
+// synthetic NewPageSlug, type=TypeNewPage, source=SourceClaude, and
+// status=StatusPending. The function returns counts in a RunResult so the
+// caller can fold them into the overall nightly/run-handler totals.
+//
+// Errors at any step (loading context, calling Claude, parsing JSON, inserting)
+// are logged and surfaced via RunResult.Errors. The returned error is reserved
+// for context cancellation so the scheduler can decide whether to abort the
+// run; all other failures are non-fatal and counted in Errors.
+func RunNewPageSuggestion(
+	ctx context.Context,
+	db *sql.DB,
+	cfg *training.ClaudeConfig,
+	userID int64,
+) (RunResult, error) {
+	var result RunResult
+
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, NewPageTimeout)
+	defer cancel()
+
+	registered := AllRegistered()
+
+	recent, err := recentNewPageSuggestions(runCtx, db, userID, NewPageWindowDays)
+	if err != nil {
+		log.Printf("suggestions: load recent new_page suggestions: %v; continuing without", err)
+		recent = nil
+	}
+
+	prompt := buildNewPagePrompt(registered, recent)
+
+	parsed, err := callAndParseNewPage(runCtx, cfg, prompt)
+	if err != nil {
+		log.Printf("suggestions: new_page generation failed: %v", err)
+		result.Errors++
+		return result, nil
+	}
+
+	row := Suggestion{
+		UserID:      userID,
+		GeneratedAt: time.Now().UTC(),
+		PageSlug:    NewPageSlug,
+		Source:      SourceClaude,
+		Type:        TypeNewPage,
+		Size:        parsed.Size,
+		Title:       parsed.Title,
+		Body:        parsed.Body,
+		Status:      StatusPending,
+	}
+	if _, err := Insert(runCtx, db, row); err != nil {
+		log.Printf("suggestions: insert new_page suggestion: %v", err)
+		result.Errors++
+		return result, nil
+	}
+	result.Generated++
+	return result, nil
+}
+
+// callAndParseNewPage invokes runPromptFn and parses the response, retrying
+// once on malformed JSON. The retry uses the same prompt — no nudge text is
+// appended because the original prompt already insists on JSON-only output.
+// This mirrors the behaviour in callAndParse for per-page generation so both
+// passes have the same retry semantics.
+func callAndParseNewPage(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (newPageGenerated, error) {
+	var lastErr error
+	for attempt := 0; attempt <= MaxRetriesOnMalformedJSON; attempt++ {
+		resp, err := runPromptFn(ctx, cfg, prompt)
+		if err != nil {
+			return newPageGenerated{}, fmt.Errorf("claude prompt: %w", err)
+		}
+		parsed, err := parseNewPageResponse(resp)
+		if err == nil {
+			return parsed, nil
+		}
+		lastErr = err
+		log.Printf("suggestions: new_page parse attempt %d failed: %v", attempt+1, err)
+	}
+	return newPageGenerated{}, fmt.Errorf("parse new_page response after %d attempts: %w", MaxRetriesOnMalformedJSON+1, lastErr)
+}
+
+// parseNewPageResponse strips an optional markdown fence and decodes a single
+// validated newPageGenerated object. Mirrors parseSuggestionsResponse but
+// expects an object, not an array, and validates only size/title/body.
+func parseNewPageResponse(response string) (newPageGenerated, error) {
+	response = strings.TrimSpace(response)
+
+	if strings.HasPrefix(response, "```") {
+		lines := strings.Split(response, "\n")
+		if len(lines) >= 3 {
+			response = strings.Join(lines[1:len(lines)-1], "\n")
+		}
+	}
+
+	var item newPageGenerated
+	if err := json.Unmarshal([]byte(response), &item); err != nil {
+		return newPageGenerated{}, fmt.Errorf("unmarshal: %w", err)
+	}
+	if !validSizes[item.Size] {
+		return newPageGenerated{}, fmt.Errorf("invalid size %q", item.Size)
+	}
+	if strings.TrimSpace(item.Title) == "" {
+		return newPageGenerated{}, fmt.Errorf("empty title")
+	}
+	if strings.TrimSpace(item.Body) == "" {
+		return newPageGenerated{}, fmt.Errorf("empty body")
+	}
+	return item, nil
+}
+
+// buildNewPagePrompt assembles the prompt for a single new-page idea. The
+// registry is included so Claude does not propose a page that already exists,
+// and recent new_page suggestions are listed so it can avoid repeating its
+// own past ideas. Output schema is a single JSON object with size/title/body.
+func buildNewPagePrompt(allRegistered []Page, recentNewPageSuggestions []Suggestion) string {
+	var sb strings.Builder
+
+	sb.WriteString("You are a senior product engineer brainstorming new pages for a personal web app called Hytte.\n")
+	sb.WriteString("Your job: propose ONE entirely new page that does not already exist in the registry below.\n")
+	sb.WriteString("Pick something genuinely useful — not a thin variant of an existing page.\n\n")
+
+	if len(allRegistered) > 0 {
+		sb.WriteString("## Existing pages (do NOT propose anything that overlaps with these)\n")
+		for _, p := range allRegistered {
+			fmt.Fprintf(&sb, "- %s — %s", p.Slug, p.Title)
+			if p.Description != "" {
+				fmt.Fprintf(&sb, ": %s", p.Description)
+			}
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(recentNewPageSuggestions) > 0 {
+		sb.WriteString("## Recent new-page suggestions (avoid repeating these)\n")
+		for _, s := range recentNewPageSuggestions {
+			fmt.Fprintf(&sb, "- [%s/%s] %s\n", s.Status, s.Size, s.Title)
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(`## Output format
+
+Return ONLY a single JSON object. Do not wrap in markdown fences.
+The object must have these fields and only these fields:
+
+- "size": one of "s" (under a day), "m" (one to three days), "l" (more than three days)
+- "title": short imperative sentence naming the new page, max 80 chars, no trailing period
+- "body": 2 to 5 sentences explaining what the page does, who it is for, and the user-visible value it adds
+
+Example shape (do NOT copy these contents):
+{"size": "m", "title": "...", "body": "..."}
+`)
+
+	return sb.String()
+}
+
+// recentNewPageSuggestions returns suggestions of type new_page whose status
+// is not "rejected" and that were generated within the last `days` days.
+// Used by buildNewPagePrompt to discourage repeats.
+func recentNewPageSuggestions(ctx context.Context, db *sql.DB, userID int64, days int) ([]Suggestion, error) {
+	cutoff := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, user_id, generated_at, page_slug, source, type, size,
+		       title, body_enc, status, feedback_enc, plan_enc, bead_id,
+		       rejected_at, planned_at, bead_created_at
+		FROM suggestions
+		WHERE user_id = ? AND type = ?
+		  AND status IN (?, ?, ?)
+		  AND generated_at >= ?
+		ORDER BY generated_at DESC
+	`, userID, TypeNewPage,
+		StatusPending, StatusPlanned, StatusBeadCreated,
+		cutoff,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("recent new_page suggestions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Suggestion
+	for rows.Next() {
+		s, err := scanSuggestion(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}

--- a/internal/suggestions/new_page.go
+++ b/internal/suggestions/new_page.go
@@ -37,10 +37,13 @@ type newPageGenerated struct {
 // status=StatusPending. The function returns counts in a RunResult so the
 // caller can fold them into the overall nightly/run-handler totals.
 //
-// Errors at any step (loading context, calling Claude, parsing JSON, inserting)
-// are logged and surfaced via RunResult.Errors. The returned error is reserved
-// for context cancellation so the scheduler can decide whether to abort the
-// run; all other failures are non-fatal and counted in Errors.
+// Loading the deduplication context (recent new_page suggestions) is non-fatal:
+// a failure is logged and the prompt proceeds without that context; it is not
+// counted in RunResult.Errors. Failures in the Claude call, JSON parsing, or DB
+// insert are logged and counted in RunResult.Errors. If the caller's ctx is
+// cancelled or its deadline exceeded during any of these steps, the context
+// error is returned directly so the scheduler can decide whether to abort the
+// run.
 func RunNewPageSuggestion(
 	ctx context.Context,
 	db *sql.DB,
@@ -68,6 +71,9 @@ func RunNewPageSuggestion(
 
 	parsed, err := callAndParseNewPage(runCtx, cfg, prompt)
 	if err != nil {
+		if ctx.Err() != nil {
+			return result, ctx.Err()
+		}
 		log.Printf("suggestions: new_page generation failed: %v", err)
 		result.Errors++
 		return result, nil
@@ -85,6 +91,9 @@ func RunNewPageSuggestion(
 		Status:      StatusPending,
 	}
 	if _, err := Insert(runCtx, db, row); err != nil {
+		if ctx.Err() != nil {
+			return result, ctx.Err()
+		}
 		log.Printf("suggestions: insert new_page suggestion: %v", err)
 		result.Errors++
 		return result, nil
@@ -129,7 +138,9 @@ func parseNewPageResponse(response string) (newPageGenerated, error) {
 	}
 
 	var item newPageGenerated
-	if err := json.Unmarshal([]byte(response), &item); err != nil {
+	dec := json.NewDecoder(strings.NewReader(response))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&item); err != nil {
 		return newPageGenerated{}, fmt.Errorf("unmarshal: %w", err)
 	}
 	if !validSizes[item.Size] {

--- a/internal/suggestions/new_page_test.go
+++ b/internal/suggestions/new_page_test.go
@@ -203,3 +203,9 @@ func TestParseNewPageResponseRejectsEmptyBody(t *testing.T) {
 		t.Fatal("expected error for empty body, got nil")
 	}
 }
+
+func TestParseNewPageResponseRejectsUnknownFields(t *testing.T) {
+	if _, err := parseNewPageResponse(`{"size":"s","title":"X","body":"y","extra":"oops"}`); err == nil {
+		t.Fatal("expected error for unknown fields, got nil")
+	}
+}

--- a/internal/suggestions/new_page_test.go
+++ b/internal/suggestions/new_page_test.go
@@ -1,0 +1,205 @@
+package suggestions
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+const validNewPageJSON = `{"size": "m", "title": "Reading log", "body": "A page that tracks books I am reading, with notes per chapter and a finished-by-date target. Useful for spotting which books I drop, and for keeping a backlog of next-up titles. Adds a small dashboard widget for current progress."}`
+
+func TestRunNewPageSuggestionInsertsOneRow(t *testing.T) {
+	d := setupTestDB(t)
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		return validNewPageJSON, nil
+	})()
+
+	res, err := RunNewPageSuggestion(context.Background(), d, dummyCfg(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Generated != 1 {
+		t.Fatalf("expected 1 generated, got %d", res.Generated)
+	}
+	if res.Errors != 0 {
+		t.Fatalf("expected 0 errors, got %d", res.Errors)
+	}
+
+	var n int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM suggestions WHERE page_slug = ? AND type = ? AND source = ? AND status = ?`,
+		NewPageSlug, TypeNewPage, SourceClaude, StatusPending).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly 1 row matching new_page contract, got %d", n)
+	}
+
+	var size, title string
+	if err := d.QueryRow(`SELECT size, title FROM suggestions WHERE page_slug = ?`, NewPageSlug).Scan(&size, &title); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if size != SizeM {
+		t.Fatalf("expected size=%q, got %q", SizeM, size)
+	}
+	if title != "Reading log" {
+		t.Fatalf("expected title 'Reading log', got %q", title)
+	}
+}
+
+func TestRunNewPageSuggestionMalformedJSONRetriesAndFails(t *testing.T) {
+	d := setupTestDB(t)
+
+	var calls int
+	var mu sync.Mutex
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		// Return invalid JSON on every call: original + one retry, both fail.
+		return "not valid json at all", nil
+	})()
+
+	res, err := RunNewPageSuggestion(context.Background(), d, dummyCfg(), 1)
+	if err != nil {
+		t.Fatalf("expected nil error for log-but-don't-abort semantics, got %v", err)
+	}
+	if calls != MaxRetriesOnMalformedJSON+1 {
+		t.Fatalf("expected exactly %d calls (original + retries), got %d", MaxRetriesOnMalformedJSON+1, calls)
+	}
+	if res.Generated != 0 {
+		t.Fatalf("expected 0 generated after parse failures, got %d", res.Generated)
+	}
+	if res.Errors == 0 {
+		t.Fatalf("expected Errors > 0 when parse fails; got %d", res.Errors)
+	}
+
+	var n int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM suggestions`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected no rows inserted on parse failure, got %d", n)
+	}
+}
+
+func TestBuildNewPagePromptIncludesRegistryAndRecentTitles(t *testing.T) {
+	registered := []Page{
+		{Slug: "weather", Title: "Weather", Description: "Forecast page."},
+		{Slug: "notes", Title: "Notes", Description: "Encrypted notes."},
+		{Slug: "training", Title: "Training", Description: "Workouts."},
+	}
+	recent := []Suggestion{
+		{Title: "Reading log", Status: StatusPending, Size: SizeM, Type: TypeNewPage},
+		{Title: "Recipe vault", Status: StatusPlanned, Size: SizeL, Type: TypeNewPage},
+	}
+
+	prompt := buildNewPagePrompt(registered, recent)
+
+	for _, p := range registered {
+		if !strings.Contains(prompt, p.Title) {
+			t.Errorf("prompt missing registered page title %q", p.Title)
+		}
+		if !strings.Contains(prompt, p.Slug) {
+			t.Errorf("prompt missing registered page slug %q", p.Slug)
+		}
+	}
+
+	for _, s := range recent {
+		if !strings.Contains(prompt, s.Title) {
+			t.Errorf("prompt missing recent new_page suggestion title %q", s.Title)
+		}
+	}
+}
+
+func TestRunNewPageSuggestionPromptCarriesRecentNewPageTitles(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	// Seed two prior new_page suggestions so the prompt should mention them.
+	mustInsert := func(title string) {
+		t.Helper()
+		_, err := Insert(ctx, d, Suggestion{
+			UserID:      1,
+			GeneratedAt: time.Now().UTC().Add(-24 * time.Hour),
+			PageSlug:    NewPageSlug,
+			Source:      SourceClaude,
+			Type:        TypeNewPage,
+			Size:        SizeM,
+			Title:       title,
+			Body:        "irrelevant body",
+			Status:      StatusPending,
+		})
+		if err != nil {
+			t.Fatalf("seed insert %q: %v", title, err)
+		}
+	}
+	mustInsert("Reading log")
+	mustInsert("Recipe vault")
+
+	var captured string
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		captured = prompt
+		return validNewPageJSON, nil
+	})()
+
+	if _, err := RunNewPageSuggestion(ctx, d, dummyCfg(), 1); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	for _, want := range []string{"Reading log", "Recipe vault"} {
+		if !strings.Contains(captured, want) {
+			t.Errorf("expected prompt to contain recent title %q, got: %s", want, captured)
+		}
+	}
+
+	for _, p := range AllRegistered() {
+		if !strings.Contains(captured, p.Title) {
+			t.Errorf("expected prompt to contain registered page title %q", p.Title)
+		}
+	}
+}
+
+func TestParseNewPageResponseAcceptsValid(t *testing.T) {
+	got, err := parseNewPageResponse(validNewPageJSON)
+	if err != nil {
+		t.Fatalf("expected valid JSON to parse, got: %v", err)
+	}
+	if got.Size != SizeM {
+		t.Errorf("size: got %q want %q", got.Size, SizeM)
+	}
+	if got.Title != "Reading log" {
+		t.Errorf("title: got %q", got.Title)
+	}
+	if got.Body == "" {
+		t.Errorf("body should not be empty")
+	}
+}
+
+func TestParseNewPageResponseStripsMarkdownFence(t *testing.T) {
+	wrapped := "```json\n" + validNewPageJSON + "\n```"
+	if _, err := parseNewPageResponse(wrapped); err != nil {
+		t.Fatalf("expected fence-stripped parse to succeed: %v", err)
+	}
+}
+
+func TestParseNewPageResponseRejectsInvalidSize(t *testing.T) {
+	if _, err := parseNewPageResponse(`{"size":"xl","title":"X","body":"y"}`); err == nil {
+		t.Fatal("expected error for invalid size, got nil")
+	}
+}
+
+func TestParseNewPageResponseRejectsEmptyTitle(t *testing.T) {
+	if _, err := parseNewPageResponse(`{"size":"s","title":"","body":"y"}`); err == nil {
+		t.Fatal("expected error for empty title, got nil")
+	}
+}
+
+func TestParseNewPageResponseRejectsEmptyBody(t *testing.T) {
+	if _, err := parseNewPageResponse(`{"size":"s","title":"X","body":""}`); err == nil {
+		t.Fatal("expected error for empty body, got nil")
+	}
+}

--- a/web/public/locales/en/suggestions.json
+++ b/web/public/locales/en/suggestions.json
@@ -58,6 +58,7 @@
   },
   "form": {
     "title": "New suggestion",
+    "newPageOption": "New page idea",
     "fields": {
       "page": "Page",
       "title": "Title",
@@ -95,6 +96,7 @@
   "card": {
     "showMore": "Show more",
     "showLess": "Show less",
+    "newPageChip": "New page idea",
     "types": {
       "addition": "Addition",
       "bugfix": "Bugfix",

--- a/web/public/locales/nb/suggestions.json
+++ b/web/public/locales/nb/suggestions.json
@@ -58,6 +58,7 @@
   },
   "form": {
     "title": "Nytt forslag",
+    "newPageOption": "Ny side-idé",
     "fields": {
       "page": "Side",
       "title": "Tittel",
@@ -95,6 +96,7 @@
   "card": {
     "showMore": "Vis mer",
     "showLess": "Vis mindre",
+    "newPageChip": "Ny side-idé",
     "types": {
       "addition": "Tillegg",
       "bugfix": "Feilretting",

--- a/web/public/locales/th/suggestions.json
+++ b/web/public/locales/th/suggestions.json
@@ -58,6 +58,7 @@
   },
   "form": {
     "title": "ข้อเสนอแนะใหม่",
+    "newPageOption": "ไอเดียหน้าใหม่",
     "fields": {
       "page": "หน้า",
       "title": "หัวข้อ",
@@ -95,6 +96,7 @@
   "card": {
     "showMore": "แสดงเพิ่มเติม",
     "showLess": "แสดงน้อยลง",
+    "newPageChip": "ไอเดียหน้าใหม่",
     "types": {
       "addition": "เพิ่มเติม",
       "bugfix": "แก้บั๊ก",

--- a/web/src/components/suggestions/NewSuggestionForm.tsx
+++ b/web/src/components/suggestions/NewSuggestionForm.tsx
@@ -2,13 +2,14 @@ import { useEffect, useId, useMemo, useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Loader2 } from 'lucide-react'
 import { Dialog, DialogBody, DialogFooter, DialogHeader } from '../ui/dialog'
-import type {
-  Suggestion,
-  SuggestionSize,
-  SuggestionType,
+import {
+  NEW_PAGE_SLUG,
+  type Suggestion,
+  type SuggestionSize,
+  type SuggestionType,
 } from './SuggestionCard'
 
-export const NEW_PAGE_SLUG = '__new_page__'
+export { NEW_PAGE_SLUG }
 export const TITLE_MAX = 120
 export const BODY_MAX_BYTES = 4096
 
@@ -277,7 +278,7 @@ export function NewSuggestionForm({ open, onClose, onCreated }: NewSuggestionFor
                 </option>
                 {visiblePages.map(p => (
                   <option key={p.slug} value={p.slug}>
-                    {p.title}
+                    {p.slug === NEW_PAGE_SLUG ? t('form.newPageOption') : p.title}
                   </option>
                 ))}
               </select>

--- a/web/src/components/suggestions/SuggestionCard.tsx
+++ b/web/src/components/suggestions/SuggestionCard.tsx
@@ -34,6 +34,8 @@ export interface SuggestionCardProps {
   actionsSlot?: ReactNode
 }
 
+export const NEW_PAGE_SLUG = '__new_page__'
+
 function typeBadgeClass(type: SuggestionType): string {
   switch (type) {
     case 'addition':
@@ -87,9 +89,18 @@ export function SuggestionCard({ suggestion, actionsSlot }: SuggestionCardProps)
       className="rounded-lg border border-gray-700 bg-gray-800 p-4 text-sm text-gray-200"
     >
       <div className="flex flex-wrap items-center gap-2">
-        <span className="inline-flex max-w-full items-center rounded-full border border-gray-600 bg-gray-700/60 px-2 py-0.5 text-xs font-medium text-gray-300 break-all">
-          {suggestion.page_slug}
-        </span>
+        {suggestion.page_slug === NEW_PAGE_SLUG ? (
+          <span
+            data-testid="new-page-chip"
+            className="inline-flex max-w-full items-center rounded-full border border-purple-500/40 bg-purple-500/15 px-2 py-0.5 text-xs font-medium text-purple-300 break-all"
+          >
+            {t('card.newPageChip')}
+          </span>
+        ) : (
+          <span className="inline-flex max-w-full items-center rounded-full border border-gray-600 bg-gray-700/60 px-2 py-0.5 text-xs font-medium text-gray-300 break-all">
+            {suggestion.page_slug}
+          </span>
+        )}
         <span
           className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${typeBadgeClass(suggestion.type)}`}
         >


### PR DESCRIPTION
## Changes

- **New-page suggestion pass** - The suggestions engine now runs a separate Claude pass per nightly rotation (and per Run-now click) that proposes one entirely new page idea. Generated rows use page_slug `__new_page__`, type `new_page`, and surface in the Suggestions UI with a distinct "New page idea" chip. (Hytte-1qag)

## Original Issue (task): New-page suggestion prompt and wiring

Add a separate Claude pass that proposes one entirely new page idea per run. Create internal/suggestions/new_page.go with RunNewPageSuggestion(ctx, db, cfg, userID) (RunResult, error) producing exactly one row with page_slug='__new_page__', type='new_page', source='claude', status='pending'. Add buildNewPagePrompt(allRegistered []Page, recentNewPageSuggestions []Suggestion) string that includes the registry (slug+title+description) and last-30-days new_page suggestions for de-duplication; strict JSON shape {size,title,body}. Add a parser mirroring parseSuggestionsResponse with one-retry-on-malformed-JSON, returning a single result. Wire into cmd/server/main.go:183 nightly scheduler (after per-page rotation, log-but-don't-abort on failure) and POST /api/suggestions/run handler in handlers.go RunHandler, folding generated/error counts into the existing RunResult. Frontend: SuggestionCard renders a distinct chip ('New page idea', nb/th i18n) when page_slug==='__new_page__'; new-suggestion form's page-slug dropdown includes '__new_page__' as a labelled option. Tests in internal/suggestions/new_page_test.go: happy path, malformed-JSON-then-retry-fails (no row), prompt context contains registry titles and recent new_page titles. Sibling dependency: cost-tracking sub-task will switch runPromptFn to a cost-aware version — write this pass to call runPromptFn so the swap is transparent.

---
Bead: Hytte-1qag | Branch: forge/Hytte-1qag
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)