### PR TITLE
Backend: bump PerPageTimeout, OverallRunTimeout, RotationDefaultN (Hytte-h22b)

### DIFF
--- a/changelog.d/Hytte-h22b.md
+++ b/changelog.d/Hytte-h22b.md
@@ -1,2 +1,2 @@
 category: Changed
-- **Bumped suggestion-run timeouts and rotation size** - `PerPageTimeout` increased from 90s to 240s to accommodate slow Claude calls on large pages, `OverallRunTimeout` from 10 to 30 minutes to fit the larger rotation, and `RotationDefaultN` from 10 to 20 so the ~35-page registry cycles every couple of nights. (Hytte-h22b)
+- **Bumped suggestion-run timeouts and rotation size** - `PerPageTimeout` increased from 90s to 240s to accommodate slow Claude calls on large pages, `OverallRunTimeout` from 10 to 30 minutes as a safety bound against stalled runs (not a worst-case budget for all pages), and `RotationDefaultN` from 10 to 20 so the ~35-page registry cycles every couple of nights. (Hytte-h22b)

--- a/changelog.d/Hytte-h22b.md
+++ b/changelog.d/Hytte-h22b.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Bumped suggestion-run timeouts and rotation size** - `PerPageTimeout` increased from 90s to 240s to accommodate slow Claude calls on large pages, `OverallRunTimeout` from 10 to 30 minutes to fit the larger rotation, and `RotationDefaultN` from 10 to 20 so the ~35-page registry cycles every couple of nights. (Hytte-h22b)

--- a/internal/suggestions/generate.go
+++ b/internal/suggestions/generate.go
@@ -25,8 +25,11 @@ var runPromptFn = training.RunPromptWithCost
 
 // PerPageTimeout is the deadline applied to each individual page's generation
 // attempt. RunSuggestionsForPages caps each Claude call at this duration so a
-// single hung page cannot starve the overall run.
-const PerPageTimeout = 90 * time.Second
+// single hung page cannot starve the overall run. Bumped to 240s because
+// Claude calls on large pages (many source files / long git history) can run
+// well past the original 90s budget; the previous value was timing manual
+// runs out before they could finish.
+const PerPageTimeout = 240 * time.Second
 
 // recentSuggestionsWindowDays is the look-back window used when injecting prior
 // suggestion titles into the prompt to discourage repeats.

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -18,10 +18,13 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// OverallRunTimeout caps the entire RunHandler invocation. Five pages × 90s
-// per-page worst case fits under 10 minutes, but Claude can occasionally
-// stall — we want to return a result rather than hang the request indefinitely.
-const OverallRunTimeout = 10 * time.Minute
+// OverallRunTimeout caps the entire RunHandler invocation. Sized to fit the
+// worst case of RotationDefaultN (20) pages × PerPageTimeout (240s) ≈ 80
+// minutes of compute, halved by the fact that not every page hits its
+// per-page deadline; 30 minutes leaves headroom for the streaming run to
+// complete while still bounding hangs so a stalled Claude call cannot pin
+// the request indefinitely.
+const OverallRunTimeout = 30 * time.Minute
 
 // PlanTimeout caps a single PlanHandler Claude invocation. Declared as var so
 // tests can shrink it to verify timeout handling without hanging for two

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -18,12 +18,12 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// OverallRunTimeout caps the entire RunHandler invocation. Sized to fit the
-// worst case of RotationDefaultN (20) pages × PerPageTimeout (240s) ≈ 80
-// minutes of compute, halved by the fact that not every page hits its
-// per-page deadline; 30 minutes leaves headroom for the streaming run to
-// complete while still bounding hangs so a stalled Claude call cannot pin
-// the request indefinitely.
+// OverallRunTimeout caps the entire RunHandler invocation as a safety bound
+// against stalled Claude calls pinning the request indefinitely. It is not
+// sized to cover the absolute worst case (RotationDefaultN × PerPageTimeout
+// = 20 × 240s ≈ 80 min); pages that have not completed when the deadline
+// fires are skipped. 30 minutes bounds typical multi-page runs while
+// allowing normally-slow pages to complete without premature cancellation.
 const OverallRunTimeout = 30 * time.Minute
 
 // PlanTimeout caps a single PlanHandler Claude invocation. Declared as var so

--- a/internal/suggestions/rotation.go
+++ b/internal/suggestions/rotation.go
@@ -10,9 +10,10 @@ import (
 
 // RotationDefaultN is the default number of pages selected per nightly
 // rotation. With ~35 eligible pages in the registry, picking 20 cycles
-// through the full set every two nights while keeping a single run within
-// the OverallRunTimeout budget. Tune downward if cost-per-run becomes a
-// problem after observing real spend.
+// through the full set every two nights. Note: 20 × PerPageTimeout (240s)
+// exceeds OverallRunTimeout (30 min) in the absolute worst case; the
+// overall timeout is a safety bound, not a per-page completion guarantee.
+// Tune downward if cost-per-run becomes a problem after observing real spend.
 const RotationDefaultN = 20
 
 // PickRotation selects up to n pages from eligible, ordered so that the most

--- a/internal/suggestions/rotation.go
+++ b/internal/suggestions/rotation.go
@@ -9,10 +9,11 @@ import (
 )
 
 // RotationDefaultN is the default number of pages selected per nightly
-// rotation. Picked to keep one nightly run well under the per-admin time
-// budget while still cycling through the full registry within a couple of
-// weeks.
-const RotationDefaultN = 10
+// rotation. With ~35 eligible pages in the registry, picking 20 cycles
+// through the full set every two nights while keeping a single run within
+// the OverallRunTimeout budget. Tune downward if cost-per-run becomes a
+// problem after observing real spend.
+const RotationDefaultN = 20
 
 // PickRotation selects up to n pages from eligible, ordered so that the most
 // stale pages run first. The ordering is:


### PR DESCRIPTION
## Changes

- **Bumped suggestion-run timeouts and rotation size** - `PerPageTimeout` increased from 90s to 240s to accommodate slow Claude calls on large pages, `OverallRunTimeout` from 10 to 30 minutes to fit the larger rotation, and `RotationDefaultN` from 10 to 20 so the ~35-page registry cycles every couple of nights. (Hytte-h22b)

## Original Issue (task): Backend: bump PerPageTimeout, OverallRunTimeout, RotationDefaultN

In `internal/suggestions/generate.go`: change `PerPageTimeout` from `90 * time.Second` to `240 * time.Second` with comment explaining slow Claude calls on large pages. Bump `OverallRunTimeout` from 10 min to 30 min to accommodate 240s × 20 pages. In `internal/suggestions/rotation.go`: change `RotationDefaultN` from `10` to `20` with comment about ~35 eligible pages and tuning after observing cost. Confirm manual runs continue to bypass rotation quota (hit every eligible page) — the streaming handler should NOT apply the rotation cap for manual triggers. Connects to: streaming handler sub-task (handler uses these constants); ensures the streaming run has enough headroom to finish.

---
Bead: Hytte-h22b | Branch: forge/Hytte-h22b
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)