### PR TITLE
Backend: SSE streaming run handler with detached context (Hytte-lnk1)

### DIFF
--- a/changelog.d/Hytte-lnk1.md
+++ b/changelog.d/Hytte-lnk1.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Suggestions run streams progress over Server-Sent Events** - `POST /api/suggestions/run` now streams `started`, `page_complete`, `new_page_complete`, and `done` events instead of returning a single JSON blob. The work loop runs on a detached context so a client disconnect mid-run no longer aborts persistence. A second concurrent run for the same user returns 409 with the in-flight `run_id`. (Hytte-lnk1)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1572,6 +1572,7 @@ func createSchema(db *sql.DB) error {
 		FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 	);
 	CREATE INDEX IF NOT EXISTS idx_suggestion_runs_user_started ON suggestion_runs(user_id, started_at DESC);
+	CREATE INDEX IF NOT EXISTS idx_suggestion_runs_user_inflight ON suggestion_runs(user_id) WHERE finished_at IS NULL;
 
 	`
 

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -31,20 +32,81 @@ var PlanTimeout = 120 * time.Second
 // do not target an existing page in the registry.
 const NewPageSlug = "__new_page__"
 
-// RunHandler triggers a synchronous suggestions-generation pass for all enabled
-// pages in the registry. Admin-only — relies on auth.RequireAdmin upstream to
-// guarantee a non-nil admin user in the request context.
+// sseEvent is a single Server-Sent Event the work goroutine emits to the
+// client. Name is the event: line; Data is JSON-marshalled into the data: line.
+type sseEvent struct {
+	Name string
+	Data any
+}
+
+// startedEvent is the first event the SSE stream emits after the run row has
+// been inserted. The frontend uses run_id to correlate later UpdateSuggestionRun
+// audit rows with the in-flight stream.
+type startedEvent struct {
+	RunID      int64    `json:"run_id"`
+	TotalPages int      `json:"total_pages"`
+	PageSlugs  []string `json:"page_slugs"`
+}
+
+// pageCompleteEvent is emitted after each runForPage finishes (success or
+// failure). Status is "ok" when the per-page Claude call returned and at least
+// one row was inserted, "error" otherwise. Error carries the page-level error
+// message (Claude / parse failure) when status != "ok"; per-row insert
+// failures are surfaced via the errors counter.
+type pageCompleteEvent struct {
+	PageSlug  string  `json:"page_slug"`
+	Generated int     `json:"generated"`
+	Errors    int     `json:"errors"`
+	CostUSD   float64 `json:"cost_usd"`
+	ElapsedMS int64   `json:"elapsed_ms"`
+	Status    string  `json:"status"`
+	Error     string  `json:"error,omitempty"`
+}
+
+// newPageCompleteEvent mirrors pageCompleteEvent but for the separate
+// new-page Claude pass. PageSlug is always NewPageSlug.
+type newPageCompleteEvent struct {
+	PageSlug  string  `json:"page_slug"`
+	Generated int     `json:"generated"`
+	Errors    int     `json:"errors"`
+	CostUSD   float64 `json:"cost_usd"`
+	ElapsedMS int64   `json:"elapsed_ms"`
+	Status    string  `json:"status"`
+	Error     string  `json:"error,omitempty"`
+}
+
+// doneEvent is the final event in the stream. Totals match the row written to
+// suggestion_runs by UpdateSuggestionRun, so a client that misses
+// page_complete events can still render the final outcome.
+type doneEvent struct {
+	RunID     int64   `json:"run_id"`
+	Generated int     `json:"generated"`
+	Errors    int     `json:"errors"`
+	CostUSD   float64 `json:"cost_usd"`
+}
+
+// RunHandler triggers a suggestions-generation pass for all rotation-enabled
+// pages in the registry plus a separate new-page idea pass, streaming progress
+// to the client over Server-Sent Events. Admin-only — relies on
+// auth.RequireAdmin upstream to guarantee a non-nil admin user in the request
+// context.
 //
-// On completion (or error after the run has started) a row is inserted into
-// suggestion_runs with trigger='manual' so the operator can audit cost and
-// outcomes from the runs API. The insert uses a fresh background context so
-// a client disconnect after the run finishes does not lose the audit row.
+// The work loop runs on a context derived from context.Background() (not
+// r.Context()) so a client disconnect mid-run does not abort persistence: the
+// suggestion_runs row is still updated with finished_at and per-page
+// suggestions still land in the DB. Concurrency is bounded per-user — a second
+// call while a previous run is in flight returns 409.
 //
 // POST /api/suggestions/run
-// Response: { "generated": int, "errors": int, "cost_usd": float }
+// Response: text/event-stream with events:
+//   - started        {run_id, total_pages, page_slugs}
+//   - page_complete  {page_slug, generated, errors, cost_usd, elapsed_ms, status, error?}
+//   - new_page_complete {…same shape as page_complete, page_slug=__new_page__}
+//   - done           {run_id, generated, errors, cost_usd}
 func RunHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
+
 		cfg, err := training.LoadClaudeConfig(db, user.ID)
 		if err != nil {
 			log.Printf("suggestions: load claude config for user %d: %v", user.ID, err)
@@ -56,64 +118,191 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(r.Context(), OverallRunTimeout)
-		defer cancel()
+		// Concurrency guard: a single user may have at most one in-flight run
+		// at a time. The partial index idx_suggestion_runs_user_inflight keeps
+		// this lookup O(1). Returning 409 with the in-flight run_id lets the
+		// frontend resume tailing the existing stream rather than fork a
+		// duplicate one.
+		if existing, err := InflightRunForUser(r.Context(), db, user.ID); err != nil {
+			log.Printf("suggestions: check inflight runs for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to check in-flight runs"})
+			return
+		} else if existing != 0 {
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"error":  "a suggestion run is already in progress",
+				"run_id": existing,
+			})
+			return
+		}
 
-		pages, err := RotationEligible(ctx, db)
+		pages, err := RotationEligible(r.Context(), db)
 		if err != nil {
 			log.Printf("suggestions: load rotation-eligible pages for user %d: %v", user.ID, err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load page settings"})
 			return
 		}
 
-		startedAt := time.Now().UTC()
-		result := RunSuggestionsForPages(ctx, db, cfg, user.ID, pages)
-
-		// Also run the separate new-page idea pass. Errors are logged and
-		// counted in the aggregated RunResult so a single failure here cannot
-		// hide the per-page totals from the operator.
-		newPageResult, err := RunNewPageSuggestion(ctx, db, cfg, user.ID)
-		newPageRan := true
-		if err != nil {
-			log.Printf("suggestions: new_page run for user %d: %v", user.ID, err)
-			result.Errors++
-			// A pre-flight context error means the new-page pass did not run
-			// at all; in that case we should not list __new_page__ in
-			// page_slugs. Any other error still produced an attempt and the
-			// slug is informative for the operator.
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				newPageRan = false
-			}
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "streaming not supported"})
+			return
 		}
-		result.Generated += newPageResult.Generated
-		result.Errors += newPageResult.Errors
-		result.CostUSD += newPageResult.CostUSD
 
-		finishedAt := time.Now().UTC()
+		startedAt := time.Now().UTC()
 		pageSlugs := make([]string, len(pages))
 		for i, p := range pages {
 			pageSlugs[i] = p.Slug
 		}
-		runRow := SuggestionRun{
-			UserID:     user.ID,
-			StartedAt:  startedAt,
-			FinishedAt: &finishedAt,
-			Trigger:    TriggerManual,
-			PageSlugs:  BuildPageSlugsCSV(pageSlugs, newPageRan),
-			Generated:  result.Generated,
-			Errors:     result.Errors,
-			CostUSD:    result.CostUSD,
-		}
-		// Use a fresh context for the audit insert so a client disconnect
-		// after the run finishes does not drop the row.
-		insertCtx, insertCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if _, err := InsertSuggestionRun(insertCtx, db, runRow); err != nil {
-			log.Printf("suggestions: record manual run for user %d: %v", user.ID, err)
-		}
-		insertCancel()
 
-		writeJSON(w, http.StatusOK, result)
+		// Insert the in-flight row before any header is written so a 500 here
+		// surfaces as a normal JSON error rather than a torn SSE stream.
+		runRow := SuggestionRun{
+			UserID:    user.ID,
+			StartedAt: startedAt,
+			Trigger:   TriggerManual,
+			PageSlugs: BuildPageSlugsCSV(pageSlugs, true),
+		}
+		runID, err := InsertSuggestionRun(r.Context(), db, runRow)
+		if err != nil {
+			log.Printf("suggestions: insert in-flight run for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to start run"})
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		// Detached context: client disconnect must NOT abort persistence. The
+		// work goroutine uses runCtx so suggestion_runs and per-page rows
+		// continue to be written even after r.Context() cancels.
+		runCtx, cancel := context.WithTimeout(context.Background(), OverallRunTimeout)
+
+		eventCh := make(chan sseEvent, 16)
+
+		go func() {
+			defer close(eventCh)
+			defer cancel()
+
+			eventCh <- sseEvent{Name: "started", Data: startedEvent{
+				RunID:      runID,
+				TotalPages: len(pages),
+				PageSlugs:  pageSlugs,
+			}}
+
+			var totals RunResult
+
+			for _, page := range pages {
+				if err := runCtx.Err(); err != nil {
+					log.Printf("suggestions: context done before page %q: %v", page.Slug, err)
+					totals.Errors++
+					break
+				}
+				pageStart := time.Now()
+				inserted, failed, cost, err := runForPage(runCtx, db, cfg, user.ID, page)
+				elapsed := time.Since(pageStart).Milliseconds()
+				totals.Generated += inserted
+				totals.Errors += failed
+				totals.CostUSD += cost
+
+				ev := pageCompleteEvent{
+					PageSlug:  page.Slug,
+					Generated: inserted,
+					Errors:    failed,
+					CostUSD:   cost,
+					ElapsedMS: elapsed,
+					Status:    "ok",
+				}
+				if err != nil {
+					totals.Errors++
+					log.Printf("suggestions: page %q errored: %v", page.Slug, err)
+					ev.Status = "error"
+					ev.Error = err.Error()
+					ev.Errors++
+				}
+				eventCh <- sseEvent{Name: "page_complete", Data: ev}
+			}
+
+			newPageStart := time.Now()
+			newPageResult, err := RunNewPageSuggestion(runCtx, db, cfg, user.ID)
+			newPageElapsed := time.Since(newPageStart).Milliseconds()
+			totals.Generated += newPageResult.Generated
+			totals.Errors += newPageResult.Errors
+			totals.CostUSD += newPageResult.CostUSD
+
+			npEvent := newPageCompleteEvent{
+				PageSlug:  NewPageSlug,
+				Generated: newPageResult.Generated,
+				Errors:    newPageResult.Errors,
+				CostUSD:   newPageResult.CostUSD,
+				ElapsedMS: newPageElapsed,
+				Status:    "ok",
+			}
+			if err != nil {
+				log.Printf("suggestions: new_page run for user %d: %v", user.ID, err)
+				totals.Errors++
+				npEvent.Status = "error"
+				npEvent.Error = err.Error()
+				npEvent.Errors++
+			}
+			eventCh <- sseEvent{Name: "new_page_complete", Data: npEvent}
+
+			// Update the audit row with the final totals using a fresh
+			// context: runCtx may be near its deadline by now, and we want
+			// the audit write to land regardless.
+			updateCtx, updateCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := UpdateSuggestionRun(updateCtx, db, runID, totals.Generated, totals.Errors, totals.CostUSD); err != nil {
+				log.Printf("suggestions: update run %d for user %d: %v", runID, user.ID, err)
+			}
+			updateCancel()
+
+			eventCh <- sseEvent{Name: "done", Data: doneEvent{
+				RunID:     runID,
+				Generated: totals.Generated,
+				Errors:    totals.Errors,
+				CostUSD:   totals.CostUSD,
+			}}
+		}()
+
+	streaming:
+		for {
+			select {
+			case ev, ok := <-eventCh:
+				if !ok {
+					return
+				}
+				writeSSE(w, flusher, ev)
+			case <-r.Context().Done():
+				// Client disconnected. We stop streaming but intentionally do
+				// NOT cancel runCtx — the work goroutine continues so
+				// suggestion_runs and generated suggestions are persisted to
+				// completion.
+				break streaming
+			}
+		}
+		// Keep draining eventCh (without writing) so the work goroutine can
+		// never block on a full channel and leak.
+		for range eventCh {
+		}
 	}
+}
+
+// writeSSE serialises an event in the standard "event: <name>\ndata: <json>\n\n"
+// shape and flushes it to the wire. Errors are swallowed because a write
+// failure means the client is gone and the work goroutine continues anyway.
+func writeSSE(w http.ResponseWriter, flusher http.Flusher, ev sseEvent) {
+	data, err := json.Marshal(ev.Data)
+	if err != nil {
+		log.Printf("suggestions: marshal sse event %q: %v", ev.Name, err)
+		return
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Name, data); err != nil {
+		return
+	}
+	flusher.Flush()
 }
 
 // listResponse is the shape returned by GET /api/suggestions: the caller gets

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -3,6 +3,7 @@ package suggestions
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -51,7 +52,7 @@ func TestRunHandlerRejectsNonAdmin(t *testing.T) {
 	}
 }
 
-func TestRunHandlerAdminReturnsCounts(t *testing.T) {
+func TestRunHandlerAdminStreamsEvents(t *testing.T) {
 	d := setupTestDB(t)
 	defer withSavedPages([]Page{
 		{Slug: "weather", Title: "Weather"},
@@ -83,18 +84,81 @@ func TestRunHandlerAdminReturnsCounts(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200 for admin, got %d: %s", rec.Code, rec.Body.String())
 	}
-
-	var got RunResult
-	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
-		t.Fatalf("decode body: %v", err)
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("expected text/event-stream, got %q", ct)
 	}
-	if got.Errors != 0 {
-		t.Fatalf("expected 0 errors, got %d", got.Errors)
+
+	events := parseSSEEvents(t, rec.Body.String())
+
+	// Expect: started, page_complete×2, new_page_complete, done.
+	if len(events) != 5 {
+		t.Fatalf("expected 5 events (started + 2 page_complete + new_page_complete + done), got %d: %+v", len(events), events)
+	}
+	if events[0].name != "started" {
+		t.Fatalf("event 0: expected started, got %q", events[0].name)
+	}
+	var started startedEvent
+	if err := json.Unmarshal([]byte(events[0].data), &started); err != nil {
+		t.Fatalf("decode started: %v", err)
+	}
+	if started.RunID == 0 {
+		t.Fatalf("started.run_id should be > 0")
+	}
+	if started.TotalPages != 2 {
+		t.Fatalf("started.total_pages: got %d want 2", started.TotalPages)
+	}
+	if len(started.PageSlugs) != 2 || started.PageSlugs[0] != "weather" || started.PageSlugs[1] != "notes" {
+		t.Fatalf("started.page_slugs: got %+v", started.PageSlugs)
+	}
+
+	for i, want := range []string{"weather", "notes"} {
+		ev := events[1+i]
+		if ev.name != "page_complete" {
+			t.Fatalf("event %d: expected page_complete, got %q", 1+i, ev.name)
+		}
+		var pc pageCompleteEvent
+		if err := json.Unmarshal([]byte(ev.data), &pc); err != nil {
+			t.Fatalf("decode page_complete %d: %v", i, err)
+		}
+		if pc.PageSlug != want {
+			t.Errorf("page_complete %d: page_slug got %q want %q", i, pc.PageSlug, want)
+		}
+		if pc.Status != "ok" {
+			t.Errorf("page_complete %d: status got %q want ok", i, pc.Status)
+		}
+		if pc.Generated != 3 {
+			t.Errorf("page_complete %d: generated got %d want 3", i, pc.Generated)
+		}
+	}
+
+	if events[3].name != "new_page_complete" {
+		t.Fatalf("event 3: expected new_page_complete, got %q", events[3].name)
+	}
+	var npc newPageCompleteEvent
+	if err := json.Unmarshal([]byte(events[3].data), &npc); err != nil {
+		t.Fatalf("decode new_page_complete: %v", err)
+	}
+	if npc.PageSlug != NewPageSlug || npc.Status != "ok" || npc.Generated != 1 {
+		t.Errorf("new_page_complete: %+v", npc)
+	}
+
+	if events[4].name != "done" {
+		t.Fatalf("event 4: expected done, got %q", events[4].name)
+	}
+	var done doneEvent
+	if err := json.Unmarshal([]byte(events[4].data), &done); err != nil {
+		t.Fatalf("decode done: %v", err)
+	}
+	if done.RunID != started.RunID {
+		t.Errorf("done.run_id: got %d want %d", done.RunID, started.RunID)
 	}
 	// 3 per page × 2 pages = 6 from per-page rotation, plus 1 from the
 	// new-page pass = 7 total.
-	if got.Generated != 7 {
-		t.Fatalf("expected 7 generated (3 per page × 2 + 1 new_page), got %d", got.Generated)
+	if done.Generated != 7 {
+		t.Errorf("done.generated: got %d want 7", done.Generated)
+	}
+	if done.Errors != 0 {
+		t.Errorf("done.errors: got %d want 0", done.Errors)
 	}
 
 	var rowCount int
@@ -112,6 +176,98 @@ func TestRunHandlerAdminReturnsCounts(t *testing.T) {
 	if newPageCount != 1 {
 		t.Fatalf("expected exactly 1 new_page row, got %d", newPageCount)
 	}
+
+	// The audit row should be marked finished with the same totals as the
+	// done event.
+	var (
+		gotGenerated, gotErrors int
+		gotCost                 float64
+		finishedAt              sql.NullString
+	)
+	if err := d.QueryRow(`SELECT generated, errors, cost_usd, finished_at FROM suggestion_runs WHERE id = ?`, started.RunID).
+		Scan(&gotGenerated, &gotErrors, &gotCost, &finishedAt); err != nil {
+		t.Fatalf("read run row: %v", err)
+	}
+	if !finishedAt.Valid {
+		t.Errorf("finished_at should be set after a successful run")
+	}
+	if gotGenerated != done.Generated || gotErrors != done.Errors {
+		t.Errorf("audit row mismatch: generated=%d errors=%d, want done %+v", gotGenerated, gotErrors, done)
+	}
+}
+
+func TestRunHandlerReturns409WhenInflightRunExists(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{{Slug: "weather", Title: "Weather"}})()
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	// Seed an in-flight run (finished_at NULL).
+	existingID, err := InsertSuggestionRun(context.Background(), d, SuggestionRun{
+		UserID:    1,
+		StartedAt: time.Now().UTC(),
+		Trigger:   TriggerManual,
+		PageSlugs: "weather",
+	})
+	if err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/suggestions/run", auth.RequireAdmin()(RunHandler(d)))
+
+	user := &auth.User{ID: 1, IsAdmin: true}
+	req := httptest.NewRequest(http.MethodPost, "/api/suggestions/run", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 when run in flight, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Error string `json:"error"`
+		RunID int64  `json:"run_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.RunID != existingID {
+		t.Fatalf("expected run_id %d, got %d", existingID, body.RunID)
+	}
+}
+
+// sseTestEvent is the parsed shape of a single Server-Sent Event used by tests.
+type sseTestEvent struct {
+	name string
+	data string
+}
+
+// parseSSEEvents splits a raw SSE response body into individual events.
+// Only event/data pairs are recognised; comments and other fields are skipped.
+func parseSSEEvents(t *testing.T, body string) []sseTestEvent {
+	t.Helper()
+	var out []sseTestEvent
+	for _, block := range strings.Split(strings.TrimSpace(body), "\n\n") {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		var ev sseTestEvent
+		for _, line := range strings.Split(block, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				ev.name = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				ev.data = strings.TrimPrefix(line, "data: ")
+			}
+		}
+		if ev.name != "" {
+			out = append(out, ev)
+		}
+	}
+	return out
 }
 
 func TestRunHandlerRequiresClaudeEnabled(t *testing.T) {

--- a/internal/suggestions/runs.go
+++ b/internal/suggestions/runs.go
@@ -44,6 +44,51 @@ type SuggestionRun struct {
 	CostUSD    float64    `json:"cost_usd"`
 }
 
+// UpdateSuggestionRun marks an in-flight suggestion-run row as finished and
+// writes the final totals. Used by the SSE RunHandler after the work goroutine
+// completes so the row reflects the actual outcome rather than the in-progress
+// placeholder inserted at start. finished_at is set to the current UTC time.
+func UpdateSuggestionRun(ctx context.Context, db *sql.DB, runID int64, generated, errCount int, costUSD float64) error {
+	finishedAt := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.ExecContext(ctx, `
+		UPDATE suggestion_runs
+		SET finished_at = ?, generated = ?, errors = ?, cost_usd = ?
+		WHERE id = ?
+	`, finishedAt, generated, errCount, costUSD, runID)
+	if err != nil {
+		return fmt.Errorf("update suggestion_run: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("update suggestion_run %d: no rows", runID)
+	}
+	return nil
+}
+
+// InflightRunForUser returns the id of an in-flight suggestion run for userID
+// (one whose finished_at is NULL), or 0 with no error if no such row exists.
+// Used as a concurrency guard so a second RunHandler call cannot start while a
+// previous run is still streaming. A partial index on finished_at IS NULL
+// keeps this lookup cheap as the suggestion_runs table grows.
+func InflightRunForUser(ctx context.Context, db *sql.DB, userID int64) (int64, error) {
+	var id int64
+	err := db.QueryRowContext(ctx, `
+		SELECT id FROM suggestion_runs
+		WHERE user_id = ? AND finished_at IS NULL
+		LIMIT 1
+	`, userID).Scan(&id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("inflight run for user %d: %w", userID, err)
+	}
+	return id, nil
+}
+
 // InsertSuggestionRun persists a completed (or in-progress, when FinishedAt is
 // nil) suggestion-run row. The caller is responsible for assembling the
 // page_slugs CSV; this helper does no formatting beyond storing the supplied

--- a/internal/suggestions/runs_test.go
+++ b/internal/suggestions/runs_test.go
@@ -261,7 +261,8 @@ func TestRunHandlerInsertsSuggestionRunRow(t *testing.T) {
 	if r.Trigger != TriggerManual {
 		t.Errorf("trigger: got %q want %q", r.Trigger, TriggerManual)
 	}
-	// 1 page + new_page sentinel.
+	// 1 page + new_page sentinel — included up-front when the row is first
+	// inserted because the new-page pass always runs.
 	if r.PageSlugs != "weather,"+NewPageSlug {
 		t.Errorf("page_slugs: got %q", r.PageSlugs)
 	}
@@ -277,7 +278,93 @@ func TestRunHandlerInsertsSuggestionRunRow(t *testing.T) {
 		t.Errorf("cost: got %f want 0.07", r.CostUSD)
 	}
 	if r.FinishedAt == nil {
-		t.Errorf("finished_at should be set")
+		t.Errorf("finished_at should be set after UpdateSuggestionRun")
+	}
+}
+
+func TestUpdateSuggestionRunMarksFinishedAndOverwritesTotals(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	id, err := InsertSuggestionRun(ctx, d, SuggestionRun{
+		UserID:    1,
+		StartedAt: time.Now().UTC(),
+		Trigger:   TriggerManual,
+		PageSlugs: "weather",
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	if err := UpdateSuggestionRun(ctx, d, id, 5, 1, 0.42); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	rows, err := ListSuggestionRuns(ctx, d, 1, 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.FinishedAt == nil {
+		t.Fatal("finished_at should be set after UpdateSuggestionRun")
+	}
+	if r.Generated != 5 || r.Errors != 1 {
+		t.Errorf("totals: got generated=%d errors=%d, want 5/1", r.Generated, r.Errors)
+	}
+	if math.Abs(r.CostUSD-0.42) > 1e-9 {
+		t.Errorf("cost: got %f want 0.42", r.CostUSD)
+	}
+}
+
+func TestUpdateSuggestionRunErrorsOnUnknownID(t *testing.T) {
+	d := setupTestDB(t)
+	if err := UpdateSuggestionRun(context.Background(), d, 9999, 0, 0, 0); err == nil {
+		t.Fatal("expected error when updating non-existent run, got nil")
+	}
+}
+
+func TestInflightRunForUserDistinguishesInProgressFromFinished(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	// Finished run — must not show up.
+	finished := time.Now().UTC()
+	if _, err := InsertSuggestionRun(ctx, d, SuggestionRun{
+		UserID:     1,
+		StartedAt:  finished.Add(-time.Minute),
+		FinishedAt: &finished,
+		Trigger:    TriggerManual,
+		PageSlugs:  "weather",
+	}); err != nil {
+		t.Fatalf("seed finished: %v", err)
+	}
+
+	if id, err := InflightRunForUser(ctx, d, 1); err != nil {
+		t.Fatalf("inflight: %v", err)
+	} else if id != 0 {
+		t.Fatalf("expected no in-flight run, got id %d", id)
+	}
+
+	// Now insert an in-flight run and confirm it surfaces.
+	inflight, err := InsertSuggestionRun(ctx, d, SuggestionRun{
+		UserID:    1,
+		StartedAt: time.Now().UTC(),
+		Trigger:   TriggerManual,
+		PageSlugs: "weather",
+	})
+	if err != nil {
+		t.Fatalf("seed inflight: %v", err)
+	}
+
+	got, err := InflightRunForUser(ctx, d, 1)
+	if err != nil {
+		t.Fatalf("inflight after seed: %v", err)
+	}
+	if got != inflight {
+		t.Fatalf("expected in-flight id %d, got %d", inflight, got)
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Suggestions run streams progress over Server-Sent Events** - `POST /api/suggestions/run` now streams `started`, `page_complete`, `new_page_complete`, and `done` events instead of returning a single JSON blob. The work loop runs on a detached context so a client disconnect mid-run no longer aborts persistence. A second concurrent run for the same user returns 409 with the in-flight `run_id`. (Hytte-lnk1)

## Original Issue (task): Backend: SSE streaming run handler with detached context

Modify `internal/suggestions/handlers.go` to replace synchronous `RunHandler` with an SSE streaming handler. Set `Content-Type: text/event-stream`, flush headers, and run the work loop on `runCtx, cancel := context.WithTimeout(context.Background(), OverallRunTimeout)` in a goroutine so client disconnect doesn't abort persistence. Reference `internal/forge/handlers.go` SSE pattern. Insert a `suggestion_runs` row at start (via existing `InsertSuggestionRun`) and add a new `UpdateSuggestionRun` function in `internal/suggestions/runs.go` to set `finished_at` + final totals. Emit events: `started {run_id, total_pages, page_slugs}`, `page_complete {page_slug, generated, errors, cost_usd, elapsed_ms, status, error?}` after each `runForPage` returns, `new_page_complete` after `RunNewPageSuggestion`, then `done {run_id, generated, errors, cost_usd}`. If `r.Context()` cancels, stop streaming but let the goroutine finish — add a comment. Concurrency guard: at handler entry, query `suggestion_runs` for `user_id` with `finished_at IS NULL`; if found, return 409 with `{error, run_id}`. Add migration for `CREATE INDEX IF NOT EXISTS idx_suggestion_runs_user_inflight ON suggestion_runs(user_id) WHERE finished_at IS NULL`. Verify `finished_at` is nullable per Hytte-eino. Connects to: timeouts/cap sub-task (uses bumped constants); frontend sub-task (consumes these events).

---
Bead: Hytte-lnk1 | Branch: forge/Hytte-lnk1
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)