### PR TITLE
Backend: paginate /api/stride/history with offset and zone-split fields (Hytte-va3f)

### DIFF
--- a/changelog.d/Hytte-va3f.md
+++ b/changelog.d/Hytte-va3f.md
@@ -1,0 +1,2 @@
+category: Added
+- **Paginate `/api/stride/history` with offset and per-week zone seconds** - Added an `offset` query param (default 0), clamped `limit` server-side to 24, capped pagination depth at 156 weeks, and added a `has_more` field plus per-week `easy_seconds` / `threshold_seconds` / `hard_seconds` to the response. The default (no-offset) response shape is preserved so older clients keep working. (Hytte-va3f)

--- a/internal/stride/handlers.go
+++ b/internal/stride/handlers.go
@@ -174,23 +174,60 @@ func TriggerEvaluationHandler(db *sql.DB) http.HandlerFunc {
 // PlanHistoryHandler returns past weeks' training plans with completion metadata
 // and monthly compliance rollups.
 //
-// GET /api/stride/history?limit=12
-// Response: {"weeks": [...], "months": [...]}
+// GET /api/stride/history?limit=12&offset=0
+//
+// limit defaults to HistoryDefaultLimit (12) and is clamped server-side to
+// HistoryMaxLimit (24). offset defaults to 0 and may not be negative. Pagination
+// is capped at HistoryDepthCapWeeks (156); offsets at or beyond that depth
+// return an empty page with has_more=false.
+//
+// Response: {"weeks": [...], "months": [...], "limit": N, "offset": N, "has_more": bool}.
+// The weeks/months payload shape is unchanged from the pre-pagination response;
+// the additional fields are additive so older clients continue to work.
 func PlanHistoryHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
 
-		limit := 12
+		limit := HistoryDefaultLimit
 		if raw := r.URL.Query().Get("limit"); raw != "" {
 			n, err := strconv.Atoi(raw)
-			if err != nil || n < 1 || n > 52 {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "limit must be between 1 and 52"})
+			if err != nil || n < 1 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "limit must be a positive integer"})
 				return
 			}
 			limit = n
 		}
+		if limit > HistoryMaxLimit {
+			limit = HistoryMaxLimit
+		}
 
-		weeks, months, err := GetPlanHistory(db, user.ID, limit)
+		offset := 0
+		if raw := r.URL.Query().Get("offset"); raw != "" {
+			n, err := strconv.Atoi(raw)
+			if err != nil || n < 0 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "offset must be a non-negative integer"})
+				return
+			}
+			offset = n
+		}
+
+		// Cap pagination depth: pages beyond HistoryDepthCapWeeks return empty.
+		if offset >= HistoryDepthCapWeeks {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"weeks":    []WeekSummary{},
+				"months":   []MonthSummary{},
+				"limit":    limit,
+				"offset":   offset,
+				"has_more": false,
+			})
+			return
+		}
+		// Clamp the page so it never extends past the depth cap.
+		if offset+limit > HistoryDepthCapWeeks {
+			limit = HistoryDepthCapWeeks - offset
+		}
+
+		weeks, months, hasMore, err := GetPlanHistory(db, user.ID, limit, offset)
 		if err != nil {
 			log.Printf("stride: plan history for user %d: %v", user.ID, err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load plan history"})
@@ -198,8 +235,11 @@ func PlanHistoryHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{
-			"weeks":  weeks,
-			"months": months,
+			"weeks":    weeks,
+			"months":   months,
+			"limit":    limit,
+			"offset":   offset,
+			"has_more": hasMore,
 		})
 	}
 }

--- a/internal/stride/handlers_test.go
+++ b/internal/stride/handlers_test.go
@@ -1236,17 +1236,19 @@ func TestPlanHistoryHandler_MissedNotCounted(t *testing.T) {
 	}
 }
 
-// insertTestWorkout inserts a workout row in the test DB on the given date
-// with the supplied duration and avg HR, returning its ID. It's used by the
-// stride history pagination tests to seed week-level zone aggregation data.
-func insertTestWorkout(t *testing.T, db *sql.DB, userID int64, startedAt string, durationSeconds, avgHR int) int64 {
+// insertTestWorkoutWithHR inserts a workout row in the test DB on the given
+// date with the supplied duration and avg HR, returning its ID. It's used by
+// the stride history pagination tests to seed week-level zone aggregation
+// data. (Distinct from insertTestWorkout in stride_test.go, which takes
+// distance + fit hash and does not set avg HR.)
+func insertTestWorkoutWithHR(t *testing.T, db *sql.DB, userID int64, startedAt string, durationSeconds, avgHR int) int64 {
 	t.Helper()
 	res, err := db.Exec(`
 		INSERT INTO workouts (user_id, started_at, duration_seconds, avg_heart_rate, fit_file_hash)
 		VALUES (?, ?, ?, ?, ?)
 	`, userID, startedAt, durationSeconds, avgHR, "wh-"+startedAt+"-"+strconv.Itoa(durationSeconds)+"-"+strconv.Itoa(avgHR))
 	if err != nil {
-		t.Fatalf("insertTestWorkout: %v", err)
+		t.Fatalf("insertTestWorkoutWithHR: %v", err)
 	}
 	id, _ := res.LastInsertId()
 	return id
@@ -1442,14 +1444,14 @@ func TestPlanHistoryHandler_ZoneSecondsPopulated(t *testing.T) {
 	insertTestPlan(t, db, 1, weekStart, weekEnd, planJSON)
 
 	// Three workouts inside the week, one per bucket.
-	insertTestWorkout(t, db, 1, weekStart+"T08:00:00Z", 3600, 130) // Z2 → easy
-	insertTestWorkout(t, db, 1, weekStart+"T09:00:00Z", 1800, 160) // Z3 → threshold
-	insertTestWorkout(t, db, 1, weekStart+"T10:00:00Z", 900, 190)  // Z5 → hard
+	insertTestWorkoutWithHR(t, db, 1, weekStart+"T08:00:00Z", 3600, 130) // Z2 → easy
+	insertTestWorkoutWithHR(t, db, 1, weekStart+"T09:00:00Z", 1800, 160) // Z3 → threshold
+	insertTestWorkoutWithHR(t, db, 1, weekStart+"T10:00:00Z", 900, 190)  // Z5 → hard
 	// A workout with no HR data should be excluded from the buckets.
-	insertTestWorkout(t, db, 1, weekStart+"T11:00:00Z", 1200, 0)
+	insertTestWorkoutWithHR(t, db, 1, weekStart+"T11:00:00Z", 1200, 0)
 	// A workout outside the week (one day after week_end) should be excluded.
 	parsedEnd, _ := time.Parse("2006-01-02", weekEnd)
-	insertTestWorkout(t, db, 1, parsedEnd.AddDate(0, 0, 1).Format("2006-01-02")+"T08:00:00Z", 1200, 140)
+	insertTestWorkoutWithHR(t, db, 1, parsedEnd.AddDate(0, 0, 1).Format("2006-01-02")+"T08:00:00Z", 1200, 140)
 
 	req := withUser(httptest.NewRequest("GET", "/api/stride/history", nil), 1)
 	rec := httptest.NewRecorder()

--- a/internal/stride/handlers_test.go
+++ b/internal/stride/handlers_test.go
@@ -1425,6 +1425,51 @@ func TestPlanHistoryHandler_DepthCap(t *testing.T) {
 	}
 }
 
+// TestPlanHistoryHandler_DepthCapBoundaryHasMoreFalse verifies that a page
+// whose offset+limit reaches HistoryDepthCapWeeks returns has_more=false even
+// though a row exists at index HistoryDepthCapWeeks (which the probe query
+// would discover and flag as has_more=true without the cap override).
+func TestPlanHistoryHandler_DepthCapBoundaryHasMoreFalse(t *testing.T) {
+	db := setupTestDB(t)
+
+	planJSON := `[{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true}]`
+	// Insert HistoryDepthCapWeeks+1 plans so a row exists at DB index
+	// HistoryDepthCapWeeks (position 156). The probe query for the last
+	// in-cap page would otherwise return that extra row and set has_more=true.
+	for i := 1; i <= HistoryDepthCapWeeks+1; i++ {
+		ws, we := pastWeekDates(i)
+		insertTestPlan(t, db, 1, ws, we, planJSON)
+	}
+
+	// offset=HistoryDepthCapWeeks-2, limit=10 → handler clamps limit to 2,
+	// making offset+limit == HistoryDepthCapWeeks exactly.
+	offset := HistoryDepthCapWeeks - 2
+	url := "/api/stride/history?limit=10&offset=" + strconv.Itoa(offset)
+	req := withUser(httptest.NewRequest("GET", url, nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Weeks   []WeekSummary `json:"weeks"`
+		HasMore bool          `json:"has_more"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// The clamped page covers the last 2 in-cap slots.
+	if len(body.Weeks) != 2 {
+		t.Errorf("expected 2 weeks at cap boundary, got %d", len(body.Weeks))
+	}
+	// has_more must be false: offset+limit == HistoryDepthCapWeeks, so no
+	// further pages are advertised even though a row exists beyond the cap.
+	if body.HasMore {
+		t.Errorf("has_more = true at cap boundary, want false")
+	}
+}
+
 // TestPlanHistoryHandler_ZoneSecondsPopulated seeds workouts at distinct HR
 // intensities and verifies they land in the correct easy/threshold/hard bucket
 // when bucketed against the user's default zones (computed from max_hr=200).

--- a/internal/stride/handlers_test.go
+++ b/internal/stride/handlers_test.go
@@ -1082,15 +1082,50 @@ func TestPlanHistoryHandler_InvalidLimit(t *testing.T) {
 	}
 }
 
-func TestPlanHistoryHandler_LimitOutOfRange(t *testing.T) {
+func TestPlanHistoryHandler_LimitClampedToMax(t *testing.T) {
+	// Oversized limit values are silently clamped to HistoryMaxLimit rather than
+	// rejected, so paginating clients don't need to know the server-side cap.
 	db := setupTestDB(t)
 
 	req := withUser(httptest.NewRequest("GET", "/api/stride/history?limit=99", nil), 1)
 	rec := httptest.NewRecorder()
 	PlanHistoryHandler(db).ServeHTTP(rec, req)
 
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 with clamped limit, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Limit int `json:"limit"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Limit != HistoryMaxLimit {
+		t.Errorf("limit = %d, want %d (HistoryMaxLimit)", body.Limit, HistoryMaxLimit)
+	}
+}
+
+func TestPlanHistoryHandler_RejectsNegativeOffset(t *testing.T) {
+	db := setupTestDB(t)
+
+	req := withUser(httptest.NewRequest("GET", "/api/stride/history?offset=-1", nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+
 	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for limit > 52, got %d", rec.Code)
+		t.Fatalf("expected 400 for negative offset, got %d", rec.Code)
+	}
+}
+
+func TestPlanHistoryHandler_RejectsInvalidOffset(t *testing.T) {
+	db := setupTestDB(t)
+
+	req := withUser(httptest.NewRequest("GET", "/api/stride/history?offset=abc", nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-numeric offset, got %d", rec.Code)
 	}
 }
 
@@ -1198,6 +1233,297 @@ func TestPlanHistoryHandler_MissedNotCounted(t *testing.T) {
 	}
 	if body.Weeks[0].CompletionRate != 0 {
 		t.Errorf("completion_rate = %.1f, want 0.0", body.Weeks[0].CompletionRate)
+	}
+}
+
+// insertTestWorkout inserts a workout row in the test DB on the given date
+// with the supplied duration and avg HR, returning its ID. It's used by the
+// stride history pagination tests to seed week-level zone aggregation data.
+func insertTestWorkout(t *testing.T, db *sql.DB, userID int64, startedAt string, durationSeconds, avgHR int) int64 {
+	t.Helper()
+	res, err := db.Exec(`
+		INSERT INTO workouts (user_id, started_at, duration_seconds, avg_heart_rate, fit_file_hash)
+		VALUES (?, ?, ?, ?, ?)
+	`, userID, startedAt, durationSeconds, avgHR, "wh-"+startedAt+"-"+strconv.Itoa(durationSeconds)+"-"+strconv.Itoa(avgHR))
+	if err != nil {
+		t.Fatalf("insertTestWorkout: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+// TestPlanHistoryHandler_OffsetPagination verifies that offset skips the most
+// recent N weeks and that legacy response fields are still present alongside
+// the new pagination fields.
+func TestPlanHistoryHandler_OffsetPagination(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Insert 4 past weeks of plans (week 1 = most recent, week 4 = oldest).
+	planJSON := `[{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true}]`
+	var planIDs [5]int64
+	for i := 1; i <= 4; i++ {
+		ws, we := pastWeekDates(i)
+		planIDs[i] = insertTestPlan(t, db, 1, ws, we, planJSON)
+	}
+
+	// Page 1: limit=2, offset=0 → two most recent weeks.
+	req := withUser(httptest.NewRequest("GET", "/api/stride/history?limit=2&offset=0", nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("page 1: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var page1 struct {
+		Weeks   []WeekSummary `json:"weeks"`
+		Limit   int           `json:"limit"`
+		Offset  int           `json:"offset"`
+		HasMore bool          `json:"has_more"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&page1); err != nil {
+		t.Fatalf("page 1 decode: %v", err)
+	}
+	if page1.Limit != 2 || page1.Offset != 0 {
+		t.Errorf("page 1 limit/offset = %d/%d, want 2/0", page1.Limit, page1.Offset)
+	}
+	if len(page1.Weeks) != 2 {
+		t.Fatalf("page 1: expected 2 weeks, got %d", len(page1.Weeks))
+	}
+	if page1.Weeks[0].PlanID != planIDs[1] || page1.Weeks[1].PlanID != planIDs[2] {
+		t.Errorf("page 1 plan IDs = [%d,%d], want [%d,%d] (most-recent-first)",
+			page1.Weeks[0].PlanID, page1.Weeks[1].PlanID, planIDs[1], planIDs[2])
+	}
+	if !page1.HasMore {
+		t.Errorf("page 1 has_more = false, want true (2 more weeks remain)")
+	}
+
+	// Page 2: limit=2, offset=2 → the next two (older) weeks.
+	req = withUser(httptest.NewRequest("GET", "/api/stride/history?limit=2&offset=2", nil), 1)
+	rec = httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("page 2: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var page2 struct {
+		Weeks   []WeekSummary `json:"weeks"`
+		Offset  int           `json:"offset"`
+		HasMore bool          `json:"has_more"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&page2); err != nil {
+		t.Fatalf("page 2 decode: %v", err)
+	}
+	if page2.Offset != 2 {
+		t.Errorf("page 2 offset = %d, want 2", page2.Offset)
+	}
+	if len(page2.Weeks) != 2 {
+		t.Fatalf("page 2: expected 2 weeks, got %d", len(page2.Weeks))
+	}
+	if page2.Weeks[0].PlanID != planIDs[3] || page2.Weeks[1].PlanID != planIDs[4] {
+		t.Errorf("page 2 plan IDs = [%d,%d], want [%d,%d]",
+			page2.Weeks[0].PlanID, page2.Weeks[1].PlanID, planIDs[3], planIDs[4])
+	}
+	if page2.HasMore {
+		t.Errorf("page 2 has_more = true, want false (final page)")
+	}
+}
+
+// TestPlanHistoryHandler_HasMoreTrueWhenMoreExist asserts that has_more is true
+// whenever rows exist beyond offset+limit and within the depth cap.
+func TestPlanHistoryHandler_HasMoreTrueWhenMoreExist(t *testing.T) {
+	db := setupTestDB(t)
+
+	planJSON := `[{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true}]`
+	for i := 1; i <= 3; i++ {
+		ws, we := pastWeekDates(i)
+		insertTestPlan(t, db, 1, ws, we, planJSON)
+	}
+
+	req := withUser(httptest.NewRequest("GET", "/api/stride/history?limit=1&offset=0", nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Weeks   []WeekSummary `json:"weeks"`
+		HasMore bool          `json:"has_more"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Weeks) != 1 {
+		t.Fatalf("expected 1 week, got %d", len(body.Weeks))
+	}
+	if !body.HasMore {
+		t.Errorf("has_more = false, want true (2 more weeks remain)")
+	}
+}
+
+// TestPlanHistoryHandler_HasMoreFalseAtEnd asserts has_more is false on the
+// final page (no rows remain beyond it).
+func TestPlanHistoryHandler_HasMoreFalseAtEnd(t *testing.T) {
+	db := setupTestDB(t)
+
+	planJSON := `[{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true}]`
+	for i := 1; i <= 2; i++ {
+		ws, we := pastWeekDates(i)
+		insertTestPlan(t, db, 1, ws, we, planJSON)
+	}
+
+	// Request a page large enough to swallow everything.
+	req := withUser(httptest.NewRequest("GET", "/api/stride/history?limit=5&offset=0", nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Weeks   []WeekSummary `json:"weeks"`
+		HasMore bool          `json:"has_more"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Weeks) != 2 {
+		t.Fatalf("expected 2 weeks, got %d", len(body.Weeks))
+	}
+	if body.HasMore {
+		t.Errorf("has_more = true, want false (no more rows)")
+	}
+}
+
+// TestPlanHistoryHandler_DepthCap verifies that requesting a page entirely
+// beyond HistoryDepthCapWeeks returns an empty page with has_more=false.
+func TestPlanHistoryHandler_DepthCap(t *testing.T) {
+	db := setupTestDB(t)
+
+	url := "/api/stride/history?limit=10&offset=" + strconv.Itoa(HistoryDepthCapWeeks+4)
+	req := withUser(httptest.NewRequest("GET", url, nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Weeks   []WeekSummary `json:"weeks"`
+		HasMore bool          `json:"has_more"`
+		Offset  int           `json:"offset"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Weeks) != 0 {
+		t.Errorf("expected 0 weeks beyond depth cap, got %d", len(body.Weeks))
+	}
+	if body.HasMore {
+		t.Errorf("has_more = true beyond depth cap, want false")
+	}
+	if body.Offset != HistoryDepthCapWeeks+4 {
+		t.Errorf("offset echoed back as %d, want %d", body.Offset, HistoryDepthCapWeeks+4)
+	}
+}
+
+// TestPlanHistoryHandler_ZoneSecondsPopulated seeds workouts at distinct HR
+// intensities and verifies they land in the correct easy/threshold/hard bucket
+// when bucketed against the user's default zones (computed from max_hr=200).
+func TestPlanHistoryHandler_ZoneSecondsPopulated(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Configure the user's max HR so default zones resolve.
+	//   Z1 0-120, Z2 120-144, Z3 144-164, Z4 164-184, Z5 184-200.
+	if _, err := db.Exec(
+		`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'max_hr', '200')`,
+	); err != nil {
+		t.Fatalf("seed max_hr: %v", err)
+	}
+
+	weekStart, weekEnd := pastWeekDates(1)
+	planJSON := `[{"rest_day":false,"session":{"type":"easy","distance_m":5000,"notes":""}},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true}]`
+	insertTestPlan(t, db, 1, weekStart, weekEnd, planJSON)
+
+	// Three workouts inside the week, one per bucket.
+	insertTestWorkout(t, db, 1, weekStart+"T08:00:00Z", 3600, 130) // Z2 → easy
+	insertTestWorkout(t, db, 1, weekStart+"T09:00:00Z", 1800, 160) // Z3 → threshold
+	insertTestWorkout(t, db, 1, weekStart+"T10:00:00Z", 900, 190)  // Z5 → hard
+	// A workout with no HR data should be excluded from the buckets.
+	insertTestWorkout(t, db, 1, weekStart+"T11:00:00Z", 1200, 0)
+	// A workout outside the week (one day after week_end) should be excluded.
+	parsedEnd, _ := time.Parse("2006-01-02", weekEnd)
+	insertTestWorkout(t, db, 1, parsedEnd.AddDate(0, 0, 1).Format("2006-01-02")+"T08:00:00Z", 1200, 140)
+
+	req := withUser(httptest.NewRequest("GET", "/api/stride/history", nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Weeks []WeekSummary `json:"weeks"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Weeks) != 1 {
+		t.Fatalf("expected 1 week, got %d", len(body.Weeks))
+	}
+	w := body.Weeks[0]
+	if w.EasySeconds != 3600 {
+		t.Errorf("easy_seconds = %d, want 3600", w.EasySeconds)
+	}
+	if w.ThresholdSeconds != 1800 {
+		t.Errorf("threshold_seconds = %d, want 1800", w.ThresholdSeconds)
+	}
+	if w.HardSeconds != 900 {
+		t.Errorf("hard_seconds = %d, want 900", w.HardSeconds)
+	}
+}
+
+// TestPlanHistoryHandler_DefaultsPreserveLegacyShape ensures the no-query-param
+// response continues to surface weeks/months exactly as before, with the new
+// fields present as additive metadata that older clients can ignore.
+func TestPlanHistoryHandler_DefaultsPreserveLegacyShape(t *testing.T) {
+	db := setupTestDB(t)
+
+	weekStart, weekEnd := pastWeekDates(1)
+	planJSON := `[{"rest_day":false,"session":{"type":"easy","distance_m":5000,"notes":""}},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true}]`
+	insertTestPlan(t, db, 1, weekStart, weekEnd, planJSON)
+
+	req := withUser(httptest.NewRequest("GET", "/api/stride/history", nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, k := range []string{"weeks", "months", "limit", "offset", "has_more"} {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("missing field %q in default response", k)
+		}
+	}
+
+	var body struct {
+		Weeks  []WeekSummary `json:"weeks"`
+		Limit  int           `json:"limit"`
+		Offset int           `json:"offset"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Limit != HistoryDefaultLimit {
+		t.Errorf("default limit = %d, want %d", body.Limit, HistoryDefaultLimit)
+	}
+	if body.Offset != 0 {
+		t.Errorf("default offset = %d, want 0", body.Offset)
+	}
+	if len(body.Weeks) != 1 {
+		t.Fatalf("expected 1 week, got %d", len(body.Weeks))
+	}
+	w := body.Weeks[0]
+	if w.SessionsPlanned != 1 {
+		t.Errorf("sessions_planned = %d, want 1", w.SessionsPlanned)
 	}
 }
 

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -11,7 +11,21 @@ import (
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/Robin831/Hytte/internal/hrzones"
 	"github.com/Robin831/Hytte/internal/training"
+)
+
+// History pagination limits for GetPlanHistory and PlanHistoryHandler.
+const (
+	// HistoryDefaultLimit is the default number of weeks returned per page
+	// when the client does not specify a limit.
+	HistoryDefaultLimit = 12
+	// HistoryMaxLimit is the server-side cap on the per-page weeks limit.
+	// Oversized client requests are clamped to this value.
+	HistoryMaxLimit = 24
+	// HistoryDepthCapWeeks is the maximum total pagination depth in weeks.
+	// Pages beyond this depth return an empty page with has_more=false.
+	HistoryDepthCapWeeks = 156
 )
 
 // Race represents an upcoming race in the user's race calendar.
@@ -864,6 +878,10 @@ func ListEvaluations(db *sql.DB, userID int64, planID *int64, workoutID *int64) 
 }
 
 // WeekSummary holds completion statistics for a single historical training week.
+// EasySeconds/ThresholdSeconds/HardSeconds aggregate duration_seconds across the
+// week's workouts, bucketed by avg_heart_rate against the user's HR zone
+// boundaries (zones 1-2 → easy, zones 3-4 → threshold, zone 5 → hard).
+// Workouts without a usable avg_heart_rate are excluded from these buckets.
 type WeekSummary struct {
 	PlanID            int64   `json:"plan_id"`
 	WeekStart         string  `json:"week_start"`
@@ -872,6 +890,9 @@ type WeekSummary struct {
 	SessionsPlanned   int     `json:"sessions_planned"`
 	SessionsCompleted int     `json:"sessions_completed"`
 	CompletionRate    float64 `json:"completion_rate"`
+	EasySeconds       int     `json:"easy_seconds"`
+	ThresholdSeconds  int     `json:"threshold_seconds"`
+	HardSeconds       int     `json:"hard_seconds"`
 }
 
 // MonthSummary aggregates completion data across all weeks in a calendar month.
@@ -884,8 +905,14 @@ type MonthSummary struct {
 
 // GetPlanHistory returns past weeks' plans with per-week completion metadata
 // and per-month compliance rollups. Plans for the current week are excluded.
-// limit caps the number of weeks returned (most recent first).
-func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []MonthSummary, error) {
+// limit caps the number of weeks returned (most recent first); offset skips
+// that many older weeks from the head of the result set (0 = most recent page).
+// hasMore is true when more weeks exist beyond offset+limit and the next page
+// would still fall within the depth cap.
+//
+// Caller is expected to clamp limit to HistoryMaxLimit and offset to
+// HistoryDepthCapWeeks before invoking — this function trusts its inputs.
+func GetPlanHistory(db *sql.DB, userID int64, limit, offset int) ([]WeekSummary, []MonthSummary, bool, error) {
 	// Compute the Monday of the current week so we exclude the current plan
 	// even on Sunday (when week_end == today). Plans whose week_end falls on
 	// or after this Monday are still active or in the current week.
@@ -896,15 +923,17 @@ func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []Month
 	}
 	currentWeekStart := now.AddDate(0, 0, -(weekday - 1)).Format("2006-01-02")
 
+	// Probe one extra row beyond the requested page to detect more pages.
+	probeLimit := limit + 1
 	rows, err := db.Query(`
 		SELECT id, week_start, week_end, phase, plan_json
 		FROM stride_plans
 		WHERE user_id = ? AND week_end < ?
 		ORDER BY week_start DESC
-		LIMIT ?
-	`, userID, currentWeekStart, limit)
+		LIMIT ? OFFSET ?
+	`, userID, currentWeekStart, probeLimit, offset)
 	if err != nil {
-		return nil, nil, fmt.Errorf("query plan history: %w", err)
+		return nil, nil, false, fmt.Errorf("query plan history: %w", err)
 	}
 	defer rows.Close()
 
@@ -919,17 +948,28 @@ func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []Month
 	for rows.Next() {
 		var pr planRow
 		if err := rows.Scan(&pr.id, &pr.weekStart, &pr.weekEnd, &pr.phase, &pr.planJSON); err != nil {
-			return nil, nil, fmt.Errorf("scan plan row: %w", err)
+			return nil, nil, false, fmt.Errorf("scan plan row: %w", err)
 		}
 		planRows = append(planRows, pr)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
+	}
+
+	// Detect whether more rows exist beyond this page, then trim the probe row.
+	hasMore := len(planRows) > limit
+	if hasMore {
+		planRows = planRows[:limit]
+	}
+	// Cap pagination depth: even if more rows exist, do not advertise pages
+	// beyond HistoryDepthCapWeeks weeks of history.
+	if offset+limit >= HistoryDepthCapWeeks {
+		hasMore = false
 	}
 
 	// Collect all plan IDs for a single evaluations query.
 	if len(planRows) == 0 {
-		return []WeekSummary{}, []MonthSummary{}, nil
+		return []WeekSummary{}, []MonthSummary{}, false, nil
 	}
 
 	planIDs := make([]int64, len(planRows))
@@ -959,7 +999,7 @@ func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []Month
 		inClause...,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("query evaluations for history: %w", err)
+		return nil, nil, false, fmt.Errorf("query evaluations for history: %w", err)
 	}
 	defer evalRows.Close()
 
@@ -971,7 +1011,7 @@ func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []Month
 		var workoutID sql.NullInt64
 		var encJSON string
 		if err := evalRows.Scan(&planID, &workoutID, &encJSON); err != nil {
-			return nil, nil, fmt.Errorf("scan evaluation row: %w", err)
+			return nil, nil, false, fmt.Errorf("scan evaluation row: %w", err)
 		}
 		// Skip duplicate evaluations for the same workout within a plan.
 		if workoutID.Valid {
@@ -985,11 +1025,11 @@ func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []Month
 		}
 		decJSON, err := encryption.DecryptField(encJSON)
 		if err != nil {
-			return nil, nil, fmt.Errorf("decrypt eval_json: %w", err)
+			return nil, nil, false, fmt.Errorf("decrypt eval_json: %w", err)
 		}
 		var eval Evaluation
 		if err := json.Unmarshal([]byte(decJSON), &eval); err != nil {
-			return nil, nil, fmt.Errorf("unmarshal eval: %w", err)
+			return nil, nil, false, fmt.Errorf("unmarshal eval: %w", err)
 		}
 		// Only count planned sessions completed as compliant or partial; exclude bonus workouts.
 		if (eval.Compliance == "compliant" || eval.Compliance == "partial") && eval.PlannedType != "none" {
@@ -997,14 +1037,24 @@ func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []Month
 		}
 	}
 	if err := evalRows.Err(); err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
+	}
+
+	// Load user HR zone boundaries once for bucketing weekly workouts into
+	// easy/threshold/hard buckets. If zones cannot be resolved (no max_hr and
+	// no custom boundaries), zone seconds remain zero — the per-week buckets
+	// are still emitted with zero values for a stable response shape.
+	zoneBoundaries, zoneErr := hrzones.GetUserZones(db, userID)
+	if zoneErr != nil {
+		log.Printf("stride: load HR zones for user %d: %v", userID, zoneErr)
+		zoneBoundaries = nil
 	}
 
 	weeks := make([]WeekSummary, 0, len(planRows))
 	for _, pr := range planRows {
 		var days []DayPlan
 		if err := json.Unmarshal([]byte(pr.planJSON), &days); err != nil {
-			return nil, nil, fmt.Errorf("decode stride plan_json for plan %d: %w", pr.id, err)
+			return nil, nil, false, fmt.Errorf("decode stride plan_json for plan %d: %w", pr.id, err)
 		}
 		sessionsPlanned := 0
 		for _, d := range days {
@@ -1017,6 +1067,10 @@ func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []Month
 		if sessionsPlanned > 0 {
 			rate = float64(completed) / float64(sessionsPlanned) * 100
 		}
+		easy, threshold, hard, err := computeWeekZoneSeconds(db, userID, pr.weekStart, pr.weekEnd, zoneBoundaries)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("compute zone seconds for plan %d: %w", pr.id, err)
+		}
 		weeks = append(weeks, WeekSummary{
 			PlanID:            pr.id,
 			WeekStart:         pr.weekStart,
@@ -1025,6 +1079,9 @@ func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []Month
 			SessionsPlanned:   sessionsPlanned,
 			SessionsCompleted: completed,
 			CompletionRate:    rate,
+			EasySeconds:       easy,
+			ThresholdSeconds:  threshold,
+			HardSeconds:       hard,
 		})
 	}
 
@@ -1053,7 +1110,86 @@ func GetPlanHistory(db *sql.DB, userID int64, limit int) ([]WeekSummary, []Month
 		months = append(months, *m)
 	}
 
-	return weeks, months, nil
+	return weeks, months, hasMore, nil
+}
+
+// computeWeekZoneSeconds sums duration_seconds across the workouts that
+// occurred within [weekStart, weekEnd] inclusive (date-only comparison) for the
+// user, bucketing each workout's full duration by its avg_heart_rate against
+// the provided 5-zone boundaries:
+//
+//	easy      = zones 1-2 (avg_hr below zone 3's lower bound)
+//	threshold = zones 3-4 (avg_hr below zone 5's lower bound)
+//	hard      = zone  5   (avg_hr at or above zone 5's lower bound)
+//
+// Workouts with avg_heart_rate <= 0 are excluded. When zoneBoundaries is empty
+// (user has no max_hr configured and no custom zones), all buckets return 0.
+func computeWeekZoneSeconds(db *sql.DB, userID int64, weekStart, weekEnd string, zoneBoundaries []hrzones.ZoneBoundary) (int, int, int, error) {
+	if len(zoneBoundaries) == 0 {
+		return 0, 0, 0, nil
+	}
+
+	// Resolve zone 3 and zone 5 lower bounds. Zone numbers are 1-5 and may be
+	// stored in any order; iterate rather than assuming index == zone-1.
+	var zone3Min, zone5Min int
+	var have3, have5 bool
+	for _, z := range zoneBoundaries {
+		switch z.Zone {
+		case 3:
+			zone3Min = z.MinBPM
+			have3 = true
+		case 5:
+			zone5Min = z.MinBPM
+			have5 = true
+		}
+	}
+	if !have3 || !have5 {
+		return 0, 0, 0, nil
+	}
+
+	// Compare against the day after week_end so workouts logged late on the
+	// last day of the week are included regardless of timestamp format.
+	endParsed, err := time.Parse("2006-01-02", weekEnd)
+	if err != nil {
+		return 0, 0, 0, nil
+	}
+	exclusiveEnd := endParsed.AddDate(0, 0, 1).Format("2006-01-02")
+
+	rows, err := db.Query(`
+		SELECT duration_seconds, avg_heart_rate
+		FROM workouts
+		WHERE user_id = ?
+		  AND started_at >= ?
+		  AND started_at < ?
+	`, userID, weekStart, exclusiveEnd)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("query weekly workouts: %w", err)
+	}
+	defer rows.Close()
+
+	var easy, threshold, hard int
+	for rows.Next() {
+		var dur int
+		var avgHR int
+		if err := rows.Scan(&dur, &avgHR); err != nil {
+			return 0, 0, 0, fmt.Errorf("scan weekly workout row: %w", err)
+		}
+		if dur <= 0 || avgHR <= 0 {
+			continue
+		}
+		switch {
+		case avgHR < zone3Min:
+			easy += dur
+		case avgHR < zone5Min:
+			threshold += dur
+		default:
+			hard += dur
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, 0, 0, err
+	}
+	return easy, threshold, hard, nil
 }
 
 // getPlanByWeekStart returns the plan for a specific week_start, scoped to the user.

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -1184,7 +1184,7 @@ func computeWeeksZoneSeconds(db *sql.DB, userID int64, weeks []weekRange, zoneBo
 	}
 	endParsed, err := time.Parse("2006-01-02", maxEnd)
 	if err != nil {
-		return result, nil
+		return nil, fmt.Errorf("parse week_end %q: %w", maxEnd, err)
 	}
 	exclusiveEnd := endParsed.AddDate(0, 0, 1).Format("2006-01-02")
 

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -1050,6 +1050,18 @@ func GetPlanHistory(db *sql.DB, userID int64, limit, offset int) ([]WeekSummary,
 		zoneBoundaries = nil
 	}
 
+	// Compute easy/threshold/hard seconds for every week on the page in a
+	// single batched workouts query. This avoids an N+1 against the workouts
+	// table (one query per week, up to HistoryMaxLimit per page).
+	weekRanges := make([]weekRange, len(planRows))
+	for i, pr := range planRows {
+		weekRanges[i] = weekRange{start: pr.weekStart, end: pr.weekEnd}
+	}
+	zoneByWeek, err := computeWeeksZoneSeconds(db, userID, weekRanges, zoneBoundaries)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("compute zone seconds for page: %w", err)
+	}
+
 	weeks := make([]WeekSummary, 0, len(planRows))
 	for _, pr := range planRows {
 		var days []DayPlan
@@ -1067,10 +1079,7 @@ func GetPlanHistory(db *sql.DB, userID int64, limit, offset int) ([]WeekSummary,
 		if sessionsPlanned > 0 {
 			rate = float64(completed) / float64(sessionsPlanned) * 100
 		}
-		easy, threshold, hard, err := computeWeekZoneSeconds(db, userID, pr.weekStart, pr.weekEnd, zoneBoundaries)
-		if err != nil {
-			return nil, nil, false, fmt.Errorf("compute zone seconds for plan %d: %w", pr.id, err)
-		}
+		buckets := zoneByWeek[pr.weekStart]
 		weeks = append(weeks, WeekSummary{
 			PlanID:            pr.id,
 			WeekStart:         pr.weekStart,
@@ -1079,9 +1088,9 @@ func GetPlanHistory(db *sql.DB, userID int64, limit, offset int) ([]WeekSummary,
 			SessionsPlanned:   sessionsPlanned,
 			SessionsCompleted: completed,
 			CompletionRate:    rate,
-			EasySeconds:       easy,
-			ThresholdSeconds:  threshold,
-			HardSeconds:       hard,
+			EasySeconds:       buckets[0],
+			ThresholdSeconds:  buckets[1],
+			HardSeconds:       buckets[2],
 		})
 	}
 
@@ -1113,20 +1122,33 @@ func GetPlanHistory(db *sql.DB, userID int64, limit, offset int) ([]WeekSummary,
 	return weeks, months, hasMore, nil
 }
 
-// computeWeekZoneSeconds sums duration_seconds across the workouts that
-// occurred within [weekStart, weekEnd] inclusive (date-only comparison) for the
-// user, bucketing each workout's full duration by its avg_heart_rate against
-// the provided 5-zone boundaries:
+// weekRange is the (start, end) inclusive date pair used to assign workouts
+// to weeks when bucketing HR-zone seconds across a page of history.
+type weekRange struct {
+	start string // YYYY-MM-DD
+	end   string // YYYY-MM-DD (inclusive)
+}
+
+// computeWeeksZoneSeconds aggregates duration_seconds across workouts for all
+// the given weeks in a single batched query, bucketing each workout's full
+// duration by its avg_heart_rate against the provided 5-zone boundaries:
 //
 //	easy      = zones 1-2 (avg_hr below zone 3's lower bound)
 //	threshold = zones 3-4 (avg_hr below zone 5's lower bound)
 //	hard      = zone  5   (avg_hr at or above zone 5's lower bound)
 //
-// Workouts with avg_heart_rate <= 0 are excluded. When zoneBoundaries is empty
-// (user has no max_hr configured and no custom zones), all buckets return 0.
-func computeWeekZoneSeconds(db *sql.DB, userID int64, weekStart, weekEnd string, zoneBoundaries []hrzones.ZoneBoundary) (int, int, int, error) {
-	if len(zoneBoundaries) == 0 {
-		return 0, 0, 0, nil
+// The returned map is keyed by weekStart with a [3]int of {easy, threshold,
+// hard} seconds. Workouts with avg_heart_rate <= 0 are excluded. When
+// zoneBoundaries lacks zone 3 or 5 lower bounds, every entry resolves to
+// zeros (callers still get a stable response shape).
+//
+// One query is issued spanning [min(weekStart), max(weekEnd)+1day); each row
+// is then assigned to the first matching week by date prefix comparison. Weeks
+// are expected to be non-overlapping (Monday-Sunday in stride plans).
+func computeWeeksZoneSeconds(db *sql.DB, userID int64, weeks []weekRange, zoneBoundaries []hrzones.ZoneBoundary) (map[string][3]int, error) {
+	result := make(map[string][3]int, len(weeks))
+	if len(weeks) == 0 || len(zoneBoundaries) == 0 {
+		return result, nil
 	}
 
 	// Resolve zone 3 and zone 5 lower bounds. Zone numbers are 1-5 and may be
@@ -1144,52 +1166,74 @@ func computeWeekZoneSeconds(db *sql.DB, userID int64, weekStart, weekEnd string,
 		}
 	}
 	if !have3 || !have5 {
-		return 0, 0, 0, nil
+		return result, nil
 	}
 
-	// Compare against the day after week_end so workouts logged late on the
-	// last day of the week are included regardless of timestamp format.
-	endParsed, err := time.Parse("2006-01-02", weekEnd)
+	// Determine the overall query window: from the earliest weekStart to the
+	// day after the latest weekEnd (exclusive upper bound, matching the
+	// single-week semantics).
+	minStart := weeks[0].start
+	maxEnd := weeks[0].end
+	for _, w := range weeks[1:] {
+		if w.start < minStart {
+			minStart = w.start
+		}
+		if w.end > maxEnd {
+			maxEnd = w.end
+		}
+	}
+	endParsed, err := time.Parse("2006-01-02", maxEnd)
 	if err != nil {
-		return 0, 0, 0, nil
+		return result, nil
 	}
 	exclusiveEnd := endParsed.AddDate(0, 0, 1).Format("2006-01-02")
 
 	rows, err := db.Query(`
-		SELECT duration_seconds, avg_heart_rate
+		SELECT started_at, duration_seconds, avg_heart_rate
 		FROM workouts
 		WHERE user_id = ?
 		  AND started_at >= ?
 		  AND started_at < ?
-	`, userID, weekStart, exclusiveEnd)
+	`, userID, minStart, exclusiveEnd)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("query weekly workouts: %w", err)
+		return nil, fmt.Errorf("query weekly workouts (batched): %w", err)
 	}
 	defer rows.Close()
 
-	var easy, threshold, hard int
 	for rows.Next() {
+		var startedAt string
 		var dur int
 		var avgHR int
-		if err := rows.Scan(&dur, &avgHR); err != nil {
-			return 0, 0, 0, fmt.Errorf("scan weekly workout row: %w", err)
+		if err := rows.Scan(&startedAt, &dur, &avgHR); err != nil {
+			return nil, fmt.Errorf("scan weekly workout row (batched): %w", err)
 		}
 		if dur <= 0 || avgHR <= 0 {
 			continue
 		}
-		switch {
-		case avgHR < zone3Min:
-			easy += dur
-		case avgHR < zone5Min:
-			threshold += dur
-		default:
-			hard += dur
+		date := startedAt
+		if len(date) > 10 {
+			date = date[:10]
+		}
+		for _, w := range weeks {
+			if date >= w.start && date <= w.end {
+				bucket := result[w.start]
+				switch {
+				case avgHR < zone3Min:
+					bucket[0] += dur
+				case avgHR < zone5Min:
+					bucket[1] += dur
+				default:
+					bucket[2] += dur
+				}
+				result[w.start] = bucket
+				break
+			}
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return 0, 0, 0, err
+		return nil, err
 	}
-	return easy, threshold, hard, nil
+	return result, nil
 }
 
 // getPlanByWeekStart returns the plan for a specific week_start, scoped to the user.


### PR DESCRIPTION
## Changes

- **Paginate `/api/stride/history` with offset and per-week zone seconds** - Added an `offset` query param (default 0), clamped `limit` server-side to 24, capped pagination depth at 156 weeks, and added a `has_more` field plus per-week `easy_seconds` / `threshold_seconds` / `hard_seconds` to the response. The default (no-offset) response shape is preserved so older clients keep working. (Hytte-va3f)

## Original Issue (task): Backend: paginate /api/stride/history with offset and zone-split fields

Modify internal/stride/handlers.go (around line 177) to extend GET /api/stride/history. Add `offset` query param (default 0), keep `limit` (default unchanged) but cap server-side at 24. Cap pagination depth at 156 weeks; beyond that return has_more=false. Extend the response struct to include `has_more bool` (or `next_cursor`) and per-week zone fields (`easy_seconds`, `threshold_seconds`, `hard_seconds`) — first search the existing response struct and the zone-distribution helpers in internal/hrzones/ and internal/training/ to reuse existing field names if present. Default behaviour without offset must preserve current response shape (additive only). Add tests in internal/stride/handlers_test.go covering: offset pagination correctness, has_more=true when more rows exist, has_more=false at the end, server-side limit cap clamps oversized requests, and depth cap behaviour. This sub-task is the data foundation for the frontend sub-tasks; the field names chosen here (zone seconds + has_more shape) must be agreed before sub-task 2/3 can render them.

---
Bead: Hytte-va3f | Branch: forge/Hytte-va3f
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)