### PR TITLE
Auto-run AI summary on workout context save (Hytte-gm7w)

### DIFF
--- a/changelog.d/Hytte-gm7w.md
+++ b/changelog.d/Hytte-gm7w.md
@@ -1,0 +1,2 @@
+category: Added
+- **Auto-run AI summary on workout context save** - Saving workout context now spawns the same background Claude analysis used at FIT upload time, so admins no longer need to click Analyze after capturing context. Skips when an analysis is already running or completed. (Hytte-gm7w)

--- a/internal/training/context_handlers.go
+++ b/internal/training/context_handlers.go
@@ -125,6 +125,11 @@ func PutWorkoutContextHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		// Auto-trigger Claude analysis now that the prompt inputs are captured.
+		// Mirrors the FIT-import flow; gates on admin + claude_ai and skips when
+		// an analysis is already running or completed.
+		scheduleAnalysisAfterContextSave(db, user.ID, user.IsAdmin, workoutID)
+
 		saved, err := GetWorkoutContext(db, workoutID)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load context"})

--- a/internal/training/context_handlers_test.go
+++ b/internal/training/context_handlers_test.go
@@ -2,13 +2,18 @@ package training
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
 )
 
 func createWorkoutForUser(t *testing.T, database *sql.DB, userID int64, hash string) int64 {
@@ -223,5 +228,196 @@ func TestPutWorkoutContext_InvalidJSON(t *testing.T) {
 	PutWorkoutContextHandler(database)(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- scheduleAnalysisAfterContextSave ---
+
+func setWorkoutAnalysisStatus(t *testing.T, database *sql.DB, workoutID int64, status string) {
+	t.Helper()
+	if _, err := database.Exec(`UPDATE workouts SET analysis_status = ? WHERE id = ?`, status, workoutID); err != nil {
+		t.Fatalf("set analysis_status %q for workout %d: %v", status, workoutID, err)
+	}
+}
+
+func getWorkoutAnalysisStatus(t *testing.T, database *sql.DB, workoutID int64) string {
+	t.Helper()
+	var status string
+	if err := database.QueryRow(`SELECT analysis_status FROM workouts WHERE id = ?`, workoutID).Scan(&status); err != nil {
+		t.Fatalf("get analysis_status for workout %d: %v", workoutID, err)
+	}
+	return status
+}
+
+// TestScheduleAnalysisAfterContextSave_Fires_WhenStatusEmpty verifies that
+// Claude analysis is triggered (and status is claimed atomically) when the
+// workout has never been analysed (analysis_status='').
+func TestScheduleAnalysisAfterContextSave_Fires_WhenStatusEmpty(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "saa-empty-hash")
+	seedWorkoutContext(t, database, workoutID)
+	if err := auth.SetPreference(database, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set pref: %v", err)
+	}
+
+	called := make(chan struct{}, 1)
+	origFunc := runPromptFunc
+	runPromptFunc = func(_ context.Context, _ *ClaudeConfig, _ string) (string, error) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		return `{"type":"easy_run","tag":"easy","summary":"Test","title":"Test Run"}`, nil
+	}
+	t.Cleanup(func() { runPromptFunc = origFunc })
+
+	scheduleAnalysisAfterContextSave(database, 1, true, workoutID)
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: analysis did not fire within 2s for status=''")
+	}
+}
+
+// TestScheduleAnalysisAfterContextSave_Fires_WhenStatusFailed verifies that
+// Claude analysis is re-triggered when the previous run failed.
+func TestScheduleAnalysisAfterContextSave_Fires_WhenStatusFailed(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "saa-failed-hash")
+	setWorkoutAnalysisStatus(t, database, workoutID, "failed")
+	seedWorkoutContext(t, database, workoutID)
+	if err := auth.SetPreference(database, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set pref: %v", err)
+	}
+
+	called := make(chan struct{}, 1)
+	origFunc := runPromptFunc
+	runPromptFunc = func(_ context.Context, _ *ClaudeConfig, _ string) (string, error) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		return `{"type":"easy_run","tag":"easy","summary":"Test","title":"Test Run"}`, nil
+	}
+	t.Cleanup(func() { runPromptFunc = origFunc })
+
+	scheduleAnalysisAfterContextSave(database, 1, true, workoutID)
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: analysis did not fire within 2s for status='failed'")
+	}
+}
+
+// TestScheduleAnalysisAfterContextSave_Skips_WhenStatusPending verifies that
+// the atomic UPDATE returns 0 rows (no goroutine spawned) when analysis is
+// already in progress.
+func TestScheduleAnalysisAfterContextSave_Skips_WhenStatusPending(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "saa-pending-hash")
+	setWorkoutAnalysisStatus(t, database, workoutID, "pending")
+
+	origFunc := runPromptFunc
+	called := false
+	runPromptFunc = func(_ context.Context, _ *ClaudeConfig, _ string) (string, error) {
+		called = true
+		return "", nil
+	}
+	t.Cleanup(func() { runPromptFunc = origFunc })
+
+	scheduleAnalysisAfterContextSave(database, 1, true, workoutID)
+	time.Sleep(150 * time.Millisecond)
+
+	if called {
+		t.Fatal("expected no Claude call when analysis_status='pending'")
+	}
+	if status := getWorkoutAnalysisStatus(t, database, workoutID); status != "pending" {
+		t.Errorf("status should remain 'pending', got %q", status)
+	}
+}
+
+// TestScheduleAnalysisAfterContextSave_Skips_WhenStatusCompleted verifies that
+// a completed analysis is not re-run.
+func TestScheduleAnalysisAfterContextSave_Skips_WhenStatusCompleted(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "saa-completed-hash")
+	setWorkoutAnalysisStatus(t, database, workoutID, "completed")
+
+	origFunc := runPromptFunc
+	called := false
+	runPromptFunc = func(_ context.Context, _ *ClaudeConfig, _ string) (string, error) {
+		called = true
+		return "", nil
+	}
+	t.Cleanup(func() { runPromptFunc = origFunc })
+
+	scheduleAnalysisAfterContextSave(database, 1, true, workoutID)
+	time.Sleep(150 * time.Millisecond)
+
+	if called {
+		t.Fatal("expected no Claude call when analysis_status='completed'")
+	}
+	if status := getWorkoutAnalysisStatus(t, database, workoutID); status != "completed" {
+		t.Errorf("status should remain 'completed', got %q", status)
+	}
+}
+
+// TestScheduleAnalysisAfterContextSave_Skips_WhenNotAdmin verifies that the
+// function is a no-op for non-admin users.
+func TestScheduleAnalysisAfterContextSave_Skips_WhenNotAdmin(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "saa-nonadmin-hash")
+
+	origFunc := runPromptFunc
+	called := false
+	runPromptFunc = func(_ context.Context, _ *ClaudeConfig, _ string) (string, error) {
+		called = true
+		return "", nil
+	}
+	t.Cleanup(func() { runPromptFunc = origFunc })
+
+	scheduleAnalysisAfterContextSave(database, 1, false, workoutID)
+	time.Sleep(100 * time.Millisecond)
+
+	if called {
+		t.Fatal("expected no Claude call for non-admin user")
+	}
+}
+
+// TestScheduleAnalysisAfterContextSave_SetsStatusPendingBeforeRun verifies that
+// the atomic UPDATE claims 'pending' synchronously (before the goroutine body
+// executes), so a second concurrent call sees the updated status and does not
+// enqueue a duplicate run.
+func TestScheduleAnalysisAfterContextSave_SetsStatusPendingBeforeRun(t *testing.T) {
+	database := setupTestDB(t)
+	workoutID := createWorkoutForUser(t, database, 1, "saa-claim-hash")
+	seedWorkoutContext(t, database, workoutID)
+	if err := auth.SetPreference(database, 1, "claude_enabled", "true"); err != nil {
+		t.Fatalf("set pref: %v", err)
+	}
+
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	origFunc := runPromptFunc
+	runPromptFunc = func(_ context.Context, _ *ClaudeConfig, _ string) (string, error) {
+		defer wg.Done()
+		<-release
+		return `{"type":"easy_run","tag":"easy","summary":"Test","title":"Test Run"}`, nil
+	}
+	t.Cleanup(func() {
+		close(release)
+		wg.Wait()
+		runPromptFunc = origFunc
+	})
+
+	scheduleAnalysisAfterContextSave(database, 1, true, workoutID)
+
+	// The atomic UPDATE is synchronous — status must be 'pending' before the
+	// goroutine finishes and flips it to 'completed'.
+	if status := getWorkoutAnalysisStatus(t, database, workoutID); status != "pending" {
+		t.Errorf("expected status='pending' immediately after scheduling, got %q", status)
 	}
 }

--- a/internal/training/handlers.go
+++ b/internal/training/handlers.go
@@ -301,12 +301,9 @@ func scheduleBackgroundAnalysis(db *sql.DB, userID int64, isAdmin bool, workouts
 // workout_context row is saved or updated, mirroring the FIT-import auto-trigger
 // in scheduleBackgroundAnalysis. It gates on:
 //   - admin user with the claude_ai feature flag
-//   - existing analysis_status not 'completed' or 'pending' (re-runs only when
-//     absent or 'failed')
-//
-// The goroutine pattern (semaphore acquisition, RunClaudeAnalysis, status
-// updates, optional RunInsightsAnalysis when ai_auto_analyze is enabled)
-// matches the upload path exactly so the two trigger sites stay in sync.
+//   - an atomic conditional UPDATE that flips analysis_status '' or 'failed' →
+//     'pending', preventing duplicate runs from concurrent context saves
+//     (TOCTOU-safe; the goroutine is spawned only when RowsAffected == 1)
 func scheduleAnalysisAfterContextSave(db *sql.DB, userID int64, isAdmin bool, workoutID int64) {
 	if !isAdmin {
 		return
@@ -320,20 +317,21 @@ func scheduleAnalysisAfterContextSave(db *sql.DB, userID int64, isAdmin bool, wo
 		return
 	}
 
-	// Skip when an analysis is already running or has completed; only re-trigger
-	// when the status is empty (never run) or 'failed' (a previous attempt errored).
-	var status string
-	if err := db.QueryRow(
-		`SELECT analysis_status FROM workouts WHERE id = ? AND user_id = ?`,
+	// Atomically claim the 'pending' slot. The UPDATE only matches when
+	// analysis_status is '' or 'failed', so two concurrent context saves
+	// cannot both enqueue a duplicate run — the second UPDATE matches 0 rows.
+	res, err := db.Exec(
+		`UPDATE workouts SET analysis_status = 'pending'
+		 WHERE id = ? AND user_id = ?
+		 AND (analysis_status = '' OR analysis_status IS NULL OR analysis_status = 'failed')`,
 		workoutID, userID,
-	).Scan(&status); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return
-		}
-		log.Printf("Failed to read analysis_status for workout %d on context save: %v", workoutID, err)
+	)
+	if err != nil {
+		log.Printf("Failed to claim analysis slot for workout %d on context save: %v", workoutID, err)
 		return
 	}
-	if status == "completed" || status == "pending" {
+	n, _ := res.RowsAffected()
+	if n == 0 {
 		return
 	}
 
@@ -342,14 +340,6 @@ func scheduleAnalysisAfterContextSave(db *sql.DB, userID int64, isAdmin bool, wo
 		log.Printf("Failed to load preferences for auto-insights (user %d): %v", userID, prefErr)
 	} else {
 		autoInsights = prefs["ai_auto_analyze"] == "true"
-	}
-
-	if err := UpdateAnalysisStatus(db, workoutID, userID, "pending"); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			log.Printf("Workout %d not found when setting pending analysis status: %v", workoutID, err)
-			return
-		}
-		log.Printf("Failed to set pending analysis status for workout %d (continuing with analysis): %v", workoutID, err)
 	}
 
 	go func() {

--- a/internal/training/handlers.go
+++ b/internal/training/handlers.go
@@ -297,6 +297,91 @@ func scheduleBackgroundAnalysis(db *sql.DB, userID int64, isAdmin bool, workouts
 	}
 }
 
+// scheduleAnalysisAfterContextSave triggers async Claude analysis after a
+// workout_context row is saved or updated, mirroring the FIT-import auto-trigger
+// in scheduleBackgroundAnalysis. It gates on:
+//   - admin user with the claude_ai feature flag
+//   - existing analysis_status not 'completed' or 'pending' (re-runs only when
+//     absent or 'failed')
+//
+// The goroutine pattern (semaphore acquisition, RunClaudeAnalysis, status
+// updates, optional RunInsightsAnalysis when ai_auto_analyze is enabled)
+// matches the upload path exactly so the two trigger sites stay in sync.
+func scheduleAnalysisAfterContextSave(db *sql.DB, userID int64, isAdmin bool, workoutID int64) {
+	if !isAdmin {
+		return
+	}
+	features, err := auth.GetUserFeatures(db, userID, isAdmin)
+	if err != nil {
+		log.Printf("Failed to load user features for context-save Claude trigger (user %d): %v", userID, err)
+		return
+	}
+	if !features["claude_ai"] {
+		return
+	}
+
+	// Skip when an analysis is already running or has completed; only re-trigger
+	// when the status is empty (never run) or 'failed' (a previous attempt errored).
+	var status string
+	if err := db.QueryRow(
+		`SELECT analysis_status FROM workouts WHERE id = ? AND user_id = ?`,
+		workoutID, userID,
+	).Scan(&status); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return
+		}
+		log.Printf("Failed to read analysis_status for workout %d on context save: %v", workoutID, err)
+		return
+	}
+	if status == "completed" || status == "pending" {
+		return
+	}
+
+	autoInsights := false
+	if prefs, prefErr := auth.GetPreferences(db, userID); prefErr != nil {
+		log.Printf("Failed to load preferences for auto-insights (user %d): %v", userID, prefErr)
+	} else {
+		autoInsights = prefs["ai_auto_analyze"] == "true"
+	}
+
+	if err := UpdateAnalysisStatus(db, workoutID, userID, "pending"); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			log.Printf("Workout %d not found when setting pending analysis status: %v", workoutID, err)
+			return
+		}
+		log.Printf("Failed to set pending analysis status for workout %d (continuing with analysis): %v", workoutID, err)
+	}
+
+	go func() {
+		claudeSemaphore <- struct{}{}
+		defer func() { <-claudeSemaphore }()
+		bgCtx := context.Background()
+		if err := RunClaudeAnalysis(bgCtx, db, workoutID, userID); err != nil {
+			if errors.Is(err, ErrClaudeNotEnabled) {
+				if updateErr := UpdateAnalysisStatus(db, workoutID, userID, ""); updateErr != nil {
+					log.Printf("Failed to reset analysis status for workout %d: %v", workoutID, updateErr)
+				}
+			} else {
+				log.Printf("Background Claude analysis failed for workout %d: %v", workoutID, err)
+				if updateErr := UpdateAnalysisStatus(db, workoutID, userID, "failed"); updateErr != nil {
+					log.Printf("Failed to set failed analysis status for workout %d: %v", workoutID, updateErr)
+				}
+			}
+		} else {
+			if updateErr := UpdateAnalysisStatus(db, workoutID, userID, "completed"); updateErr != nil {
+				log.Printf("Failed to set completed analysis status for workout %d: %v", workoutID, updateErr)
+			}
+		}
+		if autoInsights {
+			if insErr := RunInsightsAnalysis(bgCtx, db, workoutID, userID); insErr != nil {
+				if !errors.Is(insErr, ErrClaudeNotEnabled) && !errors.Is(insErr, ErrInsightsAlreadyCached) {
+					log.Printf("Auto insights analysis failed for workout %d: %v", workoutID, insErr)
+				}
+			}
+		}
+	}()
+}
+
 // ListHandler handles GET /api/training/workouts.
 func ListHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/web/src/pages/TrainingDetail.tsx
+++ b/web/src/pages/TrainingDetail.tsx
@@ -294,6 +294,24 @@ export default function TrainingDetail() {
         if ((err as Error).name === 'AbortError') return
         console.warn('Failed to refetch workout context:', err)
       })
+    // The backend auto-triggers Claude analysis once context is saved and flips
+    // analysis_status to 'pending'. Refetch the workout so the existing polling
+    // effect (keyed on workout.analysis_status) picks up the new state.
+    fetch(`/api/training/workouts/${id}`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        if (controller.signal.aborted) return
+        if (res.ok) {
+          const data = await res.json()
+          setWorkout(data.workout)
+        }
+      })
+      .catch((err) => {
+        if ((err as Error).name === 'AbortError') return
+        console.warn('Failed to refetch workout after context save:', err)
+      })
   }, [id])
 
   // Poll for analysis completion when status is 'pending'.


### PR DESCRIPTION
## Changes

- **Auto-run AI summary on workout context save** - Saving workout context now spawns the same background Claude analysis used at FIT upload time, so admins no longer need to click Analyze after capturing context. Skips when an analysis is already running or completed. (Hytte-gm7w)

## Original Issue (task): Auto-run AI summary on workout context save

Backend-only change in internal/training/handlers.go. Locate the UpsertWorkoutContext handler (POST/PUT for workout_context) and, after successful persistence, spawn the same auto-analysis goroutine pattern used at FIT upload time around handlers.go:264. Gate on: claude_ai feature flag enabled for the user; skip if existing analysis_status is 'completed' or 'pending' (only re-trigger when absent or 'failed'). Goroutine should set analysis_status='pending', acquire claudeSemaphore, call RunClaudeAnalysis, update status to 'completed'/'failed', and call RunInsightsAnalysis when ai_auto_analyze is enabled — mirroring the upload path exactly. Frontend verification: confirm TrainingDetail.tsx:244 polling picks up the pending status after modal save resolves; if not, add a toast using the existing pending-state i18n key. No type/schema changes. Connects to sibling tasks only via shared file (WorkoutContextModal.tsx) but logic is independent — can ship standalone.

---
Bead: Hytte-gm7w | Branch: forge/Hytte-gm7w
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)