### PR TITLE
Suggestions runner integration + runs API (Hytte-66y0)

### DIFF
--- a/changelog.d/Hytte-66y0.md
+++ b/changelog.d/Hytte-66y0.md
@@ -1,0 +1,2 @@
+category: Added
+- **Suggestion runs API and audit log** - The suggestion runner now records a row in `suggestion_runs` for every manual or scheduled run, capturing start/finish time, trigger, page slugs (including the `__new_page__` sentinel when the new-page pass ran), generated/error counts, and total Claude cost in USD. A new admin-only `GET /api/suggestions/runs?limit=20` endpoint returns runs newest-first (default 20, hard cap 100). (Hytte-66y0)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"os"
@@ -250,22 +251,50 @@ func main() {
 					}
 
 					runCtx, runCancel := context.WithTimeout(notifCtx, 30*time.Minute)
+					startedAt := time.Now().UTC()
 					result := suggestions.RunSuggestionsForPages(runCtx, database, cfg, adminID, rotation)
 
 					// Run a separate Claude pass that proposes one new page idea.
 					// Failures are logged and folded into the same RunResult; we
 					// do not abort the rest of the schedule when this pass fails.
 					newPageResult, err := suggestions.RunNewPageSuggestion(runCtx, database, cfg, adminID)
+					newPageRan := true
 					if err != nil {
 						log.Printf("suggestions: new_page run for admin=%d: %v", adminID, err)
 						result.Errors++
+						// Pre-flight context errors mean the new-page pass did
+						// not run at all; in that case we should not list
+						// __new_page__ in page_slugs.
+						if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+							newPageRan = false
+						}
 					}
 					result.Generated += newPageResult.Generated
 					result.Errors += newPageResult.Errors
+					result.CostUSD += newPageResult.CostUSD
 					runCancel()
 
-					log.Printf("suggestions: nightly run for admin=%d generated=%d errors=%d pages=%v",
-						adminID, result.Generated, result.Errors, pageSlugs)
+					finishedAt := time.Now().UTC()
+					runRow := suggestions.SuggestionRun{
+						UserID:     adminID,
+						StartedAt:  startedAt,
+						FinishedAt: &finishedAt,
+						Trigger:    suggestions.TriggerScheduled,
+						PageSlugs:  suggestions.BuildPageSlugsCSV(pageSlugs, newPageRan),
+						Generated:  result.Generated,
+						Errors:     result.Errors,
+						CostUSD:    result.CostUSD,
+					}
+					// Use a background context so a notifCtx cancel between
+					// run and insert does not drop the audit row.
+					insertCtx, insertCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					if _, err := suggestions.InsertSuggestionRun(insertCtx, database, runRow); err != nil {
+						log.Printf("suggestions: record scheduled run for admin=%d: %v", adminID, err)
+					}
+					insertCancel()
+
+					log.Printf("suggestions: nightly run for admin=%d generated=%d errors=%d cost=$%.4f pages=%v",
+						adminID, result.Generated, result.Errors, result.CostUSD, pageSlugs)
 				}
 			}
 		}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -201,6 +201,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Get("/suggestions", suggestions.ListHandler(db))
 				r.Post("/suggestions", suggestions.CreateHandler(db))
 				r.Post("/suggestions/run", suggestions.RunHandler(db))
+				r.Get("/suggestions/runs", suggestions.RunsHandler(db))
 				r.Post("/suggestions/{id}/reject", suggestions.RejectHandler(db))
 				r.Post("/suggestions/{id}/plan", suggestions.PlanHandler(db))
 				r.Post("/suggestions/{id}/bead", suggestions.CreateBeadHandler(db))

--- a/internal/suggestions/generate.go
+++ b/internal/suggestions/generate.go
@@ -17,9 +17,11 @@ import (
 	"github.com/Robin831/Hytte/internal/training"
 )
 
-// runPromptFn is the function used to invoke Claude. Replaced in tests, mirroring
-// the package-level pattern used in chat/handlers.go.
-var runPromptFn = training.RunPrompt
+// runPromptFn is the function used to invoke Claude. It returns the response
+// text, the cost of the call in USD parsed from the CLI envelope, and any
+// error. Replaced in tests, mirroring the package-level pattern used in
+// chat/handlers.go.
+var runPromptFn = training.RunPromptWithCost
 
 // PerPageTimeout is the deadline applied to each individual page's generation
 // attempt. RunSuggestionsForPages caps each Claude call at this duration so a
@@ -34,10 +36,13 @@ const recentSuggestionsWindowDays = 14
 // returns a response that does not parse as the expected JSON shape.
 const MaxRetriesOnMalformedJSON = 1
 
-// RunResult summarises a generation pass.
+// RunResult summarises a generation pass. CostUSD is the total cost in US
+// dollars of all Claude calls made during the pass, summed even across
+// retried-on-malformed-JSON attempts (since each attempt is a paid API call).
 type RunResult struct {
-	Generated int `json:"generated"`
-	Errors    int `json:"errors"`
+	Generated int     `json:"generated"`
+	Errors    int     `json:"errors"`
+	CostUSD   float64 `json:"cost_usd"`
 }
 
 // generated is the per-suggestion shape we expect from Claude.
@@ -89,9 +94,10 @@ func RunSuggestionsForPages(
 			result.Errors++
 			break
 		}
-		inserted, failed, err := runForPage(ctx, db, cfg, userID, page)
+		inserted, failed, cost, err := runForPage(ctx, db, cfg, userID, page)
 		result.Generated += inserted
 		result.Errors += failed
+		result.CostUSD += cost
 		if err != nil {
 			result.Errors++
 			log.Printf("suggestions: page %q errored: %v", page.Slug, err)
@@ -113,7 +119,7 @@ func runForPage(
 	cfg *training.ClaudeConfig,
 	userID int64,
 	page Page,
-) (inserted int, failed int, err error) {
+) (inserted int, failed int, costUSD float64, err error) {
 	pageCtx, cancel := context.WithTimeout(ctx, PerPageTimeout)
 	defer cancel()
 
@@ -128,9 +134,9 @@ func runForPage(
 
 	prompt := buildPagePrompt(page, sources, gitLog, recent)
 
-	suggestions, err := callAndParse(pageCtx, cfg, prompt)
+	suggestions, costUSD, err := callAndParse(pageCtx, cfg, prompt)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, costUSD, err
 	}
 
 	now := time.Now().UTC()
@@ -153,27 +159,33 @@ func runForPage(
 		}
 		inserted++
 	}
-	return inserted, failed, nil
+	return inserted, failed, costUSD, nil
 }
 
 // callAndParse calls Claude and parses the response. On a malformed JSON
 // response it retries up to MaxRetriesOnMalformedJSON times, then returns the
-// last error.
-func callAndParse(ctx context.Context, cfg *training.ClaudeConfig, prompt string) ([]generated, error) {
-	var lastErr error
+// last error. The accumulated cost across all attempts (including the failed
+// attempts that triggered retries) is returned so the caller can fold it into
+// the run total — every attempt is a paid CLI invocation.
+func callAndParse(ctx context.Context, cfg *training.ClaudeConfig, prompt string) ([]generated, float64, error) {
+	var (
+		lastErr   error
+		totalCost float64
+	)
 	for attempt := 0; attempt <= MaxRetriesOnMalformedJSON; attempt++ {
-		resp, err := runPromptFn(ctx, cfg, prompt)
+		resp, cost, err := runPromptFn(ctx, cfg, prompt)
+		totalCost += cost
 		if err != nil {
-			return nil, fmt.Errorf("claude prompt: %w", err)
+			return nil, totalCost, fmt.Errorf("claude prompt: %w", err)
 		}
 		parsed, err := parseSuggestionsResponse(resp)
 		if err == nil {
-			return parsed, nil
+			return parsed, totalCost, nil
 		}
 		lastErr = err
 		log.Printf("suggestions: parse attempt %d failed: %v", attempt+1, err)
 	}
-	return nil, fmt.Errorf("parse response after %d attempts: %w", MaxRetriesOnMalformedJSON+1, lastErr)
+	return nil, totalCost, fmt.Errorf("parse response after %d attempts: %w", MaxRetriesOnMalformedJSON+1, lastErr)
 }
 
 // parseSuggestionsResponse strips an optional markdown fence and decodes the

--- a/internal/suggestions/generate_test.go
+++ b/internal/suggestions/generate_test.go
@@ -11,8 +11,22 @@ import (
 )
 
 // withRunPrompt swaps the package-level runPromptFn for the duration of a test
-// and returns a restore function to defer.
+// and returns a restore function to defer. The legacy (string, error) shape is
+// retained here so the existing test bodies do not need rewriting; the wrapper
+// reports a cost of 0 to runPromptFn callers. Tests that need to assert on
+// cost should use withRunPromptWithCost instead.
 func withRunPrompt(fn func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error)) func() {
+	prev := runPromptFn
+	runPromptFn = func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, float64, error) {
+		text, err := fn(ctx, cfg, prompt)
+		return text, 0, err
+	}
+	return func() { runPromptFn = prev }
+}
+
+// withRunPromptWithCost is the cost-aware variant of withRunPrompt for tests
+// that need to verify cost accumulation.
+func withRunPromptWithCost(fn func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, float64, error)) func() {
 	prev := runPromptFn
 	runPromptFn = fn
 	return func() { runPromptFn = prev }

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -35,8 +35,13 @@ const NewPageSlug = "__new_page__"
 // pages in the registry. Admin-only — relies on auth.RequireAdmin upstream to
 // guarantee a non-nil admin user in the request context.
 //
+// On completion (or error after the run has started) a row is inserted into
+// suggestion_runs with trigger='manual' so the operator can audit cost and
+// outcomes from the runs API. The insert uses a fresh background context so
+// a client disconnect after the run finishes does not lose the audit row.
+//
 // POST /api/suggestions/run
-// Response: { "generated": int, "errors": int }
+// Response: { "generated": int, "errors": int, "cost_usd": float }
 func RunHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
@@ -61,18 +66,51 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		startedAt := time.Now().UTC()
 		result := RunSuggestionsForPages(ctx, db, cfg, user.ID, pages)
 
 		// Also run the separate new-page idea pass. Errors are logged and
 		// counted in the aggregated RunResult so a single failure here cannot
 		// hide the per-page totals from the operator.
 		newPageResult, err := RunNewPageSuggestion(ctx, db, cfg, user.ID)
+		newPageRan := true
 		if err != nil {
 			log.Printf("suggestions: new_page run for user %d: %v", user.ID, err)
 			result.Errors++
+			// A pre-flight context error means the new-page pass did not run
+			// at all; in that case we should not list __new_page__ in
+			// page_slugs. Any other error still produced an attempt and the
+			// slug is informative for the operator.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				newPageRan = false
+			}
 		}
 		result.Generated += newPageResult.Generated
 		result.Errors += newPageResult.Errors
+		result.CostUSD += newPageResult.CostUSD
+
+		finishedAt := time.Now().UTC()
+		pageSlugs := make([]string, len(pages))
+		for i, p := range pages {
+			pageSlugs[i] = p.Slug
+		}
+		runRow := SuggestionRun{
+			UserID:     user.ID,
+			StartedAt:  startedAt,
+			FinishedAt: &finishedAt,
+			Trigger:    TriggerManual,
+			PageSlugs:  BuildPageSlugsCSV(pageSlugs, newPageRan),
+			Generated:  result.Generated,
+			Errors:     result.Errors,
+			CostUSD:    result.CostUSD,
+		}
+		// Use a fresh context for the audit insert so a client disconnect
+		// after the run finishes does not drop the row.
+		insertCtx, insertCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if _, err := InsertSuggestionRun(insertCtx, db, runRow); err != nil {
+			log.Printf("suggestions: record manual run for user %d: %v", user.ID, err)
+		}
+		insertCancel()
 
 		writeJSON(w, http.StatusOK, result)
 	}
@@ -362,7 +400,7 @@ func PlanHandler(db *sql.DB) http.HandlerFunc {
 		ctx, cancel := context.WithTimeout(r.Context(), PlanTimeout)
 		defer cancel()
 
-		plan, err := runPromptFn(ctx, cfg, prompt)
+		plan, _, err := runPromptFn(ctx, cfg, prompt)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				log.Printf("suggestions: plan %d timed out after %s", id, PlanTimeout)

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -778,8 +778,8 @@ func TestPlanHandlerReplacesPriorPlan(t *testing.T) {
 	}
 
 	// Second plan replaces the first.
-	runPromptFn = func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
-		return "second plan", nil
+	runPromptFn = func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, float64, error) {
+		return "second plan", 0, nil
 	}
 	req = adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/%d/plan", id), nil), 1, true)
 	rec = httptest.NewRecorder()

--- a/internal/suggestions/new_page.go
+++ b/internal/suggestions/new_page.go
@@ -69,7 +69,8 @@ func RunNewPageSuggestion(
 
 	prompt := buildNewPagePrompt(registered, recent)
 
-	parsed, err := callAndParseNewPage(runCtx, cfg, prompt)
+	parsed, cost, err := callAndParseNewPage(runCtx, cfg, prompt)
+	result.CostUSD += cost
 	if err != nil {
 		if ctx.Err() != nil {
 			return result, ctx.Err()
@@ -106,22 +107,27 @@ func RunNewPageSuggestion(
 // once on malformed JSON. The retry uses the same prompt — no nudge text is
 // appended because the original prompt already insists on JSON-only output.
 // This mirrors the behaviour in callAndParse for per-page generation so both
-// passes have the same retry semantics.
-func callAndParseNewPage(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (newPageGenerated, error) {
-	var lastErr error
+// passes have the same retry semantics. Returns the accumulated cost across
+// all attempts so callers can fold it into the run total.
+func callAndParseNewPage(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (newPageGenerated, float64, error) {
+	var (
+		lastErr   error
+		totalCost float64
+	)
 	for attempt := 0; attempt <= MaxRetriesOnMalformedJSON; attempt++ {
-		resp, err := runPromptFn(ctx, cfg, prompt)
+		resp, cost, err := runPromptFn(ctx, cfg, prompt)
+		totalCost += cost
 		if err != nil {
-			return newPageGenerated{}, fmt.Errorf("claude prompt: %w", err)
+			return newPageGenerated{}, totalCost, fmt.Errorf("claude prompt: %w", err)
 		}
 		parsed, err := parseNewPageResponse(resp)
 		if err == nil {
-			return parsed, nil
+			return parsed, totalCost, nil
 		}
 		lastErr = err
 		log.Printf("suggestions: new_page parse attempt %d failed: %v", attempt+1, err)
 	}
-	return newPageGenerated{}, fmt.Errorf("parse new_page response after %d attempts: %w", MaxRetriesOnMalformedJSON+1, lastErr)
+	return newPageGenerated{}, totalCost, fmt.Errorf("parse new_page response after %d attempts: %w", MaxRetriesOnMalformedJSON+1, lastErr)
 }
 
 // parseNewPageResponse strips an optional markdown fence and decodes a single

--- a/internal/suggestions/runs.go
+++ b/internal/suggestions/runs.go
@@ -1,0 +1,185 @@
+package suggestions
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+)
+
+// Trigger values for the suggestion_runs.trigger column. They are also the
+// only values accepted by the table's CHECK constraint.
+const (
+	TriggerManual    = "manual"
+	TriggerScheduled = "scheduled"
+)
+
+// DefaultRunsLimit is the page size GET /api/suggestions/runs uses when the
+// caller omits ?limit. MaxRunsLimit is the hard cap the same handler enforces
+// regardless of what the client requests.
+const (
+	DefaultRunsLimit = 20
+	MaxRunsLimit     = 100
+)
+
+// SuggestionRun is the in-memory representation of a row in the
+// suggestion_runs table. PageSlugs is stored as a CSV string in SQLite — it
+// is exposed as a CSV string here too so the JSON shape mirrors the table
+// columns exactly (the frontend splits on ',' itself).
+type SuggestionRun struct {
+	ID         int64      `json:"id"`
+	UserID     int64      `json:"user_id"`
+	StartedAt  time.Time  `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	Trigger    string     `json:"trigger"`
+	PageSlugs  string     `json:"page_slugs"`
+	Generated  int        `json:"generated"`
+	Errors     int        `json:"errors"`
+	CostUSD    float64    `json:"cost_usd"`
+}
+
+// InsertSuggestionRun persists a completed (or in-progress, when FinishedAt is
+// nil) suggestion-run row. The caller is responsible for assembling the
+// page_slugs CSV; this helper does no formatting beyond storing the supplied
+// string verbatim. Timestamps are stored as RFC3339 strings to match the
+// existing convention in this package (see store.go).
+func InsertSuggestionRun(ctx context.Context, db *sql.DB, row SuggestionRun) (int64, error) {
+	if row.Trigger != TriggerManual && row.Trigger != TriggerScheduled {
+		return 0, fmt.Errorf("invalid trigger %q", row.Trigger)
+	}
+	var finishedAt any
+	if row.FinishedAt != nil {
+		finishedAt = row.FinishedAt.UTC().Format(time.RFC3339)
+	}
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO suggestion_runs
+		    (user_id, started_at, finished_at, trigger, page_slugs, generated, errors, cost_usd)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		row.UserID,
+		row.StartedAt.UTC().Format(time.RFC3339),
+		finishedAt,
+		row.Trigger,
+		row.PageSlugs,
+		row.Generated,
+		row.Errors,
+		row.CostUSD,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("insert suggestion_run: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// ListSuggestionRuns returns the most recent suggestion-run rows for userID,
+// newest-first. limit is clamped to [1, MaxRunsLimit] by the caller; this
+// function applies the LIMIT directly without further validation.
+func ListSuggestionRuns(ctx context.Context, db *sql.DB, userID int64, limit int) ([]SuggestionRun, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, user_id, started_at, finished_at, trigger, page_slugs, generated, errors, cost_usd
+		FROM suggestion_runs
+		WHERE user_id = ?
+		ORDER BY started_at DESC
+		LIMIT ?
+	`, userID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list suggestion_runs: %w", err)
+	}
+	defer rows.Close()
+
+	var out []SuggestionRun
+	for rows.Next() {
+		var (
+			r          SuggestionRun
+			startedAt  string
+			finishedAt sql.NullString
+		)
+		if err := rows.Scan(
+			&r.ID,
+			&r.UserID,
+			&startedAt,
+			&finishedAt,
+			&r.Trigger,
+			&r.PageSlugs,
+			&r.Generated,
+			&r.Errors,
+			&r.CostUSD,
+		); err != nil {
+			return nil, fmt.Errorf("scan suggestion_run: %w", err)
+		}
+		if t, err := parseTimestamp(startedAt); err == nil {
+			r.StartedAt = t
+		}
+		if finishedAt.Valid {
+			if t, err := parseTimestamp(finishedAt.String); err == nil {
+				r.FinishedAt = &t
+			}
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration: %w", err)
+	}
+	return out, nil
+}
+
+// BuildPageSlugsCSV joins page slugs with commas, appending NewPageSlug when
+// the new-page pass also ran. Order is preserved so the operator can read the
+// CSV as the order pages were processed.
+func BuildPageSlugsCSV(pageSlugs []string, includedNewPage bool) string {
+	all := pageSlugs
+	if includedNewPage {
+		all = append([]string{}, pageSlugs...)
+		all = append(all, NewPageSlug)
+	}
+	return strings.Join(all, ",")
+}
+
+// RunsHandler returns the most recent suggestion-run rows for the requesting
+// admin, newest-first. Admin-only — relies on auth.RequireAdmin upstream.
+//
+// GET /api/suggestions/runs?limit=20
+// Response: JSON array of SuggestionRun, newest first.
+func RunsHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		limit := DefaultRunsLimit
+		if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+			parsed, err := strconv.Atoi(raw)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid limit"})
+				return
+			}
+			limit = parsed
+		}
+		if limit < 1 {
+			limit = 1
+		}
+		if limit > MaxRunsLimit {
+			limit = MaxRunsLimit
+		}
+
+		runs, err := ListSuggestionRuns(r.Context(), db, user.ID, limit)
+		if err != nil {
+			log.Printf("suggestions: list runs for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list runs"})
+			return
+		}
+
+		if runs == nil {
+			runs = []SuggestionRun{}
+		}
+		writeJSON(w, http.StatusOK, runs)
+	}
+}

--- a/internal/suggestions/runs_test.go
+++ b/internal/suggestions/runs_test.go
@@ -1,0 +1,425 @@
+package suggestions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+func TestInsertSuggestionRunRoundTrip(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	started := time.Now().UTC().Truncate(time.Second)
+	finished := started.Add(2 * time.Minute)
+	row := SuggestionRun{
+		UserID:     1,
+		StartedAt:  started,
+		FinishedAt: &finished,
+		Trigger:    TriggerManual,
+		PageSlugs:  "weather,notes,__new_page__",
+		Generated:  7,
+		Errors:     1,
+		CostUSD:    0.1234,
+	}
+
+	id, err := InsertSuggestionRun(ctx, d, row)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("expected positive id, got %d", id)
+	}
+
+	got, err := ListSuggestionRuns(ctx, d, 1, 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(got))
+	}
+	r := got[0]
+	if r.UserID != 1 || r.Trigger != TriggerManual {
+		t.Errorf("user/trigger mismatch: %+v", r)
+	}
+	if r.PageSlugs != "weather,notes,__new_page__" {
+		t.Errorf("page_slugs: got %q", r.PageSlugs)
+	}
+	if r.Generated != 7 || r.Errors != 1 {
+		t.Errorf("counts: got generated=%d errors=%d", r.Generated, r.Errors)
+	}
+	if math.Abs(r.CostUSD-0.1234) > 1e-9 {
+		t.Errorf("cost mismatch: got %f", r.CostUSD)
+	}
+	if !r.StartedAt.Equal(started) {
+		t.Errorf("started_at: got %v want %v", r.StartedAt, started)
+	}
+	if r.FinishedAt == nil || !r.FinishedAt.Equal(finished) {
+		t.Errorf("finished_at: got %v want %v", r.FinishedAt, finished)
+	}
+}
+
+func TestInsertSuggestionRunRejectsInvalidTrigger(t *testing.T) {
+	d := setupTestDB(t)
+	if _, err := InsertSuggestionRun(context.Background(), d, SuggestionRun{
+		UserID:    1,
+		StartedAt: time.Now().UTC(),
+		Trigger:   "from-the-future",
+		PageSlugs: "",
+	}); err == nil {
+		t.Fatal("expected error for invalid trigger, got nil")
+	}
+}
+
+func TestListSuggestionRunsNewestFirstAndLimit(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Truncate(time.Second)
+
+	for i := 0; i < 5; i++ {
+		started := base.Add(time.Duration(i) * time.Minute)
+		finished := started.Add(30 * time.Second)
+		if _, err := InsertSuggestionRun(ctx, d, SuggestionRun{
+			UserID:     1,
+			StartedAt:  started,
+			FinishedAt: &finished,
+			Trigger:    TriggerScheduled,
+			PageSlugs:  fmt.Sprintf("p%d", i),
+			Generated:  i,
+		}); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	got, err := ListSuggestionRuns(ctx, d, 1, 3)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 rows (limit), got %d", len(got))
+	}
+	// Newest first: index 4, 3, 2.
+	for i, want := range []string{"p4", "p3", "p2"} {
+		if got[i].PageSlugs != want {
+			t.Errorf("row %d: got page_slugs %q, want %q", i, got[i].PageSlugs, want)
+		}
+	}
+}
+
+func TestListSuggestionRunsScopedByUser(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	if _, err := d.Exec(`INSERT INTO users (id, google_id, email, name, picture, is_admin) VALUES (2, 'g2', 'admin2@example.com', 'Admin2', '', 1)`); err != nil {
+		t.Fatalf("create user 2: %v", err)
+	}
+
+	now := time.Now().UTC()
+	if _, err := InsertSuggestionRun(ctx, d, SuggestionRun{UserID: 1, StartedAt: now, Trigger: TriggerManual, PageSlugs: "u1"}); err != nil {
+		t.Fatalf("insert u1: %v", err)
+	}
+	if _, err := InsertSuggestionRun(ctx, d, SuggestionRun{UserID: 2, StartedAt: now, Trigger: TriggerManual, PageSlugs: "u2"}); err != nil {
+		t.Fatalf("insert u2: %v", err)
+	}
+
+	for uid, want := range map[int64]string{1: "u1", 2: "u2"} {
+		rows, err := ListSuggestionRuns(ctx, d, uid, 10)
+		if err != nil {
+			t.Fatalf("list user %d: %v", uid, err)
+		}
+		if len(rows) != 1 || rows[0].PageSlugs != want {
+			t.Errorf("user %d: got %+v, want single row with page_slugs %q", uid, rows, want)
+		}
+	}
+}
+
+func TestBuildPageSlugsCSV(t *testing.T) {
+	cases := []struct {
+		name        string
+		slugs       []string
+		newPage     bool
+		want        string
+	}{
+		{"empty no new", nil, false, ""},
+		{"empty with new", nil, true, NewPageSlug},
+		{"slugs no new", []string{"a", "b"}, false, "a,b"},
+		{"slugs with new", []string{"a", "b"}, true, "a,b," + NewPageSlug},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BuildPageSlugsCSV(tc.slugs, tc.newPage)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- Cost accumulation -------------------------------------------------------
+
+func TestRunSuggestionsForPagesAccumulatesCost(t *testing.T) {
+	d := setupTestDB(t)
+	defer withRunPromptWithCost(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, float64, error) {
+		return validJSONResponse, 0.05, nil
+	})()
+
+	res := RunSuggestionsForPages(context.Background(), d, dummyCfg(), 1, twoPages())
+	if res.Errors != 0 {
+		t.Fatalf("expected 0 errors, got %d", res.Errors)
+	}
+	if math.Abs(res.CostUSD-0.10) > 1e-9 {
+		t.Fatalf("expected cost 0.10 (2 pages × $0.05), got %f", res.CostUSD)
+	}
+}
+
+func TestRunSuggestionsForPagesIncludesRetryCost(t *testing.T) {
+	d := setupTestDB(t)
+	var calls int
+	defer withRunPromptWithCost(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, float64, error) {
+		calls++
+		// First attempt: malformed (still costs $0.03). Second attempt: valid ($0.05).
+		if calls == 1 {
+			return "{not json", 0.03, nil
+		}
+		return validJSONResponse, 0.05, nil
+	})()
+
+	res := RunSuggestionsForPages(context.Background(), d, dummyCfg(), 1, []Page{{Slug: "weather", Title: "Weather"}})
+	if res.Errors != 0 {
+		t.Fatalf("expected 0 errors after retry, got %d", res.Errors)
+	}
+	if math.Abs(res.CostUSD-0.08) > 1e-9 {
+		t.Fatalf("expected cost 0.08 ($0.03 + $0.05), got %f", res.CostUSD)
+	}
+}
+
+func TestRunNewPageSuggestionAccumulatesCost(t *testing.T) {
+	d := setupTestDB(t)
+	defer withRunPromptWithCost(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, float64, error) {
+		return validNewPageJSON, 0.07, nil
+	})()
+
+	res, err := RunNewPageSuggestion(context.Background(), d, dummyCfg(), 1)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Generated != 1 {
+		t.Fatalf("expected 1 generated, got %d", res.Generated)
+	}
+	if math.Abs(res.CostUSD-0.07) > 1e-9 {
+		t.Fatalf("expected cost 0.07, got %f", res.CostUSD)
+	}
+}
+
+// --- RunHandler row insertion ------------------------------------------------
+
+func TestRunHandlerInsertsSuggestionRunRow(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
+	defer withRunPromptWithCost(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, float64, error) {
+		if strings.Contains(prompt, "Return ONLY a single JSON object") {
+			return validNewPageJSON, 0.02, nil
+		}
+		return validJSONResponse, 0.05, nil
+	})()
+
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/run", auth.RequireAdmin()(RunHandler(d)))
+
+	user := &auth.User{ID: 1, IsAdmin: true}
+	req := httptest.NewRequest(http.MethodPost, "/api/suggestions/run", bytes.NewReader(nil))
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rows, err := ListSuggestionRuns(context.Background(), d, 1, 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 audit row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.Trigger != TriggerManual {
+		t.Errorf("trigger: got %q want %q", r.Trigger, TriggerManual)
+	}
+	// 1 page + new_page sentinel.
+	if r.PageSlugs != "weather,"+NewPageSlug {
+		t.Errorf("page_slugs: got %q", r.PageSlugs)
+	}
+	// 3 per page + 1 new_page = 4.
+	if r.Generated != 4 {
+		t.Errorf("generated: got %d want 4", r.Generated)
+	}
+	if r.Errors != 0 {
+		t.Errorf("errors: got %d want 0", r.Errors)
+	}
+	// $0.05 per-page + $0.02 new_page = $0.07.
+	if math.Abs(r.CostUSD-0.07) > 1e-9 {
+		t.Errorf("cost: got %f want 0.07", r.CostUSD)
+	}
+	if r.FinishedAt == nil {
+		t.Errorf("finished_at should be set")
+	}
+}
+
+// --- RunsHandler -------------------------------------------------------------
+
+func TestRunsHandlerRejectsNonAdmin(t *testing.T) {
+	d := setupTestDB(t)
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/runs", auth.RequireAdmin()(RunsHandler(d)))
+
+	user := &auth.User{ID: 99, IsAdmin: false}
+	req := httptest.NewRequest(http.MethodGet, "/api/suggestions/runs", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRunsHandlerReturnsNewestFirst(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Truncate(time.Second)
+	for i := 0; i < 3; i++ {
+		started := base.Add(time.Duration(i) * time.Minute)
+		finished := started.Add(time.Second)
+		if _, err := InsertSuggestionRun(ctx, d, SuggestionRun{
+			UserID:     1,
+			StartedAt:  started,
+			FinishedAt: &finished,
+			Trigger:    TriggerScheduled,
+			PageSlugs:  fmt.Sprintf("p%d", i),
+		}); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/runs", auth.RequireAdmin()(RunsHandler(d)))
+	req := httptest.NewRequest(http.MethodGet, "/api/suggestions/runs", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: 1, IsAdmin: true}))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []SuggestionRun
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(got))
+	}
+	if got[0].PageSlugs != "p2" || got[1].PageSlugs != "p1" || got[2].PageSlugs != "p0" {
+		t.Fatalf("expected newest-first order, got %+v", got)
+	}
+}
+
+func TestRunsHandlerRespectsLimit(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Truncate(time.Second)
+	for i := 0; i < 5; i++ {
+		started := base.Add(time.Duration(i) * time.Minute)
+		if _, err := InsertSuggestionRun(ctx, d, SuggestionRun{
+			UserID:    1,
+			StartedAt: started,
+			Trigger:   TriggerScheduled,
+			PageSlugs: fmt.Sprintf("p%d", i),
+		}); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/runs", auth.RequireAdmin()(RunsHandler(d)))
+	req := httptest.NewRequest(http.MethodGet, "/api/suggestions/runs?limit=2", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: 1, IsAdmin: true}))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	var got []SuggestionRun
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows (limit=2), got %d", len(got))
+	}
+}
+
+func TestRunsHandlerClampsLimitToMax(t *testing.T) {
+	d := setupTestDB(t)
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/runs", auth.RequireAdmin()(RunsHandler(d)))
+
+	// Request a limit of 9999; verify the handler accepts it without error.
+	// We can't easily inspect the SQL LIMIT here, but the Default+Cap logic is
+	// straightforward and the request should succeed (the runs table is empty).
+	req := httptest.NewRequest(http.MethodGet, "/api/suggestions/runs?limit=9999", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: 1, IsAdmin: true}))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 with clamped limit, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []SuggestionRun
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty array, got %+v", got)
+	}
+}
+
+func TestRunsHandlerEmptyReturnsArrayNotNull(t *testing.T) {
+	d := setupTestDB(t)
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/runs", auth.RequireAdmin()(RunsHandler(d)))
+	req := httptest.NewRequest(http.MethodGet, "/api/suggestions/runs", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: 1, IsAdmin: true}))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	body := strings.TrimSpace(rec.Body.String())
+	if body != "[]" {
+		t.Fatalf("expected empty JSON array, got %q", body)
+	}
+}
+
+func TestRunsHandlerInvalidLimitIsBadRequest(t *testing.T) {
+	d := setupTestDB(t)
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/runs", auth.RequireAdmin()(RunsHandler(d)))
+	req := httptest.NewRequest(http.MethodGet, "/api/suggestions/runs?limit=abc", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: 1, IsAdmin: true}))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-integer limit, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Changes

- **Suggestion runs API and audit log** - The suggestion runner now records a row in `suggestion_runs` for every manual or scheduled run, capturing start/finish time, trigger, page slugs (including the `__new_page__` sentinel when the new-page pass ran), generated/error counts, and total Claude cost in USD. A new admin-only `GET /api/suggestions/runs?limit=20` endpoint returns runs newest-first (default 20, hard cap 100). (Hytte-66y0)

## Original Issue (task): Suggestions runner integration + runs API

In the suggestions package, change runPromptFn type to the cost-aware signature and update RunSuggestionsForPages and RunNewPageSuggestion to accumulate cost across all Claude calls (including the new-page pass — depends on parent's sub-task 1). At the end of each run (both the manual HTTP handler and the scheduler goroutine), insert a suggestion_runs row with started_at, finished_at, trigger ('manual' or 'scheduled'), page_slugs CSV (include '__new_page__' when the new-page pass ran), generated count, errors count, and total cost_usd. Add GET /api/suggestions/runs?limit=20 returning rows newest first, admin-only (reuse existing admin middleware), default limit 20 with hard cap 100. Returns JSON array matching the table columns. Connects to sub-task 3 by defining the JSON shape the frontend consumes.

---
Bead: Hytte-66y0 | Branch: forge/Hytte-66y0
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)