### PR TITLE
Pokémon: pokemontcg.io metadata + price sync (Hytte-839c)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Categories: `Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security`. Si
 ### General
 
 - **No migration files** — schema is inline in `createSchema()`, column additions use `ALTER TABLE` with existence checks
-- **No env files committed** — secrets via environment variables: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URL`, `SECURE_COOKIES`
+- **No env files committed** — secrets via environment variables: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URL`, `SECURE_COOKIES`, `POKEMONTCG_API_KEY` (optional; raises pokemontcg.io rate limits for the metadata + price sync)
 - **User preferences** are key-value pairs in `user_preferences` table, allowed keys validated in handler
 - **Test auth**: set `HYTTE_TEST_AUTH=1` env var to enable `POST /api/auth/test-login` endpoint (for QuestGiver E2E testing only, never in production)
 

--- a/changelog.d/Hytte-839c.md
+++ b/changelog.d/Hytte-839c.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon TCG metadata + price sync** - New `internal/pokemon` package syncs sets, cards, and per-variant EUR prices from pokemontcg.io. A weekly full sync runs Sunday 04:00 Europe/Oslo and a daily price refresh runs at 07:00 Europe/Oslo; admins can trigger a manual run with `POST /api/pokemon/admin/sync`. Set `POKEMONTCG_API_KEY` for higher rate limits; the client honours `Retry-After` on 429 responses. (Hytte-839c)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/daemon"
 	"github.com/Robin831/Hytte/internal/db"
+	"github.com/Robin831/Hytte/internal/pokemon"
 	"github.com/Robin831/Hytte/internal/push"
 	"github.com/Robin831/Hytte/internal/stars"
 	"github.com/Robin831/Hytte/internal/stride"
@@ -346,6 +347,56 @@ func main() {
 					}
 				}
 				log.Printf("stride: weekly plan generation complete (%d users)", len(userIDs))
+			}
+		}
+	}()
+
+	// Schedule weekly Pokémon TCG full sync (Sunday 04:00 Europe/Oslo) and
+	// a daily price refresh (07:00 Europe/Oslo). Both run in the same
+	// goroutine to keep startup tidy; whichever timer fires first advances
+	// independently of the other (Hytte-839c).
+	go func() {
+		oslo, err := time.LoadLocation("Europe/Oslo")
+		if err != nil {
+			log.Printf("pokemon: failed to load Europe/Oslo timezone: %v", err)
+			return
+		}
+		for {
+			now := time.Now()
+			nextFull := pokemon.NextWeeklySync(now, oslo)
+			nextPrice := pokemon.NextDailyPriceRefresh(now, oslo)
+
+			var next time.Time
+			full := false
+			if nextFull.Before(nextPrice) {
+				next = nextFull
+				full = true
+			} else {
+				next = nextPrice
+			}
+
+			timer := time.NewTimer(time.Until(next))
+			select {
+			case <-notifCtx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+				ctx, cancel := context.WithTimeout(notifCtx, 60*time.Minute)
+				client := pokemon.NewClient()
+				if full {
+					if err := pokemon.SyncAll(ctx, database, client); err != nil {
+						log.Printf("pokemon: weekly SyncAll error: %v", err)
+					} else {
+						log.Println("pokemon: weekly SyncAll complete")
+					}
+				} else {
+					if err := pokemon.RefreshPrices(ctx, database, client); err != nil {
+						log.Printf("pokemon: daily price refresh error: %v", err)
+					} else {
+						log.Println("pokemon: daily price refresh complete")
+					}
+				}
+				cancel()
 			}
 		}
 	}()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -29,6 +29,7 @@ import (
 	mathgame "github.com/Robin831/Hytte/internal/math"
 	"github.com/Robin831/Hytte/internal/netatmo"
 	"github.com/Robin831/Hytte/internal/notes"
+	"github.com/Robin831/Hytte/internal/pokemon"
 	"github.com/Robin831/Hytte/internal/push"
 	"github.com/Robin831/Hytte/internal/settings"
 	"github.com/Robin831/Hytte/internal/skywatch"
@@ -193,6 +194,11 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Get("/admin/users", auth.AdminListUsersHandler(db))
 				r.Put("/admin/users/{id}/features", auth.AdminSetFeatureHandler(db))
 				r.Post("/admin/stars/award", stars.AdminAwardStarsHandler(db))
+
+				// Pokémon TCG: manual full metadata + price sync trigger.
+				// Long-running work runs in a detached goroutine; the handler
+				// returns 202 Accepted immediately (Hytte-839c).
+				r.Post("/pokemon/admin/sync", pokemon.AdminSyncHandler(db))
 
 				// AI prompt management — admin only.
 				r.Get("/settings/ai-prompts", settings.GetAIPromptsHandler(db))

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1589,6 +1589,42 @@ func createSchema(db *sql.DB) error {
 		completed_at TEXT NOT NULL DEFAULT ''
 	);
 
+	-- Pokémon TCG metadata + variant pricing (Hytte-839c).
+	-- Sets, cards, and per-variant EUR prices synced from pokemontcg.io.
+	-- NOK conversion is handled separately (Hytte-8pzb seeds currency_rates).
+	CREATE TABLE IF NOT EXISTS pokemon_sets (
+		id            TEXT PRIMARY KEY,
+		name          TEXT NOT NULL,
+		series        TEXT NOT NULL,
+		release_date  TEXT NOT NULL,
+		total_cards   INTEGER NOT NULL DEFAULT 0,
+		symbol_url    TEXT NOT NULL DEFAULT '',
+		logo_url      TEXT NOT NULL DEFAULT '',
+		synced_at     TIMESTAMP NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS pokemon_cards (
+		id              TEXT PRIMARY KEY,
+		set_id          TEXT NOT NULL REFERENCES pokemon_sets(id) ON DELETE CASCADE,
+		name            TEXT NOT NULL,
+		collector_no    TEXT NOT NULL,
+		rarity          TEXT NOT NULL DEFAULT '',
+		image_small_url TEXT NOT NULL DEFAULT '',
+		image_large_url TEXT NOT NULL DEFAULT '',
+		synced_at       TIMESTAMP NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_pokemon_cards_set ON pokemon_cards(set_id, collector_no);
+	CREATE INDEX IF NOT EXISTS idx_pokemon_cards_name ON pokemon_cards(name);
+
+	CREATE TABLE IF NOT EXISTS pokemon_card_variants (
+		id        INTEGER PRIMARY KEY AUTOINCREMENT,
+		card_id   TEXT NOT NULL REFERENCES pokemon_cards(id) ON DELETE CASCADE,
+		kind      TEXT NOT NULL,
+		price_eur REAL NOT NULL DEFAULT 0,
+		price_at  TIMESTAMP,
+		UNIQUE(card_id, kind)
+	);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/pokemon/client.go
+++ b/internal/pokemon/client.go
@@ -1,0 +1,118 @@
+package pokemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+// DefaultBaseURL is the production pokemontcg.io v2 API base URL.
+const DefaultBaseURL = "https://api.pokemontcg.io/v2"
+
+// Client talks to the pokemontcg.io REST API. The zero value is unusable —
+// construct via NewClient.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+	apiKey     string
+	// maxRetries bounds 429 retry attempts. Defaults to 3 in NewClient.
+	maxRetries int
+	// sleep is used in place of time.Sleep so tests can avoid real waits.
+	sleep func(time.Duration)
+}
+
+// NewClient returns a client preconfigured with the POKEMONTCG_API_KEY env var
+// (when set) and a 30s HTTP timeout.
+func NewClient() *Client {
+	return &Client{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    DefaultBaseURL,
+		apiKey:     os.Getenv("POKEMONTCG_API_KEY"),
+		maxRetries: 3,
+		sleep:      time.Sleep,
+	}
+}
+
+// WithBaseURL overrides the API base URL (used by tests with httptest).
+func (c *Client) WithBaseURL(url string) *Client {
+	c.baseURL = url
+	return c
+}
+
+// WithHTTPClient overrides the underlying *http.Client.
+func (c *Client) WithHTTPClient(hc *http.Client) *Client {
+	c.httpClient = hc
+	return c
+}
+
+// withSleep is exposed for tests to bypass real sleeps on 429 retries.
+func (c *Client) withSleep(fn func(time.Duration)) *Client {
+	c.sleep = fn
+	return c
+}
+
+// doRequest issues a GET against the given absolute URL and decodes JSON into
+// out. On HTTP 429 it inspects the Retry-After header (seconds), sleeps, and
+// retries up to maxRetries times.
+func (c *Client) doRequest(ctx context.Context, url string, out any) error {
+	for attempt := 0; attempt <= c.maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return fmt.Errorf("build request: %w", err)
+		}
+		if c.apiKey != "" {
+			req.Header.Set("X-Api-Key", c.apiKey)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("http get %s: %w", url, err)
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+			resp.Body.Close()
+			if attempt == c.maxRetries {
+				return fmt.Errorf("rate limited (429) after %d retries: %s", c.maxRetries, url)
+			}
+			if retryAfter <= 0 {
+				retryAfter = time.Duration(attempt+1) * time.Second
+			}
+			c.sleep(retryAfter)
+			continue
+		}
+
+		if resp.StatusCode >= 400 {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			resp.Body.Close()
+			return fmt.Errorf("pokemontcg %d: %s — %s", resp.StatusCode, url, string(body))
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			resp.Body.Close()
+			return fmt.Errorf("decode response: %w", err)
+		}
+		resp.Body.Close()
+		return nil
+	}
+	return fmt.Errorf("unreachable: retry loop exited without return")
+}
+
+// parseRetryAfter parses the Retry-After header value as either a delta-seconds
+// integer or returns zero if unparseable. We deliberately ignore the HTTP-date
+// form because pokemontcg.io only emits integer seconds.
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return time.Duration(n) * time.Second
+}

--- a/internal/pokemon/handler.go
+++ b/internal/pokemon/handler.go
@@ -1,0 +1,29 @@
+package pokemon
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+// AdminSyncHandler kicks off a full SyncAll in a detached goroutine and
+// returns 202 Accepted. Wrap with auth.RequireAdmin() at the router level.
+func AdminSyncHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+			defer cancel()
+			if err := SyncAll(ctx, db, NewClient()); err != nil {
+				log.Printf("pokemon: admin SyncAll failed: %v", err)
+			} else {
+				log.Printf("pokemon: admin SyncAll completed")
+			}
+		}()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "started"})
+	}
+}

--- a/internal/pokemon/scheduler.go
+++ b/internal/pokemon/scheduler.go
@@ -1,0 +1,38 @@
+package pokemon
+
+import "time"
+
+// NextWeeklySync returns the next time the weekly full sync should fire:
+// Sunday 04:00 in the given location. Mirrors the pattern used by the
+// allowance and Stride schedulers in cmd/server/main.go.
+func NextWeeklySync(now time.Time, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = time.UTC
+	}
+	now = now.In(loc)
+	// time.Sunday == 0; days until Sunday = (7 - weekday) % 7.
+	daysUntil := (7 - int(now.Weekday())) % 7
+	if daysUntil == 0 {
+		todayRun := time.Date(now.Year(), now.Month(), now.Day(), 4, 0, 0, 0, loc)
+		if now.Before(todayRun) {
+			return todayRun
+		}
+		return todayRun.AddDate(0, 0, 7)
+	}
+	return time.Date(now.Year(), now.Month(), now.Day()+daysUntil, 4, 0, 0, 0, loc)
+}
+
+// NextDailyPriceRefresh returns the next time the daily price-only sync
+// should fire: 07:00 in the given location.
+func NextDailyPriceRefresh(now time.Time, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = time.UTC
+	}
+	now = now.In(loc)
+	todayRun := time.Date(now.Year(), now.Month(), now.Day(), 7, 0, 0, 0, loc)
+	if now.Before(todayRun) {
+		return todayRun
+	}
+	tomorrow := now.AddDate(0, 0, 1)
+	return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 7, 0, 0, 0, loc)
+}

--- a/internal/pokemon/sync.go
+++ b/internal/pokemon/sync.go
@@ -1,0 +1,245 @@
+package pokemon
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// PageSize is the per-request page size used against the pokemontcg.io API.
+// 250 is the maximum the API allows and minimises total HTTP requests.
+const PageSize = 250
+
+// variantKindMap normalises the API's price-block keys to the internal `kind`
+// stored in pokemon_card_variants. Anything not in this map is left as-is.
+var variantKindMap = map[string]string{
+	"normal":             "normal",
+	"holofoil":           "holofoil",
+	"reverseHolofoil":    "reverse_holofoil",
+	"1stEditionHolofoil": "1st_edition_holofoil",
+	"1stEditionNormal":   "1st_edition_normal",
+	"unlimited":          "unlimited",
+	"unlimitedHolofoil":  "unlimited_holofoil",
+}
+
+// SyncSets paginates /v2/sets and upserts each set into pokemon_sets.
+func SyncSets(ctx context.Context, db *sql.DB, client *Client) error {
+	if client == nil {
+		client = NewClient()
+	}
+	page := 1
+	for {
+		var resp SetsResponse
+		u := fmt.Sprintf("%s/sets?page=%d&pageSize=%d", client.baseURL, page, PageSize)
+		if err := client.doRequest(ctx, u, &resp); err != nil {
+			return fmt.Errorf("fetch sets page %d: %w", page, err)
+		}
+		if len(resp.Data) == 0 {
+			break
+		}
+
+		now := time.Now().UTC()
+		for _, s := range resp.Data {
+			if err := upsertSet(ctx, db, s, now); err != nil {
+				return fmt.Errorf("upsert set %s: %w", s.ID, err)
+			}
+		}
+
+		if page*resp.PageSize >= resp.TotalCount || len(resp.Data) < resp.PageSize {
+			break
+		}
+		page++
+	}
+	return nil
+}
+
+func upsertSet(ctx context.Context, db *sql.DB, s Set, now time.Time) error {
+	// Prefer Total (full set incl. secret rares); fall back to PrintedTotal.
+	total := s.Total
+	if total == 0 {
+		total = s.PrintedTotal
+	}
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO pokemon_sets (id, name, series, release_date, total_cards, symbol_url, logo_url, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			name         = excluded.name,
+			series       = excluded.series,
+			release_date = excluded.release_date,
+			total_cards  = excluded.total_cards,
+			symbol_url   = excluded.symbol_url,
+			logo_url     = excluded.logo_url,
+			synced_at    = excluded.synced_at
+	`, s.ID, s.Name, s.Series, s.ReleaseDate, total, s.Images.Symbol, s.Images.Logo, now)
+	return err
+}
+
+// SyncCards paginates /v2/cards?q=set.id:<setID> and upserts each card plus
+// its variant pricing.
+func SyncCards(ctx context.Context, db *sql.DB, client *Client, setID string) error {
+	if client == nil {
+		client = NewClient()
+	}
+	return syncCardsImpl(ctx, db, client, setID, false)
+}
+
+// RefreshPrices walks every known set and updates only the variant prices,
+// leaving the metadata rows untouched. Use this for the daily price tick.
+func RefreshPrices(ctx context.Context, db *sql.DB, client *Client) error {
+	if client == nil {
+		client = NewClient()
+	}
+	setIDs, err := listSetIDs(ctx, db)
+	if err != nil {
+		return fmt.Errorf("list sets for price refresh: %w", err)
+	}
+	for _, id := range setIDs {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err := syncCardsImpl(ctx, db, client, id, true); err != nil {
+			log.Printf("pokemon: refresh prices for set %s: %v", id, err)
+			continue
+		}
+	}
+	return nil
+}
+
+// SyncAll first syncs the set list, then iterates each set and pulls its
+// cards. Per-set errors are logged and do not abort the run.
+func SyncAll(ctx context.Context, db *sql.DB, client *Client) error {
+	if client == nil {
+		client = NewClient()
+	}
+	if err := SyncSets(ctx, db, client); err != nil {
+		return fmt.Errorf("sync sets: %w", err)
+	}
+	setIDs, err := listSetIDs(ctx, db)
+	if err != nil {
+		return fmt.Errorf("list sets after sync: %w", err)
+	}
+	for _, id := range setIDs {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err := SyncCards(ctx, db, client, id); err != nil {
+			log.Printf("pokemon: sync cards for set %s: %v", id, err)
+			continue
+		}
+	}
+	return nil
+}
+
+func listSetIDs(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `SELECT id FROM pokemon_sets ORDER BY release_date, id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// syncCardsImpl is the shared implementation behind SyncCards and the
+// price-only refresh path.
+func syncCardsImpl(ctx context.Context, db *sql.DB, client *Client, setID string, pricesOnly bool) error {
+	page := 1
+	for {
+		q := url.Values{}
+		q.Set("q", "set.id:"+setID)
+		q.Set("page", strconv.Itoa(page))
+		q.Set("pageSize", strconv.Itoa(PageSize))
+		u := client.baseURL + "/cards?" + q.Encode()
+
+		var resp CardsResponse
+		if err := client.doRequest(ctx, u, &resp); err != nil {
+			return fmt.Errorf("fetch cards page %d for set %s: %w", page, setID, err)
+		}
+		if len(resp.Data) == 0 {
+			break
+		}
+
+		now := time.Now().UTC()
+		for _, c := range resp.Data {
+			if !pricesOnly {
+				if err := upsertCard(ctx, db, setID, c, now); err != nil {
+					return fmt.Errorf("upsert card %s: %w", c.ID, err)
+				}
+			}
+			if err := upsertVariants(ctx, db, c, now); err != nil {
+				return fmt.Errorf("upsert variants for %s: %w", c.ID, err)
+			}
+		}
+
+		if page*resp.PageSize >= resp.TotalCount || len(resp.Data) < resp.PageSize {
+			break
+		}
+		page++
+	}
+	return nil
+}
+
+func upsertCard(ctx context.Context, db *sql.DB, setID string, c Card, now time.Time) error {
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO pokemon_cards (id, set_id, name, collector_no, rarity, image_small_url, image_large_url, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			set_id          = excluded.set_id,
+			name            = excluded.name,
+			collector_no    = excluded.collector_no,
+			rarity          = excluded.rarity,
+			image_small_url = excluded.image_small_url,
+			image_large_url = excluded.image_large_url,
+			synced_at       = excluded.synced_at
+	`, c.ID, setID, c.Name, c.Number, c.Rarity, c.Images.Small, c.Images.Large, now)
+	return err
+}
+
+func upsertVariants(ctx context.Context, db *sql.DB, c Card, now time.Time) error {
+	for apiKind, price := range c.Cardmarket.Prices {
+		kind := mapVariantKind(apiKind)
+		if kind == "" {
+			continue
+		}
+		eur := price.TrendPrice
+		if eur == 0 {
+			eur = price.AverageSellPrice
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO pokemon_card_variants (card_id, kind, price_eur, price_at)
+			VALUES (?, ?, ?, ?)
+			ON CONFLICT(card_id, kind) DO UPDATE SET
+				price_eur = excluded.price_eur,
+				price_at  = excluded.price_at
+		`, c.ID, kind, eur, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mapVariantKind normalises an API price-block key to the internal `kind`
+// value persisted in pokemon_card_variants. Empty result means "skip".
+func mapVariantKind(apiKind string) string {
+	if apiKind == "" {
+		return ""
+	}
+	if mapped, ok := variantKindMap[apiKind]; ok {
+		return mapped
+	}
+	// Pass unknown kinds through unchanged — the API occasionally adds new
+	// promo / event variants, and persisting them as-is is preferable to
+	// dropping the price data silently.
+	return apiKind
+}

--- a/internal/pokemon/sync_test.go
+++ b/internal/pokemon/sync_test.go
@@ -1,0 +1,405 @@
+package pokemon
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/db"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	d, err := db.Init(":memory:")
+	if err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	d.SetMaxOpenConns(1)
+	d.SetMaxIdleConns(1)
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// newTestClient builds a Client pointed at the given test server, with sleeps
+// stubbed so 429 retries don't block real wall-clock time.
+func newTestClient(srv *httptest.Server) *Client {
+	c := NewClient().WithBaseURL(srv.URL).WithHTTPClient(srv.Client())
+	c.withSleep(func(time.Duration) {})
+	c.maxRetries = 2
+	return c
+}
+
+func TestSyncSets_SinglePage(t *testing.T) {
+	d := setupTestDB(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/sets") {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		resp := SetsResponse{
+			Page:       1,
+			PageSize:   PageSize,
+			Count:      2,
+			TotalCount: 2,
+			Data: []Set{
+				{
+					ID:           "base1",
+					Name:         "Base Set",
+					Series:       "Base",
+					PrintedTotal: 102,
+					Total:        102,
+					ReleaseDate:  "1999/01/09",
+					Images:       SetImages{Symbol: "https://example/sym.png", Logo: "https://example/logo.png"},
+				},
+				{
+					ID:          "jungle",
+					Name:        "Jungle",
+					Series:      "Base",
+					Total:       64,
+					ReleaseDate: "1999/06/16",
+				},
+			},
+		}
+		writeJSON(t, w, resp)
+	}))
+	defer srv.Close()
+
+	if err := SyncSets(context.Background(), d, newTestClient(srv)); err != nil {
+		t.Fatalf("SyncSets: %v", err)
+	}
+
+	var count int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM pokemon_sets`).Scan(&count); err != nil {
+		t.Fatalf("count sets: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 sets, got %d", count)
+	}
+
+	var name, logo string
+	var total int
+	if err := d.QueryRow(`SELECT name, total_cards, logo_url FROM pokemon_sets WHERE id = ?`, "base1").Scan(&name, &total, &logo); err != nil {
+		t.Fatalf("read base1: %v", err)
+	}
+	if name != "Base Set" || total != 102 || logo != "https://example/logo.png" {
+		t.Fatalf("unexpected base1 row: name=%q total=%d logo=%q", name, total, logo)
+	}
+}
+
+func TestSyncSets_Pagination(t *testing.T) {
+	d := setupTestDB(t)
+
+	totalCount := PageSize*2 + 5 // three pages: full, full, partial
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		pageStr := r.URL.Query().Get("page")
+		page, _ := strconv.Atoi(pageStr)
+		if page < 1 {
+			page = 1
+		}
+
+		var pageData []Set
+		switch page {
+		case 1, 2:
+			pageData = makeSetPage(page, PageSize)
+		case 3:
+			pageData = makeSetPage(page, 5)
+		default:
+			pageData = nil
+		}
+		writeJSON(t, w, SetsResponse{
+			Page:       page,
+			PageSize:   PageSize,
+			Count:      len(pageData),
+			TotalCount: totalCount,
+			Data:       pageData,
+		})
+	}))
+	defer srv.Close()
+
+	if err := SyncSets(context.Background(), d, newTestClient(srv)); err != nil {
+		t.Fatalf("SyncSets: %v", err)
+	}
+	if hits < 3 {
+		t.Fatalf("expected at least 3 page requests, got %d", hits)
+	}
+
+	var count int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM pokemon_sets`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != totalCount {
+		t.Fatalf("expected %d sets, got %d", totalCount, count)
+	}
+}
+
+func TestSyncCards_InsertsCardsAndVariants(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Seed the set so the cards row's FK passes.
+	if _, err := d.Exec(`INSERT INTO pokemon_sets (id, name, series, release_date, total_cards, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?)`, "swsh1", "Sword & Shield", "Sword & Shield", "2020/02/07", 202, time.Now()); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+
+	card := Card{
+		ID:     "swsh1-1",
+		Name:   "Celebi V",
+		Number: "001",
+		Rarity: "Rare Holo V",
+		Images: CardImages{
+			Small: "https://example/sm.png",
+			Large: "https://example/lg.png",
+		},
+		Cardmarket: Cardmarket{
+			Prices: map[string]CardmarketPrice{
+				"normal":          {AverageSellPrice: 1.5, TrendPrice: 1.7},
+				"reverseHolofoil": {AverageSellPrice: 2.0, TrendPrice: 0}, // trend missing -> fallback
+				"holofoil":        {AverageSellPrice: 3.0, TrendPrice: 3.4},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q, _ := url.QueryUnescape(r.URL.RawQuery)
+		if !strings.Contains(q, "q=set.id:swsh1") {
+			t.Fatalf("expected set.id filter in query, got %s", q)
+		}
+		writeJSON(t, w, CardsResponse{
+			Page:       1,
+			PageSize:   PageSize,
+			Count:      1,
+			TotalCount: 1,
+			Data:       []Card{card},
+		})
+	}))
+	defer srv.Close()
+
+	if err := SyncCards(context.Background(), d, newTestClient(srv), "swsh1"); err != nil {
+		t.Fatalf("SyncCards: %v", err)
+	}
+
+	var name, rarity string
+	if err := d.QueryRow(`SELECT name, rarity FROM pokemon_cards WHERE id = ?`, "swsh1-1").Scan(&name, &rarity); err != nil {
+		t.Fatalf("read card: %v", err)
+	}
+	if name != "Celebi V" || rarity != "Rare Holo V" {
+		t.Fatalf("unexpected card row: name=%q rarity=%q", name, rarity)
+	}
+
+	rows, err := d.Query(`SELECT kind, price_eur FROM pokemon_card_variants WHERE card_id = ? ORDER BY kind`, "swsh1-1")
+	if err != nil {
+		t.Fatalf("query variants: %v", err)
+	}
+	defer rows.Close()
+
+	got := map[string]float64{}
+	for rows.Next() {
+		var k string
+		var p float64
+		if err := rows.Scan(&k, &p); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[k] = p
+	}
+
+	want := map[string]float64{
+		"normal":           1.7, // trendPrice preferred
+		"reverse_holofoil": 2.0, // trendPrice=0 -> fallback to averageSellPrice
+		"holofoil":         3.4,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d variants, got %d: %+v", len(want), len(got), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("variant %s: expected %v, got %v", k, v, got[k])
+		}
+	}
+}
+
+func TestSyncCards_VariantUpsertUpdatesPrice(t *testing.T) {
+	d := setupTestDB(t)
+	if _, err := d.Exec(`INSERT INTO pokemon_sets (id, name, series, release_date, total_cards, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?)`, "s1", "S", "S", "2024/01/01", 1, time.Now()); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var hits int32
+	prices := []map[string]CardmarketPrice{
+		{"normal": {TrendPrice: 1.0}},
+		{"normal": {TrendPrice: 2.5}},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := atomic.AddInt32(&hits, 1) - 1
+		card := Card{
+			ID:         "s1-1",
+			Name:       "Pikachu",
+			Number:     "1",
+			Cardmarket: Cardmarket{Prices: prices[idx]},
+		}
+		writeJSON(t, w, CardsResponse{TotalCount: 1, Count: 1, PageSize: PageSize, Page: 1, Data: []Card{card}})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := SyncCards(context.Background(), d, c, "s1"); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if err := SyncCards(context.Background(), d, c, "s1"); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	var p float64
+	if err := d.QueryRow(`SELECT price_eur FROM pokemon_card_variants WHERE card_id = ? AND kind = ?`, "s1-1", "normal").Scan(&p); err != nil {
+		t.Fatalf("read price: %v", err)
+	}
+	if p != 2.5 {
+		t.Fatalf("expected updated price 2.5, got %v", p)
+	}
+
+	var count int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM pokemon_card_variants WHERE card_id = ?`, "s1-1").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected one variant row after upsert, got %d", count)
+	}
+}
+
+func TestDoRequest_RetriesOn429(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		writeJSON(t, w, SetsResponse{TotalCount: 0, Count: 0, PageSize: PageSize, Page: 1, Data: []Set{}})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	var resp SetsResponse
+	if err := c.doRequest(context.Background(), srv.URL+"/sets?page=1", &resp); err != nil {
+		t.Fatalf("doRequest: %v", err)
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 attempts (first 429, second OK), got %d", hits)
+	}
+}
+
+func TestMapVariantKind(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"normal", "normal"},
+		{"reverseHolofoil", "reverse_holofoil"},
+		{"holofoil", "holofoil"},
+		{"1stEditionHolofoil", "1st_edition_holofoil"},
+		{"unknownPromo", "unknownPromo"}, // unknown passes through
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := mapVariantKind(tc.in); got != tc.want {
+			t.Errorf("mapVariantKind(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNextWeeklySync_SundayAtFourOslo(t *testing.T) {
+	oslo, err := time.LoadLocation("Europe/Oslo")
+	if err != nil {
+		t.Fatalf("load tz: %v", err)
+	}
+	cases := []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "Sunday before 04:00 returns same day",
+			now:  time.Date(2026, 5, 17, 2, 0, 0, 0, oslo), // Sunday
+			want: time.Date(2026, 5, 17, 4, 0, 0, 0, oslo),
+		},
+		{
+			name: "Sunday after 04:00 returns next Sunday",
+			now:  time.Date(2026, 5, 17, 5, 0, 0, 0, oslo),
+			want: time.Date(2026, 5, 24, 4, 0, 0, 0, oslo),
+		},
+		{
+			name: "Wednesday returns upcoming Sunday",
+			now:  time.Date(2026, 5, 13, 9, 0, 0, 0, oslo),
+			want: time.Date(2026, 5, 17, 4, 0, 0, 0, oslo),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NextWeeklySync(tc.now, oslo)
+			if !got.Equal(tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+			if got.Weekday() != time.Sunday {
+				t.Errorf("expected Sunday, got %v", got.Weekday())
+			}
+			if h := got.In(oslo).Hour(); h != 4 {
+				t.Errorf("expected hour 4, got %d", h)
+			}
+		})
+	}
+}
+
+func TestNextDailyPriceRefresh_SevenAMOslo(t *testing.T) {
+	oslo, err := time.LoadLocation("Europe/Oslo")
+	if err != nil {
+		t.Fatalf("load tz: %v", err)
+	}
+	now := time.Date(2026, 5, 13, 8, 0, 0, 0, oslo) // after 07:00
+	got := NextDailyPriceRefresh(now, oslo)
+	want := time.Date(2026, 5, 14, 7, 0, 0, 0, oslo)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	now2 := time.Date(2026, 5, 13, 6, 0, 0, 0, oslo) // before 07:00
+	got2 := NextDailyPriceRefresh(now2, oslo)
+	want2 := time.Date(2026, 5, 13, 7, 0, 0, 0, oslo)
+	if !got2.Equal(want2) {
+		t.Errorf("same-day case: got %v, want %v", got2, want2)
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func makeSetPage(page, n int) []Set {
+	out := make([]Set, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("p%d-%d", page, i)
+		out[i] = Set{
+			ID:          id,
+			Name:        id,
+			Series:      "Test",
+			Total:       1,
+			ReleaseDate: "2024/01/01",
+		}
+	}
+	return out
+}

--- a/internal/pokemon/types.go
+++ b/internal/pokemon/types.go
@@ -1,0 +1,67 @@
+package pokemon
+
+// SetsResponse is the paginated /v2/sets response from pokemontcg.io.
+type SetsResponse struct {
+	Data       []Set `json:"data"`
+	Page       int   `json:"page"`
+	PageSize   int   `json:"pageSize"`
+	Count      int   `json:"count"`
+	TotalCount int   `json:"totalCount"`
+}
+
+// Set is a Pokémon TCG set as returned by /v2/sets.
+type Set struct {
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	Series       string    `json:"series"`
+	PrintedTotal int       `json:"printedTotal"`
+	Total        int       `json:"total"`
+	ReleaseDate  string    `json:"releaseDate"`
+	Images       SetImages `json:"images"`
+}
+
+// SetImages holds the symbol/logo URLs returned for a set.
+type SetImages struct {
+	Symbol string `json:"symbol"`
+	Logo   string `json:"logo"`
+}
+
+// CardsResponse is the paginated /v2/cards response from pokemontcg.io.
+type CardsResponse struct {
+	Data       []Card `json:"data"`
+	Page       int    `json:"page"`
+	PageSize   int    `json:"pageSize"`
+	Count      int    `json:"count"`
+	TotalCount int    `json:"totalCount"`
+}
+
+// Card is a single card record from /v2/cards.
+type Card struct {
+	ID         string     `json:"id"`
+	Name       string     `json:"name"`
+	Number     string     `json:"number"`
+	Rarity     string     `json:"rarity"`
+	Images     CardImages `json:"images"`
+	Cardmarket Cardmarket `json:"cardmarket"`
+}
+
+// CardImages holds small/large image URLs for a card.
+type CardImages struct {
+	Small string `json:"small"`
+	Large string `json:"large"`
+}
+
+// Cardmarket is the price block from the API. Prices are keyed by variant
+// name (normal, reverseHolofoil, holofoil, 1stEditionHolofoil, ...).
+type Cardmarket struct {
+	URL       string                    `json:"url"`
+	UpdatedAt string                    `json:"updatedAt"`
+	Prices    map[string]CardmarketPrice `json:"prices"`
+}
+
+// CardmarketPrice contains the price quotes for one variant. We persist
+// trendPrice when available and fall back to averageSellPrice.
+type CardmarketPrice struct {
+	AverageSellPrice float64 `json:"averageSellPrice"`
+	TrendPrice       float64 `json:"trendPrice"`
+}


### PR DESCRIPTION
## Changes

- **Pokémon TCG metadata + price sync** - New `internal/pokemon` package syncs sets, cards, and per-variant EUR prices from pokemontcg.io. A weekly full sync runs Sunday 04:00 Europe/Oslo and a daily price refresh runs at 07:00 Europe/Oslo; admins can trigger a manual run with `POST /api/pokemon/admin/sync`. Set `POKEMONTCG_API_KEY` for higher rate limits; the client honours `Retry-After` on 429 responses. (Hytte-839c)

## Original Issue (feature): Pokémon: pokemontcg.io metadata + price sync

Part of the Pokémon Collection chain seeded from Suggestions id=146. See that suggestion's plan for the full architecture, data sources (pokemontcg.io + Norges Bank EUR/NOK), and scope decisions (per-kid collections, NOK only, variants from day 1, local image cache).

This bead is step 2/7: Metadata sync of the chain.

## Scope

New package `internal/pokemon/` with the metadata + price sync from [pokemontcg.io](https://pokemontcg.io).

### Sync logic

- `SyncSets(ctx, db)` — GET /v2/sets with pagination, upsert into `pokemon_sets`.
- `SyncCards(ctx, db, setID)` — GET /v2/cards?q=set.id:<id>&pageSize=250 with pagination, upsert into `pokemon_cards`. For each card, extract variants from the response's `cardmarket.prices` block (averageSellPrice, trendPrice — prefer trendPrice). Insert / update `pokemon_card_variants` rows keyed by `(card_id, kind)` where kind is mapped from the API's price kind (normal, reverseHolofoil, holofoil, 1stEditionHolofoil → 1st_edition, etc.).
- `SyncAll(ctx, db)` calls SyncSets then iterates each set and calls SyncCards. Per-set errors are isolated.

### Scheduling

- Background goroutine in `cmd/server/main.go`:
    - Weekly full sync (SyncAll) at 04:00 Sunday Europe/Oslo.
    - Daily price refresh at 07:00 Europe/Oslo — same as SyncCards but only updates price columns (don't reinsert metadata).
- Manual trigger: POST /api/pokemon/admin/sync (admin-only) for testing.

### Configuration

- New env var `POKEMONTCG_API_KEY` (optional but recommended for higher rate limit). Document in CLAUDE.md.
- Rate limit awareness: respect the `Retry-After` header on 429; back off and retry.

### Tests

- `sync_test.go` with an HTTP fixture server returning canned set + card JSON; assert rows inserted with correct fields and EUR prices parsed.
- Pagination test (3 pages).

### Acceptance

- `make build`, `make test ./internal/pokemon/...` pass.
- After a manual sync, `SELECT COUNT(*) FROM pokemon_sets` returns ~150+.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-839c | Branch: forge/Hytte-839c
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->