### PR TITLE
Stride: show the workout_context summary inline in the evaluation card (Hytte-ajpg)

### DIFF
--- a/changelog.d/Hytte-ajpg.md
+++ b/changelog.d/Hytte-ajpg.md
@@ -1,0 +1,2 @@
+category: Added
+- **Stride evaluation cards show workout context inline** - Each Stride coach evaluation now displays a "What coach saw for this day" panel with the user's saved workout context summary (feel notes, planned speed segments, surface/run type metadata), so the data that informed the coach's assessment is visible alongside the evaluation itself. (Hytte-ajpg)

--- a/internal/stride/handlers_test.go
+++ b/internal/stride/handlers_test.go
@@ -776,6 +776,97 @@ func TestListEvaluationsHandler_EncryptedEvalJSON(t *testing.T) {
 	}
 }
 
+func TestListEvaluationsHandler_PopulatesWorkoutContextSummary(t *testing.T) {
+	db := setupTestDB(t)
+	planID := insertTestPlan(t, db, 1, "2026-04-06", "2026-04-12", `[]`)
+
+	eval := Evaluation{
+		PlannedType: "easy",
+		ActualType:  "easy",
+		Compliance:  "compliant",
+		Notes:       "Solid",
+		Flags:       []string{},
+	}
+	const workoutID = int64(500)
+	insertTestEvaluation(t, db, 1, planID, workoutID, eval)
+
+	feelEnc, err := encryption.EncryptField("Felt strong, no soreness.")
+	if err != nil {
+		t.Fatalf("encrypt feel: %v", err)
+	}
+	emptyPlanEnc, err := encryption.EncryptField("")
+	if err != nil {
+		t.Fatalf("encrypt empty plan: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO workout_context (workout_id, surface, run_type, hr_source, feel_notes, speed_plan, completed_at)
+		 VALUES (?, ?, ?, ?, ?, ?, '')`,
+		workoutID, "road", "outdoor", "watch", feelEnc, emptyPlanEnc,
+	); err != nil {
+		t.Fatalf("insert workout_context: %v", err)
+	}
+
+	req := withUser(httptest.NewRequest("GET", "/api/stride/evaluations", nil), 1)
+	rec := httptest.NewRecorder()
+	ListEvaluationsHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Evaluations []EvaluationRecord `json:"evaluations"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Evaluations) != 1 {
+		t.Fatalf("expected 1 evaluation, got %d", len(body.Evaluations))
+	}
+	got := body.Evaluations[0].WorkoutContextSummary
+	if got == "" {
+		t.Fatalf("WorkoutContextSummary is empty; expected populated formatted string")
+	}
+	if !strings.Contains(got, "Felt strong, no soreness.") {
+		t.Errorf("summary missing feel notes: %q", got)
+	}
+	if !strings.Contains(got, "surface=road") {
+		t.Errorf("summary missing surface metadata: %q", got)
+	}
+}
+
+func TestListEvaluationsHandler_NoWorkoutContextLeavesSummaryEmpty(t *testing.T) {
+	db := setupTestDB(t)
+	planID := insertTestPlan(t, db, 1, "2026-04-06", "2026-04-12", `[]`)
+
+	eval := Evaluation{
+		PlannedType: "easy",
+		ActualType:  "easy",
+		Compliance:  "compliant",
+		Flags:       []string{},
+	}
+	insertTestEvaluation(t, db, 1, planID, 600, eval)
+
+	req := withUser(httptest.NewRequest("GET", "/api/stride/evaluations", nil), 1)
+	rec := httptest.NewRecorder()
+	ListEvaluationsHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Evaluations []EvaluationRecord `json:"evaluations"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Evaluations) != 1 {
+		t.Fatalf("expected 1 evaluation, got %d", len(body.Evaluations))
+	}
+	if body.Evaluations[0].WorkoutContextSummary != "" {
+		t.Errorf("expected empty summary when no context saved, got %q", body.Evaluations[0].WorkoutContextSummary)
+	}
+}
+
 func TestTriggerEvaluationHandler_ClaudeNotEnabled(t *testing.T) {
 	// claude_enabled is not set → ErrClaudeNotEnabled → 400.
 	db := extendedTestDB(t)

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -834,31 +834,30 @@ func ListEvaluations(db *sql.DB, userID int64, planID *int64, workoutID *int64) 
 		records = []EvaluationRecord{}
 	}
 
-	// Attach the workout_context summary so the frontend can render
-	// "what coach saw for this day" inline on each evaluation card without
-	// a second fetch. Multiple evaluations sharing a workout reuse the same
-	// formatted string; cache by workout ID to avoid redundant DB hits.
-	contextCache := make(map[int64]string)
+	// Collect distinct workout IDs then batch-load their contexts in a single query
+	// that also verifies ownership via JOIN on workouts.user_id.
+	seenWorkouts := make(map[int64]struct{})
+	for _, rec := range records {
+		if rec.WorkoutID != nil {
+			seenWorkouts[*rec.WorkoutID] = struct{}{}
+		}
+	}
+	distinctIDs := make([]int64, 0, len(seenWorkouts))
+	for wid := range seenWorkouts {
+		distinctIDs = append(distinctIDs, wid)
+	}
+	contextMap, batchErr := training.GetWorkoutContextsBatch(db, userID, distinctIDs)
+	if batchErr != nil {
+		log.Printf("stride: batch-load workout contexts: %v", batchErr)
+		contextMap = map[int64]*training.WorkoutContext{}
+	}
 	for i := range records {
 		if records[i].WorkoutID == nil {
 			continue
 		}
-		wid := *records[i].WorkoutID
-		if cached, ok := contextCache[wid]; ok {
-			records[i].WorkoutContextSummary = cached
-			continue
+		if wctx, ok := contextMap[*records[i].WorkoutID]; ok {
+			records[i].WorkoutContextSummary = training.FormatWorkoutContextNote(wctx)
 		}
-		wctx, err := training.GetWorkoutContext(db, wid)
-		if err != nil {
-			if !errors.Is(err, sql.ErrNoRows) {
-				log.Printf("stride: load workout_context for workout %d: %v", wid, err)
-			}
-			contextCache[wid] = ""
-			continue
-		}
-		summary := training.FormatWorkoutContextNote(wctx)
-		contextCache[wid] = summary
-		records[i].WorkoutContextSummary = summary
 	}
 
 	return records, nil

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/Robin831/Hytte/internal/training"
 )
 
 // Race represents an upcoming race in the user's race calendar.
@@ -759,12 +761,13 @@ func GetCurrentPlan(db *sql.DB, userID int64, today string) (*Plan, error) {
 
 // EvaluationRecord represents a stored evaluation from stride_evaluations.
 type EvaluationRecord struct {
-	ID        int64      `json:"id"`
-	UserID    int64      `json:"user_id"`
-	PlanID    int64      `json:"plan_id"`
-	WorkoutID *int64     `json:"workout_id"`
-	Eval      Evaluation `json:"eval"`
-	CreatedAt string     `json:"created_at"`
+	ID                    int64      `json:"id"`
+	UserID                int64      `json:"user_id"`
+	PlanID                int64      `json:"plan_id"`
+	WorkoutID             *int64     `json:"workout_id"`
+	Eval                  Evaluation `json:"eval"`
+	CreatedAt             string     `json:"created_at"`
+	WorkoutContextSummary string     `json:"workout_context_summary,omitempty"`
 }
 
 // ListEvaluations returns evaluation records for a user from stride_evaluations.
@@ -830,6 +833,34 @@ func ListEvaluations(db *sql.DB, userID int64, planID *int64, workoutID *int64) 
 	if records == nil {
 		records = []EvaluationRecord{}
 	}
+
+	// Attach the workout_context summary so the frontend can render
+	// "what coach saw for this day" inline on each evaluation card without
+	// a second fetch. Multiple evaluations sharing a workout reuse the same
+	// formatted string; cache by workout ID to avoid redundant DB hits.
+	contextCache := make(map[int64]string)
+	for i := range records {
+		if records[i].WorkoutID == nil {
+			continue
+		}
+		wid := *records[i].WorkoutID
+		if cached, ok := contextCache[wid]; ok {
+			records[i].WorkoutContextSummary = cached
+			continue
+		}
+		wctx, err := training.GetWorkoutContext(db, wid)
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				log.Printf("stride: load workout_context for workout %d: %v", wid, err)
+			}
+			contextCache[wid] = ""
+			continue
+		}
+		summary := training.FormatWorkoutContextNote(wctx)
+		contextCache[wid] = summary
+		records[i].WorkoutContextSummary = summary
+	}
+
 	return records, nil
 }
 

--- a/internal/stride/stride_test.go
+++ b/internal/stride/stride_test.go
@@ -128,6 +128,15 @@ func setupTestDB(t *testing.T) *sql.DB {
 			value   TEXT NOT NULL DEFAULT '',
 			PRIMARY KEY (user_id, key)
 		);
+		CREATE TABLE workout_context (
+			workout_id   INTEGER PRIMARY KEY REFERENCES workouts(id) ON DELETE CASCADE,
+			surface      TEXT NOT NULL DEFAULT '',
+			run_type     TEXT NOT NULL DEFAULT '',
+			hr_source    TEXT NOT NULL DEFAULT '',
+			feel_notes   TEXT NOT NULL DEFAULT '',
+			speed_plan   TEXT NOT NULL DEFAULT '',
+			completed_at TEXT NOT NULL DEFAULT ''
+		);
 	`)
 	if err != nil {
 		t.Fatalf("create schema: %v", err)

--- a/internal/training/storage.go
+++ b/internal/training/storage.go
@@ -407,6 +407,73 @@ func GetWorkoutContext(db *sql.DB, workoutID int64) (*WorkoutContext, error) {
 	return ctx, nil
 }
 
+// GetWorkoutContextsBatch fetches workout contexts for multiple workouts in a single
+// query, verifying ownership via a JOIN against workouts.user_id. Contexts for
+// workout IDs that belong to a different user are silently excluded.
+// Returns a map of workoutID → *WorkoutContext.
+func GetWorkoutContextsBatch(db *sql.DB, userID int64, workoutIDs []int64) (map[int64]*WorkoutContext, error) {
+	if len(workoutIDs) == 0 {
+		return map[int64]*WorkoutContext{}, nil
+	}
+	placeholders := make([]string, len(workoutIDs))
+	args := make([]interface{}, 0, len(workoutIDs)+1)
+	args = append(args, userID)
+	for i, wid := range workoutIDs {
+		placeholders[i] = "?"
+		args = append(args, wid)
+	}
+	query := `
+		SELECT wc.workout_id, wc.surface, wc.run_type, wc.hr_source, wc.feel_notes, wc.speed_plan, wc.completed_at
+		FROM workout_context wc
+		JOIN workouts w ON w.id = wc.workout_id
+		WHERE w.user_id = ? AND wc.workout_id IN (` + strings.Join(placeholders, ",") + `)`
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[int64]*WorkoutContext)
+	for rows.Next() {
+		var feelEnc, planEnc, completedAt string
+		ctx := &WorkoutContext{SpeedPlan: []SpeedSegment{}}
+		if err := rows.Scan(&ctx.WorkoutID, &ctx.Surface, &ctx.RunType, &ctx.HRSource, &feelEnc, &planEnc, &completedAt); err != nil {
+			return nil, err
+		}
+		feelNotes, err := encryption.DecryptField(feelEnc)
+		if err != nil {
+			return nil, err
+		}
+		ctx.FeelNotes = feelNotes
+
+		planJSON, err := encryption.DecryptField(planEnc)
+		if err != nil {
+			return nil, err
+		}
+		if planJSON != "" {
+			var segments []SpeedSegment
+			if err := json.Unmarshal([]byte(planJSON), &segments); err != nil {
+				return nil, err
+			}
+			if segments == nil {
+				segments = []SpeedSegment{}
+			}
+			ctx.SpeedPlan = segments
+		}
+
+		if completedAt != "" {
+			if parsed, perr := time.Parse(time.RFC3339, completedAt); perr == nil {
+				ctx.CompletedAt = &parsed
+			}
+		}
+		result[ctx.WorkoutID] = ctx
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // HashExists checks whether a workout with the given file hash already exists.
 func HashExists(db *sql.DB, userID int64, hash string) (bool, error) {
 	var count int

--- a/web/public/locales/en/stride.json
+++ b/web/public/locales/en/stride.json
@@ -131,6 +131,7 @@
     "bonus": "Bonus",
     "rest_day": "Rest day",
     "coachNotes": "Coach notes",
+    "contextPanelTitle": "What coach saw for this day",
     "warnings": "Warnings",
     "adjustments": "Adjustments",
     "flagLabels": {

--- a/web/public/locales/nb/stride.json
+++ b/web/public/locales/nb/stride.json
@@ -131,6 +131,7 @@
     "bonus": "Bonus",
     "rest_day": "Hviledag",
     "coachNotes": "Trenerkommentar",
+    "contextPanelTitle": "Det treneren så for denne dagen",
     "warnings": "Advarsler",
     "adjustments": "Justeringer",
     "flagLabels": {

--- a/web/public/locales/th/stride.json
+++ b/web/public/locales/th/stride.json
@@ -131,6 +131,7 @@
     "bonus": "โบนัส",
     "rest_day": "วันพัก",
     "coachNotes": "บันทึกโค้ช",
+    "contextPanelTitle": "สิ่งที่โค้ชเห็นในวันนี้",
     "warnings": "คำเตือน",
     "adjustments": "การปรับ",
     "flagLabels": {

--- a/web/src/pages/StridePage.test.tsx
+++ b/web/src/pages/StridePage.test.tsx
@@ -384,6 +384,107 @@ describe('StridePage – delete race', () => {
   })
 })
 
+describe('StridePage – workout context panel on evaluation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  function makePlanFetchMock(evaluation: Record<string, unknown>) {
+    const planDay: DayPlan = {
+      date: '2099-01-13',
+      rest_day: false,
+      session: {
+        description: 'Easy run',
+        warmup: '',
+        main_set: '30 min easy',
+        cooldown: '',
+        strides: '',
+        target_hr_cap: 150,
+      },
+    }
+    const plan = {
+      id: 1,
+      user_id: 1,
+      week_start: '2099-01-13',
+      week_end: '2099-01-19',
+      phase: 'Base',
+      model: 'test',
+      created_at: '2099-01-13T00:00:00Z',
+      plan: [planDay],
+    }
+    return vi.fn((url: string) => {
+      const make = (data: unknown) =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response)
+      if (url.includes('/api/stride/plans/current')) return make({ plan })
+      if (url.includes('/api/stride/plans?limit=2')) return make({ plans: [plan] })
+      if (url.includes('/api/stride/plans?limit=1')) return make({ total: 1 })
+      if (url.includes('/api/stride/evaluations')) return make({ evaluations: [evaluation] })
+      if (url.includes('/api/training/workouts')) {
+        return make({ workouts: [{ id: 42, started_at: '2099-01-13T08:00:00Z' }] })
+      }
+      if (url.includes('/api/stride/races')) return make({ races: [] })
+      if (url.includes('/api/stride/notes')) return make({ notes: [] })
+      return make({})
+    })
+  }
+
+  it('renders the panel title when workout_context_summary is non-empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makePlanFetchMock({
+        id: 1,
+        user_id: 1,
+        plan_id: 1,
+        workout_id: 42,
+        eval: {
+          planned_type: 'easy',
+          actual_type: 'easy',
+          compliance: 'compliant',
+          notes: 'Solid easy run',
+          flags: [],
+          adjustments: '',
+        },
+        created_at: '2099-01-13T20:00:00Z',
+        workout_context_summary: 'Feel notes: legs felt fresh | Context: surface=road',
+      }),
+    )
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('What coach saw for this day')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('Feel notes: legs felt fresh | Context: surface=road'),
+    ).toBeInTheDocument()
+  })
+
+  it('omits the panel when workout_context_summary is null/empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makePlanFetchMock({
+        id: 1,
+        user_id: 1,
+        plan_id: 1,
+        workout_id: 42,
+        eval: {
+          planned_type: 'easy',
+          actual_type: 'easy',
+          compliance: 'compliant',
+          notes: 'Solid easy run',
+          flags: [],
+          adjustments: '',
+        },
+        created_at: '2099-01-13T20:00:00Z',
+      }),
+    )
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Solid easy run')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('What coach saw for this day')).not.toBeInTheDocument()
+  })
+})
+
 describe('StridePage – plan highlight on update', () => {
   afterEach(() => {
     vi.useRealTimers()

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -273,8 +273,15 @@ function DayCard({ day, completed, evaluation, changedDates, onRerun, rerunning 
             {/* Stride evaluation section */}
             {evaluation && (() => {
               const flags = Array.isArray(evaluation.eval.flags) ? evaluation.eval.flags : []
+              const contextSummary = evaluation.workout_context_summary?.trim()
               return (
                 <div className={`space-y-2 ${!day.rest_day && day.session ? 'mt-3 pt-3 border-t border-gray-700' : ''}`}>
+                  {contextSummary && (
+                    <div className="rounded-lg border border-gray-700 bg-gray-900/40 p-2">
+                      <p className="text-xs font-semibold text-gray-500 uppercase mb-1">{t('evaluation.contextPanelTitle')}</p>
+                      <p className="text-sm text-gray-300 whitespace-pre-wrap">{contextSummary}</p>
+                    </div>
+                  )}
                   {evaluation.eval.notes && (
                     <div>
                       <p className="text-xs font-semibold text-gray-500 uppercase mb-1">{t('evaluation.coachNotes')}</p>
@@ -1597,6 +1604,7 @@ export default function StridePage() {
             {previousPlanEvals.map(({ date, eval: rec }) => {
               const dateStr = `${date}T00:00:00`
               const flags = Array.isArray(rec.eval.flags) ? rec.eval.flags : []
+              const contextSummary = rec.workout_context_summary?.trim()
               return (
                 <div key={rec.id} className="bg-gray-800 rounded-xl border border-gray-700 p-3 space-y-2">
                   <div className="flex items-center gap-3">
@@ -1618,6 +1626,12 @@ export default function StridePage() {
                       )}
                     </div>
                   </div>
+                  {contextSummary && (
+                    <div className="rounded-lg border border-gray-700 bg-gray-900/40 p-2">
+                      <p className="text-xs font-semibold text-gray-500 uppercase mb-1">{t('evaluation.contextPanelTitle')}</p>
+                      <p className="text-sm text-gray-300 whitespace-pre-wrap">{contextSummary}</p>
+                    </div>
+                  )}
                   {rec.eval.notes && (
                     <div>
                       <p className="text-xs font-semibold text-gray-500 uppercase mb-1">{t('evaluation.coachNotes')}</p>

--- a/web/src/types/stride.ts
+++ b/web/src/types/stride.ts
@@ -30,4 +30,5 @@ export interface StrideEvaluationRecord {
   workout_id: number | null
   eval: StrideEvaluation
   created_at: string
+  workout_context_summary?: string
 }


### PR DESCRIPTION
## Changes

- **Stride evaluation cards show workout context inline** - Each Stride coach evaluation now displays a "What coach saw for this day" panel with the user's saved workout context summary (feel notes, planned speed segments, surface/run type metadata), so the data that informed the coach's assessment is visible alongside the evaluation itself. (Hytte-ajpg)

## Original Issue (feature): Stride: show the workout_context summary inline in the evaluation card

The workout_context the user fills in on the Training detail modal IS fed into Stride's nightly evaluation prompt today (`internal/stride/evaluate.go:674` calls `appendWorkoutContextNote`, which loads the row and formats it via `training.FormatWorkoutContextNote` into a synthetic Note for that evaluation). But the synthetic note is constructed in-memory only — it never appears in the Coach Notes UI, so the user can't see what data informed the coach's evaluation.

This bead surfaces that data inline on the Stride evaluation card, so the user sees "this is what the coach saw for this day" alongside the evaluation itself.

## Backend

Add the workout_context summary to the evaluation response payload so the frontend can render it without a second fetch.

- In whatever struct populates the evaluation list response (likely `internal/stride/handlers.go` and `internal/stride/models.go` — search for the type that carries `Verdict`, `CriticalFlags`, `CoachNotes`, etc.), add a new field `WorkoutContextSummary string` (or `*string` if you prefer absent vs empty distinction).
- Populate it in the handler that returns evaluations: for each evaluation that links to a workout, call `training.GetWorkoutContext(db, workoutID)` and `training.FormatWorkoutContextNote(wctx)`. On `sql.ErrNoRows`, leave the field empty/nil.
- Treat decryption failures the same as the rest of the codebase (log + skip).
- Don't modify the evaluation prompt path — the synthetic-note injection in `appendWorkoutContextNote` stays as-is; this bead only adds a presentation channel.

If multiple evaluations share a single workout, they all get the same summary string — that's expected.

## Frontend

In `web/src/pages/StridePage.tsx`, on the evaluation card:

- When the new `workout_context_summary` field is non-empty, render a small read-only panel under the evaluation body (above or below CoachNotes — pick whichever reads better in the current layout). Title via i18n: "What coach saw for this day" / "Det treneren så for denne dagen" / Thai equivalent.
- Render the summary as plain text or simple markdown — no editing, no actions.
- If empty/null, omit the panel entirely (no "no context saved" placeholder; the absence of a saved modal is the absence of the panel).

i18n keys under the existing stride namespace:
- `evaluation.contextPanelTitle`
- (no other strings; the panel body is the formatted summary itself, generated by `FormatWorkoutContextNote`)

## Tests

- Backend: extend the evaluation list handler test to assert the new field is populated when context exists, empty when it doesn't.
- Frontend: small RTL test that the panel renders when the field is non-empty and is absent when null.

## Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build` all pass.
- Open Stride for a date with a saved workout context: the evaluation card shows the new panel with the summary text.
- A date without saved context: panel absent, layout unchanged from today.
- Changelog fragment in changelog.d/ (category: Added).

## Non-goals

- Persisting the context summary as a real Note row. Considered and rejected — it would create dual-edit semantics and stale-duplication risk.
- Editing context from the Stride page. Edit lives in the Training detail modal; Stride just mirrors.
- Surfacing context in weekly plan generation cards. Could be a follow-up; nightly evaluation is the primary signal.

## Reference

- internal/stride/evaluate.go:996–1021 — `appendWorkoutContextNote` shows the existing synthesis path and the call into `FormatWorkoutContextNote`.
- internal/stride/handlers.go — the GET handler for evaluations (search for the response struct that carries the verdict).
- internal/training/models.go — `GetWorkoutContext` and `FormatWorkoutContextNote` are the helpers to reuse.
- web/src/pages/StridePage.tsx:1424 onwards — current Coach Notes section; the new panel sits near the evaluation card, NOT inside the user-authored notes list.


---
Bead: Hytte-ajpg | Branch: forge/Hytte-ajpg
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)