### PR TITLE
Changelog fragment and acceptance verification (Hytte-dm50)

### DIFF
--- a/changelog.d/Hytte-dm50.md
+++ b/changelog.d/Hytte-dm50.md
@@ -1,0 +1,6 @@
+category: Added
+- **Long and tempo run types in workout context** - Workout context modal now offers four run types (slow, long, tempo, interval), with values persisted and round-tripped across saves. (Hytte-dm50)
+- **Minutes and seconds inputs in speed plan editor** - Per-row interval and shared pause durations are entered as minutes plus seconds in the speed plan editor; existing values stored as `duration_sec` continue to load and edit without data loss. (Hytte-dm50)
+
+category: Changed
+- **Auto-run AI summary on workout context save** - Saving the workout context modal now flips `analysis_status` to pending and triggers the same background Claude analysis used at FIT upload, so the summary completes via polling without a manual Analyze click. Skips when an analysis is already running or completed. (Hytte-dm50)


### PR DESCRIPTION
## Changes

- **Long and tempo run types in workout context** - Workout context modal now offers four run types (slow, long, tempo, interval), with values persisted and round-tripped across saves. (Hytte-dm50)
- **Minutes and seconds inputs in speed plan editor** - Per-row interval and shared pause durations are entered as minutes plus seconds in the speed plan editor; existing values stored as `duration_sec` continue to load and edit without data loss. (Hytte-dm50)
- **Auto-run AI summary on workout context save** - Saving the workout context modal now flips `analysis_status` to pending and triggers the same background Claude analysis used at FIT upload, so the summary completes via polling without a manual Analyze click. Skips when an analysis is already running or completed. (Hytte-dm50)

## Original Issue (task): Changelog fragment and acceptance verification

Add a changelog fragment in changelog.d/ covering the three changes (categories: Added for new run types and minutes+seconds widget; Changed for auto-run AI summary on context save). Run the full acceptance suite: `make build`, `make test`, `npm run lint`, `npm run build`, and `npm test -- --run src/pages/TrainingDetail src/components/training/`. Manually verify: saving the context modal flips analysis_status to pending and the polling completes the summary without a manual click; the run-type toggle shows four options and 'long'/'tempo' persist and round-trip; speed plan interval and pause inputs accept minutes and seconds and existing workouts with raw duration_sec values load correctly. Depends on all three sibling tasks landing first.

---
Bead: Hytte-dm50 | Branch: forge/Hytte-dm50
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)