### PR TITLE
Frontend: streaming progress UI in Suggestions page (Hytte-39fp)

### DIFF
--- a/changelog.d/Hytte-39fp.md
+++ b/changelog.d/Hytte-39fp.md
@@ -1,0 +1,2 @@
+category: Added
+- **Streaming progress UI on Suggestions page** - Run now now consumes the SSE event stream from `POST /api/suggestions/run`: a header progress pill and per-page log update live, the Pending tab refetches between events, a 409 response surfaces a banner pointing to recent runs, and a Reconnect button appears if the stream drops mid-run. (Hytte-39fp)

--- a/changelog.d/Hytte-39fp.md
+++ b/changelog.d/Hytte-39fp.md
@@ -1,2 +1,2 @@
 category: Added
-- **Streaming progress UI on Suggestions page** - Run now now consumes the SSE event stream from `POST /api/suggestions/run`: a header progress pill and per-page log update live, the Pending tab refetches between events, a 409 response surfaces a banner pointing to recent runs, and a Reconnect button appears if the stream drops mid-run. (Hytte-39fp)
+- **Streaming progress UI on Suggestions page** - Run now consumes the SSE event stream from `POST /api/suggestions/run`: a header progress pill and per-page log update live, the Pending tab refetches between events, a 409 response surfaces a banner pointing to recent runs, and a Reconnect button appears if the stream drops mid-run. (Hytte-39fp)

--- a/web/public/locales/en/suggestions.json
+++ b/web/public/locales/en/suggestions.json
@@ -78,6 +78,16 @@
     "planFailed": "Failed to plan suggestion",
     "unknown": "unknown error"
   },
+  "run": {
+    "inProgress": "Run in progress: {{done}} / {{total}} pages",
+    "pageOk": "{{slug}} ({{count}} ideas, ${{cost}})",
+    "pageError": "{{slug}} ({{reason}}, {{seconds}}s)",
+    "alreadyRunning": "A run is already in progress.",
+    "alreadyRunningLink": "View recent runs",
+    "reconnect": "Reconnect",
+    "streamError": "Lost connection to the run stream.",
+    "dismiss": "Dismiss"
+  },
   "form": {
     "title": "New suggestion",
     "newPageOption": "New page idea",

--- a/web/public/locales/nb/suggestions.json
+++ b/web/public/locales/nb/suggestions.json
@@ -78,6 +78,16 @@
     "planFailed": "Kunne ikke planlegge forslag",
     "unknown": "ukjent feil"
   },
+  "run": {
+    "inProgress": "Kjøring pågår: {{done}} / {{total}} sider",
+    "pageOk": "{{slug}} ({{count}} idéer, ${{cost}})",
+    "pageError": "{{slug}} ({{reason}}, {{seconds}}s)",
+    "alreadyRunning": "En kjøring pågår allerede.",
+    "alreadyRunningLink": "Vis nylige kjøringer",
+    "reconnect": "Koble til på nytt",
+    "streamError": "Mistet forbindelsen til kjøringsstrømmen.",
+    "dismiss": "Lukk"
+  },
   "form": {
     "title": "Nytt forslag",
     "newPageOption": "Ny side-idé",

--- a/web/public/locales/th/suggestions.json
+++ b/web/public/locales/th/suggestions.json
@@ -78,6 +78,16 @@
     "planFailed": "วางแผนข้อเสนอแนะไม่สำเร็จ",
     "unknown": "ข้อผิดพลาดที่ไม่รู้จัก"
   },
+  "run": {
+    "inProgress": "กำลังทำงาน: {{done}} / {{total}} หน้า",
+    "pageOk": "{{slug}} ({{count}} ไอเดีย, ${{cost}})",
+    "pageError": "{{slug}} ({{reason}}, {{seconds}} วิ)",
+    "alreadyRunning": "มีการทำงานที่กำลังดำเนินอยู่แล้ว",
+    "alreadyRunningLink": "ดูการทำงานล่าสุด",
+    "reconnect": "เชื่อมต่อใหม่",
+    "streamError": "การเชื่อมต่อกับสตรีมการทำงานหลุด",
+    "dismiss": "ปิด"
+  },
   "form": {
     "title": "ข้อเสนอแนะใหม่",
     "newPageOption": "ไอเดียหน้าใหม่",

--- a/web/src/components/suggestions/RecentRunsPanel.test.tsx
+++ b/web/src/components/suggestions/RecentRunsPanel.test.tsx
@@ -244,6 +244,48 @@ describe('RecentRunsPanel', () => {
     )
   })
 
+  it('reloadSignal > 0 opens the panel and triggers a fetch', async () => {
+    const runs = [
+      {
+        id: 20,
+        user_id: 1,
+        started_at: '2026-05-06T19:00:00Z',
+        finished_at: '2026-05-06T19:01:00Z',
+        trigger: 'manual',
+        page_slugs: 'weather',
+        generated: 1,
+        errors: 0,
+        cost_usd: 0.01,
+      },
+    ]
+    let fetchCalls = 0
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/api/suggestions/runs?limit=20') {
+        fetchCalls += 1
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(runs) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender } = render(<RecentRunsPanel reloadSignal={0} />)
+
+    // Initially collapsed, no fetch.
+    expect(screen.getByRole('button', { name: /Recent runs/ })).toHaveAttribute('aria-expanded', 'false')
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    // Incrementing reloadSignal should open the panel and trigger a fetch.
+    rerender(<RecentRunsPanel reloadSignal={1} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Recent runs/ })).toHaveAttribute('aria-expanded', 'true')
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('recent-run-20')).toBeInTheDocument()
+    })
+    expect(fetchCalls).toBeGreaterThanOrEqual(1)
+  })
+
   it('toggling collapses the panel and hides content', async () => {
     vi.stubGlobal(
       'fetch',

--- a/web/src/components/suggestions/RecentRunsPanel.tsx
+++ b/web/src/components/suggestions/RecentRunsPanel.tsx
@@ -31,7 +31,16 @@ function formatCost(cost: number, placeholder: string): string {
   return `$${cost.toFixed(4)}`
 }
 
-export function RecentRunsPanel() {
+interface RecentRunsPanelProps {
+  /**
+   * Incrementing this value forces the panel to refetch from the server
+   * (and to open if it is currently collapsed). Used by the SSE run flow to
+   * surface the just-finished run without making the user toggle the panel.
+   */
+  reloadSignal?: number
+}
+
+export function RecentRunsPanel({ reloadSignal = 0 }: RecentRunsPanelProps = {}) {
   const { t } = useTranslation('suggestions')
   const { t: tCommon } = useTranslation('common')
   const [open, setOpen] = useState(false)
@@ -40,9 +49,16 @@ export function RecentRunsPanel() {
   const [loaded, setLoaded] = useState(false)
   const [hasError, setHasError] = useState(false)
   const [now] = useState(() => Date.now())
+  const [reloadKey, setReloadKey] = useState(0)
 
   useEffect(() => {
-    if (!open || loaded) return
+    if (reloadSignal === 0) return
+    setOpen(true)
+    setReloadKey(k => k + 1)
+  }, [reloadSignal])
+
+  useEffect(() => {
+    if (!open || (loaded && reloadKey === 0)) return
     const controller = new AbortController()
     ;(async () => {
       setLoading(true)
@@ -64,7 +80,7 @@ export function RecentRunsPanel() {
       }
     })()
     return () => controller.abort()
-  }, [open, loaded])
+  }, [open, loaded, reloadKey])
 
   const summary = useMemo(() => {
     const cutoff = now - SEVEN_DAYS_MS
@@ -85,6 +101,7 @@ export function RecentRunsPanel() {
 
   return (
     <section
+      id="recent-runs"
       aria-labelledby="recent-runs-heading"
       data-testid="recent-runs-panel"
       className="rounded-lg border border-gray-800 bg-gray-900/40"

--- a/web/src/components/suggestions/RecentRunsPanel.tsx
+++ b/web/src/components/suggestions/RecentRunsPanel.tsx
@@ -50,12 +50,15 @@ export function RecentRunsPanel({ reloadSignal = 0 }: RecentRunsPanelProps = {})
   const [hasError, setHasError] = useState(false)
   const [now] = useState(() => Date.now())
   const [reloadKey, setReloadKey] = useState(0)
+  const [prevReloadSignal, setPrevReloadSignal] = useState(reloadSignal)
 
-  useEffect(() => {
-    if (reloadSignal === 0) return
-    setOpen(true)
-    setReloadKey(k => k + 1)
-  }, [reloadSignal])
+  if (reloadSignal !== prevReloadSignal) {
+    setPrevReloadSignal(reloadSignal)
+    if (reloadSignal > 0) {
+      setOpen(true)
+      setReloadKey(k => k + 1)
+    }
+  }
 
   useEffect(() => {
     if (!open || (loaded && reloadKey === 0)) return

--- a/web/src/pages/Suggestions.test.tsx
+++ b/web/src/pages/Suggestions.test.tsx
@@ -76,6 +76,58 @@ function renderPage() {
   )
 }
 
+interface SSEFrame {
+  event: string
+  data: unknown
+}
+
+// Build a minimal Response-shaped object whose `body` is a ReadableStream
+// emitting the supplied SSE frames. The Suggestions page only reads
+// res.status, res.ok, and res.body, so the structural shape is sufficient.
+function sseResponse(frames: SSEFrame[]): Response {
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const f of frames) {
+        controller.enqueue(
+          encoder.encode(`event: ${f.event}\ndata: ${JSON.stringify(f.data)}\n\n`),
+        )
+      }
+      controller.close()
+    },
+  })
+  return { ok: true, status: 200, body: stream } as unknown as Response
+}
+
+// Build a streaming SSE response whose frames are pushed manually by the
+// test. Returns helpers to enqueue more frames or close the stream — useful
+// for asserting incremental UI updates between events.
+function manualSSEResponse() {
+  const encoder = new TextEncoder()
+  let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllerRef = controller
+    },
+  })
+  return {
+    response: { ok: true, status: 200, body: stream } as unknown as Response,
+    push(frame: SSEFrame) {
+      controllerRef?.enqueue(
+        encoder.encode(
+          `event: ${frame.event}\ndata: ${JSON.stringify(frame.data)}\n\n`,
+        ),
+      )
+    },
+    close() {
+      controllerRef?.close()
+    },
+    error(err: Error) {
+      controllerRef?.error(err)
+    },
+  }
+}
+
 beforeEach(() => {
   // Pin Date so the header next-run helper renders deterministically. We only
   // fake Date — leaving setTimeout/queueMicrotask alive — because React/RTL
@@ -225,7 +277,7 @@ describe('Suggestions – data fetch', () => {
 })
 
 describe('Suggestions – Run now flow', () => {
-  it('refetches list on successful Run now', async () => {
+  it('streams SSE progress and refetches the list on done', async () => {
     const initial = {
       pending: [makeSuggestion({ id: 1, title: 'Old item' })],
       planned: [],
@@ -243,7 +295,29 @@ describe('Suggestions – Run now flow', () => {
     let listCalls = 0
     const fetchMock = vi.fn((url: string, init?: RequestInit) => {
       if (url === '/api/suggestions/run' && init?.method === 'POST') {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+        return Promise.resolve(
+          sseResponse([
+            {
+              event: 'started',
+              data: { run_id: 1, total_pages: 1, page_slugs: ['weather'] },
+            },
+            {
+              event: 'page_complete',
+              data: {
+                page_slug: 'weather',
+                generated: 3,
+                errors: 0,
+                cost_usd: 0.04,
+                elapsed_ms: 1200,
+                status: 'ok',
+              },
+            },
+            {
+              event: 'done',
+              data: { run_id: 1, generated: 3, errors: 0, cost_usd: 0.04 },
+            },
+          ]),
+        )
       }
       if (url === '/api/suggestions') {
         listCalls += 1
@@ -265,8 +339,192 @@ describe('Suggestions – Run now flow', () => {
     await waitFor(() => {
       expect(screen.getByText('Fresh item')).toBeInTheDocument()
     })
-    expect(listCalls).toBe(2)
+    // page_complete and done both call refetch — at least 3 list loads total.
+    expect(listCalls).toBeGreaterThanOrEqual(2)
     expect(screen.queryByTestId('run-error')).not.toBeInTheDocument()
+    // Progress UI cleared after `done`.
+    expect(screen.queryByTestId('run-progress')).not.toBeInTheDocument()
+  })
+
+  it('shows progress pill and log entries as page_complete events arrive', async () => {
+    const initial = { pending: [], planned: [], rejected: [] }
+
+    const stream = manualSSEResponse()
+    let resolveRun: ((v: Response) => void) | null = null
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/run' && init?.method === 'POST') {
+        return new Promise<Response>(resolve => {
+          resolveRun = resolve
+        })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(initial) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Run now/ }))
+    resolveRun!(stream.response)
+
+    // started: pill should read 0 / 2.
+    stream.push({
+      event: 'started',
+      data: { run_id: 7, total_pages: 2, page_slugs: ['weather', 'webhooks'] },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('0 / 2')
+    })
+
+    // First page completes successfully.
+    stream.push({
+      event: 'page_complete',
+      data: {
+        page_slug: 'weather',
+        generated: 3,
+        errors: 0,
+        cost_usd: 0.04,
+        elapsed_ms: 1200,
+        status: 'ok',
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('1 / 2')
+    })
+    expect(screen.getByTestId('run-progress-log-weather')).toHaveTextContent(
+      'weather (3 ideas, $0.04)',
+    )
+
+    // Second page errors out.
+    stream.push({
+      event: 'page_complete',
+      data: {
+        page_slug: 'webhooks',
+        generated: 0,
+        errors: 1,
+        cost_usd: 0,
+        elapsed_ms: 240_000,
+        status: 'error',
+        error: 'timeout',
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('2 / 2')
+    })
+    expect(screen.getByTestId('run-progress-log-webhooks')).toHaveTextContent(
+      'webhooks (timeout, 240s)',
+    )
+
+    // done clears the progress UI.
+    stream.push({
+      event: 'done',
+      data: { run_id: 7, generated: 3, errors: 1, cost_usd: 0.04 },
+    })
+    stream.close()
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('run-progress')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows already-running banner on 409 and does not enter progress state', async () => {
+    const initial = { pending: [], planned: [], rejected: [] }
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/run' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: () => Promise.resolve({ error: 'in progress', run_id: 42 }),
+        })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(initial) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Run now/ }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('already-running-banner')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('already-running-banner')).toHaveTextContent(
+      'A run is already in progress',
+    )
+    // Banner has a link/anchor to the recent runs panel.
+    const link = within(screen.getByTestId('already-running-banner')).getByRole(
+      'link',
+    )
+    expect(link).toHaveAttribute('href', '#recent-runs')
+    // No progress state and no run-error banner.
+    expect(screen.queryByTestId('run-progress')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('run-error')).not.toBeInTheDocument()
+  })
+
+  it('shows Reconnect button when stream errors mid-run', async () => {
+    const initial = { pending: [], planned: [], rejected: [] }
+    const stream = manualSSEResponse()
+    let resolveRun: ((v: Response) => void) | null = null
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/run' && init?.method === 'POST') {
+        return new Promise<Response>(resolve => {
+          resolveRun = resolve
+        })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(initial) })
+      }
+      if (url === '/api/suggestions/runs?limit=1') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              { id: 9, finished_at: '2026-05-06T20:01:00Z' },
+            ]),
+        })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Run now/ }))
+    resolveRun!(stream.response)
+    stream.push({
+      event: 'started',
+      data: { run_id: 9, total_pages: 2, page_slugs: ['weather', 'notes'] },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('0 / 2')
+    })
+
+    // Network drop mid-run.
+    stream.error(new Error('connection reset'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-reconnect')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('run-stream-error')).toBeInTheDocument()
+    // Progress UI should still be visible so the user keeps the context.
+    expect(screen.getByTestId('run-progress')).toBeInTheDocument()
+
+    // Clicking Reconnect polls /runs?limit=1; the latest is finished so
+    // progress UI is cleared.
+    fireEvent.click(screen.getByTestId('run-reconnect'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('run-progress')).not.toBeInTheDocument()
+    })
   })
 
   it('keeps loaded data visible and shows banner when Run now fails', async () => {
@@ -312,7 +570,14 @@ describe('Suggestions – Run now flow', () => {
     let listCalls = 0
     const fetchMock = vi.fn((url: string, init?: RequestInit) => {
       if (url === '/api/suggestions/run' && init?.method === 'POST') {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+        return Promise.resolve(
+          sseResponse([
+            {
+              event: 'done',
+              data: { run_id: 1, generated: 0, errors: 0, cost_usd: 0 },
+            },
+          ]),
+        )
       }
       if (url === '/api/suggestions') {
         listCalls += 1
@@ -342,12 +607,12 @@ describe('Suggestions – Run now flow', () => {
     expect(screen.queryByTestId('run-error')).not.toBeInTheDocument()
   })
 
-  it('disables Run now button while in flight', async () => {
+  it('disables Run now button while a run is in flight', async () => {
     const initial = { pending: [], planned: [], rejected: [] }
-    let resolveRun: ((v: { ok: boolean; json: () => Promise<unknown> }) => void) | null = null
+    let resolveRun: ((v: Response) => void) | null = null
     const fetchMock = vi.fn((url: string, init?: RequestInit) => {
       if (url === '/api/suggestions/run' && init?.method === 'POST') {
-        return new Promise<{ ok: boolean; json: () => Promise<unknown> }>(resolve => {
+        return new Promise<Response>(resolve => {
           resolveRun = resolve
         })
       }
@@ -368,7 +633,16 @@ describe('Suggestions – Run now flow', () => {
       expect(inFlightBtn).toBeDisabled()
     })
 
-    resolveRun!({ ok: true, json: () => Promise.resolve({}) })
+    // Resolve with a stream that emits a `done` event and closes — the
+    // button should re-enable once the stream is fully consumed.
+    resolveRun!(
+      sseResponse([
+        {
+          event: 'done',
+          data: { run_id: 1, generated: 0, errors: 0, cost_usd: 0 },
+        },
+      ]),
+    )
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Run now/ })).not.toBeDisabled()

--- a/web/src/pages/Suggestions.test.tsx
+++ b/web/src/pages/Suggestions.test.tsx
@@ -432,6 +432,90 @@ describe('Suggestions – Run now flow', () => {
     })
   })
 
+  it('new_page_complete does not increment done counter beyond total', async () => {
+    const initial = { pending: [], planned: [], rejected: [] }
+
+    const stream = manualSSEResponse()
+    let resolveRun: ((v: Response) => void) | null = null
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/run' && init?.method === 'POST') {
+        return new Promise<Response>(resolve => {
+          resolveRun = resolve
+        })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(initial) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Run now/ }))
+    resolveRun!(stream.response)
+
+    // started: total_pages=1 (backend excludes the new-page pass)
+    stream.push({
+      event: 'started',
+      data: { run_id: 5, total_pages: 1, page_slugs: ['weather'] },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('0 / 1')
+    })
+
+    // Regular page completes — counter goes to 1/1.
+    stream.push({
+      event: 'page_complete',
+      data: {
+        page_slug: 'weather',
+        generated: 2,
+        errors: 0,
+        cost_usd: 0.02,
+        elapsed_ms: 800,
+        status: 'ok',
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('1 / 1')
+    })
+
+    // new_page_complete fires — counter must stay at 1/1 (not exceed total).
+    stream.push({
+      event: 'new_page_complete',
+      data: {
+        page_slug: '__new_page__',
+        generated: 1,
+        errors: 0,
+        cost_usd: 0.01,
+        elapsed_ms: 500,
+        status: 'ok',
+      },
+    })
+
+    await waitFor(() => {
+      // Counter must not go to 2/1 — it stays at 1/1.
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('1 / 1')
+    })
+    // The new_page_complete entry does appear in the log.
+    expect(screen.getByTestId('run-progress-log-__new_page__')).toBeInTheDocument()
+
+    // Progressbar aria attributes must be valid (valuenow <= valuemax).
+    const progressbar = screen.getByRole('progressbar')
+    const valueNow = Number(progressbar.getAttribute('aria-valuenow'))
+    const valueMax = Number(progressbar.getAttribute('aria-valuemax'))
+    expect(valueNow).toBeLessThanOrEqual(valueMax)
+
+    stream.push({ event: 'done', data: { run_id: 5, generated: 3, errors: 0, cost_usd: 0.03 } })
+    stream.close()
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('run-progress')).not.toBeInTheDocument()
+    })
+  })
+
   it('shows already-running banner on 409 and does not enter progress state', async () => {
     const initial = { pending: [], planned: [], rejected: [] }
     const fetchMock = vi.fn((url: string, init?: RequestInit) => {

--- a/web/src/pages/Suggestions.tsx
+++ b/web/src/pages/Suggestions.tsx
@@ -163,7 +163,7 @@ export default function Suggestions() {
         })
         return
       }
-      if (eventName === 'page_complete' || eventName === 'new_page_complete') {
+      if (eventName === 'page_complete') {
         const ev = data as PageCompleteEvent
         const entry: RunLogEntry = {
           slug: ev.page_slug,
@@ -180,6 +180,25 @@ export default function Suggestions() {
         )
         // Refetch the Pending tab so newly persisted suggestions appear as
         // soon as each page finishes.
+        refetch()
+        return
+      }
+      if (eventName === 'new_page_complete') {
+        const ev = data as PageCompleteEvent
+        const entry: RunLogEntry = {
+          slug: ev.page_slug,
+          status: ev.status,
+          count: ev.generated,
+          cost: ev.cost_usd,
+          seconds: Math.round((ev.elapsed_ms ?? 0) / 1000),
+        }
+        if (ev.status === 'error' && ev.error) {
+          entry.reason = ev.error
+        }
+        // Don't increment done — this pass is not counted in total_pages from the server.
+        setRunProgress(p =>
+          p ? { ...p, log: [...p.log, entry] } : p,
+        )
         refetch()
         return
       }
@@ -264,7 +283,6 @@ export default function Suggestions() {
   // whether the latest run has finished. If yes, clear the progress UI and
   // refetch everything; if no, just clear the error so the user can wait.
   async function handleReconnect() {
-    setStreamError(false)
     try {
       const res = await fetch('/api/suggestions/runs?limit=1', {
         credentials: 'include',
@@ -273,10 +291,13 @@ export default function Suggestions() {
       const data = (await res.json()) as Array<{ finished_at?: string | null }>
       const latest = Array.isArray(data) ? data[0] : null
       if (latest && latest.finished_at) {
+        setStreamError(false)
         setRunProgress(null)
         refetch()
         setRecentRunsReloadSignal(s => s + 1)
       }
+      // If run is still in progress, leave streamError true so the Reconnect
+      // button stays visible for another retry.
     } catch {
       setStreamError(true)
     }

--- a/web/src/pages/Suggestions.tsx
+++ b/web/src/pages/Suggestions.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Lightbulb, Plus, Play } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Lightbulb, Plus, Play, X, AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../components/ui/skeleton'
 import { Tabs, TabList, TabTrigger, TabPanel } from '../components/ui/tabs'
@@ -19,6 +19,39 @@ interface ListResponse {
   bead_created?: Suggestion[]
 }
 
+interface RunLogEntry {
+  slug: string
+  status: 'ok' | 'error'
+  count?: number
+  cost?: number
+  reason?: string
+  seconds?: number
+}
+
+interface RunProgress {
+  done: number
+  total: number
+  pageSlugs: string[]
+  log: RunLogEntry[]
+}
+
+// SSE event payloads sent by POST /api/suggestions/run.
+// See internal/suggestions/handlers.go:RunHandler for the source of truth.
+interface StartedEvent {
+  run_id: number
+  total_pages: number
+  page_slugs: string[]
+}
+interface PageCompleteEvent {
+  page_slug: string
+  generated: number
+  errors: number
+  cost_usd: number
+  elapsed_ms: number
+  status: 'ok' | 'error'
+  error?: string
+}
+
 export default function Suggestions() {
   const { t, i18n } = useTranslation('suggestions')
   const { t: tCommon } = useTranslation('common')
@@ -34,6 +67,11 @@ export default function Suggestions() {
   const [activeTab, setActiveTab] = useState<TabKey>('pending')
   const [reloadKey, setReloadKey] = useState(0)
   const [newOpen, setNewOpen] = useState(false)
+  const [runProgress, setRunProgress] = useState<RunProgress | null>(null)
+  const [alreadyRunning, setAlreadyRunning] = useState(false)
+  const [streamError, setStreamError] = useState(false)
+  const [recentRunsReloadSignal, setRecentRunsReloadSignal] = useState(0)
+  const abortRef = useRef<AbortController | null>(null)
 
   const refetch = useCallback(() => {
     setReloadKey(k => k + 1)
@@ -82,6 +120,14 @@ export default function Suggestions() {
     return () => controller.abort()
   }, [reloadKey, failedToLoadMsg])
 
+  // Cancel any in-flight stream when the component unmounts.
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort()
+      abortRef.current = null
+    }
+  }, [])
+
   const counts = useMemo(
     () => ({
       pending: pending.length,
@@ -95,19 +141,144 @@ export default function Suggestions() {
     if (running) return
     setRunning(true)
     setRunError(null)
+    setStreamError(false)
+    setAlreadyRunning(false)
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    // Tracked locally so the catch handler can distinguish "stream broke
+    // after we already entered progress mode" from "request never started".
+    let started = false
+
+    const dispatch = (eventName: string, data: unknown) => {
+      if (eventName === 'started') {
+        const ev = data as StartedEvent
+        started = true
+        setRunProgress({
+          done: 0,
+          total: ev.total_pages,
+          pageSlugs: ev.page_slugs ?? [],
+          log: [],
+        })
+        return
+      }
+      if (eventName === 'page_complete' || eventName === 'new_page_complete') {
+        const ev = data as PageCompleteEvent
+        const entry: RunLogEntry = {
+          slug: ev.page_slug,
+          status: ev.status,
+          count: ev.generated,
+          cost: ev.cost_usd,
+          seconds: Math.round((ev.elapsed_ms ?? 0) / 1000),
+        }
+        if (ev.status === 'error' && ev.error) {
+          entry.reason = ev.error
+        }
+        setRunProgress(p =>
+          p ? { ...p, done: p.done + 1, log: [...p.log, entry] } : p,
+        )
+        // Refetch the Pending tab so newly persisted suggestions appear as
+        // soon as each page finishes.
+        refetch()
+        return
+      }
+      if (eventName === 'done') {
+        setRunProgress(null)
+        setStreamError(false)
+        refetch()
+        setRecentRunsReloadSignal(s => s + 1)
+        return
+      }
+    }
+
     try {
       const res = await fetch('/api/suggestions/run', {
         method: 'POST',
         credentials: 'include',
+        signal: controller.signal,
       })
-      if (!res.ok) {
+      if (res.status === 409) {
+        // Surface a banner pointing the user at the recent runs panel.
+        // Don't auto-open it — the banner link is the explicit affordance.
+        setAlreadyRunning(true)
+        return
+      }
+      if (!res.ok || !res.body) {
         throw new Error(t('errors.runFailed'))
       }
-      refetch()
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      // SSE frame parser: events are separated by a blank line. Each event
+      // has zero or more `event:` and `data:` fields. We accumulate partial
+      // chunks in `buffer` and only consume up to the last complete frame.
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const frames = buffer.split('\n\n')
+        buffer = frames.pop() ?? ''
+        for (const frame of frames) {
+          if (!frame.trim()) continue
+          let eventName = 'message'
+          const dataLines: string[] = []
+          for (const line of frame.split('\n')) {
+            if (line.startsWith('event:')) {
+              eventName = line.slice(6).trim()
+            } else if (line.startsWith('data:')) {
+              dataLines.push(line.slice(5).trim())
+            }
+          }
+          if (dataLines.length === 0) continue
+          try {
+            const data = JSON.parse(dataLines.join('\n'))
+            dispatch(eventName, data)
+          } catch {
+            // Ignore malformed SSE frames — server should never emit them
+            // but a partial buffer flush could in theory.
+          }
+        }
+      }
     } catch (err) {
-      setRunError(err instanceof Error ? err.message : t('errors.runFailed'))
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      // If we already received a `started` event, keep the progress UI
+      // visible and surface a Reconnect affordance instead of clobbering
+      // it with the generic banner.
+      if (started) {
+        setStreamError(true)
+      } else {
+        setRunError(err instanceof Error ? err.message : t('errors.runFailed'))
+      }
     } finally {
       setRunning(false)
+      if (abortRef.current === controller) {
+        abortRef.current = null
+      }
+    }
+  }
+
+  // Polled fallback when the SSE stream is interrupted: ask the server
+  // whether the latest run has finished. If yes, clear the progress UI and
+  // refetch everything; if no, just clear the error so the user can wait.
+  async function handleReconnect() {
+    setStreamError(false)
+    try {
+      const res = await fetch('/api/suggestions/runs?limit=1', {
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('failed')
+      const data = (await res.json()) as Array<{ finished_at?: string | null }>
+      const latest = Array.isArray(data) ? data[0] : null
+      if (latest && latest.finished_at) {
+        setRunProgress(null)
+        refetch()
+        setRecentRunsReloadSignal(s => s + 1)
+      }
+    } catch {
+      setStreamError(true)
     }
   }
 
@@ -188,6 +359,11 @@ export default function Suggestions() {
     )
   }
 
+  const progressPercent =
+    runProgress && runProgress.total > 0
+      ? Math.min(100, Math.round((runProgress.done / runProgress.total) * 100))
+      : 0
+
   return (
     <div className="min-h-screen bg-gray-950 text-gray-100">
       <div className="mx-auto w-full max-w-3xl px-4 py-6 space-y-6">
@@ -203,12 +379,12 @@ export default function Suggestions() {
             <button
               type="button"
               onClick={handleRunNow}
-              disabled={running}
+              disabled={running || runProgress !== null}
               className="inline-flex items-center gap-2 rounded-lg border border-blue-500/40 bg-blue-500/20 px-3 py-2 text-sm font-medium text-blue-300 hover:bg-blue-500/30 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Play size={16} />
               <span>
-                {running ? t('actions.running') : t('actions.runNow')}
+                {running || runProgress !== null ? t('actions.running') : t('actions.runNow')}
               </span>
             </button>
             <button
@@ -220,7 +396,119 @@ export default function Suggestions() {
               <span>{t('actions.newSuggestion')}</span>
             </button>
           </div>
-          <RecentRunsPanel />
+
+          {alreadyRunning && (
+            <div
+              role="alert"
+              data-testid="already-running-banner"
+              className="flex items-start gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200"
+            >
+              <AlertTriangle size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+              <div className="flex-1 space-y-1">
+                <p>{t('run.alreadyRunning')}</p>
+                <a
+                  href="#recent-runs"
+                  className="inline-block text-xs font-medium text-amber-300 underline hover:text-amber-200"
+                >
+                  {t('run.alreadyRunningLink')}
+                </a>
+              </div>
+              <button
+                type="button"
+                onClick={() => setAlreadyRunning(false)}
+                aria-label={t('run.dismiss')}
+                className="text-amber-300/70 hover:text-amber-200"
+              >
+                <X size={16} aria-hidden="true" />
+              </button>
+            </div>
+          )}
+
+          {runProgress && (
+            <div
+              data-testid="run-progress"
+              className="space-y-2 rounded-lg border border-gray-800 bg-gray-900/60 px-4 py-3"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span
+                  data-testid="run-progress-pill"
+                  className="inline-flex items-center rounded-full border border-blue-500/40 bg-blue-500/15 px-2.5 py-0.5 text-xs font-medium text-blue-200"
+                >
+                  {t('run.inProgress', {
+                    done: runProgress.done,
+                    total: runProgress.total,
+                  })}
+                </span>
+                {streamError && (
+                  <button
+                    type="button"
+                    onClick={handleReconnect}
+                    data-testid="run-reconnect"
+                    className="inline-flex items-center gap-1 rounded-md border border-yellow-500/40 bg-yellow-500/10 px-2 py-1 text-xs font-medium text-yellow-200 hover:bg-yellow-500/20"
+                  >
+                    {t('run.reconnect')}
+                  </button>
+                )}
+              </div>
+              <div
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={runProgress.total}
+                aria-valuenow={runProgress.done}
+                className="h-1.5 w-full overflow-hidden rounded-full bg-gray-800"
+              >
+                <div
+                  className="h-full bg-blue-500 transition-all"
+                  style={{ width: `${progressPercent}%` }}
+                />
+              </div>
+              {streamError && (
+                <p
+                  data-testid="run-stream-error"
+                  className="text-xs text-yellow-300"
+                >
+                  {t('run.streamError')}
+                </p>
+              )}
+              {runProgress.log.length > 0 && (
+                <ul
+                  data-testid="run-progress-log"
+                  className="space-y-1 text-xs"
+                >
+                  {runProgress.log.map((entry, idx) => (
+                    <li
+                      key={`${entry.slug}-${idx}`}
+                      data-testid={`run-progress-log-${entry.slug}`}
+                      className={`flex items-center gap-2 ${
+                        entry.status === 'ok' ? 'text-emerald-300' : 'text-red-300'
+                      }`}
+                    >
+                      {entry.status === 'ok' ? (
+                        <CheckCircle2 size={14} aria-hidden="true" />
+                      ) : (
+                        <XCircle size={14} aria-hidden="true" />
+                      )}
+                      <span className="font-mono">
+                        {entry.status === 'ok'
+                          ? t('run.pageOk', {
+                              slug: entry.slug,
+                              count: entry.count ?? 0,
+                              cost: (entry.cost ?? 0).toFixed(2),
+                            })
+                          : t('run.pageError', {
+                              slug: entry.slug,
+                              reason: entry.reason ?? t('errors.unknown'),
+                              seconds: entry.seconds ?? 0,
+                            })}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          <RecentRunsPanel reloadSignal={recentRunsReloadSignal} />
         </header>
 
         <Tabs
@@ -295,4 +583,3 @@ export default function Suggestions() {
     </div>
   )
 }
-


### PR DESCRIPTION
## Changes

- **Streaming progress UI on Suggestions page** - Run now now consumes the SSE event stream from `POST /api/suggestions/run`: a header progress pill and per-page log update live, the Pending tab refetches between events, a 409 response surfaces a banner pointing to recent runs, and a Reconnect button appears if the stream drops mid-run. (Hytte-39fp)

## Original Issue (task): Frontend: streaming progress UI in Suggestions page

Modify `web/src/pages/Suggestions.tsx`. Replace `handleRunNow`'s `fetch().then(refetch)` with a fetch+ReadableStream SSE consumer (native EventSource is GET-only). Reference `web/src/pages/Webhooks.tsx` for existing SSE pattern. State: `runProgress: {done, total, pageSlugs, log: Array<{slug, status, count?, cost?, reason?}>}`. On `started`: show header pill 'Run in progress: 0 / Y pages' with progress bar. On `page_complete`: increment counter, append log row ('✓ weather (3 ideas, $0.04)' or '✗ webhooks (timeout, 240s)'), refetch Pending tab so new suggestions appear. On `done`: clear in-progress UI, refetch all tabs + Recent runs panel. On stream error/interruption: keep UI with 'Reconnect' button; optionally poll `GET /api/suggestions/runs?limit=1` to detect completion. On 409 response: show banner 'A run is already in progress' with link to runs panel. Add i18n keys to en/nb/th `suggestions:` namespace: `run.inProgress`, `run.pageOk`, `run.pageError`, `run.alreadyRunning`, `run.reconnect`. Update `Suggestions.test.tsx`: mock SSE response sequence, assert progress pill updates and log appends; mock 409, assert banner. Connects to: consumes events from streaming handler sub-task.

---
Bead: Hytte-39fp | Branch: forge/Hytte-39fp
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)