### PR TITLE
Minutes+seconds duration inputs in SpeedPlanEditor (Hytte-rsor)

### DIFF
--- a/changelog.d/Hytte-rsor.md
+++ b/changelog.d/Hytte-rsor.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Minutes + seconds duration inputs in SpeedPlanEditor** - Replaced the single seconds-only duration field with adjacent minutes and seconds inputs in the speed plan editor (per-row intervals and the shared pause). Existing values stored in seconds (e.g. 75) now render as 1m 15s. Storage shape (`duration_sec`) is unchanged. (Hytte-rsor)

--- a/web/public/locales/en/training.json
+++ b/web/public/locales/en/training.json
@@ -359,6 +359,7 @@
     "sharedIntervalSpeed": "Shared interval speed",
     "sharedPause": "Pause / gap",
     "kmh": "km/h",
+    "min": "min",
     "sec": "sec"
   },
   "workoutContextModal": {

--- a/web/public/locales/nb/training.json
+++ b/web/public/locales/nb/training.json
@@ -359,6 +359,7 @@
     "sharedIntervalSpeed": "Felles intervallfart",
     "sharedPause": "Pause / hvile",
     "kmh": "km/t",
+    "min": "min",
     "sec": "sek"
   },
   "workoutContextModal": {

--- a/web/public/locales/th/training.json
+++ b/web/public/locales/th/training.json
@@ -359,6 +359,7 @@
     "sharedIntervalSpeed": "ความเร็วอินเทอร์วัลร่วม",
     "sharedPause": "พัก / ช่วงพัก",
     "kmh": "กม./ชม.",
+    "min": "นาที",
     "sec": "วินาที"
   },
   "workoutContextModal": {

--- a/web/src/components/training/SpeedPlanEditor.test.tsx
+++ b/web/src/components/training/SpeedPlanEditor.test.tsx
@@ -10,6 +10,15 @@ function StatefulEditor({ initial }: { initial: SpeedPlanSegment[] }) {
   return <SpeedPlanEditor value={segments} onChange={setSegments} />
 }
 
+function StatefulEditorWithSpy({ initial, spy }: { initial: SpeedPlanSegment[], spy: (s: SpeedPlanSegment[]) => void }) {
+  const [segments, setSegments] = useState<SpeedPlanSegment[]>(initial)
+  function handleChange(segs: SpeedPlanSegment[]) {
+    setSegments(segs)
+    spy(segs)
+  }
+  return <SpeedPlanEditor value={segments} onChange={handleChange} />
+}
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -46,15 +55,14 @@ describe('SpeedPlanEditor duration inputs', () => {
   })
 
   it('combines minutes=2 + seconds=30 into duration_sec=150 on the per-row interval', () => {
-    render(<StatefulEditor initial={[intervalSeg(0)]} />)
+    const spy = vi.fn()
+    render(<StatefulEditorWithSpy initial={[intervalSeg(0)]} spy={spy} />)
 
     fireEvent.change(screen.getByTestId('speed-plan-row-0-duration-minutes'), { target: { value: '2' } })
     fireEvent.change(screen.getByTestId('speed-plan-row-0-duration-seconds'), { target: { value: '30' } })
 
-    const minutes = screen.getByTestId('speed-plan-row-0-duration-minutes') as HTMLInputElement
-    const seconds = screen.getByTestId('speed-plan-row-0-duration-seconds') as HTMLInputElement
-    expect(minutes.value).toBe('2')
-    expect(seconds.value).toBe('30')
+    const lastCall = spy.mock.calls[spy.mock.calls.length - 1][0] as SpeedPlanSegment[]
+    expect(lastCall[0].duration_sec).toBe(150)
   })
 
   it('emits duration_sec=120 when minutes is set to 2 from a zero start', () => {

--- a/web/src/components/training/SpeedPlanEditor.test.tsx
+++ b/web/src/components/training/SpeedPlanEditor.test.tsx
@@ -5,11 +5,6 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import SpeedPlanEditor from './SpeedPlanEditor'
 import type { SpeedPlanSegment } from '../../types/training'
 
-function StatefulEditor({ initial }: { initial: SpeedPlanSegment[] }) {
-  const [segments, setSegments] = useState<SpeedPlanSegment[]>(initial)
-  return <SpeedPlanEditor value={segments} onChange={setSegments} />
-}
-
 function StatefulEditorWithSpy({ initial, spy }: { initial: SpeedPlanSegment[], spy: (s: SpeedPlanSegment[]) => void }) {
   const [segments, setSegments] = useState<SpeedPlanSegment[]>(initial)
   function handleChange(segs: SpeedPlanSegment[]) {

--- a/web/src/components/training/SpeedPlanEditor.test.tsx
+++ b/web/src/components/training/SpeedPlanEditor.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { useState } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import SpeedPlanEditor from './SpeedPlanEditor'
+import type { SpeedPlanSegment } from '../../types/training'
+
+function StatefulEditor({ initial }: { initial: SpeedPlanSegment[] }) {
+  const [segments, setSegments] = useState<SpeedPlanSegment[]>(initial)
+  return <SpeedPlanEditor value={segments} onChange={setSegments} />
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: () => {} },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+function intervalSeg(durationSec: number): SpeedPlanSegment {
+  return { kind: 'interval', speed_kmph: 12, duration_sec: durationSec, repeats: 1, same_as_previous: false }
+}
+
+function pauseSeg(durationSec: number): SpeedPlanSegment {
+  return { kind: 'pause', speed_kmph: 6, duration_sec: durationSec, repeats: 1, same_as_previous: false }
+}
+
+describe('SpeedPlanEditor duration inputs', () => {
+  it('splits duration_sec=90 into 1m 30s on the per-row interval', () => {
+    render(<SpeedPlanEditor value={[intervalSeg(90)]} onChange={() => {}} />)
+
+    const minutes = screen.getByTestId('speed-plan-row-0-duration-minutes') as HTMLInputElement
+    const seconds = screen.getByTestId('speed-plan-row-0-duration-seconds') as HTMLInputElement
+    expect(minutes.value).toBe('1')
+    expect(seconds.value).toBe('30')
+  })
+
+  it('splits a legacy duration_sec=75 into 1m 15s (backwards compatible)', () => {
+    render(<SpeedPlanEditor value={[intervalSeg(75)]} onChange={() => {}} />)
+
+    const minutes = screen.getByTestId('speed-plan-row-0-duration-minutes') as HTMLInputElement
+    const seconds = screen.getByTestId('speed-plan-row-0-duration-seconds') as HTMLInputElement
+    expect(minutes.value).toBe('1')
+    expect(seconds.value).toBe('15')
+  })
+
+  it('combines minutes=2 + seconds=30 into duration_sec=150 on the per-row interval', () => {
+    render(<StatefulEditor initial={[intervalSeg(0)]} />)
+
+    fireEvent.change(screen.getByTestId('speed-plan-row-0-duration-minutes'), { target: { value: '2' } })
+    fireEvent.change(screen.getByTestId('speed-plan-row-0-duration-seconds'), { target: { value: '30' } })
+
+    const minutes = screen.getByTestId('speed-plan-row-0-duration-minutes') as HTMLInputElement
+    const seconds = screen.getByTestId('speed-plan-row-0-duration-seconds') as HTMLInputElement
+    expect(minutes.value).toBe('2')
+    expect(seconds.value).toBe('30')
+  })
+
+  it('emits duration_sec=120 when minutes is set to 2 from a zero start', () => {
+    const onChange = vi.fn()
+    render(<SpeedPlanEditor value={[intervalSeg(0)]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByTestId('speed-plan-row-0-duration-minutes'), { target: { value: '2' } })
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ kind: 'interval', duration_sec: 120 }),
+    ])
+  })
+
+  it('renders the shared pause duration as min+sec inputs', () => {
+    render(<SpeedPlanEditor value={[pauseSeg(75)]} onChange={() => {}} />)
+
+    const minutes = screen.getByTestId('speed-plan-shared-pause-duration-minutes') as HTMLInputElement
+    const seconds = screen.getByTestId('speed-plan-shared-pause-duration-seconds') as HTMLInputElement
+    expect(minutes.value).toBe('1')
+    expect(seconds.value).toBe('15')
+  })
+
+  it('updates duration_sec across all pause segments when shared pause min/sec changes', () => {
+    const onChange = vi.fn()
+    render(<SpeedPlanEditor value={[pauseSeg(0), pauseSeg(0)]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByTestId('speed-plan-shared-pause-duration-minutes'), { target: { value: '2' } })
+    const calls = onChange.mock.calls
+    const last = calls[calls.length - 1][0] as SpeedPlanSegment[]
+    expect(last).toHaveLength(2)
+    expect(last.every((s) => s.kind === 'pause' && s.duration_sec === 120)).toBe(true)
+  })
+
+  it('clamps seconds input above 59 down to 59', () => {
+    const onChange = vi.fn()
+    render(<SpeedPlanEditor value={[intervalSeg(60)]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByTestId('speed-plan-row-0-duration-seconds'), { target: { value: '90' } })
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ duration_sec: 60 + 59 }),
+    ])
+  })
+
+  it('treats an empty seconds value as 0', () => {
+    const onChange = vi.fn()
+    render(<SpeedPlanEditor value={[intervalSeg(150)]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByTestId('speed-plan-row-0-duration-seconds'), { target: { value: '' } })
+    expect(onChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ duration_sec: 120 }),
+    ])
+  })
+})

--- a/web/src/components/training/SpeedPlanEditor.tsx
+++ b/web/src/components/training/SpeedPlanEditor.tsx
@@ -23,7 +23,7 @@ function safeNumber(raw: string): number {
 
 function safeIntInRange(raw: string, max: number): number {
   if (raw === '') return 0
-  const n = Math.floor(Number(raw))
+  const n = Math.round(Number(raw))
   if (!Number.isFinite(n) || n < 0) return 0
   return n > max ? max : n
 }

--- a/web/src/components/training/SpeedPlanEditor.tsx
+++ b/web/src/components/training/SpeedPlanEditor.tsx
@@ -37,6 +37,7 @@ interface DurationInputsProps {
 }
 
 function DurationInputs({ durationSec, onChange, minLabel, secLabel, testIdPrefix }: DurationInputsProps) {
+  const uid = useId()
   const safeBase = Number.isFinite(durationSec) && durationSec >= 0 ? Math.floor(durationSec) : 0
   const minutesValue = Math.floor(safeBase / 60)
   const secondsValue = safeBase % 60
@@ -44,11 +45,11 @@ function DurationInputs({ durationSec, onChange, minLabel, secLabel, testIdPrefi
   return (
     <>
       <div className="flex flex-col">
-        <label htmlFor={`${testIdPrefix}-minutes`} className="text-[11px] text-gray-400">
+        <label htmlFor={`${uid}-minutes`} className="text-[11px] text-gray-400">
           {minLabel}
         </label>
         <input
-          id={`${testIdPrefix}-minutes`}
+          id={`${uid}-minutes`}
           type="number"
           min={0}
           step={1}
@@ -62,11 +63,11 @@ function DurationInputs({ durationSec, onChange, minLabel, secLabel, testIdPrefi
         />
       </div>
       <div className="flex flex-col">
-        <label htmlFor={`${testIdPrefix}-seconds`} className="text-[11px] text-gray-400">
+        <label htmlFor={`${uid}-seconds`} className="text-[11px] text-gray-400">
           {secLabel}
         </label>
         <input
-          id={`${testIdPrefix}-seconds`}
+          id={`${uid}-seconds`}
           type="number"
           min={0}
           max={59}

--- a/web/src/components/training/SpeedPlanEditor.tsx
+++ b/web/src/components/training/SpeedPlanEditor.tsx
@@ -21,11 +21,73 @@ function safeNumber(raw: string): number {
   return Number.isFinite(n) && n >= 0 ? n : 0
 }
 
+function safeIntInRange(raw: string, max: number): number {
+  if (raw === '') return 0
+  const n = Math.floor(Number(raw))
+  if (!Number.isFinite(n) || n < 0) return 0
+  return n > max ? max : n
+}
+
+interface DurationInputsProps {
+  durationSec: number
+  onChange: (nextDurationSec: number) => void
+  minLabel: string
+  secLabel: string
+  testIdPrefix: string
+}
+
+function DurationInputs({ durationSec, onChange, minLabel, secLabel, testIdPrefix }: DurationInputsProps) {
+  const safeBase = Number.isFinite(durationSec) && durationSec >= 0 ? Math.floor(durationSec) : 0
+  const minutesValue = Math.floor(safeBase / 60)
+  const secondsValue = safeBase % 60
+
+  return (
+    <>
+      <div className="flex flex-col">
+        <label htmlFor={`${testIdPrefix}-minutes`} className="text-[11px] text-gray-400">
+          {minLabel}
+        </label>
+        <input
+          id={`${testIdPrefix}-minutes`}
+          type="number"
+          min={0}
+          step={1}
+          value={minutesValue}
+          onChange={(e) => {
+            const minutes = safeIntInRange(e.target.value, Number.MAX_SAFE_INTEGER)
+            onChange(minutes * 60 + secondsValue)
+          }}
+          data-testid={`${testIdPrefix}-minutes`}
+          className="w-20 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
+        />
+      </div>
+      <div className="flex flex-col">
+        <label htmlFor={`${testIdPrefix}-seconds`} className="text-[11px] text-gray-400">
+          {secLabel}
+        </label>
+        <input
+          id={`${testIdPrefix}-seconds`}
+          type="number"
+          min={0}
+          max={59}
+          step={1}
+          value={secondsValue}
+          onChange={(e) => {
+            const seconds = safeIntInRange(e.target.value, 59)
+            onChange(minutesValue * 60 + seconds)
+          }}
+          data-testid={`${testIdPrefix}-seconds`}
+          className="w-20 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
+        />
+      </div>
+    </>
+  )
+}
+
 export default function SpeedPlanEditor({ value, onChange }: SpeedPlanEditorProps) {
   const { t } = useTranslation('training')
   const sharedIntervalSpeedId = useId()
   const sharedPauseSpeedId = useId()
-  const sharedPauseDurationId = useId()
   const addKindId = useId()
 
   const intervalSegments = useMemo(() => value.filter(s => s.kind === 'interval'), [value])
@@ -141,23 +203,13 @@ export default function SpeedPlanEditor({ value, onChange }: SpeedPlanEditorProp
                 className="w-24 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
               />
             </div>
-            <div className="flex flex-col">
-              <label htmlFor={sharedPauseDurationId} className="text-[11px] text-gray-400">
-                {t('speedPlan.sec')}
-              </label>
-              <input
-                id={sharedPauseDurationId}
-                type="number"
-                min={0}
-                step={1}
-                value={sharedPauseDuration}
-                onChange={(e) =>
-                  updateAllOfKind('pause', { duration_sec: Math.round(safeNumber(e.target.value)) })
-                }
-                data-testid="speed-plan-shared-pause-duration"
-                className="w-24 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
-              />
-            </div>
+            <DurationInputs
+              durationSec={sharedPauseDuration}
+              onChange={(next) => updateAllOfKind('pause', { duration_sec: next })}
+              minLabel={t('speedPlan.min')}
+              secLabel={t('speedPlan.sec')}
+              testIdPrefix="speed-plan-shared-pause-duration"
+            />
           </div>
         </div>
       )}
@@ -169,7 +221,6 @@ export default function SpeedPlanEditor({ value, onChange }: SpeedPlanEditorProp
           const hideSpeed = (isInterval && sameSpeedForIntervals) || isPause
           const hideDuration = isPause
           const speedInputId = `speed-plan-row-${index}-speed`
-          const durationInputId = `speed-plan-row-${index}-duration`
           return (
             <li
               key={index}
@@ -199,23 +250,13 @@ export default function SpeedPlanEditor({ value, onChange }: SpeedPlanEditorProp
               )}
 
               {!hideDuration && (
-                <div className="flex flex-col">
-                  <label htmlFor={durationInputId} className="text-[11px] text-gray-400">
-                    {t('speedPlan.sec')}
-                  </label>
-                  <input
-                    id={durationInputId}
-                    type="number"
-                    min={0}
-                    step={1}
-                    value={seg.duration_sec}
-                    onChange={(e) =>
-                      updateSegment(index, { duration_sec: Math.round(safeNumber(e.target.value)) })
-                    }
-                    data-testid={`speed-plan-row-${index}-duration`}
-                    className="w-24 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white focus:border-blue-500 focus:outline-none"
-                  />
-                </div>
+                <DurationInputs
+                  durationSec={seg.duration_sec}
+                  onChange={(next) => updateSegment(index, { duration_sec: next })}
+                  minLabel={t('speedPlan.min')}
+                  secLabel={t('speedPlan.sec')}
+                  testIdPrefix={`speed-plan-row-${index}-duration`}
+                />
               )}
 
               <button


### PR DESCRIPTION
## Changes

- **Minutes + seconds duration inputs in SpeedPlanEditor** - Replaced the single seconds-only duration field with adjacent minutes and seconds inputs in the speed plan editor (per-row intervals and the shared pause). Existing values stored in seconds (e.g. 75) now render as 1m 15s. Storage shape (`duration_sec`) is unchanged. (Hytte-rsor)

## Original Issue (task): Minutes+seconds duration inputs in SpeedPlanEditor

Frontend-only in web/src/components/training/SpeedPlanEditor.tsx. Replace the single `<input type='number'>` for duration_sec at the shared pause block (~line 155) and per-row interval (~line 211) with two adjacent inputs: minutes (min=0, step=1) and seconds (min=0, max=59, step=1). On change derive duration_sec = minutes*60 + seconds; on render split as minutes=floor(duration_sec/60), seconds=duration_sec%60. Storage stays as duration_sec (no backend or migration change). Backwards-compat: a stored 75 must render as 1m 15s. Add i18n keys under `speedPlan.` in en/nb/th: `min` ('min') if missing; `sec` already exists. Update SpeedPlanEditor.test.tsx with cases: 2m+30s → 150; load 90 → 1m 30s; load 75 → 1m 15s. Independent of sibling tasks — different file, no shared state.

---
Bead: Hytte-rsor | Branch: forge/Hytte-rsor
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)