### PR TITLE
Stride: collapse Coach Notes history (Hytte-wsrz)

### DIFF
--- a/changelog.d/Hytte-wsrz.md
+++ b/changelog.d/Hytte-wsrz.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Stride Coach Notes collapse older notes** - Coach Notes on the Stride page now show notes from the last seven days inline and tuck everything older under an "Older notes (N)" collapsible so last week's plan and feedback stay visible without scrolling past weeks of history. (Hytte-wsrz)

--- a/web/public/locales/en/stride.json
+++ b/web/public/locales/en/stride.json
@@ -85,6 +85,8 @@
     "activeLabel": "Active",
     "historyLabel": "History",
     "olderNotes": "Older notes ({{count}})",
+    "olderNotes_one": "Older notes ({{count}})",
+    "olderNotes_other": "Older notes ({{count}})",
     "toggleOlderAria": "Toggle older notes",
     "consumedBy": "Used by {{process}} on {{date}}",
     "consumedByProcess": {

--- a/web/public/locales/en/stride.json
+++ b/web/public/locales/en/stride.json
@@ -84,6 +84,8 @@
     },
     "activeLabel": "Active",
     "historyLabel": "History",
+    "olderNotes": "Older notes ({{count}})",
+    "toggleOlderAria": "Toggle older notes",
     "consumedBy": "Used by {{process}} on {{date}}",
     "consumedByProcess": {
       "nightly": "Nightly",

--- a/web/public/locales/nb/stride.json
+++ b/web/public/locales/nb/stride.json
@@ -84,6 +84,8 @@
     },
     "activeLabel": "Aktive",
     "historyLabel": "Historikk",
+    "olderNotes": "Eldre notater ({{count}})",
+    "toggleOlderAria": "Veksle eldre notater",
     "consumedBy": "Brukt av {{process}} den {{date}}",
     "consumedByProcess": {
       "nightly": "Nattlig",

--- a/web/public/locales/nb/stride.json
+++ b/web/public/locales/nb/stride.json
@@ -85,6 +85,8 @@
     "activeLabel": "Aktive",
     "historyLabel": "Historikk",
     "olderNotes": "Eldre notater ({{count}})",
+    "olderNotes_one": "Eldre notater ({{count}})",
+    "olderNotes_other": "Eldre notater ({{count}})",
     "toggleOlderAria": "Veksle eldre notater",
     "consumedBy": "Brukt av {{process}} den {{date}}",
     "consumedByProcess": {

--- a/web/public/locales/th/stride.json
+++ b/web/public/locales/th/stride.json
@@ -85,6 +85,8 @@
     "activeLabel": "ใช้งานอยู่",
     "historyLabel": "ประวัติ",
     "olderNotes": "บันทึกเก่า ({{count}})",
+    "olderNotes_one": "บันทึกเก่า ({{count}})",
+    "olderNotes_other": "บันทึกเก่า ({{count}})",
     "toggleOlderAria": "สลับบันทึกเก่า",
     "consumedBy": "ใช้โดย {{process}} เมื่อ {{date}}",
     "consumedByProcess": {

--- a/web/public/locales/th/stride.json
+++ b/web/public/locales/th/stride.json
@@ -84,6 +84,8 @@
     },
     "activeLabel": "ใช้งานอยู่",
     "historyLabel": "ประวัติ",
+    "olderNotes": "บันทึกเก่า ({{count}})",
+    "toggleOlderAria": "สลับบันทึกเก่า",
     "consumedBy": "ใช้โดย {{process}} เมื่อ {{date}}",
     "consumedByProcess": {
       "nightly": "ทุกคืน",

--- a/web/src/pages/StridePage.test.tsx
+++ b/web/src/pages/StridePage.test.tsx
@@ -97,6 +97,7 @@ vi.mock('lucide-react', () => ({
   AlertTriangle: () => null,
   XCircle: () => null,
   History: () => null,
+  Pencil: () => null,
   Flag: () => null,
   MessageCircle: () => null,
   Send: () => null,
@@ -163,30 +164,6 @@ const NOTE = {
   consumed_by: null,
   scope: 'any',
   created_at: '2024-01-15T10:00:00Z',
-}
-
-const OLDER_NOTE = {
-  id: 2,
-  user_id: 1,
-  plan_id: null,
-  content: 'Old reflection from months ago',
-  target_date: isoDate(-60),
-  consumed_at: null,
-  consumed_by: null,
-  scope: 'any',
-  created_at: '2023-11-15T10:00:00Z',
-}
-
-const OLDER_CONSUMED_NOTE = {
-  id: 3,
-  user_id: 1,
-  plan_id: null,
-  content: 'Long-since-consumed weekly note',
-  target_date: isoDate(-30),
-  consumed_at: '2023-12-15T10:00:00Z',
-  consumed_by: 'weekly',
-  scope: 'weekly',
-  created_at: '2023-12-01T10:00:00Z',
 }
 
 // ── Fetch mock ────────────────────────────────────────────────────────────────
@@ -601,7 +578,40 @@ describe('StridePage – plan highlight on update', () => {
 })
 
 describe('StridePage – Coach Notes older-bucket collapse', () => {
+  // Pin the system clock so isoDate() is deterministic in both component and fixtures.
+  const FIXED_SYSTEM_TIME = new Date('2024-06-15T12:00:00Z')
+
+  // Factories call isoDate() at test-run time, after fake timers are set in beforeEach.
+  const olderNote = () => ({
+    id: 2,
+    user_id: 1,
+    plan_id: null,
+    content: 'Old reflection from months ago',
+    target_date: isoDate(-60),
+    consumed_at: null,
+    consumed_by: null,
+    scope: 'any',
+    created_at: '2023-11-15T10:00:00Z',
+  })
+  const olderConsumedNote = () => ({
+    id: 3,
+    user_id: 1,
+    plan_id: null,
+    content: 'Long-since-consumed weekly note',
+    target_date: isoDate(-30),
+    consumed_at: '2023-12-15T10:00:00Z',
+    consumed_by: 'weekly',
+    scope: 'weekly',
+    created_at: '2023-12-01T10:00:00Z',
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(FIXED_SYSTEM_TIME)
+  })
+
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.clearAllMocks()
   })
@@ -620,7 +630,7 @@ describe('StridePage – Coach Notes older-bucket collapse', () => {
   }
 
   it('renders active notes inline (visible without expanding)', async () => {
-    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE]))
+    vi.stubGlobal('fetch', notesFetch([NOTE, olderNote()]))
     renderPage()
     await waitFor(() => {
       expect(screen.getByText('Feeling good this week')).toBeInTheDocument()
@@ -631,7 +641,7 @@ describe('StridePage – Coach Notes older-bucket collapse', () => {
   })
 
   it('hides older notes inside a collapsed <details> by default', async () => {
-    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE, OLDER_CONSUMED_NOTE]))
+    vi.stubGlobal('fetch', notesFetch([NOTE, olderNote(), olderConsumedNote()]))
     const { container } = renderPage()
     await waitFor(() => {
       expect(screen.getByText('Feeling good this week')).toBeInTheDocument()
@@ -652,7 +662,7 @@ describe('StridePage – Coach Notes older-bucket collapse', () => {
   })
 
   it('expands older notes when the summary is clicked', async () => {
-    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE]))
+    vi.stubGlobal('fetch', notesFetch([NOTE, olderNote()]))
     renderPage()
     await waitFor(() => {
       expect(screen.getByText('Older notes (1)')).toBeInTheDocument()
@@ -662,7 +672,6 @@ describe('StridePage – Coach Notes older-bucket collapse', () => {
     const detailsEl = summary.closest('details') as HTMLDetailsElement
     expect(detailsEl.open).toBe(false)
 
-    // <summary> click toggles its parent <details>; happy-dom honours this.
     await act(async () => {
       fireEvent.click(summary)
     })
@@ -676,9 +685,9 @@ describe('StridePage – Coach Notes older-bucket collapse', () => {
       notesFetch([
         { ...NOTE, id: 10, target_date: isoDate(-1), content: 'within-week note A' },
         { ...NOTE, id: 11, target_date: isoDate(0), content: 'within-week note B' },
-        { ...OLDER_NOTE, id: 12, content: 'older A' },
-        { ...OLDER_NOTE, id: 13, content: 'older B' },
-        { ...OLDER_CONSUMED_NOTE, id: 14, content: 'older consumed' },
+        { ...olderNote(), id: 12, content: 'older A' },
+        { ...olderNote(), id: 13, content: 'older B' },
+        { ...olderConsumedNote(), id: 14, content: 'older consumed' },
       ]),
     )
     renderPage()
@@ -694,16 +703,14 @@ describe('StridePage – Coach Notes older-bucket collapse', () => {
   })
 
   it('deletes an active note from the inline list', async () => {
-    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE]))
+    vi.stubGlobal('fetch', notesFetch([NOTE, olderNote()]))
     renderPage()
 
     await waitFor(() => {
       expect(screen.getByText('Feeling good this week')).toBeInTheDocument()
     })
 
-    // The active note has both edit + delete; older active note (inside details)
-    // also has the same controls. Target the active one by traversing from the
-    // note text.
+    // Target the active note card specifically (not the older one inside details).
     const activeNoteCard = screen.getByText('Feeling good this week').closest('div.group')!
     const deleteBtn = activeNoteCard.querySelectorAll('button[aria-label="Delete note"]')[0] as HTMLButtonElement
     expect(deleteBtn).toBeDefined()
@@ -720,7 +727,7 @@ describe('StridePage – Coach Notes older-bucket collapse', () => {
   })
 
   it('deletes an older note from inside the collapsed group', async () => {
-    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE]))
+    vi.stubGlobal('fetch', notesFetch([NOTE, olderNote()]))
     renderPage()
 
     await waitFor(() => {
@@ -740,5 +747,71 @@ describe('StridePage – Coach Notes older-bucket collapse', () => {
     expect(screen.queryByText(/Older notes/)).not.toBeInTheDocument()
     // Active note still rendered.
     expect(screen.getByText('Feeling good this week')).toBeInTheDocument()
+  })
+
+  it('opens edit dialog for an active note and saves changes', async () => {
+    vi.stubGlobal('fetch', notesFetch([NOTE, olderNote()]))
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Feeling good this week')).toBeInTheDocument()
+    })
+
+    const activeNoteCard = screen.getByText('Feeling good this week').closest('div.group')!
+    const editBtn = activeNoteCard.querySelector('button[aria-label="Edit note"]') as HTMLButtonElement
+    expect(editBtn).not.toBeNull()
+
+    await act(async () => {
+      fireEvent.click(editBtn)
+    })
+
+    // Dialog opens with the note content pre-filled.
+    const textarea = screen.getByRole('textbox', { name: 'Edit note' })
+    expect(textarea).toBeInTheDocument()
+    expect((textarea as HTMLTextAreaElement).value).toBe('Feeling good this week')
+
+    // Submit via the Save button.
+    const saveBtn = screen.getByRole('button', { name: 'Save' })
+    await act(async () => {
+      fireEvent.click(saveBtn)
+    })
+
+    // Dialog closes after a successful save.
+    await waitFor(() => {
+      expect(screen.queryByRole('textbox', { name: 'Edit note' })).not.toBeInTheDocument()
+    })
+  })
+
+  it('opens edit dialog for an older note and saves changes', async () => {
+    vi.stubGlobal('fetch', notesFetch([NOTE, olderNote()]))
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Old reflection from months ago')).toBeInTheDocument()
+    })
+
+    const olderCard = screen.getByText('Old reflection from months ago').closest('div.group')!
+    const editBtn = olderCard.querySelector('button[aria-label="Edit note"]') as HTMLButtonElement
+    expect(editBtn).not.toBeNull()
+
+    await act(async () => {
+      fireEvent.click(editBtn)
+    })
+
+    // Dialog opens with the older note's content pre-filled.
+    const textarea = screen.getByRole('textbox', { name: 'Edit note' })
+    expect(textarea).toBeInTheDocument()
+    expect((textarea as HTMLTextAreaElement).value).toBe('Old reflection from months ago')
+
+    // Submit via the Save button.
+    const saveBtn = screen.getByRole('button', { name: 'Save' })
+    await act(async () => {
+      fireEvent.click(saveBtn)
+    })
+
+    // Dialog closes after a successful save.
+    await waitFor(() => {
+      expect(screen.queryByRole('textbox', { name: 'Edit note' })).not.toBeInTheDocument()
+    })
   })
 })

--- a/web/src/pages/StridePage.test.tsx
+++ b/web/src/pages/StridePage.test.tsx
@@ -145,12 +145,48 @@ const PAST_RACE = {
   created_at: '2019-12-01T00:00:00Z',
 }
 
+// Build target dates relative to "today" so tests stay deterministic regardless
+// of when they run — Coach Notes now splits on a rolling 7-day window.
+function isoDate(daysFromToday: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + daysFromToday)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
 const NOTE = {
   id: 1,
   user_id: 1,
   plan_id: null,
   content: 'Feeling good this week',
+  target_date: isoDate(0),
+  consumed_at: null,
+  consumed_by: null,
+  scope: 'any',
   created_at: '2024-01-15T10:00:00Z',
+}
+
+const OLDER_NOTE = {
+  id: 2,
+  user_id: 1,
+  plan_id: null,
+  content: 'Old reflection from months ago',
+  target_date: isoDate(-60),
+  consumed_at: null,
+  consumed_by: null,
+  scope: 'any',
+  created_at: '2023-11-15T10:00:00Z',
+}
+
+const OLDER_CONSUMED_NOTE = {
+  id: 3,
+  user_id: 1,
+  plan_id: null,
+  content: 'Long-since-consumed weekly note',
+  target_date: isoDate(-30),
+  consumed_at: '2023-12-15T10:00:00Z',
+  consumed_by: 'weekly',
+  scope: 'weekly',
+  created_at: '2023-12-01T10:00:00Z',
 }
 
 // ── Fetch mock ────────────────────────────────────────────────────────────────
@@ -561,5 +597,148 @@ describe('StridePage – plan highlight on update', () => {
 
     // Ring should be cleared
     expect(container.querySelector('.ring-2')).toBeNull()
+  })
+})
+
+describe('StridePage – Coach Notes older-bucket collapse', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  function notesFetch(notes: unknown[]) {
+    return vi.fn((url: string, init?: RequestInit) => {
+      const make = (data: unknown, ok = true) =>
+        Promise.resolve({ ok, json: () => Promise.resolve(data) } as Response)
+      if (url.includes('/api/stride/notes') && (init?.method === 'DELETE' || init?.method === 'PATCH')) {
+        return make({ status: 'ok' })
+      }
+      if (url.includes('/api/stride/notes')) return make({ notes })
+      if (url.includes('/api/stride/races')) return make({ races: [] })
+      return make({})
+    })
+  }
+
+  it('renders active notes inline (visible without expanding)', async () => {
+    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE]))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Feeling good this week')).toBeInTheDocument()
+    })
+    // Active note is not inside the <details> wrapper.
+    const activeNote = screen.getByText('Feeling good this week')
+    expect(activeNote.closest('details')).toBeNull()
+  })
+
+  it('hides older notes inside a collapsed <details> by default', async () => {
+    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE, OLDER_CONSUMED_NOTE]))
+    const { container } = renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Feeling good this week')).toBeInTheDocument()
+    })
+
+    // Summary visible with count.
+    expect(screen.getByText('Older notes (2)')).toBeInTheDocument()
+
+    // The older notes are wrapped in a <details> that is closed by default.
+    const olderNoteEl = screen.getByText('Old reflection from months ago')
+    const detailsEl = olderNoteEl.closest('details') as HTMLDetailsElement | null
+    expect(detailsEl).not.toBeNull()
+    expect(detailsEl!.open).toBe(false)
+
+    // Both older entries (active + consumed) live inside the same <details>.
+    expect(container.querySelectorAll('details').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Long-since-consumed weekly note').closest('details')).toBe(detailsEl)
+  })
+
+  it('expands older notes when the summary is clicked', async () => {
+    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE]))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Older notes (1)')).toBeInTheDocument()
+    })
+
+    const summary = screen.getByText('Older notes (1)')
+    const detailsEl = summary.closest('details') as HTMLDetailsElement
+    expect(detailsEl.open).toBe(false)
+
+    // <summary> click toggles its parent <details>; happy-dom honours this.
+    await act(async () => {
+      fireEvent.click(summary)
+    })
+
+    expect(detailsEl.open).toBe(true)
+  })
+
+  it('counts only older notes in the summary label', async () => {
+    vi.stubGlobal(
+      'fetch',
+      notesFetch([
+        { ...NOTE, id: 10, target_date: isoDate(-1), content: 'within-week note A' },
+        { ...NOTE, id: 11, target_date: isoDate(0), content: 'within-week note B' },
+        { ...OLDER_NOTE, id: 12, content: 'older A' },
+        { ...OLDER_NOTE, id: 13, content: 'older B' },
+        { ...OLDER_CONSUMED_NOTE, id: 14, content: 'older consumed' },
+      ]),
+    )
+    renderPage()
+
+    await waitFor(() => {
+      // 2 older active + 1 older consumed = 3 older
+      expect(screen.getByText('Older notes (3)')).toBeInTheDocument()
+    })
+
+    // Active notes remain outside the collapsible.
+    expect(screen.getByText('within-week note A').closest('details')).toBeNull()
+    expect(screen.getByText('within-week note B').closest('details')).toBeNull()
+  })
+
+  it('deletes an active note from the inline list', async () => {
+    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE]))
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Feeling good this week')).toBeInTheDocument()
+    })
+
+    // The active note has both edit + delete; older active note (inside details)
+    // also has the same controls. Target the active one by traversing from the
+    // note text.
+    const activeNoteCard = screen.getByText('Feeling good this week').closest('div.group')!
+    const deleteBtn = activeNoteCard.querySelectorAll('button[aria-label="Delete note"]')[0] as HTMLButtonElement
+    expect(deleteBtn).toBeDefined()
+
+    await act(async () => {
+      fireEvent.click(deleteBtn)
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Feeling good this week')).not.toBeInTheDocument()
+    })
+    // Older note still present.
+    expect(screen.getByText('Old reflection from months ago')).toBeInTheDocument()
+  })
+
+  it('deletes an older note from inside the collapsed group', async () => {
+    vi.stubGlobal('fetch', notesFetch([NOTE, OLDER_NOTE]))
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Old reflection from months ago')).toBeInTheDocument()
+    })
+
+    const olderCard = screen.getByText('Old reflection from months ago').closest('div.group')!
+    const deleteBtn = olderCard.querySelectorAll('button[aria-label="Delete note"]')[0] as HTMLButtonElement
+    await act(async () => {
+      fireEvent.click(deleteBtn)
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Old reflection from months ago')).not.toBeInTheDocument()
+    })
+    // Older-notes summary disappears once the collapsed bucket is empty.
+    expect(screen.queryByText(/Older notes/)).not.toBeInTheDocument()
+    // Active note still rendered.
+    expect(screen.getByText('Feeling good this week')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -1113,6 +1113,25 @@ export default function StridePage() {
       .sort((a, b) => a.date.localeCompare(b.date))
   }, [currentPlan, previousPlanId, evaluations, sortedPlanDays, workoutIdToDate])
 
+  // Partition notes into "active" (target_date within the last 7 days or in the future)
+  // and "older" so the Coach Notes section stays compact when weeks of history accumulate.
+  const noteRecentCutoff = useMemo(() => {
+    const d = new Date()
+    d.setDate(d.getDate() - 7)
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  }, [])
+
+  const { activeNotes, olderNotes, activeConsumedNotes, olderConsumedNotes } = useMemo(() => {
+    const isRecent = (n: Note) => (n.target_date ?? '') >= noteRecentCutoff
+    return {
+      activeNotes: notes.filter(isRecent),
+      olderNotes: notes.filter(n => !isRecent(n)),
+      activeConsumedNotes: consumedNotes.filter(isRecent),
+      olderConsumedNotes: consumedNotes.filter(n => !isRecent(n)),
+    }
+  }, [notes, consumedNotes, noteRecentCutoff])
+  const olderNoteCount = olderNotes.length + olderConsumedNotes.length
+
   // Map each plan day date to its newest stride evaluation (via workout date lookup,
   // or via eval.date for rest_day/missed evaluations without a workout).
   // evaluations is ordered created_at DESC so the first entry per date is the newest.
@@ -1480,107 +1499,128 @@ export default function StridePage() {
           <p className="text-sm text-gray-400">{t('loading')}</p>
         ) : notes.length === 0 && consumedNotes.length === 0 ? (
           <p className="text-sm text-gray-500">{t('notes.empty')}</p>
-        ) : (
-          <>
-            {notes.length > 0 && (
-              <>
-                <h3 className="text-sm font-medium text-gray-400 mb-2">{t('notes.activeLabel')}</h3>
-                <div className="space-y-2 mb-4">
-                  {notes.map(note => {
-                    const scope: NoteScope = note.scope ?? 'any'
-                    return (
-                      <div key={note.id} className="flex items-start gap-3 p-3 bg-gray-800 rounded-xl border border-gray-700 group">
-                        <div className="flex-1 min-w-0 space-y-1">
-                          <p className="text-sm text-gray-200 whitespace-pre-wrap">{note.content}</p>
-                          <span className={`inline-flex items-center px-1.5 py-0.5 text-xs rounded ${noteScopeBadgeClass(scope)}`}>
-                            {t(`notes.scope.${scope}`)}
-                          </span>
-                        </div>
-                        <div className="flex-shrink-0 flex flex-col items-end gap-1">
-                          <div className="flex items-center gap-1">
-                            <button
-                              type="button"
-                              onClick={() => openEditNote(note)}
-                              className="sm:opacity-0 sm:group-hover:opacity-100 p-1.5 text-gray-500 hover:text-blue-400 transition-all"
-                              aria-label={t('notes.edit')}
-                            >
-                              <Pencil size={14} />
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => handleDeleteNote(note.id)}
-                              className="sm:opacity-0 sm:group-hover:opacity-100 p-1.5 text-gray-500 hover:text-red-400 transition-all"
-                              aria-label={t('notes.delete')}
-                            >
-                              <Trash2 size={14} />
-                            </button>
-                          </div>
-                          <span className="text-xs text-gray-500">
-                            {note.target_date && <span className="mr-1">{formatDate(`${note.target_date}T00:00:00`)}</span>}
-                            {formatDateTime(note.created_at, { dateStyle: 'short', timeStyle: 'short' })}
-                          </span>
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
-              </>
-            )}
-
-            {consumedNotes.length > 0 && (
-              <>
-                <h3 className="text-sm font-medium text-gray-400 mb-2">{t('notes.historyLabel')}</h3>
-                <div className="space-y-2">
-                  {consumedNotes.map(note => {
-                    const scope: NoteScope = note.scope ?? 'any'
-                    return (
-                    <div key={note.id} className="flex items-start gap-3 p-3 bg-gray-800/60 rounded-xl border border-gray-700/50 group">
-                      <div className="flex-1 min-w-0 space-y-1">
-                        <p className="text-sm text-gray-400 whitespace-pre-wrap">{note.content}</p>
-                        <span className={`inline-flex items-center px-1.5 py-0.5 text-xs rounded ${noteScopeBadgeClass(scope)} opacity-70`}>
-                          {t(`notes.scope.${scope}`)}
-                        </span>
-                      </div>
-                      <div className="flex-shrink-0 flex flex-col items-end gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handleDeleteNote(note.id)}
-                          className="sm:opacity-0 sm:group-hover:opacity-100 p-1.5 text-gray-500 hover:text-red-400 transition-all"
-                          aria-label={t('notes.delete')}
-                        >
-                          <Trash2 size={14} />
-                        </button>
-                        <div className="flex flex-col items-end gap-0.5">
-                          {(() => {
-                            const consumedByLabel = note.consumed_by === 'nightly'
-                              ? t('notes.consumedByProcess.nightly')
-                              : note.consumed_by === 'weekly'
-                                ? t('notes.consumedByProcess.weekly')
-                                : note.consumed_by === 'manual'
-                                  ? t('notes.consumedByProcess.manual')
-                                  : null
-                            const consumedDate = note.consumed_at ? formatDate(note.consumed_at) : null
-                            if (!consumedByLabel || !consumedDate) return null
-                            return (
-                              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-gray-700/50 text-gray-400">
-                                {t('notes.consumedBy', { process: consumedByLabel, date: consumedDate })}
-                              </span>
-                            )
-                          })()}
-                          <span className="text-xs text-gray-500">
-                            {note.target_date && <span className="mr-1">{formatDate(`${note.target_date}T00:00:00`)}</span>}
-                            {formatDateTime(note.created_at, { dateStyle: 'short', timeStyle: 'short' })}
-                          </span>
-                        </div>
-                      </div>
+        ) : (() => {
+            const renderActiveNote = (note: Note) => {
+              const scope: NoteScope = note.scope ?? 'any'
+              return (
+                <div key={note.id} className="flex items-start gap-3 p-3 bg-gray-800 rounded-xl border border-gray-700 group">
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <p className="text-sm text-gray-200 whitespace-pre-wrap">{note.content}</p>
+                    <span className={`inline-flex items-center px-1.5 py-0.5 text-xs rounded ${noteScopeBadgeClass(scope)}`}>
+                      {t(`notes.scope.${scope}`)}
+                    </span>
+                  </div>
+                  <div className="flex-shrink-0 flex flex-col items-end gap-1">
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => openEditNote(note)}
+                        className="sm:opacity-0 sm:group-hover:opacity-100 p-1.5 text-gray-500 hover:text-blue-400 transition-all"
+                        aria-label={t('notes.edit')}
+                      >
+                        <Pencil size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteNote(note.id)}
+                        className="sm:opacity-0 sm:group-hover:opacity-100 p-1.5 text-gray-500 hover:text-red-400 transition-all"
+                        aria-label={t('notes.delete')}
+                      >
+                        <Trash2 size={14} />
+                      </button>
                     </div>
-                    )
-                  })}
+                    <span className="text-xs text-gray-500">
+                      {note.target_date && <span className="mr-1">{formatDate(`${note.target_date}T00:00:00`)}</span>}
+                      {formatDateTime(note.created_at, { dateStyle: 'short', timeStyle: 'short' })}
+                    </span>
+                  </div>
                 </div>
+              )
+            }
+
+            const renderConsumedNote = (note: Note) => {
+              const scope: NoteScope = note.scope ?? 'any'
+              return (
+                <div key={note.id} className="flex items-start gap-3 p-3 bg-gray-800/60 rounded-xl border border-gray-700/50 group">
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <p className="text-sm text-gray-400 whitespace-pre-wrap">{note.content}</p>
+                    <span className={`inline-flex items-center px-1.5 py-0.5 text-xs rounded ${noteScopeBadgeClass(scope)} opacity-70`}>
+                      {t(`notes.scope.${scope}`)}
+                    </span>
+                  </div>
+                  <div className="flex-shrink-0 flex flex-col items-end gap-1">
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteNote(note.id)}
+                      className="sm:opacity-0 sm:group-hover:opacity-100 p-1.5 text-gray-500 hover:text-red-400 transition-all"
+                      aria-label={t('notes.delete')}
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                    <div className="flex flex-col items-end gap-0.5">
+                      {(() => {
+                        const consumedByLabel = note.consumed_by === 'nightly'
+                          ? t('notes.consumedByProcess.nightly')
+                          : note.consumed_by === 'weekly'
+                            ? t('notes.consumedByProcess.weekly')
+                            : note.consumed_by === 'manual'
+                              ? t('notes.consumedByProcess.manual')
+                              : null
+                        const consumedDate = note.consumed_at ? formatDate(note.consumed_at) : null
+                        if (!consumedByLabel || !consumedDate) return null
+                        return (
+                          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded bg-gray-700/50 text-gray-400">
+                            {t('notes.consumedBy', { process: consumedByLabel, date: consumedDate })}
+                          </span>
+                        )
+                      })()}
+                      <span className="text-xs text-gray-500">
+                        {note.target_date && <span className="mr-1">{formatDate(`${note.target_date}T00:00:00`)}</span>}
+                        {formatDateTime(note.created_at, { dateStyle: 'short', timeStyle: 'short' })}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )
+            }
+
+            return (
+              <>
+                {activeNotes.length > 0 && (
+                  <>
+                    <h3 className="text-sm font-medium text-gray-400 mb-2">{t('notes.activeLabel')}</h3>
+                    <div className="space-y-2 mb-4">
+                      {activeNotes.map(renderActiveNote)}
+                    </div>
+                  </>
+                )}
+
+                {activeConsumedNotes.length > 0 && (
+                  <>
+                    <h3 className="text-sm font-medium text-gray-400 mb-2">{t('notes.historyLabel')}</h3>
+                    <div className="space-y-2">
+                      {activeConsumedNotes.map(renderConsumedNote)}
+                    </div>
+                  </>
+                )}
+
+                {olderNoteCount > 0 && (
+                  <details className="mt-4">
+                    <summary
+                      className="text-sm text-gray-500 cursor-pointer hover:text-gray-300"
+                      aria-label={t('notes.toggleOlderAria')}
+                    >
+                      {t('notes.olderNotes', { count: olderNoteCount })}
+                    </summary>
+                    <div className="mt-2 space-y-2">
+                      {olderNotes.map(renderActiveNote)}
+                      {olderConsumedNotes.map(renderConsumedNote)}
+                    </div>
+                  </details>
+                )}
               </>
-            )}
-          </>
-        )}
+            )
+          })()}
       </section>
 
       {/* Plan History */}

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -627,6 +627,7 @@ export default function StridePage() {
   const [editScope, setEditScope] = useState<NoteScope>('any')
   const [editSubmitting, setEditSubmitting] = useState(false)
   const [editError, setEditError] = useState('')
+  const [olderNotesOpen, setOlderNotesOpen] = useState(false)
 
   const loadRaces = useCallback(async (signal?: AbortSignal) => {
     try {
@@ -1115,11 +1116,13 @@ export default function StridePage() {
 
   // Partition notes into "active" (target_date within the last 7 days or in the future)
   // and "older" so the Coach Notes section stays compact when weeks of history accumulate.
+  // Subtract 6 days so the window is exactly 7 calendar days inclusive (today + prior 6).
+  // Depend on `today` so the cutoff updates if the page stays mounted across a day boundary.
   const noteRecentCutoff = useMemo(() => {
     const d = new Date()
-    d.setDate(d.getDate() - 7)
+    d.setDate(d.getDate() - 6)
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-  }, [])
+  }, [today])
 
   const { activeNotes, olderNotes, activeConsumedNotes, olderConsumedNotes } = useMemo(() => {
     const isRecent = (n: Note) => (n.target_date ?? '') >= noteRecentCutoff
@@ -1605,10 +1608,13 @@ export default function StridePage() {
                 )}
 
                 {olderNoteCount > 0 && (
-                  <details className="mt-4">
+                  <details
+                    className="mt-4"
+                    open={olderNotesOpen}
+                  >
                     <summary
                       className="text-sm text-gray-500 cursor-pointer hover:text-gray-300"
-                      aria-label={t('notes.toggleOlderAria')}
+                      onClick={e => { e.preventDefault(); setOlderNotesOpen(prev => !prev) }}
                     >
                       {t('notes.olderNotes', { count: olderNoteCount })}
                     </summary>


### PR DESCRIPTION
## Changes

- **Stride Coach Notes collapse older notes** - Coach Notes on the Stride page now show notes from the last seven days inline and tuck everything older under an "Older notes (N)" collapsible so last week's plan and feedback stay visible without scrolling past weeks of history. (Hytte-wsrz)

## Original Issue (chore): Stride: collapse Coach Notes history

The Coach Notes section on the Stride page now lists every note ever written. With weeks of accumulated notes, the section is long enough that the user has to scroll past it to see last week's plan + feedback. Collapse the history under a toggle so the section stays compact by default.

## Change

In `web/src/pages/StridePage.tsx` (around line 1424, the Coach Notes section):

- Split the notes into two buckets: "active" (notes from the current week — same week-anchor logic used elsewhere on the Stride page) and "older" (everything else).
- Render active notes inline as today.
- Render older notes under a collapsed `<details>` (or equivalent React-Aria collapsible) with a header like "Older notes ({{count}})". Collapsed by default.
- Keep the create-note textarea + form at the top of the section unchanged.
- Preserve all existing note actions (edit, delete, consumed-by indicator) inside the collapsed group.

Per-section expand state lives in component state, no localStorage.

If "current week" is the wrong cutoff and "last 7 days from today" reads better, use that instead — pick whichever lines up cleanest with the existing date helpers in the file. Both are acceptable.

## i18n

Add to the existing stride namespace in en/nb/th:
- `notes.olderNotes` — "Older notes ({{count}})" / "Eldre notater ({{count}})" / Thai
- `notes.toggleOlderAria` — "Toggle older notes"

## Tests

Update `StridePage.test.tsx`:
- Active notes (current week) render inline.
- Older notes are collapsed; clicking the header expands them.
- Counts match.
- Editing/deleting works in both buckets.

## Acceptance

- `npm run lint`, `npm run build`, `npm test -- --run src/pages/StridePage` all pass.
- Coach Notes section is short enough that last week's plan + feedback is visible without scrolling past acres of history.
- Changelog fragment in changelog.d/ (category: Changed).

## Reference

- web/src/pages/StridePage.tsx:1424 — Coach Notes section.
- Existing week-boundary helpers in the same file (look near the history/plan rendering for the current convention).


---
Bead: Hytte-wsrz | Branch: forge/Hytte-wsrz
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)