### PR TITLE
Frontend: dense summary rows + Load more pagination on StridePage (Hytte-6jro)

### DIFF
--- a/changelog.d/Hytte-6jro.md
+++ b/changelog.d/Hytte-6jro.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Stride Plan History uses dense summary rows with Load more pagination** - Replaced the large weekly cards with compact rows showing week label, completion-percent chip, total distance, total moving time, and a proportional easy/threshold/hard zone-split bar with hover tooltip. Added a Load older weeks button that pages the new offset/has_more response from /api/stride/history twelve weeks at a time, with inline spinner and inline error+retry on failure. (Hytte-6jro)

--- a/internal/stride/handlers_test.go
+++ b/internal/stride/handlers_test.go
@@ -1525,6 +1525,102 @@ func TestPlanHistoryHandler_ZoneSecondsPopulated(t *testing.T) {
 	}
 }
 
+// insertTestWorkoutWithDistance inserts a workout row with a specific distance
+// and no HR data, returning its ID. Used for testing the distance bucketing.
+func insertTestWorkoutWithDistance(t *testing.T, db *sql.DB, userID int64, startedAt string, distanceMeters float64) int64 {
+	t.Helper()
+	res, err := db.Exec(`
+		INSERT INTO workouts (user_id, started_at, distance_meters, fit_file_hash)
+		VALUES (?, ?, ?, ?)
+	`, userID, startedAt, distanceMeters, "wd-"+startedAt+"-"+strconv.FormatFloat(distanceMeters, 'f', 0, 64))
+	if err != nil {
+		t.Fatalf("insertTestWorkoutWithDistance: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+// TestPlanHistoryHandler_DistancePopulated verifies that total_distance_meters
+// sums positive-distance workouts within each week and excludes workouts with
+// distance_meters <= 0 and workouts outside the week range.
+func TestPlanHistoryHandler_DistancePopulated(t *testing.T) {
+	db := setupTestDB(t)
+
+	weekStart, weekEnd := pastWeekDates(1)
+	planJSON := `[{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true}]`
+	insertTestPlan(t, db, 1, weekStart, weekEnd, planJSON)
+
+	// Two workouts inside the week with positive distance.
+	insertTestWorkoutWithDistance(t, db, 1, weekStart+"T08:00:00Z", 5000)
+	insertTestWorkoutWithDistance(t, db, 1, weekStart+"T09:00:00Z", 3000)
+	// A workout with distance_meters <= 0 should be excluded.
+	insertTestWorkoutWithDistance(t, db, 1, weekStart+"T10:00:00Z", 0)
+	insertTestWorkoutWithDistance(t, db, 1, weekStart+"T11:00:00Z", -100)
+	// A workout outside the week (one day after week_end) should be excluded.
+	parsedEnd, _ := time.Parse("2006-01-02", weekEnd)
+	insertTestWorkoutWithDistance(t, db, 1, parsedEnd.AddDate(0, 0, 1).Format("2006-01-02")+"T08:00:00Z", 8000)
+
+	req := withUser(httptest.NewRequest("GET", "/api/stride/history", nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Weeks []WeekSummary `json:"weeks"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Weeks) != 1 {
+		t.Fatalf("expected 1 week, got %d", len(body.Weeks))
+	}
+	w := body.Weeks[0]
+	const want = 8000.0
+	if w.TotalDistanceMeters != want {
+		t.Errorf("total_distance_meters = %.1f, want %.1f", w.TotalDistanceMeters, want)
+	}
+}
+
+// TestPlanHistoryHandler_DistanceMultiWeek verifies that distances are bucketed
+// per week when multiple plan weeks are present on the same page.
+func TestPlanHistoryHandler_DistanceMultiWeek(t *testing.T) {
+	db := setupTestDB(t)
+
+	planJSON := `[{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true},{"rest_day":true}]`
+	ws1, we1 := pastWeekDates(1)
+	ws2, we2 := pastWeekDates(2)
+	insertTestPlan(t, db, 1, ws1, we1, planJSON)
+	insertTestPlan(t, db, 1, ws2, we2, planJSON)
+
+	// 10 km in week 1, 6 km in week 2.
+	insertTestWorkoutWithDistance(t, db, 1, ws1+"T08:00:00Z", 10000)
+	insertTestWorkoutWithDistance(t, db, 1, ws2+"T08:00:00Z", 6000)
+
+	req := withUser(httptest.NewRequest("GET", "/api/stride/history", nil), 1)
+	rec := httptest.NewRecorder()
+	PlanHistoryHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Weeks []WeekSummary `json:"weeks"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Weeks) != 2 {
+		t.Fatalf("expected 2 weeks, got %d", len(body.Weeks))
+	}
+	// Weeks are newest-first.
+	if body.Weeks[0].TotalDistanceMeters != 10000 {
+		t.Errorf("week1 total_distance_meters = %.1f, want 10000", body.Weeks[0].TotalDistanceMeters)
+	}
+	if body.Weeks[1].TotalDistanceMeters != 6000 {
+		t.Errorf("week2 total_distance_meters = %.1f, want 6000", body.Weeks[1].TotalDistanceMeters)
+	}
+}
+
 // TestPlanHistoryHandler_DefaultsPreserveLegacyShape ensures the no-query-param
 // response continues to surface weeks/months exactly as before, with the new
 // fields present as additive metadata that older clients can ignore.

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -883,16 +883,17 @@ func ListEvaluations(db *sql.DB, userID int64, planID *int64, workoutID *int64) 
 // boundaries (zones 1-2 → easy, zones 3-4 → threshold, zone 5 → hard).
 // Workouts without a usable avg_heart_rate are excluded from these buckets.
 type WeekSummary struct {
-	PlanID            int64   `json:"plan_id"`
-	WeekStart         string  `json:"week_start"`
-	WeekEnd           string  `json:"week_end"`
-	Phase             string  `json:"phase"`
-	SessionsPlanned   int     `json:"sessions_planned"`
-	SessionsCompleted int     `json:"sessions_completed"`
-	CompletionRate    float64 `json:"completion_rate"`
-	EasySeconds       int     `json:"easy_seconds"`
-	ThresholdSeconds  int     `json:"threshold_seconds"`
-	HardSeconds       int     `json:"hard_seconds"`
+	PlanID               int64   `json:"plan_id"`
+	WeekStart            string  `json:"week_start"`
+	WeekEnd              string  `json:"week_end"`
+	Phase                string  `json:"phase"`
+	SessionsPlanned      int     `json:"sessions_planned"`
+	SessionsCompleted    int     `json:"sessions_completed"`
+	CompletionRate       float64 `json:"completion_rate"`
+	EasySeconds          int     `json:"easy_seconds"`
+	ThresholdSeconds     int     `json:"threshold_seconds"`
+	HardSeconds          int     `json:"hard_seconds"`
+	TotalDistanceMeters  float64 `json:"total_distance_meters"`
 }
 
 // MonthSummary aggregates completion data across all weeks in a calendar month.
@@ -1061,6 +1062,10 @@ func GetPlanHistory(db *sql.DB, userID int64, limit, offset int) ([]WeekSummary,
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("compute zone seconds for page: %w", err)
 	}
+	distByWeek, err := computeWeeksDistanceMeters(db, userID, weekRanges)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("compute distance for page: %w", err)
+	}
 
 	weeks := make([]WeekSummary, 0, len(planRows))
 	for _, pr := range planRows {
@@ -1081,16 +1086,17 @@ func GetPlanHistory(db *sql.DB, userID int64, limit, offset int) ([]WeekSummary,
 		}
 		buckets := zoneByWeek[pr.weekStart]
 		weeks = append(weeks, WeekSummary{
-			PlanID:            pr.id,
-			WeekStart:         pr.weekStart,
-			WeekEnd:           pr.weekEnd,
-			Phase:             pr.phase,
-			SessionsPlanned:   sessionsPlanned,
-			SessionsCompleted: completed,
-			CompletionRate:    rate,
-			EasySeconds:       buckets[0],
-			ThresholdSeconds:  buckets[1],
-			HardSeconds:       buckets[2],
+			PlanID:              pr.id,
+			WeekStart:           pr.weekStart,
+			WeekEnd:             pr.weekEnd,
+			Phase:               pr.phase,
+			SessionsPlanned:     sessionsPlanned,
+			SessionsCompleted:   completed,
+			CompletionRate:      rate,
+			EasySeconds:         buckets[0],
+			ThresholdSeconds:    buckets[1],
+			HardSeconds:         buckets[2],
+			TotalDistanceMeters: distByWeek[pr.weekStart],
 		})
 	}
 
@@ -1234,6 +1240,64 @@ func computeWeeksZoneSeconds(db *sql.DB, userID int64, weeks []weekRange, zoneBo
 		return nil, err
 	}
 	return result, nil
+}
+
+// computeWeeksDistanceMeters sums distance_meters across all workouts for each
+// of the given week ranges, returning a map keyed by weekStart. Workouts with
+// no recorded distance (distance_meters <= 0) are included with zero
+// contribution. All workouts — regardless of HR data — are counted.
+func computeWeeksDistanceMeters(db *sql.DB, userID int64, weeks []weekRange) (map[string]float64, error) {
+	result := make(map[string]float64, len(weeks))
+	if len(weeks) == 0 {
+		return result, nil
+	}
+
+	minStart := weeks[0].start
+	maxEnd := weeks[0].end
+	for _, w := range weeks[1:] {
+		if w.start < minStart {
+			minStart = w.start
+		}
+		if w.end > maxEnd {
+			maxEnd = w.end
+		}
+	}
+	endParsed, err := time.Parse("2006-01-02", maxEnd)
+	if err != nil {
+		return nil, fmt.Errorf("parse week_end %q: %w", maxEnd, err)
+	}
+	exclusiveEnd := endParsed.AddDate(0, 0, 1).Format("2006-01-02")
+
+	rows, err := db.Query(`
+		SELECT started_at, distance_meters
+		FROM workouts
+		WHERE user_id = ?
+		  AND started_at >= ?
+		  AND started_at < ?
+	`, userID, minStart, exclusiveEnd)
+	if err != nil {
+		return nil, fmt.Errorf("query weekly workout distances: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var startedAt string
+		var dist float64
+		if err := rows.Scan(&startedAt, &dist); err != nil {
+			return nil, fmt.Errorf("scan workout distance row: %w", err)
+		}
+		date := startedAt
+		if len(date) > 10 {
+			date = date[:10]
+		}
+		for _, w := range weeks {
+			if date >= w.start && date <= w.end {
+				result[w.start] += dist
+				break
+			}
+		}
+	}
+	return result, rows.Err()
 }
 
 // getPlanByWeekStart returns the plan for a specific week_start, scoped to the user.

--- a/internal/stride/stride.go
+++ b/internal/stride/stride.go
@@ -1244,8 +1244,8 @@ func computeWeeksZoneSeconds(db *sql.DB, userID int64, weeks []weekRange, zoneBo
 
 // computeWeeksDistanceMeters sums distance_meters across all workouts for each
 // of the given week ranges, returning a map keyed by weekStart. Workouts with
-// no recorded distance (distance_meters <= 0) are included with zero
-// contribution. All workouts — regardless of HR data — are counted.
+// distance_meters <= 0 are skipped. All workouts — regardless of HR data — are
+// counted.
 func computeWeeksDistanceMeters(db *sql.DB, userID int64, weeks []weekRange) (map[string]float64, error) {
 	result := make(map[string]float64, len(weeks))
 	if len(weeks) == 0 {
@@ -1285,6 +1285,9 @@ func computeWeeksDistanceMeters(db *sql.DB, userID int64, weeks []weekRange) (ma
 		var dist float64
 		if err := rows.Scan(&startedAt, &dist); err != nil {
 			return nil, fmt.Errorf("scan workout distance row: %w", err)
+		}
+		if dist <= 0 {
+			continue
 		}
 		date := startedAt
 		if len(date) > 10 {

--- a/web/public/locales/en/stride.json
+++ b/web/public/locales/en/stride.json
@@ -102,7 +102,13 @@
     "week": {
       "listLabel": "Weekly completion history",
       "sessions": "{{completed}} of {{planned}} sessions",
-      "completionProgress": "{{pct}}% completion"
+      "completionProgress": "{{pct}}% completion",
+      "totalDistance": "Distance",
+      "totalTime": "Time",
+      "zoneSplit": "Easy {{easy}}% · Threshold {{threshold}}% · Hard {{hard}}%",
+      "openAria": "Open week {{week}}",
+      "loadMore": "Load older weeks",
+      "loadingMore": "Loading older weeks…"
     },
     "month": {
       "sessions": "{{completed}} / {{planned}} sessions"

--- a/web/public/locales/nb/stride.json
+++ b/web/public/locales/nb/stride.json
@@ -102,7 +102,13 @@
     "week": {
       "listLabel": "Ukentlig gjennomføringshistorikk",
       "sessions": "{{completed}} av {{planned}} økter",
-      "completionProgress": "{{pct}}% gjennomført"
+      "completionProgress": "{{pct}}% gjennomført",
+      "totalDistance": "Distanse",
+      "totalTime": "Tid",
+      "zoneSplit": "Lett {{easy}}% · Terskel {{threshold}}% · Hard {{hard}}%",
+      "openAria": "Åpne uke {{week}}",
+      "loadMore": "Last eldre uker",
+      "loadingMore": "Laster eldre uker…"
     },
     "month": {
       "sessions": "{{completed}} / {{planned}} økter"

--- a/web/public/locales/th/stride.json
+++ b/web/public/locales/th/stride.json
@@ -102,7 +102,13 @@
     "week": {
       "listLabel": "ประวัติการทำสำเร็จรายสัปดาห์",
       "sessions": "{{completed}} จาก {{planned}} เซสชัน",
-      "completionProgress": "{{pct}}% เสร็จสิ้น"
+      "completionProgress": "{{pct}}% เสร็จสิ้น",
+      "totalDistance": "ระยะทาง",
+      "totalTime": "เวลา",
+      "zoneSplit": "เบา {{easy}}% · เทรชโฮลด์ {{threshold}}% · หนัก {{hard}}%",
+      "openAria": "เปิดสัปดาห์ {{week}}",
+      "loadMore": "โหลดสัปดาห์ก่อนหน้า",
+      "loadingMore": "กำลังโหลดสัปดาห์ก่อนหน้า…"
     },
     "month": {
       "sessions": "{{completed}} / {{planned}} เซสชัน"

--- a/web/src/pages/StridePage.test.tsx
+++ b/web/src/pages/StridePage.test.tsx
@@ -34,24 +34,28 @@ function resolveKey(obj: JsonObject, parts: string[]): JsonValue | undefined {
   return undefined
 }
 
+function interpolate(template: string, opts: Record<string, unknown>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, k) => String(opts[k] ?? `{{${k}}}`))
+}
+
 function makeT(translations: JsonObject) {
   return function t(key: string, opts?: Record<string, unknown>): string {
-    if (opts?.defaultValue && typeof opts.defaultValue === 'string') return opts.defaultValue
-
     if (opts?.count !== undefined) {
       const suffix = Number(opts.count) === 1 ? '_one' : '_other'
       const pluralVal = resolveKey(translations, (key + suffix).split('.'))
       if (typeof pluralVal === 'string') {
-        return pluralVal.replace(/\{\{(\w+)\}\}/g, (_, k) => String(opts[k] ?? `{{${k}}}`))
+        return opts ? interpolate(pluralVal, opts) : pluralVal
       }
     }
 
     const val = resolveKey(translations, key.split('.'))
     if (typeof val === 'string') {
-      if (opts) {
-        return val.replace(/\{\{(\w+)\}\}/g, (_, k) => String(opts[k] ?? `{{${k}}}`))
-      }
-      return val
+      return opts ? interpolate(val, opts) : val
+    }
+
+    // Key not found — fall back to defaultValue with interpolation
+    if (opts?.defaultValue && typeof opts.defaultValue === 'string') {
+      return opts ? interpolate(opts.defaultValue, opts) : opts.defaultValue
     }
     return key
   }
@@ -127,6 +131,7 @@ vi.mock('../utils/formatDate', () => ({
     const d = typeof date === 'string' ? new Date(date) : date
     return d.toLocaleString('en')
   },
+  formatNumber: (n: number, options?: Intl.NumberFormatOptions) => n.toLocaleString('en', options),
 }))
 
 // ── Test data ─────────────────────────────────────────────────────────────────

--- a/web/src/pages/StridePage.test.tsx
+++ b/web/src/pages/StridePage.test.tsx
@@ -75,6 +75,16 @@ vi.mock('react-i18next', () => {
   }
 })
 
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: unknown }) => children,
+  AreaChart: ({ children }: { children: unknown }) => <div data-testid="area-chart">{children as never}</div>,
+  Area: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+}))
+
 vi.mock('react-markdown', () => ({
   default: ({ children }: { children: string }) => children,
 }))
@@ -91,6 +101,7 @@ vi.mock('lucide-react', () => ({
   Zap: () => null,
   ChevronDown: () => null,
   ChevronUp: () => null,
+  ChevronRight: () => null,
   RefreshCw: () => null,
   CheckCircle2: () => null,
   Circle: () => null,
@@ -813,5 +824,151 @@ describe('StridePage – Coach Notes older-bucket collapse', () => {
     await waitFor(() => {
       expect(screen.queryByRole('textbox', { name: 'Edit note' })).not.toBeInTheDocument()
     })
+  })
+})
+
+describe('StridePage – plan history pagination', () => {
+  // Two distinct weeks belong to the first page; the third week is the next page.
+  const week1 = {
+    plan_id: 101,
+    week_start: '2099-01-13',
+    week_end: '2099-01-19',
+    phase: 'Base',
+    sessions_planned: 5,
+    sessions_completed: 4,
+    completion_rate: 80,
+    easy_seconds: 3600,
+    threshold_seconds: 1800,
+    hard_seconds: 600,
+    total_distance_meters: 42000,
+  }
+  const week2 = {
+    plan_id: 102,
+    week_start: '2099-01-06',
+    week_end: '2099-01-12',
+    phase: 'Base',
+    sessions_planned: 4,
+    sessions_completed: 3,
+    completion_rate: 75,
+    easy_seconds: 2700,
+    threshold_seconds: 900,
+    hard_seconds: 300,
+    total_distance_meters: 28500,
+  }
+  const week3 = {
+    plan_id: 103,
+    week_start: '2098-12-30',
+    week_end: '2099-01-05',
+    phase: 'Build',
+    sessions_planned: 5,
+    sessions_completed: 5,
+    completion_rate: 100,
+    easy_seconds: 1800,
+    threshold_seconds: 1800,
+    hard_seconds: 1800,
+    total_distance_meters: 50000,
+  }
+
+  function makeHistoryFetchMock(pages: Array<{ weeks: typeof week1[]; has_more: boolean; offset: number }>) {
+    return vi.fn((url: string) => {
+      const make = (data: unknown) =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response)
+      if (url.includes('/api/stride/history')) {
+        const m = url.match(/offset=(\d+)/)
+        const offset = m ? Number(m[1]) : 0
+        const page = pages.find(p => p.offset === offset) ?? { weeks: [], has_more: false, offset }
+        return make({
+          weeks: page.weeks,
+          months: [],
+          limit: 12,
+          offset,
+          has_more: page.has_more,
+        })
+      }
+      if (url.includes('/api/stride/races')) return make({ races: [] })
+      if (url.includes('/api/stride/notes')) return make({ notes: [] })
+      return make({})
+    })
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('renders rows with the new dense summary shape (label, %, distance, time, zone bar, chevron)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeHistoryFetchMock([{ offset: 0, weeks: [week1], has_more: false }]),
+    )
+    const { container } = renderPage()
+
+    // Week label rendered (English-formatted).
+    await waitFor(() => {
+      expect(screen.getByText(/Week of Jan 13/)).toBeInTheDocument()
+    })
+
+    // Completion-percent chip.
+    expect(screen.getByText('80%')).toBeInTheDocument()
+
+    // Distance: 42000m → 42.0 km, 1 decimal.
+    expect(screen.getByText('42.0 km')).toBeInTheDocument()
+
+    // Total moving time: 3600+1800+600 = 6000s → 1:40 (h:mm).
+    expect(screen.getByText('1:40')).toBeInTheDocument()
+
+    // Zone-split bar exists with tooltip-style aria-label and percentages.
+    // Easy 60% (3600/6000), Threshold 30% (1800/6000), Hard 10% (rounded remainder).
+    const zoneBar = container.querySelector('[aria-label*="Easy 60%"][aria-label*="Threshold 30%"][aria-label*="Hard 10%"]')
+    expect(zoneBar).not.toBeNull()
+  })
+
+  it('clicking Load older weeks fetches the next page and appends rows', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeHistoryFetchMock([
+        { offset: 0, weeks: [week1, week2], has_more: true },
+        { offset: 2, weeks: [week3], has_more: false },
+      ]),
+    )
+    renderPage()
+
+    // First page rows render.
+    await waitFor(() => {
+      expect(screen.getByText(/Week of Jan 13/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Week of Jan 6/)).toBeInTheDocument()
+    expect(screen.queryByText(/Week of Dec 30/)).not.toBeInTheDocument()
+
+    // Load more is visible because has_more=true.
+    const loadMoreBtn = screen.getByRole('button', { name: /Load older weeks/i })
+
+    await act(async () => {
+      fireEvent.click(loadMoreBtn)
+    })
+
+    // Next page row appended; original rows still present.
+    await waitFor(() => {
+      expect(screen.getByText(/Week of Dec 30/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Week of Jan 13/)).toBeInTheDocument()
+    expect(screen.getByText(/Week of Jan 6/)).toBeInTheDocument()
+
+    // Load more disappears once has_more=false on the latest page.
+    expect(screen.queryByRole('button', { name: /Load older weeks/i })).toBeNull()
+  })
+
+  it('hides the Load more button when has_more=false on the first page', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeHistoryFetchMock([{ offset: 0, weeks: [week1, week2], has_more: false }]),
+    )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Week of Jan 13/)).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('button', { name: /Load older weeks/i })).toBeNull()
   })
 })

--- a/web/src/pages/StridePage.test.tsx
+++ b/web/src/pages/StridePage.test.tsx
@@ -55,7 +55,7 @@ function makeT(translations: JsonObject) {
 
     // Key not found — fall back to defaultValue with interpolation
     if (opts?.defaultValue && typeof opts.defaultValue === 'string') {
-      return opts ? interpolate(opts.defaultValue, opts) : opts.defaultValue
+      return interpolate(opts.defaultValue, opts)
     }
     return key
   }

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef, useId } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Trash2, Plus, Trophy, Zap, ChevronDown, ChevronUp, RefreshCw, CheckCircle2, Circle, AlertTriangle, XCircle, History, Pencil } from 'lucide-react'
+import { Trash2, Plus, Trophy, Zap, ChevronDown, ChevronUp, ChevronRight, RefreshCw, CheckCircle2, Circle, AlertTriangle, XCircle, History, Pencil, Loader2 } from 'lucide-react'
 import { formatDate, formatDateTime } from '../utils/formatDate'
 import type { StrideEvaluation, StrideEvaluationRecord, DayPlan } from '../types/stride'
 import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
@@ -332,6 +332,15 @@ interface WeekSummary {
   sessions_planned: number
   sessions_completed: number
   completion_rate: number
+  // Per-zone moving-time aggregates from /api/stride/history. May be 0 when the
+  // user has no HR zones configured or no workouts in the week have avg_heart_rate.
+  easy_seconds?: number
+  threshold_seconds?: number
+  hard_seconds?: number
+  // Optional total distance across the week's workouts (meters). The backend
+  // pagination response does not yet emit this; consumed defensively so future
+  // additions surface without a frontend change.
+  total_distance_meters?: number
 }
 
 interface MonthSummary {
@@ -341,30 +350,158 @@ interface MonthSummary {
   compliance_rate: number
 }
 
-interface PlanHistoryData {
-  weeks: WeekSummary[]
-  months: MonthSummary[]
+const HISTORY_PAGE_SIZE = 12
+
+// Zone palette: shares the easy/threshold/hard hues with the per-zone HR card on
+// TrainingDetail (#22c55e Z1, #eab308 Z3, #ef4444 Z5).
+const ZONE_COLOR_EASY = '#22c55e'
+const ZONE_COLOR_THRESHOLD = '#eab308'
+const ZONE_COLOR_HARD = '#ef4444'
+
+function formatHHMM(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds))
+  const h = Math.floor(safe / 3600)
+  const m = Math.floor((safe % 3600) / 60)
+  return `${h}:${String(m).padStart(2, '0')}`
+}
+
+interface WeekRowProps {
+  week: WeekSummary
+  onOpen?: (week: WeekSummary) => void
+}
+
+function WeekRow({ week, onOpen }: WeekRowProps) {
+  const { t } = useTranslation('stride')
+  const pct = Math.min(Math.max(Math.round(Number(week.completion_rate) || 0), 0), 100)
+  const chipClass = pct >= 80
+    ? 'bg-green-500/20 text-green-300 border border-green-500/30'
+    : pct >= 50
+      ? 'bg-yellow-500/20 text-yellow-300 border border-yellow-500/30'
+      : 'bg-red-500/20 text-red-300 border border-red-500/30'
+
+  const easy = Math.max(0, week.easy_seconds ?? 0)
+  const threshold = Math.max(0, week.threshold_seconds ?? 0)
+  const hard = Math.max(0, week.hard_seconds ?? 0)
+  const totalSec = easy + threshold + hard
+  const distanceKm = Math.max(0, week.total_distance_meters ?? 0) / 1000
+
+  const easyPct = totalSec > 0 ? Math.round((easy / totalSec) * 100) : 0
+  const thresholdPct = totalSec > 0 ? Math.round((threshold / totalSec) * 100) : 0
+  const hardPct = totalSec > 0 ? Math.max(0, 100 - easyPct - thresholdPct) : 0
+
+  const weekLabel = t('plan.weekOf', {
+    start: formatDate(`${week.week_start}T00:00:00`, { month: 'short', day: 'numeric' }),
+    end: formatDate(`${week.week_end}T00:00:00`, { month: 'short', day: 'numeric' }),
+  })
+  const openLabel = t('history.week.openAria', { week: weekLabel, defaultValue: 'Open week {{week}}' })
+  const zoneTooltip = t('history.week.zoneSplit', {
+    easy: easyPct,
+    threshold: thresholdPct,
+    hard: hardPct,
+    defaultValue: 'Easy {{easy}}% · Threshold {{threshold}}% · Hard {{hard}}%',
+  })
+
+  // Row click handler: parent wires the actual navigation/drawer in the follow-up
+  // sub-task; if no handler is provided we render as a static row instead of a button.
+  const interactive = typeof onOpen === 'function'
+
+  const content = (
+    <>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 min-w-0">
+        <p className="text-sm font-medium text-white truncate">{weekLabel}</p>
+        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${chipClass}`}>{pct}%</span>
+        {week.phase && (
+          <span className="text-xs px-1.5 py-0.5 bg-yellow-500/10 text-yellow-500 rounded">{week.phase}</span>
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 text-xs text-gray-400">
+        <span>
+          <span className="text-gray-500">{t('history.week.totalDistance')}:</span>{' '}
+          <span className="text-gray-200">{distanceKm.toFixed(1)} km</span>
+        </span>
+        <span>
+          <span className="text-gray-500">{t('history.week.totalTime')}:</span>{' '}
+          <span className="text-gray-200">{formatHHMM(totalSec)}</span>
+        </span>
+      </div>
+      <div
+        className="mt-2 h-1.5 w-full flex rounded-full overflow-hidden bg-gray-700"
+        role="img"
+        aria-label={zoneTooltip}
+        title={zoneTooltip}
+        tabIndex={0}
+      >
+        {totalSec > 0 ? (
+          <>
+            {easy > 0 && <div style={{ flexBasis: `${(easy / totalSec) * 100}%`, backgroundColor: ZONE_COLOR_EASY }} className="h-full" />}
+            {threshold > 0 && <div style={{ flexBasis: `${(threshold / totalSec) * 100}%`, backgroundColor: ZONE_COLOR_THRESHOLD }} className="h-full" />}
+            {hard > 0 && <div style={{ flexBasis: `${(hard / totalSec) * 100}%`, backgroundColor: ZONE_COLOR_HARD }} className="h-full" />}
+          </>
+        ) : null}
+      </div>
+    </>
+  )
+
+  return (
+    <div className="bg-gray-800 rounded-xl border border-gray-700">
+      <div className="flex items-center gap-3 p-3">
+        <div className="flex-1 min-w-0">{content}</div>
+        {interactive ? (
+          <button
+            type="button"
+            onClick={() => onOpen?.(week)}
+            aria-label={openLabel}
+            className="flex-shrink-0 p-1 rounded-lg text-gray-500 hover:text-white hover:bg-gray-700 transition-colors"
+          >
+            <ChevronRight size={20} />
+          </button>
+        ) : (
+          <ChevronRight size={20} className="flex-shrink-0 text-gray-600" aria-hidden="true" />
+        )}
+      </div>
+    </div>
+  )
 }
 
 function PlanHistory() {
   const { t } = useTranslation('stride')
-  const [data, setData] = useState<PlanHistoryData | null>(null)
+  const [weeks, setWeeks] = useState<WeekSummary[]>([])
+  const [months, setMonths] = useState<MonthSummary[]>([])
+  const [offset, setOffset] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [loadMoreError, setLoadMoreError] = useState(false)
+
+  const fetchWeeks = useCallback(async (
+    pageOffset: number,
+    signal?: AbortSignal,
+  ): Promise<{ weeks: WeekSummary[]; months: MonthSummary[]; hasMore: boolean } | null> => {
+    const res = await fetch(`/api/stride/history?limit=${HISTORY_PAGE_SIZE}&offset=${pageOffset}`, {
+      credentials: 'include',
+      signal,
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const json = await res.json()
+    if (signal?.aborted) return null
+    return {
+      weeks: (json.weeks ?? []) as WeekSummary[],
+      months: (json.months ?? []) as MonthSummary[],
+      hasMore: Boolean(json.has_more),
+    }
+  }, [])
 
   useEffect(() => {
     const controller = new AbortController()
     ;(async () => {
       try {
-        const res = await fetch('/api/stride/history?limit=12', {
-          credentials: 'include',
-          signal: controller.signal,
-        })
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const json = await res.json()
-        if (!controller.signal.aborted) {
-          setData({ weeks: json.weeks ?? [], months: json.months ?? [] })
-        }
+        const result = await fetchWeeks(0, controller.signal)
+        if (!result || controller.signal.aborted) return
+        setWeeks(result.weeks)
+        setMonths(result.months)
+        setHasMore(result.hasMore)
+        setOffset(result.weeks.length)
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') return
         if (!controller.signal.aborted) setError(true)
@@ -373,16 +510,32 @@ function PlanHistory() {
       }
     })()
     return () => { controller.abort() }
-  }, [])
+  }, [fetchWeeks])
+
+  const handleLoadMore = useCallback(async () => {
+    setLoadMoreError(false)
+    setLoadingMore(true)
+    try {
+      const result = await fetchWeeks(offset)
+      if (!result) return
+      setWeeks(prev => [...prev, ...result.weeks])
+      setHasMore(result.hasMore)
+      setOffset(prev => prev + result.weeks.length)
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      setLoadMoreError(true)
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [fetchWeeks, offset])
 
   const chartData = useMemo(() => {
-    if (!data) return []
     // Reverse to chronological order for the chart (oldest first).
-    return [...data.weeks].reverse().map(w => ({
+    return [...weeks].reverse().map(w => ({
       label: formatDate(`${w.week_start}T00:00:00`, { month: 'short', day: 'numeric' }),
       rate: Math.min(Math.round(w.completion_rate), 100),
     }))
-  }, [data])
+  }, [weeks])
 
   const formatMonth = (month: string) => {
     const [year, m] = month.split('-')
@@ -391,7 +544,7 @@ function PlanHistory() {
 
   if (loading) return <p className="text-sm text-gray-400">{t('loading')}</p>
   if (error) return <p className="text-sm text-red-400">{t('history.loadError')}</p>
-  if (!data || data.weeks.length === 0) {
+  if (weeks.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-8 text-center bg-gray-800/50 rounded-xl border border-gray-700 border-dashed">
         <History size={28} className="text-gray-600 mb-2" />
@@ -432,9 +585,9 @@ function PlanHistory() {
       )}
 
       {/* Monthly compliance */}
-      {data.months.length > 0 && (
+      {months.length > 0 && (
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-          {data.months.map(m => (
+          {months.map(m => (
             <div key={m.month} className="bg-gray-800 rounded-xl border border-gray-700 p-3 text-center">
               <p className="text-xs text-gray-400 mb-1">{formatMonth(m.month)}</p>
               <p className="text-lg font-bold text-white">{Math.round(m.compliance_rate)}%</p>
@@ -444,52 +597,39 @@ function PlanHistory() {
         </div>
       )}
 
-      {/* Week list — horizontally scrollable with snap so users can swipe between weeks on mobile */}
+      {/* Dense week list — vertical column of summary rows. Wraps cleanly at 375px. */}
       <div
-        className="flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 -mx-4 px-4 sm:mx-0 sm:px-0 sm:flex-col sm:gap-2 sm:overflow-x-visible sm:snap-none"
+        className="flex flex-col gap-2"
         aria-label={t('history.week.listLabel', { defaultValue: 'Weekly completion history' })}
       >
-        {data.weeks.map(w => {
-          const pct = Math.min(Math.max(Math.round(Number(w.completion_rate) || 0), 0), 100)
-          const barColor = pct >= 80 ? 'bg-green-500' : pct >= 50 ? 'bg-yellow-500' : 'bg-red-500'
-          return (
-            <div
-              key={w.plan_id}
-              className="snap-start flex-shrink-0 w-64 sm:w-auto bg-gray-800 rounded-xl border border-gray-700 p-3"
-            >
-              <div className="flex items-center justify-between mb-2">
-                <div>
-                  <p className="text-sm font-medium text-white">
-                    {t('plan.weekOf', {
-                      start: formatDate(`${w.week_start}T00:00:00`, { month: 'short', day: 'numeric' }),
-                      end: formatDate(`${w.week_end}T00:00:00`, { month: 'short', day: 'numeric' }),
-                    })}
-                  </p>
-                  {w.phase && (
-                    <span className="text-xs px-1.5 py-0.5 bg-yellow-500/10 text-yellow-500 rounded">{w.phase}</span>
-                  )}
-                </div>
-                <div className="text-right">
-                  <p className="text-lg font-bold text-white">{pct}%</p>
-                  <p className="text-xs text-gray-400">{t('history.week.sessions', { completed: w.sessions_completed, planned: w.sessions_planned })}</p>
-                </div>
-              </div>
-              {w.sessions_planned > 0 && (
-                <div
-                  className="h-1.5 bg-gray-700 rounded-full overflow-hidden"
-                  role="progressbar"
-                  aria-valuenow={Math.min(pct, 100)}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-label={t('history.week.completionProgress', { pct: Math.min(pct, 100) })}
-                >
-                  <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${Math.min(pct, 100)}%` }} />
-                </div>
-              )}
-            </div>
-          )
-        })}
+        {weeks.map(w => (
+          <WeekRow key={w.plan_id} week={w} />
+        ))}
       </div>
+
+      {/* Load more / inline error & retry */}
+      {hasMore && (
+        <div className="flex flex-col items-center gap-2">
+          {loadMoreError && (
+            <p className="text-sm text-red-400" role="alert">{t('history.loadError')}</p>
+          )}
+          <button
+            type="button"
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-gray-800 hover:bg-gray-700 disabled:opacity-60 text-white border border-gray-700 rounded-lg transition-colors"
+          >
+            {loadingMore ? (
+              <>
+                <Loader2 size={16} className="animate-spin" />
+                {t('history.week.loadingMore')}
+              </>
+            ) : (
+              t('history.week.loadMore')
+            )}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -337,9 +337,8 @@ interface WeekSummary {
   easy_seconds?: number
   threshold_seconds?: number
   hard_seconds?: number
-  // Optional total distance across the week's workouts (meters). The backend
-  // pagination response does not yet emit this; consumed defensively so future
-  // additions surface without a frontend change.
+  // Optional total distance across the week's workouts (meters). Emitted by
+  // /api/stride/history for all pages; kept optional for type safety.
   total_distance_meters?: number
 }
 
@@ -372,6 +371,8 @@ interface WeekRowProps {
 
 function WeekRow({ week, onOpen }: WeekRowProps) {
   const { t } = useTranslation('stride')
+  const zoneTooltipId = useId()
+  const [zoneTooltipVisible, setZoneTooltipVisible] = useState(false)
   const pct = Math.min(Math.max(Math.round(Number(week.completion_rate) || 0), 0), 100)
   const chipClass = pct >= 80
     ? 'bg-green-500/20 text-green-300 border border-green-500/30'
@@ -424,20 +425,39 @@ function WeekRow({ week, onOpen }: WeekRowProps) {
           <span className="text-gray-200">{formatHHMM(totalSec)}</span>
         </span>
       </div>
-      <div
-        className="mt-2 h-1.5 w-full flex rounded-full overflow-hidden bg-gray-700"
-        role="img"
-        aria-label={zoneTooltip}
-        title={zoneTooltip}
-        tabIndex={0}
-      >
-        {totalSec > 0 ? (
-          <>
-            {easy > 0 && <div style={{ flexBasis: `${(easy / totalSec) * 100}%`, backgroundColor: ZONE_COLOR_EASY }} className="h-full" />}
-            {threshold > 0 && <div style={{ flexBasis: `${(threshold / totalSec) * 100}%`, backgroundColor: ZONE_COLOR_THRESHOLD }} className="h-full" />}
-            {hard > 0 && <div style={{ flexBasis: `${(hard / totalSec) * 100}%`, backgroundColor: ZONE_COLOR_HARD }} className="h-full" />}
-          </>
-        ) : null}
+      <div className="relative mt-2">
+        <div
+          className="h-1.5 w-full flex rounded-full overflow-hidden bg-gray-700"
+          role="img"
+          aria-label={zoneTooltip}
+          aria-describedby={totalSec > 0 ? zoneTooltipId : undefined}
+          tabIndex={0}
+          onMouseEnter={() => setZoneTooltipVisible(true)}
+          onMouseLeave={() => setZoneTooltipVisible(false)}
+          onFocus={() => setZoneTooltipVisible(true)}
+          onBlur={() => setZoneTooltipVisible(false)}
+        >
+          {totalSec > 0 ? (
+            <>
+              {easy > 0 && <div style={{ flexBasis: `${(easy / totalSec) * 100}%`, backgroundColor: ZONE_COLOR_EASY }} className="h-full" />}
+              {threshold > 0 && <div style={{ flexBasis: `${(threshold / totalSec) * 100}%`, backgroundColor: ZONE_COLOR_THRESHOLD }} className="h-full" />}
+              {hard > 0 && <div style={{ flexBasis: `${(hard / totalSec) * 100}%`, backgroundColor: ZONE_COLOR_HARD }} className="h-full" />}
+            </>
+          ) : null}
+        </div>
+        {totalSec > 0 && (
+          <div
+            id={zoneTooltipId}
+            role="tooltip"
+            aria-hidden={!zoneTooltipVisible}
+            className={
+              'absolute left-0 bottom-full mb-2 px-2.5 py-1.5 bg-gray-700 border border-gray-600 text-gray-200 text-xs rounded-lg pointer-events-none z-10 whitespace-nowrap shadow-lg transition-opacity ' +
+              (zoneTooltipVisible ? 'opacity-100 visible' : 'opacity-0 invisible')
+            }
+          >
+            {zoneTooltip}
+          </div>
+        )}
       </div>
     </>
   )

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Trash2, Plus, Trophy, Zap, ChevronDown, ChevronUp, ChevronRight, RefreshCw, CheckCircle2, Circle, AlertTriangle, XCircle, History, Pencil, Loader2 } from 'lucide-react'
-import { formatDate, formatDateTime } from '../utils/formatDate'
+import { formatDate, formatDateTime, formatNumber } from '../utils/formatDate'
 import type { StrideEvaluation, StrideEvaluationRecord, DayPlan } from '../types/stride'
 import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
 import { TrainingBlockTimeline } from '../components/stride/TrainingBlockTimeline'
@@ -417,7 +417,7 @@ function WeekRow({ week, onOpen }: WeekRowProps) {
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 text-xs text-gray-400">
         <span>
           <span className="text-gray-500">{t('history.week.totalDistance')}:</span>{' '}
-          <span className="text-gray-200">{distanceKm.toFixed(1)} km</span>
+          <span className="text-gray-200">{formatNumber(distanceKm, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} km</span>
         </span>
         <span>
           <span className="text-gray-500">{t('history.week.totalTime')}:</span>{' '}
@@ -473,6 +473,7 @@ function PlanHistory() {
   const [error, setError] = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
   const [loadMoreError, setLoadMoreError] = useState(false)
+  const loadMoreControllerRef = useRef<AbortController | null>(null)
 
   const fetchWeeks = useCallback(async (
     pageOffset: number,
@@ -509,23 +510,33 @@ function PlanHistory() {
         if (!controller.signal.aborted) setLoading(false)
       }
     })()
-    return () => { controller.abort() }
+    return () => {
+      controller.abort()
+      loadMoreControllerRef.current?.abort()
+      loadMoreControllerRef.current = null
+    }
   }, [fetchWeeks])
 
   const handleLoadMore = useCallback(async () => {
+    loadMoreControllerRef.current?.abort()
+    const controller = new AbortController()
+    loadMoreControllerRef.current = controller
     setLoadMoreError(false)
     setLoadingMore(true)
     try {
-      const result = await fetchWeeks(offset)
-      if (!result) return
+      const result = await fetchWeeks(offset, controller.signal)
+      if (!result || controller.signal.aborted) return
       setWeeks(prev => [...prev, ...result.weeks])
       setHasMore(result.hasMore)
       setOffset(prev => prev + result.weeks.length)
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return
-      setLoadMoreError(true)
+      if (!controller.signal.aborted) setLoadMoreError(true)
     } finally {
-      setLoadingMore(false)
+      if (!controller.signal.aborted) setLoadingMore(false)
+      if (loadMoreControllerRef.current === controller) {
+        loadMoreControllerRef.current = null
+      }
     }
   }, [fetchWeeks, offset])
 


### PR DESCRIPTION
## Changes

- **Stride Plan History uses dense summary rows with Load more pagination** - Replaced the large weekly cards with compact rows showing week label, completion-percent chip, total distance, total moving time, and a proportional easy/threshold/hard zone-split bar with hover tooltip. Added a Load older weeks button that pages the new offset/has_more response from /api/stride/history twelve weeks at a time, with inline spinner and inline error+retry on failure. (Hytte-6jro)

## Original Issue (task): Frontend: dense summary rows + Load more pagination on StridePage

Modify web/src/pages/StridePage.tsx (current fetch at line 359, week-list rendering from line 447). Replace the fixed limit=12 fetch with paged loads (offset 0, limit 12) consuming the new backend response. Replace large cards with dense summary rows showing: week label + completion % chip, total distance (km, 1 decimal), total moving time (hh:mm), a horizontal proportional zone-split bar (green=easy, yellow=threshold, red=hard, reusing the TrainingPage zone palette) with hover/focus tooltip showing percentages, and a chevron 'Open' affordance. Append a 'Load older weeks' button at the bottom when has_more is true; clicking fetches the next page and appends results. Show inline spinner during fetch and inline error+retry on failure. Mobile-first: rows must wrap cleanly at 375px. Add the listed i18n keys (history.week.totalDistance, totalTime, zoneSplit, openAria, loadMore, loadingMore) to the stride namespace in en/nb/th. Tests in StridePage.test.tsx cover: rows render with new summary shape, Load more loads next page, Load more disappears when has_more=false. Depends on sub-task 1 for response shape; row click handler is wired in sub-task 3.

---
Bead: Hytte-6jro | Branch: forge/Hytte-6jro
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)