### PR TITLE
Backend: workout_context schema, model, and CRUD API (Hytte-vj5h)

### DIFF
--- a/changelog.d/Hytte-vj5h.md
+++ b/changelog.d/Hytte-vj5h.md
@@ -1,0 +1,2 @@
+category: Added
+- **Workout context API** - Added per-workout context storage with `GET` and `PUT /api/training/workouts/{id}/context` endpoints for capturing surface, run type, HR source, free-text feel notes, and a structured speed plan. Sensitive fields (feel notes, speed plan JSON) are encrypted at rest. (Hytte-vj5h)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -441,6 +441,8 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Delete("/training/workouts/{id}", training.DeleteHandler(db))
 				r.Get("/training/workouts/{id}/similar", training.SimilarHandler(db))
 				r.Get("/training/workouts/{id}/zones", training.ZonesHandler(db))
+				r.Get("/training/workouts/{id}/context", training.GetWorkoutContext(db))
+				r.Put("/training/workouts/{id}/context", training.PutWorkoutContext(db))
 				r.Get("/training/summary", training.SummaryHandler(db))
 				r.Get("/training/progression", training.ProgressionHandler(db))
 				r.Get("/training/compare", training.CompareHandler(db))

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1574,6 +1574,20 @@ func createSchema(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_suggestion_runs_user_started ON suggestion_runs(user_id, started_at DESC);
 	CREATE INDEX IF NOT EXISTS idx_suggestion_runs_user_inflight ON suggestion_runs(user_id) WHERE finished_at IS NULL;
 
+	-- Per-workout context entered by the user (Hytte-vj5h): surface, run type,
+	-- HR data source, free-text feel notes, and a structured speed plan.
+	-- feel_notes and speed_plan store encrypted strings (speed_plan is encrypted
+	-- JSON, since the segment kinds may contain free-text labels).
+	CREATE TABLE IF NOT EXISTS workout_context (
+		workout_id   INTEGER PRIMARY KEY REFERENCES workouts(id) ON DELETE CASCADE,
+		surface      TEXT NOT NULL DEFAULT '',
+		run_type     TEXT NOT NULL DEFAULT '',
+		hr_source    TEXT NOT NULL DEFAULT '',
+		feel_notes   TEXT NOT NULL DEFAULT '',
+		speed_plan   TEXT NOT NULL DEFAULT '',
+		completed_at TEXT NOT NULL DEFAULT ''
+	);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1576,8 +1576,9 @@ func createSchema(db *sql.DB) error {
 
 	-- Per-workout context entered by the user (Hytte-vj5h): surface, run type,
 	-- HR data source, free-text feel notes, and a structured speed plan.
-	-- feel_notes and speed_plan store encrypted strings (speed_plan is encrypted
-	-- JSON, since the segment kinds may contain free-text labels).
+	-- feel_notes and speed_plan: empty strings are stored as-is (no data);
+	-- non-empty values are stored as enc:... ciphertext (AES-256-GCM via
+	-- EncryptField). speed_plan is encrypted JSON when non-empty.
 	CREATE TABLE IF NOT EXISTS workout_context (
 		workout_id   INTEGER PRIMARY KEY REFERENCES workouts(id) ON DELETE CASCADE,
 		surface      TEXT NOT NULL DEFAULT '',

--- a/internal/training/context_handlers.go
+++ b/internal/training/context_handlers.go
@@ -1,0 +1,192 @@
+package training
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/go-chi/chi/v5"
+)
+
+// GetWorkoutContext handles GET /api/training/workouts/{id}/context.
+// Returns 404 when the workout doesn't exist, isn't owned by the user, or has
+// no context row yet.
+func GetWorkoutContext(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		workoutID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+			return
+		}
+
+		if err := assertWorkoutOwnedBy(db, workoutID, user.ID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "workout not found"})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load workout"})
+			return
+		}
+
+		ctx, err := loadWorkoutContext(db, workoutID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "context not found"})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load context"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"context": ctx})
+	}
+}
+
+// PutWorkoutContext handles PUT /api/training/workouts/{id}/context.
+// Creates the context row if it doesn't exist, otherwise updates the existing row.
+// Returns the persisted context (after encryption round-trip).
+func PutWorkoutContext(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		workoutID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+			return
+		}
+
+		if err := assertWorkoutOwnedBy(db, workoutID, user.ID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "workout not found"})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load workout"})
+			return
+		}
+
+		var body WorkoutContext
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+		body.WorkoutID = workoutID
+		if body.SpeedPlan == nil {
+			body.SpeedPlan = []SpeedSegment{}
+		}
+
+		if err := saveWorkoutContext(db, &body); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save context"})
+			return
+		}
+
+		saved, err := loadWorkoutContext(db, workoutID)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load context"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"context": saved})
+	}
+}
+
+// assertWorkoutOwnedBy returns sql.ErrNoRows when the workout doesn't exist or
+// isn't owned by the given user. Used as a precondition for context reads/writes.
+func assertWorkoutOwnedBy(db *sql.DB, workoutID, userID int64) error {
+	var exists int
+	return db.QueryRow(
+		`SELECT 1 FROM workouts WHERE id = ? AND user_id = ?`,
+		workoutID, userID,
+	).Scan(&exists)
+}
+
+// loadWorkoutContext fetches and decrypts the workout_context row for a workout.
+// Returns sql.ErrNoRows when no context exists for the workout.
+func loadWorkoutContext(db *sql.DB, workoutID int64) (*WorkoutContext, error) {
+	var (
+		feelEnc, planEnc string
+		completedAt      string
+	)
+	ctx := &WorkoutContext{WorkoutID: workoutID, SpeedPlan: []SpeedSegment{}}
+	err := db.QueryRow(`
+		SELECT surface, run_type, hr_source, feel_notes, speed_plan, completed_at
+		FROM workout_context
+		WHERE workout_id = ?`, workoutID).Scan(
+		&ctx.Surface, &ctx.RunType, &ctx.HRSource, &feelEnc, &planEnc, &completedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	feelNotes, err := encryption.DecryptField(feelEnc)
+	if err != nil {
+		return nil, err
+	}
+	ctx.FeelNotes = feelNotes
+
+	planJSON, err := encryption.DecryptField(planEnc)
+	if err != nil {
+		return nil, err
+	}
+	if planJSON != "" {
+		var segments []SpeedSegment
+		if err := json.Unmarshal([]byte(planJSON), &segments); err != nil {
+			return nil, err
+		}
+		if segments == nil {
+			segments = []SpeedSegment{}
+		}
+		ctx.SpeedPlan = segments
+	}
+
+	if completedAt != "" {
+		if parsed, err := time.Parse(time.RFC3339, completedAt); err == nil {
+			ctx.CompletedAt = &parsed
+		}
+	}
+
+	return ctx, nil
+}
+
+// saveWorkoutContext upserts the workout_context row. feel_notes and the
+// JSON-encoded speed_plan are encrypted before storage.
+func saveWorkoutContext(db *sql.DB, ctx *WorkoutContext) error {
+	feelEnc, err := encryption.EncryptField(ctx.FeelNotes)
+	if err != nil {
+		return err
+	}
+
+	var planJSON string
+	if len(ctx.SpeedPlan) > 0 {
+		raw, err := json.Marshal(ctx.SpeedPlan)
+		if err != nil {
+			return err
+		}
+		planJSON = string(raw)
+	}
+	planEnc, err := encryption.EncryptField(planJSON)
+	if err != nil {
+		return err
+	}
+
+	var completedAt string
+	if ctx.CompletedAt != nil {
+		completedAt = ctx.CompletedAt.UTC().Format(time.RFC3339)
+	}
+
+	_, err = db.Exec(`
+		INSERT INTO workout_context (workout_id, surface, run_type, hr_source, feel_notes, speed_plan, completed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(workout_id) DO UPDATE SET
+			surface      = excluded.surface,
+			run_type     = excluded.run_type,
+			hr_source    = excluded.hr_source,
+			feel_notes   = excluded.feel_notes,
+			speed_plan   = excluded.speed_plan,
+			completed_at = excluded.completed_at`,
+		ctx.WorkoutID, ctx.Surface, ctx.RunType, ctx.HRSource, feelEnc, planEnc, completedAt,
+	)
+	return err
+}

--- a/internal/training/context_handlers.go
+++ b/internal/training/context_handlers.go
@@ -47,8 +47,21 @@ func GetWorkoutContext(db *sql.DB) http.HandlerFunc {
 	}
 }
 
+// putWorkoutContextRequest is the request body for PUT /context. All fields are
+// pointers so that absent JSON fields are distinguishable from zero values.
+// Omitted fields leave the existing persisted value unchanged.
+type putWorkoutContextRequest struct {
+	Surface     *string         `json:"surface"`
+	RunType     *string         `json:"run_type"`
+	HRSource    *string         `json:"hr_source"`
+	FeelNotes   *string         `json:"feel_notes"`
+	SpeedPlan   *[]SpeedSegment `json:"speed_plan"`
+	CompletedAt *time.Time      `json:"completed_at"`
+}
+
 // PutWorkoutContext handles PUT /api/training/workouts/{id}/context.
-// Creates the context row if it doesn't exist, otherwise updates the existing row.
+// Creates the context row if it doesn't exist, otherwise merges the provided
+// fields into the existing row so that omitted fields are not wiped.
 // Returns the persisted context (after encryption round-trip).
 func PutWorkoutContext(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -68,17 +81,46 @@ func PutWorkoutContext(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		var body WorkoutContext
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		var req putWorkoutContextRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
 			return
 		}
-		body.WorkoutID = workoutID
-		if body.SpeedPlan == nil {
-			body.SpeedPlan = []SpeedSegment{}
+
+		// Load existing context or start with defaults so omitted request
+		// fields preserve their previously saved values.
+		ctx, err := loadWorkoutContext(db, workoutID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load context"})
+			return
+		}
+		if ctx == nil {
+			ctx = &WorkoutContext{WorkoutID: workoutID, SpeedPlan: []SpeedSegment{}}
 		}
 
-		if err := saveWorkoutContext(db, &body); err != nil {
+		if req.Surface != nil {
+			ctx.Surface = *req.Surface
+		}
+		if req.RunType != nil {
+			ctx.RunType = *req.RunType
+		}
+		if req.HRSource != nil {
+			ctx.HRSource = *req.HRSource
+		}
+		if req.FeelNotes != nil {
+			ctx.FeelNotes = *req.FeelNotes
+		}
+		if req.SpeedPlan != nil {
+			ctx.SpeedPlan = *req.SpeedPlan
+		}
+		if req.CompletedAt != nil {
+			ctx.CompletedAt = req.CompletedAt
+		}
+		if ctx.SpeedPlan == nil {
+			ctx.SpeedPlan = []SpeedSegment{}
+		}
+
+		if err := saveWorkoutContext(db, ctx); err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save context"})
 			return
 		}

--- a/internal/training/context_handlers_test.go
+++ b/internal/training/context_handlers_test.go
@@ -1,0 +1,227 @@
+package training
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func createWorkoutForUser(t *testing.T, database *sql.DB, userID int64, hash string) int64 {
+	t.Helper()
+	pw := &ParsedWorkout{
+		Sport:           "running",
+		DurationSeconds: 1800,
+		DistanceMeters:  5000,
+		AvgHeartRate:    140,
+	}
+	workout, err := Create(database, userID, pw, hash)
+	if err != nil {
+		t.Fatalf("create workout: %v", err)
+	}
+	return workout.ID
+}
+
+func putContext(t *testing.T, database *sql.DB, userID, workoutID int64, body WorkoutContext) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/training/workouts/"+strconv.FormatInt(workoutID, 10)+"/context", bytes.NewReader(raw))
+	req = withUser(req, userID)
+	req = withChiParam(req, "id", strconv.FormatInt(workoutID, 10))
+	w := httptest.NewRecorder()
+	PutWorkoutContext(database)(w, req)
+	return w
+}
+
+func getContext(t *testing.T, database *sql.DB, userID, workoutID int64) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/training/workouts/"+strconv.FormatInt(workoutID, 10)+"/context", nil)
+	req = withUser(req, userID)
+	req = withChiParam(req, "id", strconv.FormatInt(workoutID, 10))
+	w := httptest.NewRecorder()
+	GetWorkoutContext(database)(w, req)
+	return w
+}
+
+func decodeContext(t *testing.T, body []byte) WorkoutContext {
+	t.Helper()
+	var wrapper struct {
+		Context WorkoutContext `json:"context"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err != nil {
+		t.Fatalf("unmarshal context: %v (body=%s)", err, string(body))
+	}
+	return wrapper.Context
+}
+
+func TestPutWorkoutContext_CreatesAndDecryptsRoundTrip(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "ctx-create-hash")
+
+	body := WorkoutContext{
+		Surface:   "trail",
+		RunType:   "tempo",
+		HRSource:  "chest_strap",
+		FeelNotes: "Felt strong on the climbs, legs heavy late.",
+		SpeedPlan: []SpeedSegment{
+			{Kind: "warmup", SpeedKmph: 9.0, DurationSec: 600, Repeats: 1},
+			{Kind: "work", SpeedKmph: 14.5, DurationSec: 180, Repeats: 6},
+			{Kind: "recovery", SpeedKmph: 8.0, DurationSec: 90, Repeats: 6, SameAsPrevious: true},
+		},
+	}
+
+	w := putContext(t, database, 1, workoutID, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT: expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	saved := decodeContext(t, w.Body.Bytes())
+	if saved.WorkoutID != workoutID {
+		t.Fatalf("expected workout_id=%d, got %d", workoutID, saved.WorkoutID)
+	}
+	if saved.FeelNotes != body.FeelNotes {
+		t.Fatalf("feel_notes round-trip failed: %q vs %q", saved.FeelNotes, body.FeelNotes)
+	}
+	if len(saved.SpeedPlan) != len(body.SpeedPlan) {
+		t.Fatalf("speed_plan length mismatch: got %d, want %d", len(saved.SpeedPlan), len(body.SpeedPlan))
+	}
+	if saved.SpeedPlan[1].Kind != "work" || saved.SpeedPlan[1].SpeedKmph != 14.5 {
+		t.Fatalf("speed_plan[1] mismatch: %+v", saved.SpeedPlan[1])
+	}
+	if !saved.SpeedPlan[2].SameAsPrevious {
+		t.Fatalf("expected same_as_previous=true on segment 2, got %+v", saved.SpeedPlan[2])
+	}
+
+	// GET should return the same data.
+	gw := getContext(t, database, 1, workoutID)
+	if gw.Code != http.StatusOK {
+		t.Fatalf("GET: expected 200, got %d", gw.Code)
+	}
+	got := decodeContext(t, gw.Body.Bytes())
+	if got.FeelNotes != body.FeelNotes {
+		t.Fatalf("GET feel_notes mismatch: %q vs %q", got.FeelNotes, body.FeelNotes)
+	}
+
+	// Verify ciphertext at rest — the raw DB value must not contain the plaintext.
+	var feelEnc, planEnc string
+	err := database.QueryRow(`SELECT feel_notes, speed_plan FROM workout_context WHERE workout_id = ?`, workoutID).Scan(&feelEnc, &planEnc)
+	if err != nil {
+		t.Fatalf("query encrypted columns: %v", err)
+	}
+	if strings.Contains(feelEnc, body.FeelNotes) {
+		t.Fatalf("feel_notes stored in plaintext: %s", feelEnc)
+	}
+	if !strings.HasPrefix(feelEnc, "enc:") {
+		t.Fatalf("expected feel_notes to be encrypted (enc: prefix), got %q", feelEnc)
+	}
+	if !strings.HasPrefix(planEnc, "enc:") {
+		t.Fatalf("expected speed_plan to be encrypted (enc: prefix), got %q", planEnc)
+	}
+	if strings.Contains(planEnc, "warmup") || strings.Contains(planEnc, "tempo") {
+		t.Fatalf("speed_plan stored in plaintext: %s", planEnc)
+	}
+}
+
+func TestPutWorkoutContext_UpdatesExistingRow(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "ctx-update-hash")
+
+	first := WorkoutContext{
+		Surface:   "road",
+		RunType:   "easy",
+		HRSource:  "wrist",
+		FeelNotes: "First note",
+		SpeedPlan: []SpeedSegment{{Kind: "steady", SpeedKmph: 10.0, DurationSec: 1800, Repeats: 1}},
+	}
+	if w := putContext(t, database, 1, workoutID, first); w.Code != http.StatusOK {
+		t.Fatalf("first PUT: expected 200, got %d", w.Code)
+	}
+
+	second := WorkoutContext{
+		Surface:   "trail",
+		RunType:   "long",
+		HRSource:  "chest_strap",
+		FeelNotes: "Updated note",
+		SpeedPlan: []SpeedSegment{{Kind: "steady", SpeedKmph: 9.5, DurationSec: 3600, Repeats: 1}},
+	}
+	w := putContext(t, database, 1, workoutID, second)
+	if w.Code != http.StatusOK {
+		t.Fatalf("second PUT: expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+
+	gw := getContext(t, database, 1, workoutID)
+	if gw.Code != http.StatusOK {
+		t.Fatalf("GET: expected 200, got %d", gw.Code)
+	}
+	got := decodeContext(t, gw.Body.Bytes())
+	if got.Surface != "trail" || got.RunType != "long" || got.HRSource != "chest_strap" {
+		t.Fatalf("plain fields not updated: %+v", got)
+	}
+	if got.FeelNotes != "Updated note" {
+		t.Fatalf("feel_notes not updated: %q", got.FeelNotes)
+	}
+	if len(got.SpeedPlan) != 1 || got.SpeedPlan[0].SpeedKmph != 9.5 || got.SpeedPlan[0].DurationSec != 3600 {
+		t.Fatalf("speed_plan not updated: %+v", got.SpeedPlan)
+	}
+
+	// Confirm only one row exists.
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM workout_context WHERE workout_id = ?`, workoutID).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 context row after update, got %d", count)
+	}
+}
+
+func TestGetWorkoutContext_MissingContextReturns404(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "ctx-missing-hash")
+
+	w := getContext(t, database, 1, workoutID)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing context, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestGetWorkoutContext_DifferentUserGets404(t *testing.T) {
+	database := setupTestDB(t)
+	if _, err := database.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (2, 'other@example.com', 'Other', 'google-2')`); err != nil {
+		t.Fatalf("create second user: %v", err)
+	}
+	workoutID := createWorkoutForUser(t, database, 1, "ctx-cross-user-hash")
+
+	// User 1 saves context.
+	body := WorkoutContext{Surface: "road", RunType: "easy", HRSource: "wrist", FeelNotes: "private"}
+	if w := putContext(t, database, 1, workoutID, body); w.Code != http.StatusOK {
+		t.Fatalf("PUT (user 1): expected 200, got %d", w.Code)
+	}
+
+	// User 2 must not be able to read or write that workout.
+	if w := getContext(t, database, 2, workoutID); w.Code != http.StatusNotFound {
+		t.Fatalf("GET (user 2): expected 404, got %d", w.Code)
+	}
+	if w := putContext(t, database, 2, workoutID, body); w.Code != http.StatusNotFound {
+		t.Fatalf("PUT (user 2): expected 404, got %d", w.Code)
+	}
+}
+
+func TestPutWorkoutContext_InvalidJSON(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "ctx-invalid-json-hash")
+
+	req := httptest.NewRequest(http.MethodPut, "/api/training/workouts/"+strconv.FormatInt(workoutID, 10)+"/context", strings.NewReader("{not json"))
+	req = withUser(req, 1)
+	req = withChiParam(req, "id", strconv.FormatInt(workoutID, 10))
+	w := httptest.NewRecorder()
+	PutWorkoutContext(database)(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}

--- a/internal/training/models.go
+++ b/internal/training/models.go
@@ -334,3 +334,27 @@ type SportDistribution struct {
 	Count         int    `json:"count"`
 	TotalDuration int    `json:"total_duration_seconds"`
 }
+
+// SpeedSegment is one entry in a planned workout's speed_plan: a steady portion,
+// an interval rep, or a recovery block. SameAsPrevious lets the UI compress
+// repeated segments without duplicating their fields.
+type SpeedSegment struct {
+	Kind            string  `json:"kind"`
+	SpeedKmph       float64 `json:"speed_kmph"`
+	DurationSec     int     `json:"duration_sec"`
+	Repeats         int     `json:"repeats"`
+	SameAsPrevious  bool    `json:"same_as_previous"`
+}
+
+// WorkoutContext is the user-entered context for a single workout: surface,
+// run type, HR source, free-text feel notes, and a structured speed plan.
+// Sensitive text fields (feel_notes, speed_plan JSON) are encrypted at rest.
+type WorkoutContext struct {
+	WorkoutID   int64          `json:"workout_id"`
+	Surface     string         `json:"surface"`
+	RunType     string         `json:"run_type"`
+	HRSource    string         `json:"hr_source"`
+	FeelNotes   string         `json:"feel_notes"`
+	SpeedPlan   []SpeedSegment `json:"speed_plan"`
+	CompletedAt *time.Time     `json:"completed_at,omitempty"`
+}


### PR DESCRIPTION
## Changes

- **Workout context API** - Added per-workout context storage with `GET` and `PUT /api/training/workouts/{id}/context` endpoints for capturing surface, run type, HR source, free-text feel notes, and a structured speed plan. Sensitive fields (feel notes, speed plan JSON) are encrypted at rest. (Hytte-vj5h)

## Original Issue (task): Backend: workout_context schema, model, and CRUD API

Create the persistence and HTTP layer for per-workout context. Add `workout_context` table in `internal/db/db.go` via `CREATE TABLE IF NOT EXISTS` with columns: workout_id (PK/FK), surface, run_type, hr_source, feel_notes (encrypted), speed_plan (JSON, encrypted free-text portions), completed_at. Add `WorkoutContext` and `SpeedSegment` structs in `internal/training/models.go` (SpeedSegment fields: kind, speed_kmph, duration_sec, repeats, same_as_previous bool). Create `internal/training/context_handlers.go` exposing `GET /api/training/workouts/{id}/context` and `PUT /api/training/workouts/{id}/context`, applying `encryption.EncryptField` on write and decrypt on read. Register routes in `internal/api/router.go` under `RequireAuth` + `RequireFeature("training")`. Add `internal/training/context_handlers_test.go` covering create/update/get with encryption round-trip. This sub-task is the foundation that the analysis-gating and frontend modal depend on — it must define the storage shape and JSON contract first.

---
Bead: Hytte-vj5h | Branch: forge/Hytte-vj5h
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)