### PR TITLE
Build SpeedPlanEditor segment list component with same-speed collapse (Hytte-z225)

### DIFF
--- a/changelog.d/Hytte-z225.md
+++ b/changelog.d/Hytte-z225.md
@@ -1,0 +1,2 @@
+category: Added
+- **Speed plan editor for treadmill workouts** - Workout context modal now offers a structured editor when Treadmill is selected, supporting warm-up, interval, pause and cool-down segments with a same-speed-for-intervals collapse toggle and a shared pause speed/duration that propagates to every pause segment. (Hytte-z225)

--- a/web/public/locales/en/training.json
+++ b/web/public/locales/en/training.json
@@ -340,6 +340,22 @@
       "pacing_issue": "Pacing issue"
     }
   },
+  "speedPlan": {
+    "kinds": {
+      "warmup": "Warm-up",
+      "interval": "Interval",
+      "pause": "Pause",
+      "cooldown": "Cool-down"
+    },
+    "add": "Add segment",
+    "addKindLabel": "Kind",
+    "removeRow": "Remove segment",
+    "sameSpeedToggle": "Same speed for all intervals",
+    "sharedIntervalSpeed": "Shared interval speed",
+    "sharedPause": "Pause / gap",
+    "kmh": "km/h",
+    "sec": "sec"
+  },
   "workoutContextModal": {
     "title": "Workout context",
     "surface": {
@@ -362,8 +378,7 @@
       "placeholder": "How did the workout feel? Anything notable?"
     },
     "speedPlan": {
-      "label": "Speed plan",
-      "placeholder": "Speed plan editor coming soon."
+      "label": "Speed plan"
     },
     "save": "Save",
     "saving": "Saving...",

--- a/web/public/locales/nb/training.json
+++ b/web/public/locales/nb/training.json
@@ -340,6 +340,22 @@
       "pacing_issue": "Tempoproblemer"
     }
   },
+  "speedPlan": {
+    "kinds": {
+      "warmup": "Oppvarming",
+      "interval": "Intervall",
+      "pause": "Pause",
+      "cooldown": "Nedjogg"
+    },
+    "add": "Legg til segment",
+    "addKindLabel": "Type",
+    "removeRow": "Fjern segment",
+    "sameSpeedToggle": "Samme fart for alle intervaller",
+    "sharedIntervalSpeed": "Felles intervallfart",
+    "sharedPause": "Pause / hvile",
+    "kmh": "km/t",
+    "sec": "sek"
+  },
   "workoutContextModal": {
     "title": "Øktkontekst",
     "surface": {

--- a/web/public/locales/th/training.json
+++ b/web/public/locales/th/training.json
@@ -340,6 +340,22 @@
       "pacing_issue": "ปัญหาเพส"
     }
   },
+  "speedPlan": {
+    "kinds": {
+      "warmup": "วอร์มอัป",
+      "interval": "อินเทอร์วัล",
+      "pause": "พัก",
+      "cooldown": "คูลดาวน์"
+    },
+    "add": "เพิ่มเซ็กเมนต์",
+    "addKindLabel": "ประเภท",
+    "removeRow": "ลบเซ็กเมนต์",
+    "sameSpeedToggle": "ใช้ความเร็วเดียวกันสำหรับทุกอินเทอร์วัล",
+    "sharedIntervalSpeed": "ความเร็วอินเทอร์วัลร่วม",
+    "sharedPause": "พัก / ช่วงพัก",
+    "kmh": "กม./ชม.",
+    "sec": "วินาที"
+  },
   "workoutContextModal": {
     "title": "บริบทของการฝึกซ้อม",
     "surface": {

--- a/web/src/components/training/SpeedPlanEditor.tsx
+++ b/web/src/components/training/SpeedPlanEditor.tsx
@@ -1,0 +1,267 @@
+import { useId, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Plus, Trash2 } from 'lucide-react'
+
+export type SpeedPlanSegmentKind = 'warmup' | 'interval' | 'pause' | 'cooldown'
+
+export interface SpeedPlanSegment {
+  kind: SpeedPlanSegmentKind | string
+  speed_kmph: number
+  duration_sec: number
+  repeats: number
+  same_as_previous: boolean
+}
+
+interface SpeedPlanEditorProps {
+  value: SpeedPlanSegment[]
+  onChange: (segments: SpeedPlanSegment[]) => void
+}
+
+const KIND_OPTIONS: SpeedPlanSegmentKind[] = ['warmup', 'interval', 'pause', 'cooldown']
+
+function emptySegment(kind: SpeedPlanSegmentKind): SpeedPlanSegment {
+  return { kind, speed_kmph: 0, duration_sec: 0, repeats: 1, same_as_previous: false }
+}
+
+function safeNumber(raw: string): number {
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 0 ? n : 0
+}
+
+export default function SpeedPlanEditor({ value, onChange }: SpeedPlanEditorProps) {
+  const { t } = useTranslation('training')
+  const sharedIntervalSpeedId = useId()
+  const sharedPauseSpeedId = useId()
+  const sharedPauseDurationId = useId()
+  const addKindId = useId()
+
+  const intervalSegments = useMemo(() => value.filter(s => s.kind === 'interval'), [value])
+  const pauseSegments = useMemo(() => value.filter(s => s.kind === 'pause'), [value])
+
+  const [sameSpeedForIntervals, setSameSpeedForIntervals] = useState(true)
+  const [addKind, setAddKind] = useState<SpeedPlanSegmentKind>('interval')
+
+  const sharedIntervalSpeed = intervalSegments[0]?.speed_kmph ?? 0
+  const sharedPauseSpeed = pauseSegments[0]?.speed_kmph ?? 0
+  const sharedPauseDuration = pauseSegments[0]?.duration_sec ?? 0
+
+  function updateSegment(index: number, patch: Partial<SpeedPlanSegment>) {
+    const next = value.map((seg, i) => (i === index ? { ...seg, ...patch } : seg))
+    onChange(next)
+  }
+
+  function updateAllOfKind(kind: SpeedPlanSegmentKind, patch: Partial<SpeedPlanSegment>) {
+    const next = value.map(seg => (seg.kind === kind ? { ...seg, ...patch } : seg))
+    onChange(next)
+  }
+
+  function appendSegment(kind: SpeedPlanSegmentKind) {
+    const seed = emptySegment(kind)
+    if (kind === 'interval' && sameSpeedForIntervals && intervalSegments.length > 0) {
+      seed.speed_kmph = sharedIntervalSpeed
+    }
+    if (kind === 'pause' && pauseSegments.length > 0) {
+      seed.speed_kmph = sharedPauseSpeed
+      seed.duration_sec = sharedPauseDuration
+    }
+    onChange([...value, seed])
+  }
+
+  function removeSegment(index: number) {
+    onChange(value.filter((_, i) => i !== index))
+  }
+
+  function handleSameSpeedToggle(next: boolean) {
+    setSameSpeedForIntervals(next)
+    if (next && intervalSegments.length > 0) {
+      updateAllOfKind('interval', { speed_kmph: sharedIntervalSpeed })
+    }
+  }
+
+  function kindLabel(kind: string): string {
+    if (KIND_OPTIONS.includes(kind as SpeedPlanSegmentKind)) {
+      return t(`speedPlan.kinds.${kind}`)
+    }
+    return kind
+  }
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="speed-plan-editor">
+      <label className="flex items-center gap-2 text-sm text-gray-300">
+        <input
+          type="checkbox"
+          checked={sameSpeedForIntervals}
+          onChange={(e) => handleSameSpeedToggle(e.target.checked)}
+          data-testid="speed-plan-same-speed-toggle"
+          className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-blue-500 focus:ring-blue-500"
+        />
+        <span>{t('speedPlan.sameSpeedToggle')}</span>
+      </label>
+
+      {sameSpeedForIntervals && intervalSegments.length > 0 && (
+        <div className="rounded border border-gray-700 bg-gray-800/40 p-3">
+          <label htmlFor={sharedIntervalSpeedId} className="block text-xs font-medium text-gray-300">
+            {t('speedPlan.sharedIntervalSpeed')}
+          </label>
+          <div className="mt-1 flex items-center gap-2">
+            <input
+              id={sharedIntervalSpeedId}
+              type="number"
+              min={0}
+              step="0.1"
+              value={sharedIntervalSpeed}
+              onChange={(e) =>
+                updateAllOfKind('interval', { speed_kmph: safeNumber(e.target.value) })
+              }
+              data-testid="speed-plan-shared-interval-speed"
+              className="w-24 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
+            />
+            <span className="text-xs text-gray-400">{t('speedPlan.kmh')}</span>
+          </div>
+        </div>
+      )}
+
+      {pauseSegments.length > 0 && (
+        <div className="rounded border border-gray-700 bg-gray-800/40 p-3">
+          <span className="block text-xs font-medium text-gray-300">
+            {t('speedPlan.sharedPause')}
+          </span>
+          <div className="mt-1 flex flex-wrap items-end gap-3">
+            <div className="flex flex-col">
+              <label htmlFor={sharedPauseSpeedId} className="text-[11px] text-gray-400">
+                {t('speedPlan.kmh')}
+              </label>
+              <input
+                id={sharedPauseSpeedId}
+                type="number"
+                min={0}
+                step="0.1"
+                value={sharedPauseSpeed}
+                onChange={(e) =>
+                  updateAllOfKind('pause', { speed_kmph: safeNumber(e.target.value) })
+                }
+                data-testid="speed-plan-shared-pause-speed"
+                className="w-24 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
+              />
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor={sharedPauseDurationId} className="text-[11px] text-gray-400">
+                {t('speedPlan.sec')}
+              </label>
+              <input
+                id={sharedPauseDurationId}
+                type="number"
+                min={0}
+                step={1}
+                value={sharedPauseDuration}
+                onChange={(e) =>
+                  updateAllOfKind('pause', { duration_sec: Math.round(safeNumber(e.target.value)) })
+                }
+                data-testid="speed-plan-shared-pause-duration"
+                className="w-24 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <ul className="flex flex-col gap-2">
+        {value.map((seg, index) => {
+          const isInterval = seg.kind === 'interval'
+          const isPause = seg.kind === 'pause'
+          const hideSpeed = (isInterval && sameSpeedForIntervals) || isPause
+          const hideDuration = isPause
+          const speedInputId = `speed-plan-row-${index}-speed`
+          const durationInputId = `speed-plan-row-${index}-duration`
+          return (
+            <li
+              key={index}
+              data-testid={`speed-plan-row-${index}`}
+              className="flex flex-wrap items-end gap-2 rounded border border-gray-800 bg-gray-900/40 p-2"
+            >
+              <span className="min-w-[5rem] text-xs font-medium uppercase tracking-wide text-gray-400">
+                {kindLabel(seg.kind)}
+              </span>
+
+              {!hideSpeed && (
+                <div className="flex flex-col">
+                  <label htmlFor={speedInputId} className="text-[11px] text-gray-400">
+                    {t('speedPlan.kmh')}
+                  </label>
+                  <input
+                    id={speedInputId}
+                    type="number"
+                    min={0}
+                    step="0.1"
+                    value={seg.speed_kmph}
+                    onChange={(e) => updateSegment(index, { speed_kmph: safeNumber(e.target.value) })}
+                    data-testid={`speed-plan-row-${index}-speed`}
+                    className="w-24 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+              )}
+
+              {!hideDuration && (
+                <div className="flex flex-col">
+                  <label htmlFor={durationInputId} className="text-[11px] text-gray-400">
+                    {t('speedPlan.sec')}
+                  </label>
+                  <input
+                    id={durationInputId}
+                    type="number"
+                    min={0}
+                    step={1}
+                    value={seg.duration_sec}
+                    onChange={(e) =>
+                      updateSegment(index, { duration_sec: Math.round(safeNumber(e.target.value)) })
+                    }
+                    data-testid={`speed-plan-row-${index}-duration`}
+                    className="w-24 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+              )}
+
+              <button
+                type="button"
+                onClick={() => removeSegment(index)}
+                aria-label={t('speedPlan.removeRow')}
+                data-testid={`speed-plan-row-${index}-remove`}
+                className="ml-auto inline-flex h-9 items-center justify-center rounded px-2 text-gray-400 hover:bg-gray-800 hover:text-red-400"
+              >
+                <Trash2 size={16} />
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <label htmlFor={addKindId} className="text-xs text-gray-400">
+          {t('speedPlan.addKindLabel')}
+        </label>
+        <select
+          id={addKindId}
+          value={addKind}
+          onChange={(e) => setAddKind(e.target.value as SpeedPlanSegmentKind)}
+          data-testid="speed-plan-add-kind"
+          className="rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
+        >
+          {KIND_OPTIONS.map((kind) => (
+            <option key={kind} value={kind}>
+              {t(`speedPlan.kinds.${kind}`)}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => appendSegment(addKind)}
+          data-testid="speed-plan-add"
+          className="inline-flex min-h-[36px] items-center gap-1 rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-500"
+        >
+          <Plus size={16} />
+          <span>{t('speedPlan.add')}</span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/training/SpeedPlanEditor.tsx
+++ b/web/src/components/training/SpeedPlanEditor.tsx
@@ -5,7 +5,7 @@ import { Plus, Trash2 } from 'lucide-react'
 export type SpeedPlanSegmentKind = 'warmup' | 'interval' | 'pause' | 'cooldown'
 
 export interface SpeedPlanSegment {
-  kind: SpeedPlanSegmentKind | string
+  kind: string
   speed_kmph: number
   duration_sec: number
   repeats: number

--- a/web/src/components/training/SpeedPlanEditor.tsx
+++ b/web/src/components/training/SpeedPlanEditor.tsx
@@ -38,7 +38,11 @@ export default function SpeedPlanEditor({ value, onChange }: SpeedPlanEditorProp
   const intervalSegments = useMemo(() => value.filter(s => s.kind === 'interval'), [value])
   const pauseSegments = useMemo(() => value.filter(s => s.kind === 'pause'), [value])
 
-  const [sameSpeedForIntervals, setSameSpeedForIntervals] = useState(true)
+  const [sameSpeedForIntervals, setSameSpeedForIntervals] = useState(() => {
+    const intervals = value.filter(s => s.kind === 'interval')
+    if (intervals.length <= 1) return true
+    return intervals.every(s => s.speed_kmph === intervals[0].speed_kmph)
+  })
   const [addKind, setAddKind] = useState<SpeedPlanSegmentKind>('interval')
 
   const sharedIntervalSpeed = intervalSegments[0]?.speed_kmph ?? 0

--- a/web/src/components/training/SpeedPlanEditor.tsx
+++ b/web/src/components/training/SpeedPlanEditor.tsx
@@ -1,16 +1,9 @@
 import { useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Plus, Trash2 } from 'lucide-react'
+import type { SpeedPlanSegment, SpeedPlanSegmentKind } from '../../types/training'
 
-export type SpeedPlanSegmentKind = 'warmup' | 'interval' | 'pause' | 'cooldown'
-
-export interface SpeedPlanSegment {
-  kind: string
-  speed_kmph: number
-  duration_sec: number
-  repeats: number
-  same_as_previous: boolean
-}
+export type { SpeedPlanSegment, SpeedPlanSegmentKind }
 
 interface SpeedPlanEditorProps {
   value: SpeedPlanSegment[]

--- a/web/src/components/training/SpeedPlanEditor.tsx
+++ b/web/src/components/training/SpeedPlanEditor.tsx
@@ -80,7 +80,7 @@ export default function SpeedPlanEditor({ value, onChange }: SpeedPlanEditorProp
 
   function kindLabel(kind: string): string {
     if (KIND_OPTIONS.includes(kind as SpeedPlanSegmentKind)) {
-      return t(`speedPlan.kinds.${kind}`)
+      return t(`speedPlan.kinds.${kind as SpeedPlanSegmentKind}`)
     }
     return kind
   }

--- a/web/src/components/training/WorkoutContextModal.test.tsx
+++ b/web/src/components/training/WorkoutContextModal.test.tsx
@@ -340,6 +340,38 @@ describe('WorkoutContextModal', () => {
       ])
     })
 
+    it('initializes same-speed toggle to false when interval speeds differ', () => {
+      openTreadmillModal([
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+        { kind: 'interval', speed_kmph: 16, duration_sec: 60, repeats: 1, same_as_previous: false },
+      ])
+
+      const toggle = screen.getByTestId('speed-plan-same-speed-toggle') as HTMLInputElement
+      expect(toggle.checked).toBe(false)
+      // Per-row speed inputs should be visible for each interval
+      expect(screen.getByTestId('speed-plan-row-0-speed')).toBeTruthy()
+      expect(screen.getByTestId('speed-plan-row-1-speed')).toBeTruthy()
+      // Shared speed input should not be rendered while toggle is off
+      expect(screen.queryByTestId('speed-plan-shared-interval-speed')).toBeNull()
+    })
+
+    it('normalizes inconsistent pause segments to first pause values on mount', async () => {
+      openTreadmillModal([
+        { kind: 'pause', speed_kmph: 5, duration_sec: 30, repeats: 1, same_as_previous: false },
+        { kind: 'pause', speed_kmph: 7, duration_sec: 45, repeats: 1, same_as_previous: false },
+      ])
+
+      // Normalization is synchronous (in initForm) and 'speed_plan' is pre-added to
+      // touched, so saving immediately sends the corrected segments.
+      const body = await saveAndReadBody()
+      const pauses = (body.speed_plan as Array<{ kind: string; speed_kmph: number; duration_sec: number }>)
+        .filter(s => s.kind === 'pause')
+      expect(pauses).toEqual([
+        { kind: 'pause', speed_kmph: 5, duration_sec: 30, repeats: 1, same_as_previous: false },
+        { kind: 'pause', speed_kmph: 5, duration_sec: 30, repeats: 1, same_as_previous: false },
+      ])
+    })
+
     it('supports adding all four kinds via the kind selector', async () => {
       openTreadmillModal()
 

--- a/web/src/components/training/WorkoutContextModal.test.tsx
+++ b/web/src/components/training/WorkoutContextModal.test.tsx
@@ -64,13 +64,13 @@ describe('WorkoutContextModal', () => {
       <WorkoutContextModal workoutId="42" isOpen={true} onClose={() => {}} />,
     )
 
-    expect(screen.queryByTestId('speed-plan-placeholder')).toBeNull()
+    expect(screen.queryByTestId('speed-plan-editor')).toBeNull()
 
     fireEvent.click(screen.getByTestId('toggle-surface-Outside'))
-    expect(screen.queryByTestId('speed-plan-placeholder')).toBeNull()
+    expect(screen.queryByTestId('speed-plan-editor')).toBeNull()
 
     fireEvent.click(screen.getByTestId('toggle-surface-Treadmill'))
-    expect(screen.getByTestId('speed-plan-placeholder')).toBeTruthy()
+    expect(screen.getByTestId('speed-plan-editor')).toBeTruthy()
   })
 
   it('renders speed plan section when initialContext.surface is Treadmill', () => {
@@ -88,7 +88,7 @@ describe('WorkoutContextModal', () => {
         }}
       />,
     )
-    expect(screen.getByTestId('speed-plan-placeholder')).toBeTruthy()
+    expect(screen.getByTestId('speed-plan-editor')).toBeTruthy()
     expect(screen.getByTestId('toggle-surface-Treadmill')).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByTestId('toggle-runType-interval')).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByTestId('toggle-hrSource-chest')).toHaveAttribute('aria-checked', 'true')
@@ -109,7 +109,7 @@ describe('WorkoutContextModal', () => {
         }}
       />,
     )
-    expect(screen.getByTestId('speed-plan-placeholder')).toBeTruthy()
+    expect(screen.getByTestId('speed-plan-editor')).toBeTruthy()
     expect(screen.getByTestId('toggle-surface-Treadmill')).toHaveAttribute('aria-checked', 'true')
   })
 
@@ -133,7 +133,7 @@ describe('WorkoutContextModal', () => {
     )
 
     fireEvent.click(screen.getByTestId('toggle-surface-Outside'))
-    expect(screen.queryByTestId('speed-plan-placeholder')).toBeNull()
+    expect(screen.queryByTestId('speed-plan-editor')).toBeNull()
 
     fireEvent.click(screen.getByText('workoutContextModal.save'))
 
@@ -174,6 +174,187 @@ describe('WorkoutContextModal', () => {
     })
 
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+  })
+
+  describe('SpeedPlanEditor integration', () => {
+    function openTreadmillModal(initialSegments: Array<{
+      kind: string
+      speed_kmph: number
+      duration_sec: number
+      repeats: number
+      same_as_previous: boolean
+    }> = []) {
+      return render(
+        <WorkoutContextModal
+          workoutId="42"
+          isOpen={true}
+          onClose={() => {}}
+          initialContext={{
+            surface: 'Treadmill',
+            run_type: 'interval',
+            hr_source: 'chest',
+            feel_notes: '',
+            speed_plan: initialSegments,
+          }}
+        />,
+      )
+    }
+
+    async function saveAndReadBody(): Promise<Record<string, unknown>> {
+      fireEvent.click(screen.getByText('workoutContextModal.save'))
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+      return JSON.parse(fetchMock.mock.calls[0][1]?.body as string)
+    }
+
+    it('appends a new segment when the + button is clicked', async () => {
+      openTreadmillModal()
+
+      // Default add-kind is 'interval'.
+      fireEvent.click(screen.getByTestId('speed-plan-add'))
+      expect(screen.getByTestId('speed-plan-row-0')).toBeTruthy()
+
+      const body = await saveAndReadBody()
+      expect(body.speed_plan).toEqual([
+        { kind: 'interval', speed_kmph: 0, duration_sec: 0, repeats: 1, same_as_previous: false },
+      ])
+    })
+
+    it('removes a segment when the row remove button is clicked', async () => {
+      openTreadmillModal([
+        { kind: 'warmup', speed_kmph: 8, duration_sec: 600, repeats: 1, same_as_previous: false },
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+      ])
+
+      fireEvent.click(screen.getByTestId('speed-plan-row-0-remove'))
+
+      const body = await saveAndReadBody()
+      expect(body.speed_plan).toEqual([
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+      ])
+    })
+
+    it('with same-speed ON, the shared interval speed input updates every interval segment', async () => {
+      openTreadmillModal([
+        { kind: 'warmup', speed_kmph: 8, duration_sec: 600, repeats: 1, same_as_previous: false },
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+      ])
+
+      // Toggle is ON by default — shared input is visible.
+      const sharedSpeed = screen.getByTestId('speed-plan-shared-interval-speed') as HTMLInputElement
+      expect(sharedSpeed.value).toBe('14')
+
+      fireEvent.change(sharedSpeed, { target: { value: '16.5' } })
+
+      const body = await saveAndReadBody()
+      const segs = body.speed_plan as Array<{ kind: string; speed_kmph: number }>
+      const intervalSpeeds = segs.filter(s => s.kind === 'interval').map(s => s.speed_kmph)
+      expect(intervalSpeeds).toEqual([16.5, 16.5, 16.5])
+      // Warm-up untouched.
+      expect(segs.find(s => s.kind === 'warmup')?.speed_kmph).toBe(8)
+    })
+
+    it('with same-speed ON, per-row speed inputs are hidden for interval rows but shown for non-interval rows', () => {
+      openTreadmillModal([
+        { kind: 'warmup', speed_kmph: 8, duration_sec: 600, repeats: 1, same_as_previous: false },
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+      ])
+
+      // Warmup row (index 0) keeps its per-row speed input.
+      expect(screen.getByTestId('speed-plan-row-0-speed')).toBeTruthy()
+      // Interval row (index 1) does not show a per-row speed input while collapsed.
+      expect(screen.queryByTestId('speed-plan-row-1-speed')).toBeNull()
+      // But the shared interval speed input is visible.
+      expect(screen.getByTestId('speed-plan-shared-interval-speed')).toBeTruthy()
+    })
+
+    it('toggling same-speed OFF reveals per-row interval speed inputs and preserves existing values', async () => {
+      openTreadmillModal([
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+      ])
+
+      const toggle = screen.getByTestId('speed-plan-same-speed-toggle') as HTMLInputElement
+      expect(toggle.checked).toBe(true)
+
+      fireEvent.click(toggle)
+      expect(toggle.checked).toBe(false)
+
+      // Shared input is gone, per-row speed inputs are shown.
+      expect(screen.queryByTestId('speed-plan-shared-interval-speed')).toBeNull()
+      const row0Speed = screen.getByTestId('speed-plan-row-0-speed') as HTMLInputElement
+      const row1Speed = screen.getByTestId('speed-plan-row-1-speed') as HTMLInputElement
+      expect(row0Speed.value).toBe('14')
+      expect(row1Speed.value).toBe('14')
+
+      // Edit only row 1 — the values diverge.
+      fireEvent.change(row1Speed, { target: { value: '17' } })
+
+      const body = await saveAndReadBody()
+      const speeds = (body.speed_plan as Array<{ speed_kmph: number }>).map(s => s.speed_kmph)
+      expect(speeds).toEqual([14, 17])
+    })
+
+    it('shared pause speed and duration update every pause segment', async () => {
+      openTreadmillModal([
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+        { kind: 'pause', speed_kmph: 6, duration_sec: 30, repeats: 1, same_as_previous: false },
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+        { kind: 'pause', speed_kmph: 6, duration_sec: 30, repeats: 1, same_as_previous: false },
+        { kind: 'interval', speed_kmph: 14, duration_sec: 60, repeats: 1, same_as_previous: false },
+      ])
+
+      const sharedPauseSpeed = screen.getByTestId('speed-plan-shared-pause-speed') as HTMLInputElement
+      const sharedPauseDuration = screen.getByTestId('speed-plan-shared-pause-duration') as HTMLInputElement
+      expect(sharedPauseSpeed.value).toBe('6')
+      expect(sharedPauseDuration.value).toBe('30')
+
+      fireEvent.change(sharedPauseSpeed, { target: { value: '5.5' } })
+      fireEvent.change(sharedPauseDuration, { target: { value: '45' } })
+
+      const body = await saveAndReadBody()
+      const pauses = (body.speed_plan as Array<{ kind: string; speed_kmph: number; duration_sec: number }>)
+        .filter(s => s.kind === 'pause')
+      expect(pauses).toEqual([
+        { kind: 'pause', speed_kmph: 5.5, duration_sec: 45, repeats: 1, same_as_previous: false },
+        { kind: 'pause', speed_kmph: 5.5, duration_sec: 45, repeats: 1, same_as_previous: false },
+      ])
+    })
+
+    it('appending a pause inherits the shared pause speed and duration', async () => {
+      openTreadmillModal([
+        { kind: 'pause', speed_kmph: 5.5, duration_sec: 45, repeats: 1, same_as_previous: false },
+      ])
+
+      const select = screen.getByTestId('speed-plan-add-kind') as HTMLSelectElement
+      fireEvent.change(select, { target: { value: 'pause' } })
+      fireEvent.click(screen.getByTestId('speed-plan-add'))
+
+      const body = await saveAndReadBody()
+      const pauses = (body.speed_plan as Array<{ kind: string; speed_kmph: number; duration_sec: number }>)
+        .filter(s => s.kind === 'pause')
+      expect(pauses).toEqual([
+        { kind: 'pause', speed_kmph: 5.5, duration_sec: 45, repeats: 1, same_as_previous: false },
+        { kind: 'pause', speed_kmph: 5.5, duration_sec: 45, repeats: 1, same_as_previous: false },
+      ])
+    })
+
+    it('supports adding all four kinds via the kind selector', async () => {
+      openTreadmillModal()
+
+      const select = screen.getByTestId('speed-plan-add-kind') as HTMLSelectElement
+      const add = screen.getByTestId('speed-plan-add')
+
+      for (const kind of ['warmup', 'interval', 'pause', 'cooldown'] as const) {
+        fireEvent.change(select, { target: { value: kind } })
+        fireEvent.click(add)
+      }
+
+      const body = await saveAndReadBody()
+      const kinds = (body.speed_plan as Array<{ kind: string }>).map(s => s.kind)
+      expect(kinds).toEqual(['warmup', 'interval', 'pause', 'cooldown'])
+    })
   })
 
   it('shows an error and does not close when the save request fails', async () => {

--- a/web/src/components/training/WorkoutContextModal.test.tsx
+++ b/web/src/components/training/WorkoutContextModal.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import WorkoutContextModal from './WorkoutContextModal'
+import type { SpeedPlanSegment } from '../../types/training'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -177,13 +178,7 @@ describe('WorkoutContextModal', () => {
   })
 
   describe('SpeedPlanEditor integration', () => {
-    function openTreadmillModal(initialSegments: Array<{
-      kind: string
-      speed_kmph: number
-      duration_sec: number
-      repeats: number
-      same_as_previous: boolean
-    }> = []) {
+    function openTreadmillModal(initialSegments: SpeedPlanSegment[] = []) {
       return render(
         <WorkoutContextModal
           workoutId="42"

--- a/web/src/components/training/WorkoutContextModal.tsx
+++ b/web/src/components/training/WorkoutContextModal.tsx
@@ -1,19 +1,13 @@
 import { useEffect, useId, useReducer, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Dialog, DialogHeader, DialogBody, DialogFooter } from '../ui/dialog'
-import SpeedPlanEditor from './SpeedPlanEditor'
+import SpeedPlanEditor, { SpeedPlanSegment } from './SpeedPlanEditor'
 
 export type Surface = 'Treadmill' | 'Outside' | ''
 export type RunType = 'slow' | 'interval' | ''
 export type HRSource = 'chest' | 'watch' | ''
 
-export interface SpeedPlanSegment {
-  kind: string
-  speed_kmph: number
-  duration_sec: number
-  repeats: number
-  same_as_previous: boolean
-}
+export type { SpeedPlanSegment }
 
 export interface WorkoutContext {
   workout_id?: number
@@ -275,6 +269,7 @@ export default function WorkoutContextModal({
               {t('workoutContextModal.speedPlan.label')}
             </span>
             <SpeedPlanEditor
+              key={workoutId}
               value={speedPlan}
               onChange={(segments) => {
                 dispatch({ speedPlan: segments })

--- a/web/src/components/training/WorkoutContextModal.tsx
+++ b/web/src/components/training/WorkoutContextModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useReducer, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Dialog, DialogHeader, DialogBody, DialogFooter } from '../ui/dialog'
+import SpeedPlanEditor from './SpeedPlanEditor'
 
 export type Surface = 'Treadmill' | 'Outside' | ''
 export type RunType = 'slow' | 'interval' | ''
@@ -247,16 +248,17 @@ export default function WorkoutContextModal({
         />
 
         {surface === 'Treadmill' && (
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2" data-testid="speed-plan-section">
             <span className="text-sm font-medium text-gray-300">
               {t('workoutContextModal.speedPlan.label')}
             </span>
-            <div
-              data-testid="speed-plan-placeholder"
-              className="rounded border border-gray-700 bg-gray-800/40 p-3 text-sm text-gray-400"
-            >
-              {t('workoutContextModal.speedPlan.placeholder')}
-            </div>
+            <SpeedPlanEditor
+              value={speedPlan}
+              onChange={(segments) => {
+                dispatch({ speedPlan: segments })
+                setTouched(prev => new Set([...prev, 'speed_plan']))
+              }}
+            />
           </div>
         )}
 

--- a/web/src/components/training/WorkoutContextModal.tsx
+++ b/web/src/components/training/WorkoutContextModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useId, useReducer, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Dialog, DialogHeader, DialogBody, DialogFooter } from '../ui/dialog'
-import SpeedPlanEditor, { SpeedPlanSegment } from './SpeedPlanEditor'
+import SpeedPlanEditor from './SpeedPlanEditor'
+import type { SpeedPlanSegment } from './SpeedPlanEditor'
 
 export type Surface = 'Treadmill' | 'Outside' | ''
 export type RunType = 'slow' | 'interval' | ''

--- a/web/src/components/training/WorkoutContextModal.tsx
+++ b/web/src/components/training/WorkoutContextModal.tsx
@@ -101,15 +101,37 @@ function normalizeHRSource(s?: string): HRSource {
   return ''
 }
 
+function normalizeSpeedPlan(segments: SpeedPlanSegment[]): SpeedPlanSegment[] {
+  const pauses = segments.filter(s => s.kind === 'pause')
+  if (pauses.length < 2) return segments
+  const first = pauses[0]
+  if (pauses.every(s => s.speed_kmph === first.speed_kmph && s.duration_sec === first.duration_sec)) {
+    return segments
+  }
+  return segments.map(seg =>
+    seg.kind === 'pause'
+      ? { ...seg, speed_kmph: first.speed_kmph, duration_sec: first.duration_sec }
+      : seg
+  )
+}
+
 function initForm(ctx?: WorkoutContext): FormState {
   return {
     surface: normalizeSurface(ctx?.surface),
     runType: normalizeRunType(ctx?.run_type),
     hrSource: normalizeHRSource(ctx?.hr_source),
     feelNotes: ctx?.feel_notes ?? '',
-    speedPlan: ctx?.speed_plan ?? [],
+    speedPlan: normalizeSpeedPlan(ctx?.speed_plan ?? []),
     error: '',
   }
+}
+
+function initTouched(ctx?: WorkoutContext): Set<string> {
+  const raw = ctx?.speed_plan ?? []
+  const normalized = normalizeSpeedPlan(raw)
+  const s = new Set<string>()
+  if (normalized !== raw) s.add('speed_plan')
+  return s
 }
 
 export default function WorkoutContextModal({
@@ -129,7 +151,7 @@ export default function WorkoutContextModal({
   )
   const { surface, runType, hrSource, feelNotes, speedPlan, error } = form
   const [saving, setSaving] = useState(false)
-  const [touched, setTouched] = useState<Set<string>>(() => new Set())
+  const [touched, setTouched] = useState<Set<string>>(() => initTouched(initialContext))
 
   function handleSurfaceChange(nextSurface: Surface) {
     dispatch({ surface: nextSurface, ...(nextSurface !== 'Treadmill' ? { speedPlan: [] } : {}) })
@@ -163,7 +185,7 @@ export default function WorkoutContextModal({
   useEffect(() => {
     if (isOpen && !wasOpenRef.current) {
       dispatch(initForm(initialContextRef.current))
-      setTouched(new Set())
+      setTouched(initTouched(initialContextRef.current))
     }
     wasOpenRef.current = isOpen
   }, [isOpen, workoutId])

--- a/web/src/components/training/WorkoutContextModal.tsx
+++ b/web/src/components/training/WorkoutContextModal.tsx
@@ -2,13 +2,11 @@ import { useEffect, useId, useReducer, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Dialog, DialogHeader, DialogBody, DialogFooter } from '../ui/dialog'
 import SpeedPlanEditor from './SpeedPlanEditor'
-import type { SpeedPlanSegment } from './SpeedPlanEditor'
+import type { SpeedPlanSegment } from '../../types/training'
 
 export type Surface = 'Treadmill' | 'Outside' | ''
 export type RunType = 'slow' | 'interval' | ''
 export type HRSource = 'chest' | 'watch' | ''
-
-export type { SpeedPlanSegment }
 
 export interface WorkoutContext {
   workout_id?: number

--- a/web/src/types/training.ts
+++ b/web/src/types/training.ts
@@ -215,6 +215,16 @@ export interface SummaryAnalysisResponse {
   cached: boolean
 }
 
+export type SpeedPlanSegmentKind = 'warmup' | 'interval' | 'pause' | 'cooldown'
+
+export interface SpeedPlanSegment {
+  kind: SpeedPlanSegmentKind
+  speed_kmph: number
+  duration_sec: number
+  repeats: number
+  same_as_previous: boolean
+}
+
 export interface VO2maxEstimate {
   id: number
   user_id: number


### PR DESCRIPTION
## Changes

- **Speed plan editor for treadmill workouts** - Workout context modal now offers a structured editor when Treadmill is selected, supporting warm-up, interval, pause and cool-down segments with a same-speed-for-intervals collapse toggle and a shared pause speed/duration that propagates to every pause segment. (Hytte-z225)

## Original Issue (task): Build SpeedPlanEditor segment list component with same-speed collapse

Create `web/src/components/training/SpeedPlanEditor.tsx`. Props: `{ value: SpeedPlanSegment[]; onChange: (segments: SpeedPlanSegment[]) => void }` where `SpeedPlanSegment = { kind: 'warmup' | 'interval' | 'pause' | 'cooldown'; speedKmh: number; durationSec: number }`. Render segments as a list with a `+` button to append. Each row has speed (km/h) and duration inputs. Implement an interval 'same speed for all' toggle: when on, collapse all interval rows to a single shared speed input that updates every interval segment's speed. Single shared pause speed+duration applies to every pause/gap segment. Support all four kinds (warmup, intervals, pause, cool-down). All strings live in the `training.json` locale files added in the modal sub-task. Add tests for same-speed collapse logic in `WorkoutContextModal.test.tsx` (per parent bead) by exercising via the modal. Connects to: imported and rendered by WorkoutContextModal when Treadmill is selected.

---
Bead: Hytte-z225 | Branch: forge/Hytte-z225
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)