### PR TITLE
Optional: cancellation endpoint + changelog (Hytte-mhuu)

### DIFF
--- a/changelog.d/Hytte-mhuu.md
+++ b/changelog.d/Hytte-mhuu.md
@@ -1,0 +1,2 @@
+category: Added
+- **Cancel an in-flight suggestion run** - `POST /api/suggestions/run/{id}/cancel` (admin-only) signals the streaming work goroutine to abort between pages. The current page's Claude call returns early via context cancellation, the new-page pass is skipped, and `suggestion_runs.finished_at` is still written so the audit row reflects what actually persisted. Caps off the streaming async run epic, which raised the per-page Claude cap to 4 minutes and the rotation default to 20 pages. (Hytte-mhuu)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -201,6 +201,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Get("/suggestions", suggestions.ListHandler(db))
 				r.Post("/suggestions", suggestions.CreateHandler(db))
 				r.Post("/suggestions/run", suggestions.RunHandler(db))
+				r.Post("/suggestions/run/{id}/cancel", suggestions.CancelHandler(db))
 				r.Get("/suggestions/runs", suggestions.RunsHandler(db))
 				r.Post("/suggestions/{id}/reject", suggestions.RejectHandler(db))
 				r.Post("/suggestions/{id}/plan", suggestions.PlanHandler(db))

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -358,7 +358,7 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 // up to one page-completion to exit.
 //
 // POST /api/suggestions/run/{id}/cancel
-// Response: 202 with {run_id} on success.
+// Response: 202 with {run_id, cancelled: true} on success.
 func CancelHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -11,12 +11,49 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/training"
 	"github.com/go-chi/chi/v5"
 )
+
+// runCancelsMu guards runCancels. The map holds the cancel func of each
+// in-flight run keyed by run_id so CancelHandler can abort the streaming
+// goroutine. Entries are inserted before the goroutine starts and removed by
+// the goroutine's deferred cleanup, so a successful Lookup means the run is
+// still executing on this server instance. After a process restart the map is
+// empty even if suggestion_runs rows are still marked in-flight (those are
+// orphaned and must be reaped by separate housekeeping, not by this endpoint).
+var (
+	runCancelsMu sync.Mutex
+	runCancels   = map[int64]context.CancelFunc{}
+)
+
+// registerRunCancel records the cancel func for an in-flight run.
+func registerRunCancel(runID int64, cancel context.CancelFunc) {
+	runCancelsMu.Lock()
+	runCancels[runID] = cancel
+	runCancelsMu.Unlock()
+}
+
+// unregisterRunCancel drops the cancel func for runID. Safe to call even if no
+// entry exists.
+func unregisterRunCancel(runID int64) {
+	runCancelsMu.Lock()
+	delete(runCancels, runID)
+	runCancelsMu.Unlock()
+}
+
+// lookupRunCancel returns the registered cancel func for runID and whether the
+// run is currently executing on this process.
+func lookupRunCancel(runID int64) (context.CancelFunc, bool) {
+	runCancelsMu.Lock()
+	cancel, ok := runCancels[runID]
+	runCancelsMu.Unlock()
+	return cancel, ok
+}
 
 // OverallRunTimeout caps the entire RunHandler invocation as a safety bound
 // against stalled Claude calls pinning the request indefinitely. It is not
@@ -184,11 +221,18 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 		// continue to be written even after r.Context() cancels.
 		runCtx, cancel := context.WithTimeout(context.Background(), OverallRunTimeout)
 
+		// Register the cancel func so CancelHandler can abort this run. The
+		// deferred unregister inside the goroutine fires after UpdateSuggestionRun
+		// has written finished_at, so a cancel call after completion sees the row
+		// as finished rather than racing the registry cleanup.
+		registerRunCancel(runID, cancel)
+
 		eventCh := make(chan sseEvent, 16)
 
 		go func() {
 			defer close(eventCh)
 			defer cancel()
+			defer unregisterRunCancel(runID)
 
 			eventCh <- sseEvent{Name: "started", Data: startedEvent{
 				RunID:      runID,
@@ -229,29 +273,36 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 				eventCh <- sseEvent{Name: "page_complete", Data: ev}
 			}
 
-			newPageStart := time.Now()
-			newPageResult, err := RunNewPageSuggestion(runCtx, db, cfg, user.ID)
-			newPageElapsed := time.Since(newPageStart).Milliseconds()
-			totals.Generated += newPageResult.Generated
-			totals.Errors += newPageResult.Errors
-			totals.CostUSD += newPageResult.CostUSD
+			// Skip the new-page pass entirely when runCtx has been cancelled
+			// (operator-triggered cancel or overall-run timeout). Calling
+			// RunNewPageSuggestion with a cancelled context would just produce a
+			// fast error event and pad the audit row's error count without doing
+			// useful work.
+			if runCtx.Err() == nil {
+				newPageStart := time.Now()
+				newPageResult, err := RunNewPageSuggestion(runCtx, db, cfg, user.ID)
+				newPageElapsed := time.Since(newPageStart).Milliseconds()
+				totals.Generated += newPageResult.Generated
+				totals.Errors += newPageResult.Errors
+				totals.CostUSD += newPageResult.CostUSD
 
-			npEvent := newPageCompleteEvent{
-				PageSlug:  NewPageSlug,
-				Generated: newPageResult.Generated,
-				Errors:    newPageResult.Errors,
-				CostUSD:   newPageResult.CostUSD,
-				ElapsedMS: newPageElapsed,
-				Status:    "ok",
+				npEvent := newPageCompleteEvent{
+					PageSlug:  NewPageSlug,
+					Generated: newPageResult.Generated,
+					Errors:    newPageResult.Errors,
+					CostUSD:   newPageResult.CostUSD,
+					ElapsedMS: newPageElapsed,
+					Status:    "ok",
+				}
+				if err != nil {
+					log.Printf("suggestions: new_page run for user %d: %v", user.ID, err)
+					totals.Errors++
+					npEvent.Status = "error"
+					npEvent.Error = err.Error()
+					npEvent.Errors++
+				}
+				eventCh <- sseEvent{Name: "new_page_complete", Data: npEvent}
 			}
-			if err != nil {
-				log.Printf("suggestions: new_page run for user %d: %v", user.ID, err)
-				totals.Errors++
-				npEvent.Status = "error"
-				npEvent.Error = err.Error()
-				npEvent.Errors++
-			}
-			eventCh <- sseEvent{Name: "new_page_complete", Data: npEvent}
 
 			// Update the audit row with the final totals using a fresh
 			// context: runCtx may be near its deadline by now, and we want
@@ -290,6 +341,79 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 		// never block on a full channel and leak.
 		for range eventCh {
 		}
+	}
+}
+
+// CancelHandler aborts an in-flight suggestion run for the requesting admin.
+// It cancels the work goroutine's runCtx, which causes the streaming loop to
+// stop after the current page and exit cleanly — UpdateSuggestionRun still
+// fires from the goroutine's deferred cleanup, so suggestion_runs.finished_at
+// is set and counts reflect what was persisted before the cancel.
+//
+// Returns 404 when the id is unknown OR belongs to another user
+// (enumeration-resistant), 409 when the run has already finished or is no
+// longer tracked on this process (e.g. after a server restart, the in-memory
+// cancel handle is gone), and 202 Accepted when the cancel signal was
+// delivered. Cancellation is observed between pages, so the goroutine may take
+// up to one page-completion to exit.
+//
+// POST /api/suggestions/run/{id}/cancel
+// Response: 202 with {run_id} on success.
+func CancelHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		idStr := chi.URLParam(r, "id")
+		runID, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+			return
+		}
+
+		var (
+			ownerID    int64
+			finishedAt sql.NullString
+		)
+		err = db.QueryRowContext(r.Context(), `
+			SELECT user_id, finished_at FROM suggestion_runs WHERE id = ?
+		`, runID).Scan(&ownerID, &finishedAt)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "run not found"})
+				return
+			}
+			log.Printf("suggestions: load run %d for cancel: %v", runID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load run"})
+			return
+		}
+
+		// Cross-user access returns 404 so other users' run IDs are not
+		// discoverable, matching the pattern used by RejectHandler/PlanHandler.
+		if ownerID != user.ID {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "run not found"})
+			return
+		}
+
+		if finishedAt.Valid {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "run has already finished"})
+			return
+		}
+
+		cancel, ok := lookupRunCancel(runID)
+		if !ok {
+			// The DB row says in-flight but no cancel handle exists on this
+			// process. Either the run is on another instance or the process
+			// restarted and orphaned the row. Either way, this handler cannot
+			// stop it — surface 409 rather than silently succeeding.
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "run is not active on this server"})
+			return
+		}
+		cancel()
+
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"run_id":    runID,
+			"cancelled": true,
+		})
 	}
 }
 

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -1549,6 +1549,16 @@ func TestCancelHandlerUnknownRunReturns404(t *testing.T) {
 func TestCancelHandlerCrossUserReturns404(t *testing.T) {
 	d := setupTestDB(t)
 
+	// suggestion_runs.user_id has a FK to users(id); seed user 2 before
+	// inserting a run on their behalf, otherwise the insert fails with a
+	// foreign-key constraint and the test never reaches the cross-user
+	// assertion.
+	if _, err := d.Exec(
+		`INSERT INTO users (id, google_id, email, name, picture, is_admin) VALUES (2, 'g2', 'other@example.com', 'Other', '', 0)`,
+	); err != nil {
+		t.Fatalf("seed other user: %v", err)
+	}
+
 	// Seed an in-flight run owned by user 2 and try to cancel as user 1.
 	otherID, err := InsertSuggestionRun(context.Background(), d, SuggestionRun{
 		UserID:    2,

--- a/internal/suggestions/handlers_test.go
+++ b/internal/suggestions/handlers_test.go
@@ -1507,3 +1507,220 @@ func TestUpdatePageSettingsHandlerInvalidBody(t *testing.T) {
 		})
 	}
 }
+
+// --- CancelHandler -----------------------------------------------------------
+
+func TestCancelHandlerRejectsNonAdmin(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(CancelHandler(d), http.MethodPost, "/api/suggestions/run/{id}/cancel")
+
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/run/1/cancel", nil), 99, false)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCancelHandlerInvalidIDReturns400(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(CancelHandler(d), http.MethodPost, "/api/suggestions/run/{id}/cancel")
+
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/run/notanumber/cancel", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-numeric id, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCancelHandlerUnknownRunReturns404(t *testing.T) {
+	d := setupTestDB(t)
+	router := mountAdmin(CancelHandler(d), http.MethodPost, "/api/suggestions/run/{id}/cancel")
+
+	req := adminContext(httptest.NewRequest(http.MethodPost, "/api/suggestions/run/9999/cancel", nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown run, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCancelHandlerCrossUserReturns404(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Seed an in-flight run owned by user 2 and try to cancel as user 1.
+	otherID, err := InsertSuggestionRun(context.Background(), d, SuggestionRun{
+		UserID:    2,
+		StartedAt: time.Now().UTC(),
+		Trigger:   TriggerManual,
+		PageSlugs: "weather",
+	})
+	if err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	// Register a cancel handle so the test would otherwise succeed if the
+	// cross-user guard were missing.
+	registerRunCancel(otherID, func() {})
+	defer unregisterRunCancel(otherID)
+
+	router := mountAdmin(CancelHandler(d), http.MethodPost, "/api/suggestions/run/{id}/cancel")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/run/%d/cancel", otherID), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-user run, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCancelHandlerAlreadyFinishedReturns409(t *testing.T) {
+	d := setupTestDB(t)
+
+	finished := time.Now().UTC().Add(-time.Minute)
+	row := SuggestionRun{
+		UserID:     1,
+		StartedAt:  time.Now().UTC().Add(-2 * time.Minute),
+		FinishedAt: &finished,
+		Trigger:    TriggerManual,
+		PageSlugs:  "weather",
+	}
+	id, err := InsertSuggestionRun(context.Background(), d, row)
+	if err != nil {
+		t.Fatalf("seed finished run: %v", err)
+	}
+
+	router := mountAdmin(CancelHandler(d), http.MethodPost, "/api/suggestions/run/{id}/cancel")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/run/%d/cancel", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for finished run, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCancelHandlerNotInRegistryReturns409 covers the orphaned-row case: the
+// suggestion_runs row says in-flight (finished_at NULL) but no cancel handle is
+// registered for it on this process. This happens after a server restart that
+// left the run row stranded.
+func TestCancelHandlerNotInRegistryReturns409(t *testing.T) {
+	d := setupTestDB(t)
+
+	id, err := InsertSuggestionRun(context.Background(), d, SuggestionRun{
+		UserID:    1,
+		StartedAt: time.Now().UTC(),
+		Trigger:   TriggerManual,
+		PageSlugs: "weather",
+	})
+	if err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	router := mountAdmin(CancelHandler(d), http.MethodPost, "/api/suggestions/run/{id}/cancel")
+	req := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/run/%d/cancel", id), nil), 1, true)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for orphaned run, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCancelHandlerCancelsInflightRunAndPersists fires a real run, blocks the
+// first Claude call until the cancel arrives, then asserts that the goroutine
+// exits cleanly: finished_at is set, remaining pages are skipped, and the
+// cancel handle is unregistered (so a second cancel returns 409).
+func TestCancelHandlerCancelsInflightRunAndPersists(t *testing.T) {
+	d := setupTestDB(t)
+	defer withSavedPages([]Page{
+		{Slug: "weather", Title: "Weather"},
+		{Slug: "notes", Title: "Notes"},
+	})()
+	if err := auth.SetPreference(d, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	// First mock invocation signals it has been entered, then blocks on ctx
+	// — the cancel signal arrives by way of runCtx propagating into pageCtx.
+	reachedMock := make(chan struct{})
+	var once sync.Once
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		once.Do(func() { close(reachedMock) })
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(5 * time.Second):
+			// Safety bound — fail loudly rather than hang the test.
+			return "", fmt.Errorf("mock never observed cancellation")
+		}
+	})()
+
+	user := &auth.User{ID: 1, IsAdmin: true}
+
+	runMux := http.NewServeMux()
+	runMux.Handle("/api/suggestions/run", auth.RequireAdmin()(RunHandler(d)))
+	cancelRouter := mountAdmin(CancelHandler(d), http.MethodPost, "/api/suggestions/run/{id}/cancel")
+
+	runRec := httptest.NewRecorder()
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		req := httptest.NewRequest(http.MethodPost, "/api/suggestions/run", nil)
+		req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+		runMux.ServeHTTP(runRec, req)
+	}()
+
+	select {
+	case <-reachedMock:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("run did not reach mock in time")
+	}
+
+	var inflightID int64
+	if err := d.QueryRow(`SELECT id FROM suggestion_runs WHERE user_id = 1 AND finished_at IS NULL`).Scan(&inflightID); err != nil {
+		t.Fatalf("read in-flight run: %v", err)
+	}
+
+	cancelReq := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/run/%d/cancel", inflightID), nil), 1, true)
+	cancelRec := httptest.NewRecorder()
+	cancelRouter.ServeHTTP(cancelRec, cancelReq)
+	if cancelRec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 from cancel, got %d: %s", cancelRec.Code, cancelRec.Body.String())
+	}
+
+	// Cancellation is asynchronous; wait for the streaming response to close.
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("run did not finish after cancel")
+	}
+	if runRec.Code != http.StatusOK {
+		t.Fatalf("run handler expected 200 (already streaming), got %d", runRec.Code)
+	}
+
+	// Audit row must be marked finished even though the run was aborted.
+	var finishedAt sql.NullString
+	if err := d.QueryRow(`SELECT finished_at FROM suggestion_runs WHERE id = ?`, inflightID).Scan(&finishedAt); err != nil {
+		t.Fatalf("read finished_at: %v", err)
+	}
+	if !finishedAt.Valid {
+		t.Errorf("finished_at should be set after cancellation")
+	}
+
+	// Cancel handle must be unregistered after the goroutine exits, so a
+	// second cancel call sees the row as finished and returns 409.
+	cancelReq2 := adminContext(httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/suggestions/run/%d/cancel", inflightID), nil), 1, true)
+	cancelRec2 := httptest.NewRecorder()
+	cancelRouter.ServeHTTP(cancelRec2, cancelReq2)
+	if cancelRec2.Code != http.StatusConflict {
+		t.Fatalf("expected 409 from second cancel, got %d: %s", cancelRec2.Code, cancelRec2.Body.String())
+	}
+
+	// No new_page row should exist — the new-page pass is skipped on
+	// cancellation rather than running with an already-cancelled context.
+	var newPageCount int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM suggestions WHERE page_slug = ? AND user_id = 1`, NewPageSlug).Scan(&newPageCount); err != nil {
+		t.Fatalf("count new_page rows: %v", err)
+	}
+	if newPageCount != 0 {
+		t.Errorf("expected 0 new_page rows on cancelled run, got %d", newPageCount)
+	}
+}


### PR DESCRIPTION
## Changes

- **Cancel an in-flight suggestion run** - `POST /api/suggestions/run/{id}/cancel` (admin-only) signals the streaming work goroutine to abort between pages. The current page's Claude call returns early via context cancellation, the new-page pass is skipped, and `suggestion_runs.finished_at` is still written so the audit row reflects what actually persisted. Caps off the streaming async run epic, which raised the per-page Claude cap to 4 minutes and the rotation default to 20 pages. (Hytte-mhuu)

## Original Issue (task): Optional: cancellation endpoint + changelog

If feasible without scope creep, add `POST /api/suggestions/run/{id}/cancel` (admin-only) in `internal/suggestions/handlers.go`. Implementation: a shared `map[int64]*atomic.Bool` (or context-cancel registry) keyed by run_id; the streaming goroutine checks the flag between pages and exits cleanly, updating `suggestion_runs` with `finished_at`. If this complicates the streaming sub-task, defer entirely — the bead explicitly says it is optional. Add a changelog fragment under `changelog.d/` (category Changed and/or Added) describing: streaming async run, 4-minute per-page cap, rotation default raised to 20. Connects to: caps off the bead's acceptance criteria.

---
Bead: Hytte-mhuu | Branch: forge/Hytte-mhuu
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)