### PR TITLE
Forge nav link should route to Mezzanine instead of the old Forge page (Hytte-3cuq)

### DIFF
--- a/changelog.d/Hytte-3cuq.md
+++ b/changelog.d/Hytte-3cuq.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Forge sidebar nav now opens Mezzanine** - The "Forge" entry in the sidebar now routes directly to `/forge/mezzanine` instead of the legacy Forge dashboard. (Hytte-3cuq)

--- a/web/src/components/Sidebar.test.tsx
+++ b/web/src/components/Sidebar.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Sidebar from './Sidebar'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: () => {} },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+vi.mock('./LanguageSwitcher', () => ({
+  default: () => null,
+}))
+
+interface MockUser {
+  name: string
+  email: string
+  picture?: string
+  is_admin: boolean
+}
+
+const authState: {
+  user: MockUser | null
+  loading: boolean
+  hasFeature: (key: string) => boolean
+  familyStatus: { is_parent: boolean; is_child: boolean } | null
+} = {
+  user: null,
+  loading: false,
+  hasFeature: () => false,
+  familyStatus: null,
+}
+
+vi.mock('../auth', () => ({
+  useAuth: () => ({
+    ...authState,
+    logout: async () => {},
+    refreshFamilyStatus: async () => {},
+  }),
+}))
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <Sidebar />
+    </MemoryRouter>,
+  )
+}
+
+describe('Sidebar – Forge nav link', () => {
+  beforeEach(() => {
+    authState.user = {
+      name: 'Admin User',
+      email: 'admin@example.com',
+      is_admin: true,
+    }
+    authState.loading = false
+    authState.hasFeature = () => true
+    authState.familyStatus = null
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ claims: [] }),
+    })))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    authState.user = null
+  })
+
+  it('routes admin Forge link to /forge/mezzanine', () => {
+    renderSidebar()
+    const links = screen.getAllByRole('link', { name: 'nav.forge' })
+    expect(links.length).toBeGreaterThan(0)
+    for (const link of links) {
+      expect(link.getAttribute('href')).toBe('/forge/mezzanine')
+    }
+  })
+})

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -84,7 +84,7 @@ const navItems: NavItem[] = [
   { to: '/math', icon: <Calculator size={20} />, label: 'nav.regnemester', requiresAuth: true, feature: 'regnemester' },
   { to: '/homework', icon: <BookOpen size={20} />, label: 'nav.homework', requiresAuth: true, feature: 'homework', familyRole: 'child' },
   { to: '/homework/review', icon: <ClipboardList size={20} />, label: 'nav.homeworkReview', requiresAuth: true, feature: 'homework', familyRole: 'parent' },
-  { to: '/forge', icon: <Hammer size={20} />, label: 'nav.forge', requiresAuth: true, requireAdmin: true },
+  { to: '/forge/mezzanine', icon: <Hammer size={20} />, label: 'nav.forge', requiresAuth: true, requireAdmin: true },
 ]
 
 export default function Sidebar() {


### PR DESCRIPTION
## Changes

- **Forge sidebar nav now opens Mezzanine** - The "Forge" entry in the sidebar now routes directly to `/forge/mezzanine` instead of the legacy Forge dashboard. (Hytte-3cuq)

## Original Issue (chore): Forge nav link should route to Mezzanine instead of the old Forge page

The "Forge" entry in the sidebar (`web/src/components/Sidebar.tsx:87`) currently navigates to `/forge`, which is the legacy ForgeDashboardPage. The Mezzanine page at `/forge/mezzanine` has fully replaced it for daily use.

## Change

Update the sidebar nav entry to point at `/forge/mezzanine` directly:

    { to: '/forge/mezzanine', icon: <Hammer size={20} />, label: 'nav.forge', requiresAuth: true, requireAdmin: true },

Don't remove the `/forge` route from `App.tsx` in this bead — that's a separate cleanup decision (deep-link bookmarks, internal links). Just retarget the nav.

## Tests

Update or add a small Sidebar test that asserts the Forge link's `href` is `/forge/mezzanine`.

## Acceptance

- Clicking the Forge sidebar entry takes you to Mezzanine.
- `npm run lint`, `npm run build`, `npm test` all pass.
- Active-link highlighting still works (the NavLink will be marked active on `/forge/mezzanine` and its sub-routes).
- Changelog fragment in changelog.d/ (category: Changed).

## Non-goals

- Removing the `/forge` route or `ForgeDashboardPage` component — defer to a follow-up if you want it gone.
- Migrating any internal links that hardcode `/forge`.


---
Bead: Hytte-3cuq | Branch: forge/Hytte-3cuq
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)