### PR TITLE
Suggestions: cap pending per page and generate only the deficit (Hytte-21ph)

### DIFF
--- a/changelog.d/Hytte-21ph.md
+++ b/changelog.d/Hytte-21ph.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Suggestions: cap pending per page and only generate the deficit** - The nightly rotation now caps pending suggestions at 3 per page (configurable in code). Pages already at the cap are skipped pre-rotation, and each picked page only requests the deficit so a backlog cannot grow unbounded across runs. The same cap also gates the new-page pass. The progress UI shows a "skipped — already at 3 pending" entry for any page that hits the cap mid-run. (Hytte-21ph)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -223,19 +223,6 @@ func main() {
 					continue
 				}
 
-				pickCtx, pickCancel := context.WithTimeout(notifCtx, 30*time.Second)
-				rotation, err := suggestions.PickRotation(pickCtx, database, eligible, suggestions.RotationDefaultN)
-				pickCancel()
-				if err != nil {
-					log.Printf("suggestions: pick rotation: %v", err)
-					continue
-				}
-
-				pageSlugs := make([]string, len(rotation))
-				for i, p := range rotation {
-					pageSlugs[i] = p.Slug
-				}
-
 				for _, adminID := range adminIDs {
 					if notifCtx.Err() != nil {
 						break
@@ -248,6 +235,32 @@ func main() {
 					if !cfg.Enabled {
 						log.Printf("suggestions: skip admin=%d (claude disabled)", adminID)
 						continue
+					}
+
+					// FilterUnderCap and PickRotation are per-admin because
+					// the cap counts each admin's pending suggestions
+					// independently. Running them inside the per-admin loop
+					// also keeps each admin's rotation fresh against any
+					// suggestions the previous admin's pass may have changed.
+					filterCtx, filterCancel := context.WithTimeout(notifCtx, 30*time.Second)
+					underCap, err := suggestions.FilterUnderCap(filterCtx, database, adminID, eligible, suggestions.MaxPendingPerPage)
+					filterCancel()
+					if err != nil {
+						log.Printf("suggestions: filter under cap for admin=%d: %v", adminID, err)
+						continue
+					}
+
+					pickCtx, pickCancel := context.WithTimeout(notifCtx, 30*time.Second)
+					rotation, err := suggestions.PickRotation(pickCtx, database, underCap, suggestions.RotationDefaultN)
+					pickCancel()
+					if err != nil {
+						log.Printf("suggestions: pick rotation for admin=%d: %v", adminID, err)
+						continue
+					}
+
+					pageSlugs := make([]string, len(rotation))
+					for i, p := range rotation {
+						pageSlugs[i] = p.Slug
 					}
 
 					runCtx, runCancel := context.WithTimeout(notifCtx, 30*time.Minute)

--- a/internal/suggestions/generate.go
+++ b/internal/suggestions/generate.go
@@ -144,10 +144,12 @@ func RunSuggestionsForPages(
 //
 // Recomputes the page's pending-suggestion count and the resulting deficit
 // against MaxPendingPerPage at entry. If the page is already at the cap, the
-// function returns (0, 0, 0, nil) without making a Claude call — this is the
-// second stage of the two-stage filter (see FilterUnderCap) and protects
-// against a page filling between the pre-rotation drop and execution. When
-// the deficit is positive, exactly that many suggestions are requested.
+// function returns (0, 0, 0, *PageAtCapError) without making a Claude call —
+// callers must check err and handle PageAtCapError as a non-failure skip
+// signal (see RunSuggestionsForPages). This is the second stage of the
+// two-stage filter (see FilterUnderCap) and protects against a page filling
+// between the pre-rotation drop and execution. When the deficit is positive,
+// exactly that many suggestions are requested.
 func runForPage(
 	ctx context.Context,
 	db *sql.DB,

--- a/internal/suggestions/generate.go
+++ b/internal/suggestions/generate.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -38,6 +39,21 @@ const recentSuggestionsWindowDays = 14
 // MaxRetriesOnMalformedJSON is the number of retries attempted when Claude
 // returns a response that does not parse as the expected JSON shape.
 const MaxRetriesOnMalformedJSON = 1
+
+// PageAtCapError is returned by runForPage when the page already has
+// MaxPendingPerPage pending suggestions, so no Claude call is made. Callers
+// detect this with errors.As and emit a "skipped" signal rather than counting
+// it against the run's error total — it is the expected outcome of the
+// per-page cap, not a failure.
+type PageAtCapError struct {
+	PageSlug     string
+	PendingCount int
+	Cap          int
+}
+
+func (e *PageAtCapError) Error() string {
+	return fmt.Sprintf("page %q at cap (%d pending, cap %d)", e.PageSlug, e.PendingCount, e.Cap)
+}
 
 // RunResult summarises a generation pass. CostUSD is the total cost in US
 // dollars of all Claude calls made during the pass, summed even across
@@ -73,10 +89,13 @@ var validSizes = map[string]bool{
 }
 
 // RunSuggestionsForPages iterates over pages, calling Claude once per page to
-// generate three improvement suggestions and inserting them as pending rows
-// owned by userID. Per-page errors are logged but do not abort the run, so a
-// single Claude failure or malformed-JSON page does not lose the rest. The
-// caller is responsible for filtering pages (see RotationEligible).
+// generate the deficit between MaxPendingPerPage and the page's current
+// pending count and inserting them as pending rows owned by userID. Per-page
+// errors are logged but do not abort the run, so a single Claude failure or
+// malformed-JSON page does not lose the rest. Pages already at the cap are
+// skipped without spending any API budget. The caller is responsible for
+// filtering pages by rotation eligibility (see RotationEligible) and may
+// optionally pre-filter at-cap pages with FilterUnderCap.
 //
 // Returns counts of inserted suggestions and total errors. Errors include both
 // page-level failures (Claude call, JSON parse) and per-row insert failures, so
@@ -102,6 +121,12 @@ func RunSuggestionsForPages(
 		result.Errors += failed
 		result.CostUSD += cost
 		if err != nil {
+			var atCap *PageAtCapError
+			if errors.As(err, &atCap) {
+				// Skipped-at-cap is the expected outcome of the per-page
+				// cap, not a failure — do not increment Errors.
+				continue
+			}
 			result.Errors++
 			log.Printf("suggestions: page %q errored: %v", page.Slug, err)
 		}
@@ -116,6 +141,13 @@ func RunSuggestionsForPages(
 // and a page-level error (Claude call / JSON parse). Per-row insert failures
 // are reported via the second return value so the caller can surface them in
 // the overall error count.
+//
+// Recomputes the page's pending-suggestion count and the resulting deficit
+// against MaxPendingPerPage at entry. If the page is already at the cap, the
+// function returns (0, 0, 0, nil) without making a Claude call — this is the
+// second stage of the two-stage filter (see FilterUnderCap) and protects
+// against a page filling between the pre-rotation drop and execution. When
+// the deficit is positive, exactly that many suggestions are requested.
 func runForPage(
 	ctx context.Context,
 	db *sql.DB,
@@ -126,6 +158,20 @@ func runForPage(
 	pageCtx, cancel := context.WithTimeout(ctx, PerPageTimeout)
 	defer cancel()
 
+	pendingCount, pendingErr := PendingCountForPage(pageCtx, db, userID, page.Slug)
+	if pendingErr != nil {
+		return 0, 0, 0, fmt.Errorf("pending count: %w", pendingErr)
+	}
+	target := MaxPendingPerPage - pendingCount
+	if target <= 0 {
+		log.Printf("suggestions: skip page %q — at cap (%d pending)", page.Slug, pendingCount)
+		return 0, 0, 0, &PageAtCapError{
+			PageSlug:     page.Slug,
+			PendingCount: pendingCount,
+			Cap:          MaxPendingPerPage,
+		}
+	}
+
 	sources := loadSourceFiles(page.SourceFiles)
 	gitLog := loadGitLog(pageCtx, page.SourceFiles)
 
@@ -135,9 +181,9 @@ func runForPage(
 		recent = nil
 	}
 
-	prompt := buildPagePrompt(page, sources, gitLog, recent)
+	prompt := buildPagePrompt(page, sources, gitLog, recent, target)
 
-	suggestions, costUSD, err := callAndParse(pageCtx, cfg, prompt)
+	suggestions, costUSD, err := callAndParse(pageCtx, cfg, prompt, target)
 	if err != nil {
 		return 0, 0, costUSD, err
 	}
@@ -165,12 +211,13 @@ func runForPage(
 	return inserted, failed, costUSD, nil
 }
 
-// callAndParse calls Claude and parses the response. On a malformed JSON
-// response it retries up to MaxRetriesOnMalformedJSON times, then returns the
-// last error. The accumulated cost across all attempts (including the failed
-// attempts that triggered retries) is returned so the caller can fold it into
-// the run total — every attempt is a paid CLI invocation.
-func callAndParse(ctx context.Context, cfg *training.ClaudeConfig, prompt string) ([]generated, float64, error) {
+// callAndParse calls Claude and parses the response into exactly `expected`
+// suggestions. On a malformed JSON response it retries up to
+// MaxRetriesOnMalformedJSON times, then returns the last error. The
+// accumulated cost across all attempts (including the failed attempts that
+// triggered retries) is returned so the caller can fold it into the run total
+// — every attempt is a paid CLI invocation.
+func callAndParse(ctx context.Context, cfg *training.ClaudeConfig, prompt string, expected int) ([]generated, float64, error) {
 	var (
 		lastErr   error
 		totalCost float64
@@ -181,7 +228,7 @@ func callAndParse(ctx context.Context, cfg *training.ClaudeConfig, prompt string
 		if err != nil {
 			return nil, totalCost, fmt.Errorf("claude prompt: %w", err)
 		}
-		parsed, err := parseSuggestionsResponse(resp)
+		parsed, err := parseSuggestionsResponse(resp, expected)
 		if err == nil {
 			return parsed, totalCost, nil
 		}
@@ -192,8 +239,10 @@ func callAndParse(ctx context.Context, cfg *training.ClaudeConfig, prompt string
 }
 
 // parseSuggestionsResponse strips an optional markdown fence and decodes the
-// response into exactly three validated generated suggestions.
-func parseSuggestionsResponse(response string) ([]generated, error) {
+// response into exactly `expected` validated generated suggestions. The
+// distinct-types check applies when expected > 1; for expected == 1 it is
+// vacuously true and skipped.
+func parseSuggestionsResponse(response string, expected int) ([]generated, error) {
 	response = strings.TrimSpace(response)
 
 	if strings.HasPrefix(response, "```") {
@@ -207,8 +256,8 @@ func parseSuggestionsResponse(response string) ([]generated, error) {
 	if err := json.Unmarshal([]byte(response), &items); err != nil {
 		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
-	if len(items) != 3 {
-		return nil, fmt.Errorf("expected exactly 3 suggestions, got %d", len(items))
+	if len(items) != expected {
+		return nil, fmt.Errorf("expected exactly %d suggestions, got %d", expected, len(items))
 	}
 	seenTypes := make(map[string]bool, len(items))
 	for i, it := range items {
@@ -224,10 +273,12 @@ func parseSuggestionsResponse(response string) ([]generated, error) {
 		if strings.TrimSpace(it.Body) == "" {
 			return nil, fmt.Errorf("item %d: empty body", i)
 		}
-		if seenTypes[it.Type] {
-			return nil, fmt.Errorf("item %d: duplicate type %q", i, it.Type)
+		if expected > 1 {
+			if seenTypes[it.Type] {
+				return nil, fmt.Errorf("item %d: duplicate type %q", i, it.Type)
+			}
+			seenTypes[it.Type] = true
 		}
-		seenTypes[it.Type] = true
 	}
 	return items, nil
 }

--- a/internal/suggestions/generate_test.go
+++ b/internal/suggestions/generate_test.go
@@ -168,7 +168,7 @@ func TestParseSuggestionsResponseRejectsWrongCount(t *testing.T) {
 	_, err := parseSuggestionsResponse(`[
 		{"type":"improvement","size":"s","title":"X","body":"y"},
 		{"type":"improvement","size":"s","title":"X","body":"y"}
-	]`)
+	]`, 3)
 	if err == nil {
 		t.Fatal("expected error for 2-item response, got nil")
 	}
@@ -179,7 +179,7 @@ func TestParseSuggestionsResponseRejectsInvalidEnum(t *testing.T) {
 		{"type":"weird","size":"s","title":"X","body":"y"},
 		{"type":"improvement","size":"s","title":"X","body":"y"},
 		{"type":"improvement","size":"s","title":"X","body":"y"}
-	]`)
+	]`, 3)
 	if err == nil {
 		t.Fatal("expected error for invalid type, got nil")
 	}
@@ -190,7 +190,7 @@ func TestParseSuggestionsResponseAllowsDuplicateSizes(t *testing.T) {
 		{"type":"improvement","size":"s","title":"A","body":"a"},
 		{"type":"addition","size":"s","title":"B","body":"b"},
 		{"type":"bugfix","size":"s","title":"C","body":"c"}
-	]`)
+	]`, 3)
 	if err != nil {
 		t.Fatalf("expected three same-size suggestions to parse, got error: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestParseSuggestionsResponseRejectsDuplicateTypes(t *testing.T) {
 		{"type":"improvement","size":"s","title":"A","body":"a"},
 		{"type":"improvement","size":"m","title":"B","body":"b"},
 		{"type":"bugfix","size":"l","title":"C","body":"c"}
-	]`)
+	]`, 3)
 	if err == nil {
 		t.Fatal("expected error for duplicate type, got nil")
 	}
@@ -215,11 +215,146 @@ func TestParseSuggestionsResponseRejectsDuplicateTypes(t *testing.T) {
 
 func TestParseSuggestionsResponseStripsMarkdownFence(t *testing.T) {
 	wrapped := "```json\n" + validJSONResponse + "\n```"
-	got, err := parseSuggestionsResponse(wrapped)
+	got, err := parseSuggestionsResponse(wrapped, 3)
 	if err != nil {
 		t.Fatalf("expected fence-stripped parse to succeed: %v", err)
 	}
 	if len(got) != 3 {
 		t.Fatalf("expected 3 items, got %d", len(got))
+	}
+}
+
+// With expected=1 the duplicate-types check is vacuously true and the parser
+// should accept a single item even though there is no second item to compare.
+func TestParseSuggestionsResponseAcceptsSingleItemWhenExpectedOne(t *testing.T) {
+	got, err := parseSuggestionsResponse(`[
+		{"type":"improvement","size":"s","title":"X","body":"y"}
+	]`, 1)
+	if err != nil {
+		t.Fatalf("expected single-item parse to succeed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(got))
+	}
+}
+
+// singleItemJSON is a one-element response used to exercise the deficit-aware
+// generator path when only one suggestion is requested.
+const singleItemJSON = `[
+  {"type": "improvement", "size": "s", "title": "Cache the forecast", "body": "Add a 10-minute in-memory cache so repeated reloads do not hammer yr.no."}
+]`
+
+// TestRunSuggestionsForPagesAtCapSkipsClaude verifies that a page already at
+// MaxPendingPerPage pending suggestions causes runForPage to short-circuit
+// before any Claude call and is not counted as an error.
+func TestRunSuggestionsForPagesAtCapSkipsClaude(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	// Pre-seed the page at the cap.
+	for i := 0; i < MaxPendingPerPage; i++ {
+		if _, err := Insert(ctx, d, Suggestion{
+			UserID: 1, PageSlug: "weather", Source: SourceClaude,
+			Type: TypeImprovement, Size: SizeS, Title: "seed", Body: "b", Status: StatusPending,
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	var calls int
+	var mu sync.Mutex
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return validJSONResponse, nil
+	})()
+
+	res := RunSuggestionsForPages(ctx, d, dummyCfg(), 1, []Page{
+		{Slug: "weather", Title: "Weather"},
+	})
+	if calls != 0 {
+		t.Fatalf("expected Claude not to be called when page is at cap, got %d calls", calls)
+	}
+	if res.Generated != 0 {
+		t.Fatalf("expected 0 generated, got %d", res.Generated)
+	}
+	if res.Errors != 0 {
+		t.Fatalf("expected at-cap to not count as error, got Errors=%d", res.Errors)
+	}
+}
+
+// TestRunSuggestionsForPagesRequestsDeficitOnly seeds the page at 2 pending
+// and asserts that the prompt asks for exactly 1 suggestion and only 1 row
+// is inserted.
+func TestRunSuggestionsForPagesRequestsDeficitOnly(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	// Seed 2 pending so target = MaxPendingPerPage - 2 = 1.
+	for i := 0; i < MaxPendingPerPage-1; i++ {
+		if _, err := Insert(ctx, d, Suggestion{
+			UserID: 1, PageSlug: "weather", Source: SourceClaude,
+			Type: TypeImprovement, Size: SizeS, Title: "seed", Body: "b", Status: StatusPending,
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	var capturedPrompts []string
+	var mu sync.Mutex
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		mu.Lock()
+		capturedPrompts = append(capturedPrompts, prompt)
+		mu.Unlock()
+		return singleItemJSON, nil
+	})()
+
+	res := RunSuggestionsForPages(ctx, d, dummyCfg(), 1, []Page{
+		{Slug: "weather", Title: "Weather"},
+	})
+	if res.Errors != 0 {
+		t.Fatalf("expected 0 errors, got %d", res.Errors)
+	}
+	if res.Generated != 1 {
+		t.Fatalf("expected 1 generated to refill to cap, got %d", res.Generated)
+	}
+	if len(capturedPrompts) != 1 {
+		t.Fatalf("expected exactly 1 Claude call, got %d", len(capturedPrompts))
+	}
+	if !strings.Contains(capturedPrompts[0], "exactly 1 object") {
+		t.Fatalf("expected prompt to ask for exactly 1 object; prompt was:\n%s", capturedPrompts[0])
+	}
+}
+
+// TestRunSuggestionsForPagesNoPendingRequestsThree verifies the default-shape
+// behaviour: a page at zero pending asks for the full MaxPendingPerPage count.
+func TestRunSuggestionsForPagesNoPendingRequestsThree(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	var capturedPrompts []string
+	var mu sync.Mutex
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		mu.Lock()
+		capturedPrompts = append(capturedPrompts, prompt)
+		mu.Unlock()
+		return validJSONResponse, nil
+	})()
+
+	res := RunSuggestionsForPages(ctx, d, dummyCfg(), 1, []Page{
+		{Slug: "weather", Title: "Weather"},
+	})
+	if res.Errors != 0 {
+		t.Fatalf("expected 0 errors, got %d", res.Errors)
+	}
+	if res.Generated != MaxPendingPerPage {
+		t.Fatalf("expected %d generated, got %d", MaxPendingPerPage, res.Generated)
+	}
+	if len(capturedPrompts) != 1 {
+		t.Fatalf("expected exactly 1 Claude call, got %d", len(capturedPrompts))
+	}
+	if !strings.Contains(capturedPrompts[0], "exactly 3 objects") {
+		t.Fatalf("expected prompt to ask for exactly 3 objects; prompt was:\n%s", capturedPrompts[0])
 	}
 }

--- a/internal/suggestions/handlers.go
+++ b/internal/suggestions/handlers.go
@@ -103,6 +103,18 @@ type pageCompleteEvent struct {
 	Error     string  `json:"error,omitempty"`
 }
 
+// pageSkippedCapEvent is emitted when a page is skipped because it already
+// has MaxPendingPerPage pending suggestions. No Claude call is made and no
+// row is written, so the event carries only the slug and the cap state.
+// The frontend renders this as a separate "skipped" entry in the run log so
+// the operator sees the page was attempted and intentionally bypassed,
+// rather than mistaking it for a silently-dropped page.
+type pageSkippedCapEvent struct {
+	PageSlug     string `json:"page_slug"`
+	PendingCount int    `json:"pending_count"`
+	Cap          int    `json:"cap"`
+}
+
 // newPageCompleteEvent mirrors pageCompleteEvent but for the separate
 // new-page Claude pass. PageSlug is always NewPageSlug.
 type newPageCompleteEvent struct {
@@ -182,6 +194,17 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		// Drop pages already at the per-page cap before scheduling work. The
+		// per-page deficit check inside runForPage is the authoritative guard,
+		// but this filter keeps the rotation slots focused on pages that need
+		// work and prevents wasted "skipped" log spam in nightly runs.
+		pages, err = FilterUnderCap(r.Context(), db, user.ID, pages, MaxPendingPerPage)
+		if err != nil {
+			log.Printf("suggestions: filter under cap for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load page settings"})
+			return
+		}
+
 		flusher, ok := w.(http.Flusher)
 		if !ok {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "streaming not supported"})
@@ -254,6 +277,19 @@ func RunHandler(db *sql.DB) http.HandlerFunc {
 				totals.Generated += inserted
 				totals.Errors += failed
 				totals.CostUSD += cost
+
+				// At-cap is a normal outcome of the deficit check, not an
+				// error. Surface it as its own event so the live progress
+				// log can show the page was skipped intentionally.
+				var atCap *PageAtCapError
+				if errors.As(err, &atCap) {
+					eventCh <- sseEvent{Name: "page_skipped_cap", Data: pageSkippedCapEvent{
+						PageSlug:     atCap.PageSlug,
+						PendingCount: atCap.PendingCount,
+						Cap:          atCap.Cap,
+					}}
+					continue
+				}
 
 				ev := pageCompleteEvent{
 					PageSlug:  page.Slug,

--- a/internal/suggestions/new_page.go
+++ b/internal/suggestions/new_page.go
@@ -59,6 +59,17 @@ func RunNewPageSuggestion(
 	runCtx, cancel := context.WithTimeout(ctx, NewPageTimeout)
 	defer cancel()
 
+	pendingCount, err := PendingCountForPage(runCtx, db, userID, NewPageSlug)
+	if err != nil {
+		log.Printf("suggestions: count pending new_page suggestions: %v", err)
+		result.Errors++
+		return result, nil
+	}
+	if pendingCount >= MaxPendingPerPage {
+		log.Printf("suggestions: skip new_page pass — at cap (%d pending, cap %d)", pendingCount, MaxPendingPerPage)
+		return result, nil
+	}
+
 	registered := AllRegistered()
 
 	recent, err := recentNewPageSuggestions(runCtx, db, userID, NewPageWindowDays)

--- a/internal/suggestions/new_page.go
+++ b/internal/suggestions/new_page.go
@@ -61,6 +61,9 @@ func RunNewPageSuggestion(
 
 	pendingCount, err := PendingCountForPage(runCtx, db, userID, NewPageSlug)
 	if err != nil {
+		if runCtx.Err() != nil {
+			return result, runCtx.Err()
+		}
 		log.Printf("suggestions: count pending new_page suggestions: %v", err)
 		result.Errors++
 		return result, nil

--- a/internal/suggestions/new_page_test.go
+++ b/internal/suggestions/new_page_test.go
@@ -209,3 +209,50 @@ func TestParseNewPageResponseRejectsUnknownFields(t *testing.T) {
 		t.Fatal("expected error for unknown fields, got nil")
 	}
 }
+
+// TestRunNewPageSuggestionAtCapSkipsClaude verifies that a backlog of pending
+// new_page suggestions at MaxPendingPerPage causes the new-page pass to skip
+// the Claude call entirely.
+func TestRunNewPageSuggestionAtCapSkipsClaude(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	// Seed MaxPendingPerPage pending new_page suggestions.
+	for i := 0; i < MaxPendingPerPage; i++ {
+		if _, err := Insert(ctx, d, Suggestion{
+			UserID:   1,
+			PageSlug: NewPageSlug,
+			Source:   SourceClaude,
+			Type:     TypeNewPage,
+			Size:     SizeM,
+			Title:    "seed",
+			Body:     "seed body",
+			Status:   StatusPending,
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	var calls int
+	var mu sync.Mutex
+	defer withRunPrompt(func(ctx context.Context, cfg *training.ClaudeConfig, prompt string) (string, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return validNewPageJSON, nil
+	})()
+
+	res, err := RunNewPageSuggestion(ctx, d, dummyCfg(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected Claude not to be called when at cap, got %d calls", calls)
+	}
+	if res.Generated != 0 {
+		t.Fatalf("expected 0 generated when at cap, got %d", res.Generated)
+	}
+	if res.Errors != 0 {
+		t.Fatalf("expected at-cap to not count as error, got Errors=%d", res.Errors)
+	}
+}

--- a/internal/suggestions/pending_count_test.go
+++ b/internal/suggestions/pending_count_test.go
@@ -1,0 +1,91 @@
+package suggestions
+
+import (
+	"context"
+	"testing"
+)
+
+// TestPendingCountForPageOnlyCountsPending verifies that PendingCountForPage
+// returns only rows whose status is "pending" — planned, rejected, and
+// bead_created rows must be excluded so that triaging a suggestion frees a
+// rotation slot for the page.
+func TestPendingCountForPageOnlyCountsPending(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	insert := func(slug, status string) {
+		t.Helper()
+		if _, err := Insert(ctx, d, Suggestion{
+			UserID: 1, PageSlug: slug, Source: SourceClaude,
+			Type: TypeImprovement, Size: SizeS, Title: "T-" + status, Body: "b", Status: status,
+		}); err != nil {
+			t.Fatalf("insert %s/%s: %v", slug, status, err)
+		}
+	}
+
+	insert("weather", StatusPending)
+	insert("weather", StatusPending)
+	insert("weather", StatusRejected)
+	insert("weather", StatusPlanned)
+	insert("weather", StatusBeadCreated)
+	// Different page should not contribute.
+	insert("notes", StatusPending)
+
+	got, err := PendingCountForPage(ctx, d, 1, "weather")
+	if err != nil {
+		t.Fatalf("PendingCountForPage: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("expected 2 pending for weather (rejected/planned/bead_created excluded), got %d", got)
+	}
+
+	other, err := PendingCountForPage(ctx, d, 1, "notes")
+	if err != nil {
+		t.Fatalf("PendingCountForPage notes: %v", err)
+	}
+	if other != 1 {
+		t.Fatalf("expected 1 pending for notes, got %d", other)
+	}
+}
+
+// TestPendingCountForPageZeroForUnknownPage confirms a slug with no rows
+// returns 0 rather than a sql.ErrNoRows error — COUNT(*) always produces a row.
+func TestPendingCountForPageZeroForUnknownPage(t *testing.T) {
+	d := setupTestDB(t)
+	got, err := PendingCountForPage(context.Background(), d, 1, "no-such-page")
+	if err != nil {
+		t.Fatalf("PendingCountForPage: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("expected 0 for empty page, got %d", got)
+	}
+}
+
+// TestPendingCountForPageScopedByUser ensures the user_id filter is honoured;
+// counting page X for user A must not return user B's pending rows.
+func TestPendingCountForPageScopedByUser(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	if _, err := d.Exec(
+		`INSERT INTO users (id, google_id, email, name, picture, is_admin) VALUES (2, 'g2', 'b@example.com', 'B', '', 1)`,
+	); err != nil {
+		t.Fatalf("create second user: %v", err)
+	}
+	for _, uid := range []int64{1, 2} {
+		if _, err := Insert(ctx, d, Suggestion{
+			UserID: uid, PageSlug: "weather", Source: SourceClaude,
+			Type: TypeImprovement, Size: SizeS, Title: "T", Body: "b", Status: StatusPending,
+		}); err != nil {
+			t.Fatalf("insert for user %d: %v", uid, err)
+		}
+	}
+
+	got, err := PendingCountForPage(ctx, d, 1, "weather")
+	if err != nil {
+		t.Fatalf("PendingCountForPage: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("expected 1 for user 1 only, got %d", got)
+	}
+}

--- a/internal/suggestions/prompt.go
+++ b/internal/suggestions/prompt.go
@@ -11,17 +11,26 @@ import (
 const maxSourceFileChars = 6000
 
 // buildPagePrompt assembles a Claude prompt for generating page-improvement
-// suggestions. The model is asked for a strict JSON array of exactly 3 objects,
-// each with the fields {type, size, title, body}.
+// suggestions. The model is asked for a strict JSON array of exactly `target`
+// objects, each with the fields {type, size, title, body}.
+//
+// target is the deficit between the per-page cap and the page's current
+// pending-suggestion count, so the generator can request only what is needed
+// to refill the page rather than always asking for three. Callers must pass
+// target >= 1; the constant MaxPendingPerPage bounds the upper end.
 //
 // sourceFiles is a map of relative path → file contents. Callers truncate
 // large files to keep the prompt within reasonable bounds; this function
 // applies a safety cap regardless.
-func buildPagePrompt(page Page, sourceFiles map[string]string, recentGitLog string, recentSuggestions []Suggestion) string {
+func buildPagePrompt(page Page, sourceFiles map[string]string, recentGitLog string, recentSuggestions []Suggestion, target int) string {
 	var sb strings.Builder
 
 	sb.WriteString("You are a senior software engineer reviewing one page of a personal web app called Hytte.\n")
-	sb.WriteString("Your job: propose three concrete, scoped improvements to that page.\n\n")
+	if target == 1 {
+		sb.WriteString("Your job: propose one concrete, scoped improvement to that page.\n\n")
+	} else {
+		fmt.Fprintf(&sb, "Your job: propose %d concrete, scoped improvements to that page.\n\n", target)
+	}
 
 	sb.WriteString("## Page\n")
 	fmt.Fprintf(&sb, "- Slug: %s\n", page.Slug)
@@ -64,26 +73,59 @@ func buildPagePrompt(page Page, sourceFiles map[string]string, recentGitLog stri
 		sb.WriteString("\n")
 	}
 
-	sb.WriteString(`## Output format
-
-Return ONLY a JSON array of exactly 3 objects. Do not wrap in markdown fences.
-Each object must have these fields and only these fields:
+	sb.WriteString("## Output format\n\n")
+	if target == 1 {
+		sb.WriteString("Return ONLY a JSON array of exactly 1 object. Do not wrap in markdown fences.\n")
+	} else {
+		fmt.Fprintf(&sb, "Return ONLY a JSON array of exactly %d objects. Do not wrap in markdown fences.\n", target)
+	}
+	sb.WriteString(`Each object must have these fields and only these fields:
 
 - "type": one of "addition", "bugfix", "improvement", "refactor"
 - "size": one of "s" (under a day), "m" (one to three days), "l" (more than three days)
 - "title": short imperative sentence, max 80 chars, no trailing period
 - "body": 2 to 5 sentences explaining the problem, the proposed change, and the user-visible impact
 
-Each suggestion must have a unique type — all three types must be different. Sizes may repeat freely: returning all three the same size is fine if that reflects the page.
-
-Example shape (do NOT copy these contents):
-[
-  {"type": "improvement", "size": "s", "title": "...", "body": "..."},
-  {"type": "addition", "size": "m", "title": "...", "body": "..."},
-  {"type": "bugfix", "size": "s", "title": "...", "body": "..."}
-]
 `)
+	if target > 1 {
+		sb.WriteString("Each suggestion must have a unique type — all types must be different. Sizes may repeat freely: returning all of them the same size is fine if that reflects the page.\n\n")
+	} else {
+		sb.WriteString("Pick whichever type best fits the change.\n\n")
+	}
+	sb.WriteString("Example shape (do NOT copy these contents):\n")
+	sb.WriteString(exampleShape(target))
+	sb.WriteString("\n")
 
+	return sb.String()
+}
+
+// exampleShape renders a JSON array example with `target` sample objects so the
+// prompt's example matches the requested count exactly. The first three slots
+// use distinct types; targets above 3 cycle the type field — only the count
+// matters for the example.
+func exampleShape(target int) string {
+	samples := []string{
+		`{"type": "improvement", "size": "s", "title": "...", "body": "..."}`,
+		`{"type": "addition", "size": "m", "title": "...", "body": "..."}`,
+		`{"type": "bugfix", "size": "s", "title": "...", "body": "..."}`,
+	}
+	if target < 1 {
+		target = 1
+	}
+	if target > len(samples) {
+		target = len(samples)
+	}
+	var sb strings.Builder
+	sb.WriteString("[\n")
+	for i := 0; i < target; i++ {
+		sb.WriteString("  ")
+		sb.WriteString(samples[i])
+		if i < target-1 {
+			sb.WriteString(",")
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("]")
 	return sb.String()
 }
 

--- a/internal/suggestions/prompt.go
+++ b/internal/suggestions/prompt.go
@@ -99,27 +99,22 @@ func buildPagePrompt(page Page, sourceFiles map[string]string, recentGitLog stri
 	return sb.String()
 }
 
-// exampleShape renders a JSON array example with `target` sample objects so the
-// prompt's example matches the requested count exactly. The first three slots
-// use distinct types; targets above 3 cycle the type field — only the count
-// matters for the example.
+// exampleShape renders a JSON array example with exactly `target` objects so
+// the prompt's example always matches the requested count. The first three
+// slots use distinct types; additional slots cycle through the type list —
+// only the count matters for the example, not the specific types used.
 func exampleShape(target int) string {
-	samples := []string{
-		`{"type": "improvement", "size": "s", "title": "...", "body": "..."}`,
-		`{"type": "addition", "size": "m", "title": "...", "body": "..."}`,
-		`{"type": "bugfix", "size": "s", "title": "...", "body": "..."}`,
-	}
+	types := []string{"improvement", "addition", "bugfix", "refactor"}
+	sizes := []string{"s", "m", "s", "m"}
 	if target < 1 {
 		target = 1
-	}
-	if target > len(samples) {
-		target = len(samples)
 	}
 	var sb strings.Builder
 	sb.WriteString("[\n")
 	for i := 0; i < target; i++ {
-		sb.WriteString("  ")
-		sb.WriteString(samples[i])
+		t := types[i%len(types)]
+		s := sizes[i%len(sizes)]
+		fmt.Fprintf(&sb, "  {\"type\": %q, \"size\": %q, \"title\": \"...\", \"body\": \"...\"}", t, s)
 		if i < target-1 {
 			sb.WriteString(",")
 		}

--- a/internal/suggestions/rotation.go
+++ b/internal/suggestions/rotation.go
@@ -16,6 +16,39 @@ import (
 // Tune downward if cost-per-run becomes a problem after observing real spend.
 const RotationDefaultN = 20
 
+// MaxPendingPerPage caps the number of pending (un-triaged) suggestions any
+// one page may have. The generator counts only status='pending' rows and asks
+// Claude for exactly the deficit, so a page already at the cap is skipped
+// entirely without spending API budget. Planned, bead_created, and rejected
+// rows do not count — those have been acted on, freeing the slot.
+const MaxPendingPerPage = 3
+
+// FilterUnderCap drops any page from pages whose pending-suggestion count for
+// userID is at or above cap. The relative order of the remaining pages is
+// preserved so the caller can compose this with PickRotation without losing
+// staleness ordering. cap <= 0 disables filtering and returns the input as-is.
+//
+// A page-level error from PendingCountForPage aborts the whole call so the
+// caller can decide whether to retry; partially filtering on a transient DB
+// error would silently shrink the rotation.
+func FilterUnderCap(ctx context.Context, db *sql.DB, userID int64, pages []Page, cap int) ([]Page, error) {
+	if cap <= 0 || len(pages) == 0 {
+		return pages, nil
+	}
+	out := make([]Page, 0, len(pages))
+	for _, p := range pages {
+		n, err := PendingCountForPage(ctx, db, userID, p.Slug)
+		if err != nil {
+			return nil, fmt.Errorf("pending count for %q: %w", p.Slug, err)
+		}
+		if n >= cap {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
 // PickRotation selects up to n pages from eligible, ordered so that the most
 // stale pages run first. The ordering is:
 //  1. Pages with no prior suggestions, alphabetical by slug.

--- a/internal/suggestions/rotation_test.go
+++ b/internal/suggestions/rotation_test.go
@@ -133,6 +133,93 @@ func TestPickRotation_EmptyEligibleReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestFilterUnderCap_DropsCappedPages(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	// Seed alpha at the cap, charlie one over the cap, leave the rest empty.
+	for i := 0; i < MaxPendingPerPage; i++ {
+		seedSuggestionStatus(t, d, "alpha", time.Now(), StatusPending)
+	}
+	for i := 0; i < MaxPendingPerPage+1; i++ {
+		seedSuggestionStatus(t, d, "charlie", time.Now(), StatusPending)
+	}
+	// Bravo has 2 pending → still under the cap.
+	seedSuggestionStatus(t, d, "bravo", time.Now(), StatusPending)
+	seedSuggestionStatus(t, d, "bravo", time.Now(), StatusPending)
+	// Delta has rejected/planned rows that must NOT count toward the cap.
+	for i := 0; i < MaxPendingPerPage; i++ {
+		seedSuggestionStatus(t, d, "delta", time.Now(), StatusRejected)
+	}
+	for i := 0; i < MaxPendingPerPage; i++ {
+		seedSuggestionStatus(t, d, "delta", time.Now(), StatusPlanned)
+	}
+
+	got, err := FilterUnderCap(ctx, d, 1, rotationFixturePages(), MaxPendingPerPage)
+	if err != nil {
+		t.Fatalf("FilterUnderCap: %v", err)
+	}
+	want := []string{"bravo", "delta", "echo"}
+	if !reflect.DeepEqual(slugs(got), want) {
+		t.Fatalf("slugs mismatch: got %v want %v", slugs(got), want)
+	}
+}
+
+func TestFilterUnderCap_PreservesInputOrder(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	// Re-shuffle input order; we want the function to preserve it.
+	input := []Page{
+		{Slug: "echo", Title: "Echo"},
+		{Slug: "alpha", Title: "Alpha"},
+		{Slug: "delta", Title: "Delta"},
+	}
+	got, err := FilterUnderCap(ctx, d, 1, input, MaxPendingPerPage)
+	if err != nil {
+		t.Fatalf("FilterUnderCap: %v", err)
+	}
+	want := []string{"echo", "alpha", "delta"}
+	if !reflect.DeepEqual(slugs(got), want) {
+		t.Fatalf("slugs mismatch: got %v want %v", slugs(got), want)
+	}
+}
+
+func TestFilterUnderCap_NonPositiveCapReturnsInputAsIs(t *testing.T) {
+	d := setupTestDB(t)
+	ctx := context.Background()
+
+	for _, c := range []int{0, -1} {
+		got, err := FilterUnderCap(ctx, d, 1, rotationFixturePages(), c)
+		if err != nil {
+			t.Fatalf("FilterUnderCap c=%d: %v", c, err)
+		}
+		if len(got) != len(rotationFixturePages()) {
+			t.Fatalf("c=%d: expected pass-through, got %v", c, slugs(got))
+		}
+	}
+}
+
+// seedSuggestionStatus inserts a minimal suggestion row with a chosen status,
+// so FilterUnderCap tests can verify that planned/rejected rows do not count
+// toward the cap. The existing seedSuggestion helper hardcodes pending.
+func seedSuggestionStatus(t *testing.T, db *sql.DB, slug string, generatedAt time.Time, status string) {
+	t.Helper()
+	if _, err := Insert(context.Background(), db, Suggestion{
+		UserID:      1,
+		PageSlug:    slug,
+		GeneratedAt: generatedAt,
+		Source:      SourceClaude,
+		Type:        TypeImprovement,
+		Size:        SizeS,
+		Title:       "seed",
+		Body:        "seed body",
+		Status:      status,
+	}); err != nil {
+		t.Fatalf("seed suggestion for %q: %v", slug, err)
+	}
+}
+
 func TestPickRotation_ReturnedSliceIsACopy(t *testing.T) {
 	d := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/suggestions/store.go
+++ b/internal/suggestions/store.go
@@ -210,6 +210,23 @@ func MarkBeadCreated(ctx context.Context, db *sql.DB, id int64, beadID string) e
 	return checkRowsAffected(res, id)
 }
 
+// PendingCountForPage returns the number of pending suggestions a user has for
+// the given page slug. Only status='pending' rows are counted; planned,
+// rejected, and bead_created rows do not contribute. Used to enforce
+// MaxPendingPerPage so a backlog of un-triaged suggestions cannot grow
+// unbounded across nightly rotations.
+func PendingCountForPage(ctx context.Context, db *sql.DB, userID int64, pageSlug string) (int, error) {
+	var n int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM suggestions
+		WHERE user_id = ? AND page_slug = ? AND status = ?
+	`, userID, pageSlug, StatusPending).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count pending for page: %w", err)
+	}
+	return n, nil
+}
+
 // recentForPage returns suggestions for a given page slug whose status is not
 // "rejected" and that were generated within the last `days` days. Used by the
 // generator to discourage repeat suggestions in the prompt.

--- a/web/public/locales/en/suggestions.json
+++ b/web/public/locales/en/suggestions.json
@@ -87,6 +87,7 @@
     "inProgress": "Run in progress: {{done}} / {{total}} pages",
     "pageOk": "{{slug}} ({{count}} ideas, ${{cost}})",
     "pageError": "{{slug}} ({{reason}}, {{seconds}}s)",
+    "pageSkippedCap": "↳ {{slug}} (skipped — already at {{cap}} pending)",
     "alreadyRunning": "A run is already in progress.",
     "alreadyRunningLink": "View recent runs",
     "reconnect": "Reconnect",

--- a/web/public/locales/nb/suggestions.json
+++ b/web/public/locales/nb/suggestions.json
@@ -87,6 +87,7 @@
     "inProgress": "Kjøring pågår: {{done}} / {{total}} sider",
     "pageOk": "{{slug}} ({{count}} idéer, ${{cost}})",
     "pageError": "{{slug}} ({{reason}}, {{seconds}}s)",
+    "pageSkippedCap": "↳ {{slug}} (hoppet over — har allerede {{cap}} ventende)",
     "alreadyRunning": "En kjøring pågår allerede.",
     "alreadyRunningLink": "Vis nylige kjøringer",
     "reconnect": "Koble til på nytt",

--- a/web/public/locales/th/suggestions.json
+++ b/web/public/locales/th/suggestions.json
@@ -87,6 +87,7 @@
     "inProgress": "กำลังทำงาน: {{done}} / {{total}} หน้า",
     "pageOk": "{{slug}} ({{count}} ไอเดีย, ${{cost}})",
     "pageError": "{{slug}} ({{reason}}, {{seconds}} วิ)",
+    "pageSkippedCap": "↳ {{slug}} (ข้าม — มี {{cap}} รายการที่รออยู่แล้ว)",
     "alreadyRunning": "มีการทำงานที่กำลังดำเนินอยู่แล้ว",
     "alreadyRunningLink": "ดูการทำงานล่าสุด",
     "reconnect": "เชื่อมต่อใหม่",

--- a/web/src/pages/Suggestions.test.tsx
+++ b/web/src/pages/Suggestions.test.tsx
@@ -521,6 +521,78 @@ describe('Suggestions – Run now flow', () => {
     })
   })
 
+  it('renders page_skipped_cap entries and counts them toward done', async () => {
+    const initial = { pending: [], planned: [], rejected: [] }
+
+    const stream = manualSSEResponse()
+    let resolveRun: ((v: Response) => void) | null = null
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/suggestions/run' && init?.method === 'POST') {
+        return new Promise<Response>(resolve => {
+          resolveRun = resolve
+        })
+      }
+      if (url === '/api/suggestions') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(initial) })
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Run now/ }))
+    resolveRun!(stream.response)
+
+    stream.push({
+      event: 'started',
+      data: { run_id: 11, total_pages: 2, page_slugs: ['weather', 'webhooks'] },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('0 / 2')
+    })
+
+    stream.push({
+      event: 'page_skipped_cap',
+      data: { page_slug: 'weather', pending_count: 3, cap: 3 },
+    })
+
+    await waitFor(() => {
+      // Skipped pages occupy a rotation slot, so done advances.
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('1 / 2')
+    })
+    expect(screen.getByTestId('run-progress-log-weather')).toHaveTextContent(
+      'weather (skipped — already at 3 pending)',
+    )
+
+    stream.push({
+      event: 'page_complete',
+      data: {
+        page_slug: 'webhooks',
+        generated: 3,
+        errors: 0,
+        cost_usd: 0.05,
+        elapsed_ms: 1500,
+        status: 'ok',
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-progress-pill')).toHaveTextContent('2 / 2')
+    })
+
+    stream.push({
+      event: 'done',
+      data: { run_id: 11, generated: 3, errors: 0, cost_usd: 0.05 },
+    })
+    stream.close()
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('run-progress')).not.toBeInTheDocument()
+    })
+  })
+
   it('shows already-running banner on 409 and does not enter progress state', async () => {
     const initial = { pending: [], planned: [], rejected: [] }
     const fetchMock = vi.fn((url: string, init?: RequestInit) => {

--- a/web/src/pages/Suggestions.tsx
+++ b/web/src/pages/Suggestions.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Lightbulb, Plus, Play, X, AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
+import { Lightbulb, Plus, Play, X, AlertTriangle, CheckCircle2, XCircle, MinusCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../components/ui/skeleton'
 import { Tabs, TabList, TabTrigger, TabPanel } from '../components/ui/tabs'
@@ -23,11 +23,13 @@ interface ListResponse {
 
 interface RunLogEntry {
   slug: string
-  status: 'ok' | 'error'
+  status: 'ok' | 'error' | 'skipped_cap'
   count?: number
   cost?: number
   reason?: string
   seconds?: number
+  cap?: number
+  pendingCount?: number
 }
 
 interface RunProgress {
@@ -52,6 +54,11 @@ interface PageCompleteEvent {
   elapsed_ms: number
   status: 'ok' | 'error'
   error?: string
+}
+interface PageSkippedCapEvent {
+  page_slug: string
+  pending_count: number
+  cap: number
 }
 
 function sortPageSlugs(slugs: string[]): string[] {
@@ -251,6 +258,21 @@ export default function Suggestions() {
         // Refetch the Pending tab so newly persisted suggestions appear as
         // soon as each page finishes.
         refetch()
+        return
+      }
+      if (eventName === 'page_skipped_cap') {
+        const ev = data as PageSkippedCapEvent
+        const entry: RunLogEntry = {
+          slug: ev.page_slug,
+          status: 'skipped_cap',
+          pendingCount: ev.pending_count,
+          cap: ev.cap,
+        }
+        // The page still occupied a rotation slot, so increment done so
+        // the progress bar tracks against total_pages.
+        setRunProgress(p =>
+          p ? { ...p, done: p.done + 1, log: [...p.log, entry] } : p,
+        )
         return
       }
       if (eventName === 'new_page_complete') {
@@ -553,34 +575,47 @@ export default function Suggestions() {
                   data-testid="run-progress-log"
                   className="space-y-1 text-xs"
                 >
-                  {runProgress.log.map((entry, idx) => (
-                    <li
-                      key={`${entry.slug}-${idx}`}
-                      data-testid={`run-progress-log-${entry.slug}`}
-                      className={`flex items-center gap-2 ${
-                        entry.status === 'ok' ? 'text-emerald-300' : 'text-red-300'
-                      }`}
-                    >
-                      {entry.status === 'ok' ? (
-                        <CheckCircle2 size={14} aria-hidden="true" />
-                      ) : (
-                        <XCircle size={14} aria-hidden="true" />
-                      )}
-                      <span className="font-mono">
-                        {entry.status === 'ok'
-                          ? t('run.pageOk', {
-                              slug: entry.slug,
-                              count: entry.count ?? 0,
-                              cost: (entry.cost ?? 0).toFixed(2),
-                            })
-                          : t('run.pageError', {
-                              slug: entry.slug,
-                              reason: entry.reason ?? t('errors.unknown'),
-                              seconds: entry.seconds ?? 0,
-                            })}
-                      </span>
-                    </li>
-                  ))}
+                  {runProgress.log.map((entry, idx) => {
+                    const tone =
+                      entry.status === 'ok'
+                        ? 'text-emerald-300'
+                        : entry.status === 'skipped_cap'
+                          ? 'text-gray-400'
+                          : 'text-red-300'
+                    return (
+                      <li
+                        key={`${entry.slug}-${idx}`}
+                        data-testid={`run-progress-log-${entry.slug}`}
+                        className={`flex items-center gap-2 ${tone}`}
+                      >
+                        {entry.status === 'ok' ? (
+                          <CheckCircle2 size={14} aria-hidden="true" />
+                        ) : entry.status === 'skipped_cap' ? (
+                          <MinusCircle size={14} aria-hidden="true" />
+                        ) : (
+                          <XCircle size={14} aria-hidden="true" />
+                        )}
+                        <span className="font-mono">
+                          {entry.status === 'ok'
+                            ? t('run.pageOk', {
+                                slug: entry.slug,
+                                count: entry.count ?? 0,
+                                cost: (entry.cost ?? 0).toFixed(2),
+                              })
+                            : entry.status === 'skipped_cap'
+                              ? t('run.pageSkippedCap', {
+                                  slug: entry.slug,
+                                  cap: entry.cap ?? 0,
+                                })
+                              : t('run.pageError', {
+                                  slug: entry.slug,
+                                  reason: entry.reason ?? t('errors.unknown'),
+                                  seconds: entry.seconds ?? 0,
+                                })}
+                        </span>
+                      </li>
+                    )
+                  })}
                 </ul>
               )}
             </div>


### PR DESCRIPTION
## Changes

- **Suggestions: cap pending per page and only generate the deficit** - The nightly rotation now caps pending suggestions at 3 per page (configurable in code). Pages already at the cap are skipped pre-rotation, and each picked page only requests the deficit so a backlog cannot grow unbounded across runs. The same cap also gates the new-page pass. The progress UI shows a "skipped — already at 3 pending" entry for any page that hits the cap mid-run. (Hytte-21ph)

## Original Issue (feature): Suggestions: cap pending per page and generate only the deficit

With the rotation now running nightly, suggestions are accumulating faster than the operator can triage. After 2 runs there are already 61 suggestions across the registry. Cap pending per page at a configurable limit (default 3) and only generate the deficit, so a backlog never grows unbounded.

## Behaviour

For each page picked into a run:
- Count the page's existing **pending** suggestions (status='pending').
- `target = max(0, MaxPendingPerPage - pendingCount)`
- If `target == 0`, skip the page entirely (no Claude call, no spend, log a one-line "skip page X — at cap").
- If `target > 0`, ask Claude for exactly `target` suggestions.

`planned` and `bead_created` and `rejected` rows do NOT count against the cap — only `pending`. Rationale: once a suggestion has been planned, beaded, or rejected, it has been acted on; the page is fair game again.

## Two-stage filter

1. **Pre-rotation eligibility**: Before `PickRotation`, drop any page whose pending count is already at the cap. This keeps the rotation slots focused on pages that actually need work.
2. **Per-page target**: Inside `runForPage`, recompute the deficit (in case multiple pages share a slug or the cap was hit between filter and execution) and ask Claude for exactly the deficit count.

## Same cap for new-page suggestions

`RunNewPageSuggestion` should also respect the cap: if pending suggestions with `page_slug='__new_page__'` are at or above the cap, skip the new-page pass for that run. Reuse the same constant.

## Implementation sketch

In `internal/suggestions/`:
- Add `MaxPendingPerPage = 3` constant in `generate.go` (or `rotation.go` — same package).
- In `store.go`, add `PendingCountForPage(ctx, db, userID, pageSlug) (int, error)`. SELECT COUNT(*) FROM suggestions WHERE user_id=? AND page_slug=? AND status='pending'.
- In `rotation.go`, add `FilterUnderCap(ctx, db, userID, pages []Page, cap int) ([]Page, error)`. Drops pages already at or above cap. Used between `RotationEligible` and `PickRotation` in both the manual-run handler (`handlers.go`) and the scheduler goroutine (`cmd/server/main.go`).
- In `runForPage` (generate.go):
    - Compute `target := MaxPendingPerPage - pendingCount` after entering the function. If `<= 0`, log and return (0,0,0,nil).
    - Pass `target` down to `buildPagePrompt`, `callAndParse`, and `parseSuggestionsResponse`. They currently hardcode `3`; thread it through as a parameter.
- In `prompt.go` `buildPagePrompt`: change "Return ONLY a JSON array of exactly 3 objects" to "Return ONLY a JSON array of exactly N objects" (use the target). Update the example shape comment to show 1, 2, or 3 example objects depending on target.
- In `parseSuggestionsResponse`: accept the expected count as an argument; assert `len(items) == expected`. The "distinct types" check still applies for >1 results; it's vacuously true for 1.
- In `new_page.go`: at the top of `RunNewPageSuggestion`, count pending new_page suggestions; if at cap, return zero RunResult and a nil error with a one-line log line.

## Logs and run summary

The streaming run handler emits per-page events. Add a new event variant `page_skipped_cap` with `{ page_slug, pending_count, cap }` so the UI shows when a page is skipped because it's full. The frontend lives in the handler today (Hytte-39fp). Render this in the live progress log alongside the existing ok/error variants.

For the suggestion_runs row, the `page_slugs` CSV should still include skipped pages (so the operator sees what was attempted). The `generated` count won't increase for skipped pages, which is the correct outcome.

## Tests

In `internal/suggestions/`:
- `pending_count_test.go` (or extend store_test): round-trip for `PendingCountForPage`, including ignoring rejected/planned/bead_created statuses.
- `generate_test.go`: 
    - Page with 0 pending → mock Claude returns 3 → 3 inserted.
    - Page with 2 pending → target=1 → mock Claude returns 1 → 1 inserted; assert prompt asked for 1 (string-contains "exactly 1 object").
    - Page with 3 pending → skip; assert Claude was NOT called.
- `rotation_test.go`: `FilterUnderCap` drops capped pages, preserves order.
- `new_page_test.go`: at-cap branch skips entirely.

## i18n

Add to suggestions: namespace in en/nb/th:
- `run.pageSkippedCap` — "↳ {{slug}} (skipped — already at {{cap}} pending)" / Norwegian / Thai.

## Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build` all pass.
- Trigger a manual run twice in succession on a page that started at 0 pending: first run produces 3, second run produces 0 and logs "skipped — already at 3 pending".
- Reject one of the 3, run again: 1 generated.
- Plan one of the 2 remaining: cap math doesn't count it (pending count drops to 1, target = 2 on next run).
- Changelog fragment in changelog.d/ (category: Changed).

## Non-goals

- A configurable per-page cap. Single global constant is fine; revisit if needed.
- Counting planned or bead_created against the cap.
- Auto-pruning old pending suggestions to make room. The user triages.
- Surfacing the cap value in the UI rotation settings panel. Could be a follow-up.

## Reference

- internal/suggestions/generate.go — RunSuggestionsForPages, runForPage, callAndParse, parseSuggestionsResponse.
- internal/suggestions/prompt.go — buildPagePrompt (the "exactly 3" string lives here).
- internal/suggestions/rotation.go — RotationDefaultN, PickRotation; new FilterUnderCap goes here.
- internal/suggestions/new_page.go — RunNewPageSuggestion.
- internal/suggestions/handlers.go — RunHandler (manual run, SSE).
- cmd/server/main.go — nightly scheduler goroutine; needs FilterUnderCap inserted between RotationEligible and PickRotation.
- web/src/components/suggestions/ + Suggestions.tsx — SSE event consumer; add page_skipped_cap variant rendering.


---
Bead: Hytte-21ph | Branch: forge/Hytte-21ph
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)