### PR TITLE
Internationalize Dashboard activity feed and widget labels (Hytte-zx0v)

### DIFF
--- a/changelog.d/Hytte-zx0v.md
+++ b/changelog.d/Hytte-zx0v.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Localized Dashboard activity feed** - The dashboard activity API now returns structured fields (`type`, `sport`, `title`, `comment`, `code`) instead of pre-built English labels, and the `ActivityFeedWidget` renders rows through `react-i18next` so Norwegian and Thai users see fully translated workout, lactate, note, and short-link entries. (Hytte-zx0v)

--- a/internal/dashboard/activity.go
+++ b/internal/dashboard/activity.go
@@ -8,14 +8,20 @@ import (
 	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/encryption"
 )
 
-// ActivityItem represents a single recent activity entry.
+// ActivityItem represents a single recent activity entry. The frontend is
+// responsible for assembling localized display text from these structured
+// fields via react-i18next.
 type ActivityItem struct {
 	Type      string `json:"type"`
-	Title     string `json:"title"`
 	Timestamp string `json:"timestamp"`
 	Link      string `json:"link,omitempty"`
+	Sport     string `json:"sport,omitempty"`
+	Title     string `json:"title,omitempty"`
+	Comment   string `json:"comment,omitempty"`
+	Code      string `json:"code,omitempty"`
 }
 
 // ActivityHandler returns GET /api/dashboard/activity — recent activity across the app.
@@ -59,15 +65,10 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 		if err := rows.Scan(&sport, &title, &startedAt); err != nil {
 			return nil, err
 		}
-		label := title
-		if label == "" {
-			label = sportLabel(sport) + " workout recorded"
-		} else {
-			label = sportLabel(sport) + ": " + label
-		}
 		items = append(items, ActivityItem{
 			Type:      "workout",
-			Title:     label,
+			Sport:     sport,
+			Title:     title,
 			Timestamp: startedAt,
 			Link:      "/training",
 		})
@@ -92,13 +93,10 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 		if err := rows2.Scan(&date, &comment); err != nil {
 			return nil, err
 		}
-		label := "Lactate test recorded"
-		if comment != "" {
-			label = "Lactate test: " + comment
-		}
+		comment = encryption.DecryptLenient(comment)
 		items = append(items, ActivityItem{
 			Type:      "lactate",
-			Title:     label,
+			Comment:   comment,
 			Timestamp: date + "T00:00:00Z",
 			Link:      "/lactate",
 		})
@@ -123,13 +121,10 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 		if err := rows3.Scan(&title, &createdAt); err != nil {
 			return nil, err
 		}
-		label := "Note created"
-		if title != "" {
-			label = "Note: " + title
-		}
+		title = encryption.DecryptLenient(title)
 		items = append(items, ActivityItem{
 			Type:      "note",
-			Title:     label,
+			Title:     title,
 			Timestamp: createdAt,
 			Link:      "/notes",
 		})
@@ -154,13 +149,10 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 		if err := rows4.Scan(&title, &code, &createdAt); err != nil {
 			return nil, err
 		}
-		label := "Short link created: /go/" + code
-		if title != "" {
-			label = "Link created: " + title
-		}
 		items = append(items, ActivityItem{
 			Type:      "link",
-			Title:     label,
+			Code:      code,
+			Title:     title,
 			Timestamp: createdAt,
 			Link:      "/links",
 		})
@@ -187,24 +179,4 @@ func sortByTimestamp(items []ActivityItem) {
 		}
 		return ti.After(tj)
 	})
-}
-
-func sportLabel(sport string) string {
-	switch sport {
-	case "running":
-		return "Running"
-	case "cycling":
-		return "Cycling"
-	case "swimming":
-		return "Swimming"
-	case "walking":
-		return "Walking"
-	case "hiking":
-		return "Hiking"
-	default:
-		if sport != "" {
-			return sport
-		}
-		return "Workout"
-	}
 }

--- a/internal/dashboard/activity.go
+++ b/internal/dashboard/activity.go
@@ -65,6 +65,7 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 		if err := rows.Scan(&sport, &title, &startedAt); err != nil {
 			return nil, err
 		}
+		title = encryption.DecryptLenient(title)
 		items = append(items, ActivityItem{
 			Type:      "workout",
 			Sport:     sport,

--- a/internal/dashboard/activity_test.go
+++ b/internal/dashboard/activity_test.go
@@ -104,13 +104,17 @@ func TestActivityHandler_WithWorkout(t *testing.T) {
 	now := time.Now().UTC()
 	ts := now.Add(-time.Hour).Format(time.RFC3339)
 
-	// Insert a workout directly.
-	_, err := d.Exec(
+	// Workout title is stored encrypted at rest; the handler must decrypt it.
+	encTitle, err := encryption.EncryptField("Morning Run")
+	if err != nil {
+		t.Fatalf("failed to encrypt workout title: %v", err)
+	}
+	_, err = d.Exec(
 		`INSERT INTO workouts (user_id, sport, title, started_at, duration_seconds, distance_meters,
 		 avg_heart_rate, max_heart_rate, avg_pace_sec_per_km, avg_cadence, calories,
 		 ascent_meters, descent_meters, fit_file_hash, created_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		user.ID, "running", "Morning Run", ts, 1800, 5000,
+		user.ID, "running", encTitle, ts, 1800, 5000,
 		150, 170, 360, 180, 300, 50, 30, "hash123", ts,
 	)
 	if err != nil {

--- a/internal/dashboard/activity_test.go
+++ b/internal/dashboard/activity_test.go
@@ -67,9 +67,10 @@ func assertNoEnglishLabels(t *testing.T, item ActivityItem) {
 	// The `type` field is a stable enum discriminator ("workout", "lactate",
 	// "note", "link") — those values are machine-readable API keys, not labels,
 	// so they are not subject to this check.
+	// `code` is excluded because short-link codes are user-controlled and may
+	// legitimately contain substrings like "workout" or "running".
 	for _, field := range []struct{ name, value string }{
 		{"sport", item.Sport},
-		{"code", item.Code},
 		{"link", item.Link},
 	} {
 		for _, frag := range englishLabelFragments {

--- a/internal/dashboard/activity_test.go
+++ b/internal/dashboard/activity_test.go
@@ -17,6 +17,14 @@ import (
 
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
+	// Pin the encryption key so EncryptField/DecryptField produce stable,
+	// hermetic output. Without this the tests share the developer's
+	// auto-generated key file or fail in CI where the config dir may not be
+	// writable. See internal/suggestions/store_test.go for the established pattern.
+	t.Setenv("ENCRYPTION_KEY", "test-encryption-key-for-dashboard-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+
 	d, err := db.Init(":memory:")
 	if err != nil {
 		t.Fatalf("failed to init test db: %v", err)

--- a/internal/dashboard/activity_test.go
+++ b/internal/dashboard/activity_test.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/db"
+	"github.com/Robin831/Hytte/internal/encryption"
 )
 
 func setupTestDB(t *testing.T) *sql.DB {
@@ -31,6 +33,41 @@ func createTestUser(t *testing.T, d *sql.DB) *auth.User {
 		t.Fatalf("failed to create test user: %v", err)
 	}
 	return u
+}
+
+// englishLabelFragments is the set of human-readable phrases that the
+// previous implementation embedded in API responses. The new contract
+// returns structured fields only, so these substrings must never appear
+// in any string field of the response.
+var englishLabelFragments = []string{
+	"recorded",
+	"Note:",
+	"Note created",
+	"Lactate test",
+	"Short link",
+	"Link created",
+	"workout",
+	"Workout",
+	"Running",
+	"Cycling",
+}
+
+func assertNoEnglishLabels(t *testing.T, item ActivityItem) {
+	t.Helper()
+	// Only the user-supplied fields (title, comment) may legitimately contain
+	// English words; the rest are enum-like keys and must stay machine-friendly.
+	for _, field := range []struct{ name, value string }{
+		{"sport", item.Sport},
+		{"code", item.Code},
+		{"link", item.Link},
+		{"type", item.Type},
+	} {
+		for _, frag := range englishLabelFragments {
+			if strings.Contains(field.value, frag) {
+				t.Errorf("item.%s = %q contains forbidden English label fragment %q", field.name, field.value, frag)
+			}
+		}
+	}
 }
 
 func TestActivityHandler_Empty(t *testing.T) {
@@ -98,12 +135,67 @@ func TestActivityHandler_WithWorkout(t *testing.T) {
 	if len(resp.Items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(resp.Items))
 	}
-	if resp.Items[0].Type != "workout" {
-		t.Errorf("expected type 'workout', got %q", resp.Items[0].Type)
+	got := resp.Items[0]
+	if got.Type != "workout" {
+		t.Errorf("expected type 'workout', got %q", got.Type)
 	}
-	if resp.Items[0].Link != "/training" {
-		t.Errorf("expected link '/training', got %q", resp.Items[0].Link)
+	if got.Sport != "running" {
+		t.Errorf("expected sport 'running', got %q", got.Sport)
 	}
+	if got.Title != "Morning Run" {
+		t.Errorf("expected title 'Morning Run', got %q", got.Title)
+	}
+	if got.Link != "/training" {
+		t.Errorf("expected link '/training', got %q", got.Link)
+	}
+	if got.Timestamp == "" {
+		t.Errorf("expected timestamp to be populated")
+	}
+	assertNoEnglishLabels(t, got)
+}
+
+func TestActivityHandler_WorkoutWithoutTitle(t *testing.T) {
+	d := setupTestDB(t)
+	user := createTestUser(t, d)
+	now := time.Now().UTC()
+	ts := now.Add(-time.Hour).Format(time.RFC3339)
+
+	_, err := d.Exec(
+		`INSERT INTO workouts (user_id, sport, title, started_at, duration_seconds, distance_meters,
+		 avg_heart_rate, max_heart_rate, avg_pace_sec_per_km, avg_cadence, calories,
+		 ascent_meters, descent_meters, fit_file_hash, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		user.ID, "cycling", "", ts, 3600, 20000,
+		140, 160, 0, 90, 500, 100, 80, "hash-empty", ts,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert workout: %v", err)
+	}
+
+	handler := ActivityHandler(d)
+	req := httptest.NewRequest("GET", "/api/dashboard/activity", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	var resp struct {
+		Items []ActivityItem `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(resp.Items))
+	}
+	got := resp.Items[0]
+	if got.Sport != "cycling" {
+		t.Errorf("expected sport 'cycling', got %q", got.Sport)
+	}
+	if got.Title != "" {
+		t.Errorf("expected empty title for blank workout, got %q", got.Title)
+	}
+	assertNoEnglishLabels(t, got)
 }
 
 func TestActivityHandler_MultipleTypes(t *testing.T) {
@@ -126,10 +218,14 @@ func TestActivityHandler_MultipleTypes(t *testing.T) {
 		t.Fatalf("failed to insert workout: %v", err)
 	}
 
-	// Insert a note.
+	// Insert a note (title is encrypted at rest).
+	encTitle, err := encryption.EncryptField("My Note")
+	if err != nil {
+		t.Fatalf("failed to encrypt note title: %v", err)
+	}
 	_, err = d.Exec(
 		`INSERT INTO notes (user_id, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
-		user.ID, "My Note", "Content here", noteTs, noteTs,
+		user.ID, encTitle, "Content here", noteTs, noteTs,
 	)
 	if err != nil {
 		t.Fatalf("failed to insert note: %v", err)
@@ -155,8 +251,17 @@ func TestActivityHandler_MultipleTypes(t *testing.T) {
 	if resp.Items[0].Type != "note" {
 		t.Errorf("expected first item type 'note', got %q", resp.Items[0].Type)
 	}
+	if resp.Items[0].Title != "My Note" {
+		t.Errorf("expected note title to be decrypted to 'My Note', got %q", resp.Items[0].Title)
+	}
 	if resp.Items[1].Type != "workout" {
 		t.Errorf("expected second item type 'workout', got %q", resp.Items[1].Type)
+	}
+	if resp.Items[1].Sport != "cycling" {
+		t.Errorf("expected sport 'cycling', got %q", resp.Items[1].Sport)
+	}
+	for _, it := range resp.Items {
+		assertNoEnglishLabels(t, it)
 	}
 }
 
@@ -165,9 +270,13 @@ func TestActivityHandler_WithLactateTest(t *testing.T) {
 	user := createTestUser(t, d)
 	now := time.Now().UTC()
 
-	_, err := d.Exec(
+	encComment, err := encryption.EncryptField("Threshold test")
+	if err != nil {
+		t.Fatalf("failed to encrypt lactate comment: %v", err)
+	}
+	_, err = d.Exec(
 		`INSERT INTO lactate_tests (user_id, date, comment, created_at) VALUES (?, ?, ?, ?)`,
-		user.ID, now.Add(-24*time.Hour).Format("2006-01-02"), "Threshold test", now.Add(-24*time.Hour).Format(time.RFC3339),
+		user.ID, now.Add(-24*time.Hour).Format("2006-01-02"), encComment, now.Add(-24*time.Hour).Format(time.RFC3339),
 	)
 	if err != nil {
 		t.Fatalf("failed to insert lactate test: %v", err)
@@ -193,14 +302,51 @@ func TestActivityHandler_WithLactateTest(t *testing.T) {
 	if len(resp.Items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(resp.Items))
 	}
-	if resp.Items[0].Type != "lactate" {
-		t.Errorf("expected type 'lactate', got %q", resp.Items[0].Type)
+	got := resp.Items[0]
+	if got.Type != "lactate" {
+		t.Errorf("expected type 'lactate', got %q", got.Type)
 	}
-	if resp.Items[0].Title != "Lactate test: Threshold test" {
-		t.Errorf("unexpected title %q", resp.Items[0].Title)
+	if got.Comment != "Threshold test" {
+		t.Errorf("expected comment 'Threshold test' (decrypted), got %q", got.Comment)
 	}
-	if resp.Items[0].Link != "/lactate" {
-		t.Errorf("expected link '/lactate', got %q", resp.Items[0].Link)
+	if got.Link != "/lactate" {
+		t.Errorf("expected link '/lactate', got %q", got.Link)
+	}
+	assertNoEnglishLabels(t, got)
+}
+
+func TestActivityHandler_WithLactateTestEmptyComment(t *testing.T) {
+	d := setupTestDB(t)
+	user := createTestUser(t, d)
+	now := time.Now().UTC()
+
+	_, err := d.Exec(
+		`INSERT INTO lactate_tests (user_id, date, comment, created_at) VALUES (?, ?, ?, ?)`,
+		user.ID, now.Add(-24*time.Hour).Format("2006-01-02"), "", now.Add(-24*time.Hour).Format(time.RFC3339),
+	)
+	if err != nil {
+		t.Fatalf("failed to insert lactate test: %v", err)
+	}
+
+	handler := ActivityHandler(d)
+	req := httptest.NewRequest("GET", "/api/dashboard/activity", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	var resp struct {
+		Items []ActivityItem `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(resp.Items))
+	}
+	got := resp.Items[0]
+	if got.Comment != "" {
+		t.Errorf("expected empty comment to round-trip as empty, got %q", got.Comment)
 	}
 }
 
@@ -237,14 +383,141 @@ func TestActivityHandler_WithShortLink(t *testing.T) {
 	if len(resp.Items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(resp.Items))
 	}
-	if resp.Items[0].Type != "link" {
-		t.Errorf("expected type 'link', got %q", resp.Items[0].Type)
+	got := resp.Items[0]
+	if got.Type != "link" {
+		t.Errorf("expected type 'link', got %q", got.Type)
 	}
-	if resp.Items[0].Title != "Link created: Example" {
-		t.Errorf("unexpected title %q", resp.Items[0].Title)
+	if got.Code != "abc" {
+		t.Errorf("expected code 'abc', got %q", got.Code)
 	}
-	if resp.Items[0].Link != "/links" {
-		t.Errorf("expected link '/links', got %q", resp.Items[0].Link)
+	if got.Title != "Example" {
+		t.Errorf("expected title 'Example', got %q", got.Title)
+	}
+	if got.Link != "/links" {
+		t.Errorf("expected link '/links', got %q", got.Link)
+	}
+	assertNoEnglishLabels(t, got)
+}
+
+func TestActivityHandler_ShortLinkWithoutTitle(t *testing.T) {
+	d := setupTestDB(t)
+	user := createTestUser(t, d)
+	now := time.Now().UTC()
+
+	_, err := d.Exec(
+		`INSERT INTO short_links (user_id, code, target_url, title, created_at) VALUES (?, ?, ?, ?, ?)`,
+		user.ID, "xyz", "https://example.com/page", "", now.Add(-time.Hour).Format(time.RFC3339),
+	)
+	if err != nil {
+		t.Fatalf("failed to insert short link: %v", err)
+	}
+
+	handler := ActivityHandler(d)
+	req := httptest.NewRequest("GET", "/api/dashboard/activity", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	var resp struct {
+		Items []ActivityItem `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(resp.Items))
+	}
+	got := resp.Items[0]
+	if got.Code != "xyz" {
+		t.Errorf("expected code 'xyz', got %q", got.Code)
+	}
+	if got.Title != "" {
+		t.Errorf("expected empty title to round-trip as empty, got %q", got.Title)
+	}
+}
+
+func TestActivityHandler_NoEnglishLabelsAcrossAllTypes(t *testing.T) {
+	d := setupTestDB(t)
+	user := createTestUser(t, d)
+	now := time.Now().UTC()
+	workoutTs := now.Add(-4 * time.Hour).Format(time.RFC3339)
+	noteTs := now.Add(-3 * time.Hour).Format(time.RFC3339)
+	linkTs := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	lactateDate := now.Add(-time.Hour).Format("2006-01-02")
+	lactateTs := now.Add(-time.Hour).Format(time.RFC3339)
+
+	if _, err := d.Exec(
+		`INSERT INTO workouts (user_id, sport, title, started_at, duration_seconds, distance_meters,
+		 avg_heart_rate, max_heart_rate, avg_pace_sec_per_km, avg_cadence, calories,
+		 ascent_meters, descent_meters, fit_file_hash, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		user.ID, "running", "", workoutTs, 1800, 5000,
+		150, 170, 360, 180, 300, 50, 30, "h-empty", workoutTs,
+	); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	if _, err := d.Exec(
+		`INSERT INTO notes (user_id, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		user.ID, "", "body", noteTs, noteTs,
+	); err != nil {
+		t.Fatalf("insert note: %v", err)
+	}
+
+	if _, err := d.Exec(
+		`INSERT INTO short_links (user_id, code, target_url, title, created_at) VALUES (?, ?, ?, ?, ?)`,
+		user.ID, "go1", "https://example.com", "", linkTs,
+	); err != nil {
+		t.Fatalf("insert short link: %v", err)
+	}
+
+	if _, err := d.Exec(
+		`INSERT INTO lactate_tests (user_id, date, comment, created_at) VALUES (?, ?, ?, ?)`,
+		user.ID, lactateDate, "", lactateTs,
+	); err != nil {
+		t.Fatalf("insert lactate: %v", err)
+	}
+
+	handler := ActivityHandler(d)
+	req := httptest.NewRequest("GET", "/api/dashboard/activity", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	var resp struct {
+		Items []ActivityItem `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Items) != 4 {
+		t.Fatalf("expected 4 items, got %d", len(resp.Items))
+	}
+
+	gotTypes := map[string]bool{}
+	for _, it := range resp.Items {
+		gotTypes[it.Type] = true
+		if it.Timestamp == "" {
+			t.Errorf("item %+v missing timestamp", it)
+		}
+		if it.Link == "" {
+			t.Errorf("item %+v missing link", it)
+		}
+		assertNoEnglishLabels(t, it)
+		// Empty user-supplied fields should round-trip as empty strings.
+		if it.Title != "" {
+			t.Errorf("expected empty title for %s, got %q", it.Type, it.Title)
+		}
+		if it.Type == "lactate" && it.Comment != "" {
+			t.Errorf("expected empty comment for lactate, got %q", it.Comment)
+		}
+	}
+	for _, want := range []string{"workout", "note", "link", "lactate"} {
+		if !gotTypes[want] {
+			t.Errorf("missing item type %q in response", want)
+		}
 	}
 }
 
@@ -280,26 +553,5 @@ func TestActivityHandler_LimitTen(t *testing.T) {
 	}
 	if len(resp.Items) != 10 {
 		t.Errorf("expected 10 items (limit), got %d", len(resp.Items))
-	}
-}
-
-func TestSportLabel(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"running", "Running"},
-		{"cycling", "Cycling"},
-		{"swimming", "Swimming"},
-		{"walking", "Walking"},
-		{"hiking", "Hiking"},
-		{"rowing", "rowing"},
-		{"", "Workout"},
-	}
-	for _, tc := range tests {
-		got := sportLabel(tc.input)
-		if got != tc.want {
-			t.Errorf("sportLabel(%q) = %q, want %q", tc.input, got, tc.want)
-		}
 	}
 }

--- a/internal/dashboard/activity_test.go
+++ b/internal/dashboard/activity_test.go
@@ -55,12 +55,14 @@ var englishLabelFragments = []string{
 func assertNoEnglishLabels(t *testing.T, item ActivityItem) {
 	t.Helper()
 	// Only the user-supplied fields (title, comment) may legitimately contain
-	// English words; the rest are enum-like keys and must stay machine-friendly.
+	// English words; the structural fields below must stay free of label text.
+	// The `type` field is a stable enum discriminator ("workout", "lactate",
+	// "note", "link") — those values are machine-readable API keys, not labels,
+	// so they are not subject to this check.
 	for _, field := range []struct{ name, value string }{
 		{"sport", item.Sport},
 		{"code", item.Code},
 		{"link", item.Link},
-		{"type", item.Type},
 	} {
 		for _, frag := range englishLabelFragments {
 			if strings.Contains(field.value, frag) {

--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -1,4 +1,22 @@
 {
+  "activity": {
+    "workout": "{{sport}} workout recorded",
+    "workoutWithTitle": "{{sport}}: {{title}}",
+    "lactate": "Lactate test recorded",
+    "lactateWithComment": "Lactate test: {{comment}}",
+    "note": "Note added",
+    "noteWithTitle": "Note: {{title}}",
+    "shortLink": "Short link created: /go/{{code}}",
+    "linkWithTitle": "Short link /go/{{code}}: {{title}}",
+    "sports": {
+      "running": "Running",
+      "cycling": "Cycling",
+      "swimming": "Swimming",
+      "walking": "Walking",
+      "hiking": "Hiking",
+      "default": "Workout"
+    }
+  },
   "widgets": {
     "weather": {
       "title": "Weather",

--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -14,8 +14,13 @@
       "swimming": "Swimming",
       "walking": "Walking",
       "hiking": "Hiking",
+      "strength": "Strength training",
+      "rowing": "Rowing",
+      "cross_country_skiing": "Cross-country skiing",
+      "other": "Workout",
       "default": "Workout"
-    }
+    },
+    "unknown": "Activity"
   },
   "widgets": {
     "weather": {

--- a/web/public/locales/nb/dashboard.json
+++ b/web/public/locales/nb/dashboard.json
@@ -1,4 +1,22 @@
 {
+  "activity": {
+    "workout": "{{sport}}-økt registrert",
+    "workoutWithTitle": "{{sport}}: {{title}}",
+    "lactate": "Laktattest registrert",
+    "lactateWithComment": "Laktattest: {{comment}}",
+    "note": "Notat lagt til",
+    "noteWithTitle": "Notat: {{title}}",
+    "shortLink": "Kortlenke opprettet: /go/{{code}}",
+    "linkWithTitle": "Kortlenke /go/{{code}}: {{title}}",
+    "sports": {
+      "running": "Løping",
+      "cycling": "Sykling",
+      "swimming": "Svømming",
+      "walking": "Gange",
+      "hiking": "Tur",
+      "default": "Økt"
+    }
+  },
   "widgets": {
     "weather": {
       "title": "Vær",

--- a/web/public/locales/nb/dashboard.json
+++ b/web/public/locales/nb/dashboard.json
@@ -14,8 +14,13 @@
       "swimming": "Svømming",
       "walking": "Gange",
       "hiking": "Tur",
+      "strength": "Styrketrening",
+      "rowing": "Roing",
+      "cross_country_skiing": "Langrenn",
+      "other": "Økt",
       "default": "Økt"
-    }
+    },
+    "unknown": "Aktivitet"
   },
   "widgets": {
     "weather": {

--- a/web/public/locales/th/dashboard.json
+++ b/web/public/locales/th/dashboard.json
@@ -1,4 +1,22 @@
 {
+  "activity": {
+    "workout": "บันทึกการออกกำลังกาย{{sport}}แล้ว",
+    "workoutWithTitle": "{{sport}}: {{title}}",
+    "lactate": "บันทึกการทดสอบแลคเตทแล้ว",
+    "lactateWithComment": "การทดสอบแลคเตท: {{comment}}",
+    "note": "เพิ่มโน้ตแล้ว",
+    "noteWithTitle": "โน้ต: {{title}}",
+    "shortLink": "สร้างลิงก์สั้นแล้ว: /go/{{code}}",
+    "linkWithTitle": "ลิงก์สั้น /go/{{code}}: {{title}}",
+    "sports": {
+      "running": "วิ่ง",
+      "cycling": "ปั่นจักรยาน",
+      "swimming": "ว่ายน้ำ",
+      "walking": "เดิน",
+      "hiking": "เดินป่า",
+      "default": "กิจกรรม"
+    }
+  },
   "widgets": {
     "weather": {
       "title": "สภาพอากาศ",

--- a/web/public/locales/th/dashboard.json
+++ b/web/public/locales/th/dashboard.json
@@ -14,8 +14,13 @@
       "swimming": "ว่ายน้ำ",
       "walking": "เดิน",
       "hiking": "เดินป่า",
+      "strength": "ฝึกความแข็งแกร่ง",
+      "rowing": "พายเรือ",
+      "cross_country_skiing": "สกีทางเรียบ",
+      "other": "กิจกรรม",
       "default": "กิจกรรม"
-    }
+    },
+    "unknown": "กิจกรรม"
   },
   "widgets": {
     "weather": {

--- a/web/src/components/widgets/ActivityFeedWidget.tsx
+++ b/web/src/components/widgets/ActivityFeedWidget.tsx
@@ -2,15 +2,19 @@ import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { Dumbbell, FlaskConical, StickyNote, LinkIcon, Activity } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
 import { useAuth } from '../../auth'
 import Widget from '../Widget'
 import { timeAgo } from '../../utils/timeAgo'
 
 interface ActivityItem {
   type: string
-  title: string
   timestamp: string
   link?: string
+  sport?: string
+  title?: string
+  comment?: string
+  code?: string
 }
 
 const typeIcons: Record<string, typeof Activity> = {
@@ -25,6 +29,45 @@ const typeColors: Record<string, string> = {
   lactate: 'text-purple-400',
   note: 'text-yellow-400',
   link: 'text-blue-400',
+}
+
+function sportLabel(t: TFunction, sport: string | undefined): string {
+  const key = sport && sport.length > 0 ? sport : 'default'
+  const i18nKey = `activity.sports.${key}`
+  const fallback = `activity.sports.default`
+  const translated = t(i18nKey, { defaultValue: '' })
+  return translated || t(fallback)
+}
+
+function renderLabel(t: TFunction, item: ActivityItem): string {
+  switch (item.type) {
+    case 'workout': {
+      const sport = sportLabel(t, item.sport)
+      if (item.title && item.title.length > 0) {
+        return t('activity.workoutWithTitle', { sport, title: item.title })
+      }
+      return t('activity.workout', { sport })
+    }
+    case 'lactate':
+      if (item.comment && item.comment.length > 0) {
+        return t('activity.lactateWithComment', { comment: item.comment })
+      }
+      return t('activity.lactate')
+    case 'note':
+      if (item.title && item.title.length > 0) {
+        return t('activity.noteWithTitle', { title: item.title })
+      }
+      return t('activity.note')
+    case 'link': {
+      const code = item.code ?? ''
+      if (item.title && item.title.length > 0) {
+        return t('activity.linkWithTitle', { code, title: item.title })
+      }
+      return t('activity.shortLink', { code })
+    }
+    default:
+      return ''
+  }
 }
 
 export default function ActivityFeedWidget() {
@@ -62,12 +105,13 @@ export default function ActivityFeedWidget() {
         {items.slice(0, 7).map((item) => {
           const Icon = typeIcons[item.type] || Activity
           const color = typeColors[item.type] || 'text-gray-400'
-          const itemKey = `${item.type}:${item.timestamp}:${item.title}`
+          const label = renderLabel(t, item)
+          const itemKey = `${item.type}:${item.timestamp}:${label}`
           const content = (
             <div className="flex items-start gap-2.5">
               <Icon size={14} className={`${color} mt-0.5 shrink-0`} />
               <div className="flex-1 min-w-0">
-                <p className="text-sm text-gray-300 truncate">{item.title}</p>
+                <p className="text-sm text-gray-300 truncate">{label}</p>
                 <p className="text-xs text-gray-600">{timeAgo(item.timestamp, tCommon)}</p>
               </div>
             </div>

--- a/web/src/components/widgets/ActivityFeedWidget.tsx
+++ b/web/src/components/widgets/ActivityFeedWidget.tsx
@@ -31,16 +31,27 @@ const typeColors: Record<string, string> = {
   link: 'text-blue-400',
 }
 
-function sportLabel(t: TFunction, sport: string | undefined): string {
-  if (!sport) {
-    return t('activity.sports.default')
+type ActivitySportKey = 'activity.sports.running' | 'activity.sports.cycling' | 'activity.sports.swimming' | 'activity.sports.walking' | 'activity.sports.hiking' | 'activity.sports.default'
+
+function sportTranslationKey(sport: string | undefined): ActivitySportKey | null {
+  switch (sport) {
+    case 'running': return 'activity.sports.running'
+    case 'cycling': return 'activity.sports.cycling'
+    case 'swimming': return 'activity.sports.swimming'
+    case 'walking': return 'activity.sports.walking'
+    case 'hiking': return 'activity.sports.hiking'
+    default: return null
   }
-  const translated = t(`activity.sports.${sport}`, { defaultValue: '' })
-  if (translated) return translated
+}
+
+function sportLabel(t: TFunction<'dashboard'>, sport: string | undefined): string {
+  if (!sport) return t('activity.sports.default')
+  const key = sportTranslationKey(sport)
+  if (key) return t(key)
   return sport.charAt(0).toUpperCase() + sport.slice(1)
 }
 
-function renderLabel(t: TFunction, item: ActivityItem): string {
+function renderLabel(t: TFunction<'dashboard'>, item: ActivityItem): string {
   switch (item.type) {
     case 'workout': {
       const sport = sportLabel(t, item.sport)

--- a/web/src/components/widgets/ActivityFeedWidget.tsx
+++ b/web/src/components/widgets/ActivityFeedWidget.tsx
@@ -31,7 +31,7 @@ const typeColors: Record<string, string> = {
   link: 'text-blue-400',
 }
 
-type ActivitySportKey = 'activity.sports.running' | 'activity.sports.cycling' | 'activity.sports.swimming' | 'activity.sports.walking' | 'activity.sports.hiking' | 'activity.sports.default'
+type ActivitySportKey = 'activity.sports.running' | 'activity.sports.cycling' | 'activity.sports.swimming' | 'activity.sports.walking' | 'activity.sports.hiking' | 'activity.sports.strength' | 'activity.sports.rowing' | 'activity.sports.cross_country_skiing' | 'activity.sports.other' | 'activity.sports.default'
 
 function sportTranslationKey(sport: string | undefined): ActivitySportKey | null {
   switch (sport) {
@@ -40,6 +40,10 @@ function sportTranslationKey(sport: string | undefined): ActivitySportKey | null
     case 'swimming': return 'activity.sports.swimming'
     case 'walking': return 'activity.sports.walking'
     case 'hiking': return 'activity.sports.hiking'
+    case 'strength': return 'activity.sports.strength'
+    case 'rowing': return 'activity.sports.rowing'
+    case 'cross_country_skiing': return 'activity.sports.cross_country_skiing'
+    case 'other': return 'activity.sports.other'
     default: return null
   }
 }
@@ -48,7 +52,7 @@ function sportLabel(t: TFunction<'dashboard'>, sport: string | undefined): strin
   if (!sport) return t('activity.sports.default')
   const key = sportTranslationKey(sport)
   if (key) return t(key)
-  return sport.charAt(0).toUpperCase() + sport.slice(1)
+  return sport.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 
 function renderLabel(t: TFunction<'dashboard'>, item: ActivityItem): string {
@@ -78,7 +82,7 @@ function renderLabel(t: TFunction<'dashboard'>, item: ActivityItem): string {
       return t('activity.shortLink', { code })
     }
     default:
-      return ''
+      return item.title || t('activity.unknown')
   }
 }
 

--- a/web/src/components/widgets/ActivityFeedWidget.tsx
+++ b/web/src/components/widgets/ActivityFeedWidget.tsx
@@ -32,11 +32,12 @@ const typeColors: Record<string, string> = {
 }
 
 function sportLabel(t: TFunction, sport: string | undefined): string {
-  const key = sport && sport.length > 0 ? sport : 'default'
-  const i18nKey = `activity.sports.${key}`
-  const fallback = `activity.sports.default`
-  const translated = t(i18nKey, { defaultValue: '' })
-  return translated || t(fallback)
+  if (!sport) {
+    return t('activity.sports.default')
+  }
+  const translated = t(`activity.sports.${sport}`, { defaultValue: '' })
+  if (translated) return translated
+  return sport.charAt(0).toUpperCase() + sport.slice(1)
 }
 
 function renderLabel(t: TFunction, item: ActivityItem): string {
@@ -102,11 +103,11 @@ export default function ActivityFeedWidget() {
   return (
     <Widget title={t('widgets.activity.title')}>
       <div className="space-y-3">
-        {items.slice(0, 7).map((item) => {
+        {items.slice(0, 7).map((item, index) => {
           const Icon = typeIcons[item.type] || Activity
           const color = typeColors[item.type] || 'text-gray-400'
           const label = renderLabel(t, item)
-          const itemKey = `${item.type}:${item.timestamp}:${label}`
+          const itemKey = `${item.type}:${item.timestamp}:${item.code ?? ''}:${index}`
           const content = (
             <div className="flex items-start gap-2.5">
               <Icon size={14} className={`${color} mt-0.5 shrink-0`} />


### PR DESCRIPTION
## Changes

- **Localized Dashboard activity feed** - The dashboard activity API now returns structured fields (`type`, `sport`, `title`, `comment`, `code`) instead of pre-built English labels, and the `ActivityFeedWidget` renders rows through `react-i18next` so Norwegian and Thai users see fully translated workout, lactate, note, and short-link entries. (Hytte-zx0v)

## Original Issue (feature): Internationalize Dashboard activity feed and widget labels

### Scope
Move English label construction out of the dashboard activity API and return structured fields so the frontend can render fully localized labels via react-i18next, restoring i18n compliance for nb/th users on the landing widget.

### Files to touch
- `internal/dashboard/activity.go` — extend `ActivityItem` with structured fields (`sport`, `title`, `comment`, `code`); stop building English labels; drop `sportLabel`. `Title` becomes the raw user-supplied value (may be empty).
- `internal/dashboard/activity_test.go` (new, if no existing test) — assert handler returns structured fields and no English-only labels.
- `web/src/components/widgets/ActivityFeedWidget.tsx` — update `ActivityItem` type, render labels via `t()` based on `item.type` and which optional fields are present.
- `web/public/locales/en/dashboard.json` — add `activity.workout`, `activity.workoutWithTitle`, `activity.lactate`, `activity.lactateWithComment`, `activity.note`, `activity.noteWithTitle`, `activity.shortLink`, `activity.linkWithTitle`, and a `activity.sports.*` map (mirror `widgets.training.sports`).
- `web/public/locales/nb/dashboard.json` — same keys, Norwegian Bokmål translations.
- `web/public/locales/th/dashboard.json` — same keys, Thai translations.
- `changelog.d/<id>-i18n-dashboard-activity.md` (new) — `Fixed` entry referencing the bead id.

### Acceptance criteria
- `GET /api/dashboard/activity` returns items with structured fields (`type`, `timestamp`, `link`, plus `sport`/`title`/`comment`/`code` where applicable) and no human-readable English label fields like "Lactate test recorded" or "Short link created: /go/...".
- `ActivityFeedWidget` renders all four item types using `t('dashboard:activity.*')` keys; no hardcoded English strings remain in the widget for activity rows.
- Switching language to `nb` or `th` in the UI immediately updates each row text (sport name, "Note:" prefix, "/go/CODE" template, etc.) without a page reload.
- An item with an empty user-supplied title falls back to the generic key (e.g. "Running workout recorded") in the active language; an item with a title uses the `*WithTitle`/`*WithComment` variant.
- Existing `go test ./...`, `npm run lint`, and `npm run build` all pass; `en`, `nb`, `th` locale files contain identical key sets under `activity.*`.
- The widget continues to link rows to `/training`, `/lactate`, `/notes`, `/links` and to render `timeAgo` correctly.

### Non-goals
- Redesigning the activity feed UI, icons, colors, or sorting/limit logic.
- Adding new activity sources (only the four current types: workout, lactate, note, link).
- Encrypting or changing storage of titles/comments/codes.
- Localizing other dashboard widgets beyond the activity feed (they already use i18n or are out of scope here).
- Backend-side translation or `Accept-Language` negotiation — translation stays purely client-side.

## Source

Created from Suggestions page (suggestion id 1, page slug "dashboard", source=claude).

## Original suggestion

The Dashboard page itself has no JSX text, but the activity feed backend builds English-only labels like "Lactate test recorded", "Note: ...", and "Short link created: /go/..." in activity.go. This violates the project's i18n rule that all user-facing strings go through react-i18next, leaving Norwegian and Thai users with hardcoded English on a prominent landing widget. Move label construction into the frontend ActivityFeedWidget by returning structured fields (type, sport, title, code) from the API and rendering with t('dashboard:activity.workout', { sport, title }) keys added to en/nb/th. Users on nb/th finally see a fully localized dashboard.


---
Bead: Hytte-zx0v | Branch: forge/Hytte-zx0v
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)