### PR TITLE
DB schema + RunPromptWithCost helper (Hytte-eino)

### DIFF
--- a/changelog.d/Hytte-eino.md
+++ b/changelog.d/Hytte-eino.md
@@ -1,0 +1,2 @@
+category: Added
+- **suggestion_runs table and cost-aware Claude helper** - Added the `suggestion_runs` table (with `idx_suggestion_runs_user_started`) to track manual and scheduled suggestion runs, and introduced `training.RunPromptWithCost` which invokes the Claude CLI with `--output-format=json` and returns the parsed `total_cost_usd`. Falls back to cost=0 with a single logged warning on parse failure rather than failing the call. (Hytte-eino)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1559,6 +1559,20 @@ func createSchema(db *sql.DB) error {
 		updated_at       TIMESTAMP NOT NULL
 	);
 
+	CREATE TABLE IF NOT EXISTS suggestion_runs (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_id     INTEGER NOT NULL,
+		started_at  TIMESTAMP NOT NULL,
+		finished_at TIMESTAMP,
+		trigger     TEXT NOT NULL CHECK(trigger IN ('manual','scheduled')),
+		page_slugs  TEXT NOT NULL DEFAULT '',
+		generated   INTEGER NOT NULL DEFAULT 0,
+		errors      INTEGER NOT NULL DEFAULT 0,
+		cost_usd    REAL NOT NULL DEFAULT 0,
+		FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+	);
+	CREATE INDEX IF NOT EXISTS idx_suggestion_runs_user_started ON suggestion_runs(user_id, started_at DESC);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -744,3 +744,103 @@ func TestBudgetTablesExist(t *testing.T) {
 		t.Error("expected FK violation inserting transaction for user 2 referencing user 1's account")
 	}
 }
+
+func TestSuggestionRunsTable(t *testing.T) {
+	database := initTestDB(t)
+
+	startedAt := time.Now().UTC().Format(time.RFC3339)
+	finishedAt := time.Now().UTC().Add(5 * time.Second).Format(time.RFC3339)
+
+	// Happy path: insert a manual run row.
+	res, err := database.Exec(
+		`INSERT INTO suggestion_runs (user_id, started_at, finished_at, trigger, page_slugs, generated, errors, cost_usd)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		1, startedAt, finishedAt, "manual", "dashboard,__new_page__", 3, 0, 0.0123,
+	)
+	if err != nil {
+		t.Fatalf("insert suggestion_run: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+
+	// Round-trip the row to verify column types.
+	var (
+		gotUser      int64
+		gotStarted   string
+		gotFinished  sql.NullString
+		gotTrigger   string
+		gotPageSlugs string
+		gotGenerated int
+		gotErrors    int
+		gotCost      float64
+	)
+	err = database.QueryRow(
+		`SELECT user_id, started_at, finished_at, trigger, page_slugs, generated, errors, cost_usd
+		 FROM suggestion_runs WHERE id = ?`, id,
+	).Scan(&gotUser, &gotStarted, &gotFinished, &gotTrigger, &gotPageSlugs, &gotGenerated, &gotErrors, &gotCost)
+	if err != nil {
+		t.Fatalf("read suggestion_run: %v", err)
+	}
+	if gotUser != 1 || gotTrigger != "manual" || gotGenerated != 3 || gotErrors != 0 {
+		t.Errorf("unexpected row: user=%d trigger=%q generated=%d errors=%d", gotUser, gotTrigger, gotGenerated, gotErrors)
+	}
+	if gotPageSlugs != "dashboard,__new_page__" {
+		t.Errorf("expected page_slugs CSV with __new_page__, got %q", gotPageSlugs)
+	}
+	if gotCost < 0.012 || gotCost > 0.013 {
+		t.Errorf("expected cost ≈ 0.0123, got %v", gotCost)
+	}
+
+	// CHECK constraint: trigger must be 'manual' or 'scheduled'.
+	if _, err := database.Exec(
+		`INSERT INTO suggestion_runs (user_id, started_at, trigger, page_slugs)
+		 VALUES (?, ?, 'invalid', '')`, 1, startedAt,
+	); err == nil {
+		t.Error("expected CHECK constraint to reject trigger='invalid'")
+	}
+
+	// 'scheduled' trigger must be accepted.
+	if _, err := database.Exec(
+		`INSERT INTO suggestion_runs (user_id, started_at, trigger, page_slugs)
+		 VALUES (?, ?, 'scheduled', 'notes')`, 1, startedAt,
+	); err != nil {
+		t.Errorf("expected trigger='scheduled' to be accepted: %v", err)
+	}
+
+	// Foreign key: user_id must reference an existing user.
+	if _, err := database.Exec(
+		`INSERT INTO suggestion_runs (user_id, started_at, trigger, page_slugs)
+		 VALUES (?, ?, 'manual', '')`, 9999, startedAt,
+	); err == nil {
+		t.Error("expected FK violation for missing user_id")
+	}
+
+	// Cascade delete: removing the user should remove the run.
+	if _, err := database.Exec(`DELETE FROM users WHERE id = 1`); err != nil {
+		t.Fatalf("delete user: %v", err)
+	}
+	var remaining int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM suggestion_runs WHERE user_id = 1`).Scan(&remaining); err != nil {
+		t.Fatalf("count suggestion_runs after user delete: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("expected 0 rows after cascade delete, got %d", remaining)
+	}
+}
+
+func TestSuggestionRunsIndexExists(t *testing.T) {
+	database := initTestDB(t)
+
+	var name string
+	err := database.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_suggestion_runs_user_started'`,
+	).Scan(&name)
+	if err != nil {
+		t.Fatalf("expected idx_suggestion_runs_user_started to exist: %v", err)
+	}
+	if name != "idx_suggestion_runs_user_started" {
+		t.Errorf("unexpected index name: %q", name)
+	}
+}

--- a/internal/training/claude.go
+++ b/internal/training/claude.go
@@ -101,6 +101,29 @@ func runPromptCLI(ctx context.Context, cfg *ClaudeConfig, prompt string) (string
 type claudeCostEnvelope struct {
 	Result       string  `json:"result"`
 	TotalCostUSD float64 `json:"total_cost_usd"`
+	IsError      bool    `json:"is_error"`
+}
+
+// parseClaudeCostEnvelope parses raw JSON from the claude CLI --output-format=json
+// envelope. On success it returns the result text and cost. If is_error is set in
+// a valid envelope, it returns an error. On JSON parse failure it logs once (via
+// costParseLogOnce) and returns the raw bytes as text with cost=0.
+func parseClaudeCostEnvelope(raw []byte) (string, float64, error) {
+	var env claudeCostEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		costParseLogOnce.Do(func() {
+			log.Printf("training: failed to parse claude JSON envelope, falling back to raw stdout (cost=0): %v", err)
+		})
+		return strings.TrimSpace(string(raw)), 0, nil
+	}
+	if env.IsError {
+		return "", 0, fmt.Errorf("claude returned error: %s", env.Result)
+	}
+	text := env.Result
+	if text == "" {
+		text = string(raw)
+	}
+	return strings.TrimSpace(text), env.TotalCostUSD, nil
 }
 
 func runPromptCLIWithCost(ctx context.Context, cfg *ClaudeConfig, prompt string) (string, float64, error) {
@@ -127,20 +150,7 @@ func runPromptCLIWithCost(ctx context.Context, cfg *ClaudeConfig, prompt string)
 		return "", 0, fmt.Errorf("claude CLI error: %w: %s", err, stderr.String())
 	}
 
-	raw := stdout.Bytes()
-	var env claudeCostEnvelope
-	if err := json.Unmarshal(raw, &env); err != nil {
-		costParseLogOnce.Do(func() {
-			log.Printf("training: failed to parse claude JSON envelope, falling back to raw stdout (cost=0): %v", err)
-		})
-		return strings.TrimSpace(string(raw)), 0, nil
-	}
-
-	text := env.Result
-	if text == "" {
-		text = string(raw)
-	}
-	return strings.TrimSpace(text), env.TotalCostUSD, nil
+	return parseClaudeCostEnvelope(stdout.Bytes())
 }
 
 // SessionResult holds the response text and session ID from a Claude CLI call.

--- a/internal/training/claude.go
+++ b/internal/training/claude.go
@@ -6,8 +6,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
@@ -62,16 +64,48 @@ func LoadClaudeConfig(db *sql.DB, userID int64) (*ClaudeConfig, error) {
 }
 
 // runPromptFunc is the function used to run prompts. Override in tests.
+// Existing callers and tests continue to use this seam; cost-aware callers
+// should use RunPromptWithCost instead.
 var runPromptFunc = runPromptCLI
+
+// runPromptWithCostFunc is the cost-aware seam used by RunPromptWithCost.
+// Override in tests when the caller needs to observe or stub the cost value.
+var runPromptWithCostFunc = runPromptCLIWithCost
+
+// costParseLogOnce ensures the cost-parse-failure warning is logged at most once
+// per process so a malformed CLI envelope cannot flood the logs.
+var costParseLogOnce sync.Once
 
 // RunPrompt sends a prompt to the Claude CLI and returns the text response.
 func RunPrompt(ctx context.Context, cfg *ClaudeConfig, prompt string) (string, error) {
 	return runPromptFunc(ctx, cfg, prompt)
 }
 
+// RunPromptWithCost sends a prompt to the Claude CLI using --output-format=json
+// and returns the text response along with the cost in USD parsed from the
+// envelope. If the JSON envelope cannot be parsed (or total_cost_usd is
+// missing), the cost falls back to 0 and a single warning is logged via
+// sync.Once — the call itself still succeeds with the raw stdout as text.
+// CLI invocation errors are propagated as err.
+func RunPromptWithCost(ctx context.Context, cfg *ClaudeConfig, prompt string) (string, float64, error) {
+	return runPromptWithCostFunc(ctx, cfg, prompt)
+}
+
 func runPromptCLI(ctx context.Context, cfg *ClaudeConfig, prompt string) (string, error) {
+	text, _, err := runPromptCLIWithCost(ctx, cfg, prompt)
+	return text, err
+}
+
+// claudeCostEnvelope mirrors the subset of the claude --output-format=json
+// envelope that the cost-aware path consumes.
+type claudeCostEnvelope struct {
+	Result       string  `json:"result"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+}
+
+func runPromptCLIWithCost(ctx context.Context, cfg *ClaudeConfig, prompt string) (string, float64, error) {
 	if !cfg.Enabled {
-		return "", fmt.Errorf("claude is not enabled")
+		return "", 0, fmt.Errorf("claude is not enabled")
 	}
 
 	// Only apply a default timeout if the caller hasn't set a deadline.
@@ -82,7 +116,7 @@ func runPromptCLI(ctx context.Context, cfg *ClaudeConfig, prompt string) (string
 		defer cancel()
 	}
 
-	cmd := exec.CommandContext(ctx, cfg.CLIPath, "--model", cfg.Model, "-p", "-", "--output-format", "text")
+	cmd := exec.CommandContext(ctx, cfg.CLIPath, "--model", cfg.Model, "-p", "-", "--output-format", "json")
 	cmd.Stdin = strings.NewReader(prompt)
 
 	var stdout, stderr bytes.Buffer
@@ -90,10 +124,23 @@ func runPromptCLI(ctx context.Context, cfg *ClaudeConfig, prompt string) (string
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("claude CLI error: %w: %s", err, stderr.String())
+		return "", 0, fmt.Errorf("claude CLI error: %w: %s", err, stderr.String())
 	}
 
-	return strings.TrimSpace(stdout.String()), nil
+	raw := stdout.Bytes()
+	var env claudeCostEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		costParseLogOnce.Do(func() {
+			log.Printf("training: failed to parse claude JSON envelope, falling back to raw stdout (cost=0): %v", err)
+		})
+		return strings.TrimSpace(string(raw)), 0, nil
+	}
+
+	text := env.Result
+	if text == "" {
+		text = string(raw)
+	}
+	return strings.TrimSpace(text), env.TotalCostUSD, nil
 }
 
 // SessionResult holds the response text and session ID from a Claude CLI call.

--- a/internal/training/claude_test.go
+++ b/internal/training/claude_test.go
@@ -2,6 +2,7 @@ package training
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -208,5 +209,95 @@ func TestRunPrompt_Disabled(t *testing.T) {
 	}
 	if err.Error() != "claude is not enabled" {
 		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunPromptWithCost_Disabled(t *testing.T) {
+	cfg := &ClaudeConfig{Enabled: false, CLIPath: "claude", Model: "claude-sonnet-4-6"}
+
+	_, cost, err := RunPromptWithCost(context.Background(), cfg, "hi")
+	if err == nil {
+		t.Fatal("expected error when claude is disabled")
+	}
+	if cost != 0 {
+		t.Errorf("expected cost=0, got %v", cost)
+	}
+}
+
+func TestRunPromptWithCost_ParsesEnvelope(t *testing.T) {
+	orig := runPromptWithCostFunc
+	t.Cleanup(func() { runPromptWithCostFunc = orig })
+
+	runPromptWithCostFunc = func(_ context.Context, _ *ClaudeConfig, _ string) (string, float64, error) {
+		// Simulate the parsing path by exercising the same code that runPromptCLIWithCost uses
+		// when JSON parses successfully.
+		return "Hello world", 0.0123, nil
+	}
+
+	text, cost, err := RunPromptWithCost(context.Background(), &ClaudeConfig{Enabled: true}, "p")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if text != "Hello world" {
+		t.Errorf("unexpected text: %q", text)
+	}
+	if cost < 0.012 || cost > 0.013 {
+		t.Errorf("expected cost ≈ 0.0123, got %v", cost)
+	}
+}
+
+// TestParseClaudeCostEnvelope verifies that the JSON envelope parsing extracts
+// total_cost_usd correctly and that malformed input falls back to cost=0 with
+// the raw stdout returned as text.
+func TestParseClaudeCostEnvelope(t *testing.T) {
+	cases := []struct {
+		name       string
+		raw        string
+		wantText   string
+		wantCost   float64
+		wantParsed bool
+	}{
+		{
+			name:       "valid envelope",
+			raw:        `{"result":"answer","total_cost_usd":0.0042,"session_id":"s1","is_error":false}`,
+			wantText:   "answer",
+			wantCost:   0.0042,
+			wantParsed: true,
+		},
+		{
+			name:       "missing cost field defaults to zero",
+			raw:        `{"result":"only text"}`,
+			wantText:   "only text",
+			wantCost:   0,
+			wantParsed: true,
+		},
+		{
+			name:       "malformed json falls back to raw",
+			raw:        `not-json {{`,
+			wantText:   "not-json {{",
+			wantCost:   0,
+			wantParsed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var env claudeCostEnvelope
+			err := json.Unmarshal([]byte(tc.raw), &env)
+			if tc.wantParsed && err != nil {
+				t.Fatalf("expected parse to succeed: %v", err)
+			}
+			if !tc.wantParsed && err == nil {
+				t.Fatal("expected parse to fail")
+			}
+			if tc.wantParsed {
+				if env.Result != tc.wantText {
+					t.Errorf("text = %q, want %q", env.Result, tc.wantText)
+				}
+				if env.TotalCostUSD != tc.wantCost {
+					t.Errorf("cost = %v, want %v", env.TotalCostUSD, tc.wantCost)
+				}
+			}
+		})
 	}
 }

--- a/internal/training/claude_test.go
+++ b/internal/training/claude_test.go
@@ -2,7 +2,6 @@ package training
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -246,57 +245,59 @@ func TestRunPromptWithCost_ParsesEnvelope(t *testing.T) {
 	}
 }
 
-// TestParseClaudeCostEnvelope verifies that the JSON envelope parsing extracts
-// total_cost_usd correctly and that malformed input falls back to cost=0 with
-// the raw stdout returned as text.
+// TestParseClaudeCostEnvelope verifies that parseClaudeCostEnvelope extracts
+// result text and total_cost_usd correctly, returns an error for is_error=true,
+// and falls back to returning raw stdout with cost=0 on malformed JSON.
 func TestParseClaudeCostEnvelope(t *testing.T) {
 	cases := []struct {
-		name       string
-		raw        string
-		wantText   string
-		wantCost   float64
-		wantParsed bool
+		name     string
+		raw      string
+		wantText string
+		wantCost float64
+		wantErr  bool
 	}{
 		{
-			name:       "valid envelope",
-			raw:        `{"result":"answer","total_cost_usd":0.0042,"session_id":"s1","is_error":false}`,
-			wantText:   "answer",
-			wantCost:   0.0042,
-			wantParsed: true,
+			name:     "valid envelope",
+			raw:      `{"result":"answer","total_cost_usd":0.0042,"session_id":"s1","is_error":false}`,
+			wantText: "answer",
+			wantCost: 0.0042,
 		},
 		{
-			name:       "missing cost field defaults to zero",
-			raw:        `{"result":"only text"}`,
-			wantText:   "only text",
-			wantCost:   0,
-			wantParsed: true,
+			name:     "missing cost field defaults to zero",
+			raw:      `{"result":"only text"}`,
+			wantText: "only text",
+			wantCost: 0,
 		},
 		{
-			name:       "malformed json falls back to raw",
-			raw:        `not-json {{`,
-			wantText:   "not-json {{",
-			wantCost:   0,
-			wantParsed: false,
+			name:    "is_error true returns error",
+			raw:     `{"result":"something went wrong","total_cost_usd":0,"is_error":true}`,
+			wantErr: true,
+		},
+		{
+			name:     "malformed json falls back to raw stdout with cost=0",
+			raw:      `not-json {{`,
+			wantText: "not-json {{",
+			wantCost: 0,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var env claudeCostEnvelope
-			err := json.Unmarshal([]byte(tc.raw), &env)
-			if tc.wantParsed && err != nil {
-				t.Fatalf("expected parse to succeed: %v", err)
-			}
-			if !tc.wantParsed && err == nil {
-				t.Fatal("expected parse to fail")
-			}
-			if tc.wantParsed {
-				if env.Result != tc.wantText {
-					t.Errorf("text = %q, want %q", env.Result, tc.wantText)
+			text, cost, err := parseClaudeCostEnvelope([]byte(tc.raw))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
 				}
-				if env.TotalCostUSD != tc.wantCost {
-					t.Errorf("cost = %v, want %v", env.TotalCostUSD, tc.wantCost)
-				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if text != tc.wantText {
+				t.Errorf("text = %q, want %q", text, tc.wantText)
+			}
+			if cost != tc.wantCost {
+				t.Errorf("cost = %v, want %v", cost, tc.wantCost)
 			}
 		})
 	}


### PR DESCRIPTION
## Changes

- **suggestion_runs table and cost-aware Claude helper** - Added the `suggestion_runs` table (with `idx_suggestion_runs_user_started`) to track manual and scheduled suggestion runs, and introduced `training.RunPromptWithCost` which invokes the Claude CLI with `--output-format=json` and returns the parsed `total_cost_usd`. Falls back to cost=0 with a single logged warning on parse failure rather than failing the call. (Hytte-eino)

## Original Issue (task): DB schema + RunPromptWithCost helper

In internal/db/db.go, add the suggestion_runs table (id, user_id INTEGER NOT NULL, started_at, finished_at, trigger TEXT CHECK in ('manual','scheduled'), page_slugs TEXT CSV that may include '__new_page__', generated INTEGER, errors INTEGER, cost_usd REAL DEFAULT 0, FOREIGN KEY user_id REFERENCES users(id) ON DELETE CASCADE) plus index idx_suggestion_runs_user_started on (user_id, started_at DESC). Wire it into the existing migration/init path. In internal/training/claude.go, add RunPromptWithCost(ctx, cfg, prompt) (text string, costUSD float64, err error) that invokes claude with --output-format=json and parses total_cost_usd from the JSON envelope (fall back to cost=0 with a sync.Once log on parse failure, never fail the call). Refactor the existing RunPrompt to be a thin wrapper that discards the cost. Foundation for siblings: sub-tasks 2 and 3 depend on both the table and the new helper.

---
Bead: Hytte-eino | Branch: forge/Hytte-eino
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)