### PR TITLE
Family Chat: webpush on incoming message (Hytte-6clp)

### DIFF
--- a/changelog.d/Hytte-56j7.md
+++ b/changelog.d/Hytte-56j7.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat REST endpoints** - Added `/api/familychat/conversations` and message routes (list/create/get/delete conversation, list/post messages, mark-read) gated by the new `family_chat` feature flag. Message bodies and attachment paths are encrypted at rest, and every endpoint resolves membership via `family_chat_members` so non-members receive 404 instead of 403 to avoid leaking conversation existence. (Hytte-56j7)

--- a/changelog.d/Hytte-6clp.md
+++ b/changelog.d/Hytte-6clp.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat: webpush on incoming message** - When a new message arrives and a recipient does not currently have a live SSE stream open for the conversation, a webpush notification is sent so their device wakes up. The notification uses the sender's display name as the title, the first ~80 chars of the message as the body, and a `familychat-<conversation_id>` tag so a second message replaces the first banner instead of stacking. Stale (410 Gone) push subscriptions are removed automatically. (Hytte-6clp)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -516,14 +516,16 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/chat/conversations/{id}/messages", chat.SendMessageHandler(db))
 			})
 
-			// Family Chat — gated by "family_chat" feature.
-			// The SSE live-delivery stream is the only route registered here so
-			// far; REST endpoints (list/create conversations, send/read messages)
-			// land in companion beads and will join this group. Message and read
-			// handlers publish into familychat.DefaultHub() so subscribers see
-			// updates within milliseconds of the row being persisted.
+			// Family Chat — gated by "family_chat" feature (Hytte-56j7).
 			r.Group(func(r chi.Router) {
 				r.Use(auth.RequireFeature(db, "family_chat"))
+				r.Get("/familychat/conversations", familychat.ListConversationsHandler(db))
+				r.Post("/familychat/conversations", familychat.CreateConversationHandler(db))
+				r.Get("/familychat/conversations/{id}", familychat.GetConversationHandler(db))
+				r.Delete("/familychat/conversations/{id}", familychat.DeleteConversationHandler(db))
+				r.Get("/familychat/conversations/{id}/messages", familychat.ListMessagesHandler(db))
+				r.Post("/familychat/conversations/{id}/messages", familychat.PostMessageHandler(db))
+				r.Post("/familychat/conversations/{id}/read", familychat.MarkReadHandler(db))
 				r.Get("/familychat/conversations/{id}/stream", familychat.StreamHandlerWithDB(db))
 			})
 

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -35,7 +35,6 @@ var FeatureDefaults = map[string]bool{
 	"grocery":          false,
 	"homework":         false,
 	"regnemester":      false,
-	"family_chat":      false,
 }
 
 // FeatureKeys is a sorted list of all known feature keys, used for stable

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -35,6 +35,7 @@ var FeatureDefaults = map[string]bool{
 	"grocery":          false,
 	"homework":         false,
 	"regnemester":      false,
+	"family_chat":      false,
 }
 
 // FeatureKeys is a sorted list of all known feature keys, used for stable

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1589,6 +1589,41 @@ func createSchema(db *sql.DB) error {
 		completed_at TEXT NOT NULL DEFAULT ''
 	);
 
+	-- Family Chat (Hytte-56j7): conversations, members, and encrypted messages.
+	-- Trust model is at-rest encryption with the server holding the key (same
+	-- as Notes); body and attachment_path are stored as enc:... ciphertext.
+	CREATE TABLE IF NOT EXISTS family_chat_conversations (
+		id              INTEGER PRIMARY KEY,
+		name            TEXT NOT NULL DEFAULT '',
+		owner_user_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+		last_message_at TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_family_chat_conversations_owner ON family_chat_conversations(owner_user_id);
+
+	CREATE TABLE IF NOT EXISTS family_chat_members (
+		conversation_id INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
+		user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		joined_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+		last_read_at    TEXT NOT NULL DEFAULT '',
+		PRIMARY KEY (conversation_id, user_id)
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_family_chat_members_user ON family_chat_members(user_id);
+
+	CREATE TABLE IF NOT EXISTS family_chat_messages (
+		id                INTEGER PRIMARY KEY,
+		conversation_id   INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
+		sender_user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		body              TEXT NOT NULL DEFAULT '',
+		attachment_path   TEXT NOT NULL DEFAULT '',
+		attachment_mime   TEXT NOT NULL DEFAULT '',
+		created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_family_chat_messages_conversation_id ON family_chat_messages(conversation_id, id DESC);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -1,0 +1,251 @@
+package familychat
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("familychat: writeJSON encode: %v", err)
+	}
+}
+
+func notFound(w http.ResponseWriter) {
+	writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+}
+
+// parseConvID extracts and validates the {id} path parameter for the
+// conversation routes. On failure we respond 404 (not 400) because an
+// unparseable id may simply be a probe for a conversation that does not
+// exist, and we never want to leak that signal.
+func parseConvID(r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
+}
+
+// ListConversationsHandler returns every conversation the authenticated user
+// is a member of.
+func ListConversationsHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convos, err := ListConversations(db, user.ID)
+		if err != nil {
+			log.Printf("familychat: list conversations for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list conversations"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"conversations": convos})
+	}
+}
+
+// CreateConversationHandler creates a new conversation with the requesting
+// user as owner. The body shape is {name, member_user_ids}.
+func CreateConversationHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		var body struct {
+			Name          string  `json:"name"`
+			MemberUserIDs []int64 `json:"member_user_ids"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+		body.Name = strings.TrimSpace(body.Name)
+		if body.Name == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+			return
+		}
+
+		c, err := CreateConversation(db, user.ID, body.Name, body.MemberUserIDs)
+		if err != nil {
+			log.Printf("familychat: create conversation for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create conversation"})
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"conversation": c})
+	}
+}
+
+// GetConversationHandler returns full metadata for a single conversation.
+// Non-members get 404 to avoid revealing existence.
+func GetConversationHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+		c, err := GetConversation(db, convID, user.ID)
+		if err != nil {
+			if errors.Is(err, ErrNotMember) || errors.Is(err, sql.ErrNoRows) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: get conversation %d for user %d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get conversation"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"conversation": c})
+	}
+}
+
+// ListMessagesHandler returns messages, newest first. Optional query params:
+//
+//	since=<id>  - return only messages with id > since
+//	limit=<n>   - cap the response size (default 50, max 500)
+func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+
+		var since int64
+		if v := strings.TrimSpace(r.URL.Query().Get("since")); v != "" {
+			n, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || n < 0 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid since parameter"})
+				return
+			}
+			since = n
+		}
+		limit := 50
+		if v := strings.TrimSpace(r.URL.Query().Get("limit")); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n <= 0 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid limit parameter"})
+				return
+			}
+			limit = n
+		}
+
+		msgs, err := ListMessages(db, convID, user.ID, since, limit)
+		if err != nil {
+			if errors.Is(err, ErrNotMember) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: list messages conv=%d user=%d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list messages"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"messages": msgs})
+	}
+}
+
+// PostMessageHandler appends a message to a conversation and returns the
+// inserted row decrypted.
+func PostMessageHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+
+		var body struct {
+			Body           string `json:"body"`
+			AttachmentPath string `json:"attachment_path"`
+			AttachmentMime string `json:"attachment_mime"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+		body.Body = strings.TrimSpace(body.Body)
+		if body.Body == "" && body.AttachmentPath == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body or attachment_path is required"})
+			return
+		}
+
+		msg, err := CreateMessage(db, convID, user.ID, body.Body, body.AttachmentPath, body.AttachmentMime)
+		if err != nil {
+			if errors.Is(err, ErrNotMember) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: post message conv=%d user=%d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to post message"})
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"message": msg})
+	}
+}
+
+// MarkReadHandler updates the requesting member's last_read_at to {at}.
+// Missing/empty `at` defaults to the current server time.
+func MarkReadHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+
+		var body struct {
+			At string `json:"at"`
+		}
+		// An empty body is valid: it just means "mark read up to now".
+		if r.ContentLength > 0 {
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+				return
+			}
+		}
+
+		if err := MarkRead(db, convID, user.ID, strings.TrimSpace(body.At)); err != nil {
+			if errors.Is(err, ErrNotMember) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: mark read conv=%d user=%d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mark read"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+}
+
+// DeleteConversationHandler removes a conversation. Only the owner may
+// delete; non-owners (including members) get 404.
+func DeleteConversationHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+		if err := DeleteConversation(db, convID, user.ID); err != nil {
+			if errors.Is(err, ErrNotMember) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: delete conversation %d for user %d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete conversation"})
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -8,9 +8,24 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/go-chi/chi/v5"
+)
+
+// Input validation bounds for the Family Chat handlers. The body cap is a
+// generous safety net to keep one client from filling the DB with one
+// request; clients should enforce friendlier UI limits well below these.
+const (
+	maxNameLen        = 200
+	maxBodyLen        = 8000
+	maxAttachmentPath = 1024
+	maxAttachmentMime = 128
+	maxMembersPerConv = 100
+	defaultMsgLimit   = 50
+	maxMsgLimit       = 500
+	maxRequestBytes   = 1 << 20 // 1 MiB
 )
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
@@ -23,6 +38,17 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func notFound(w http.ResponseWriter) {
 	writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+}
+
+// decodeJSON enforces a body-size cap and parses JSON into dst. Returns true
+// on success; on failure it writes a 400 response and returns false.
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return false
+	}
+	return true
 }
 
 // parseConvID extracts and validates the {id} path parameter for the
@@ -62,14 +88,27 @@ func CreateConversationHandler(db *sql.DB) http.HandlerFunc {
 			Name          string  `json:"name"`
 			MemberUserIDs []int64 `json:"member_user_ids"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		if !decodeJSON(w, r, &body) {
 			return
 		}
 		body.Name = strings.TrimSpace(body.Name)
 		if body.Name == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
 			return
+		}
+		if len([]rune(body.Name)) > maxNameLen {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is too long"})
+			return
+		}
+		if len(body.MemberUserIDs) > maxMembersPerConv {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "too many members"})
+			return
+		}
+		for _, uid := range body.MemberUserIDs {
+			if uid <= 0 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid member id"})
+				return
+			}
 		}
 
 		c, err := CreateConversation(db, user.ID, body.Name, body.MemberUserIDs)
@@ -128,10 +167,10 @@ func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
 			}
 			since = n
 		}
-		limit := 50
+		limit := defaultMsgLimit
 		if v := strings.TrimSpace(r.URL.Query().Get("limit")); v != "" {
 			n, err := strconv.Atoi(v)
-			if err != nil || n <= 0 {
+			if err != nil || n <= 0 || n > maxMsgLimit {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid limit parameter"})
 				return
 			}
@@ -168,13 +207,26 @@ func PostMessageHandler(db *sql.DB) http.HandlerFunc {
 			AttachmentPath string `json:"attachment_path"`
 			AttachmentMime string `json:"attachment_mime"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		if !decodeJSON(w, r, &body) {
 			return
 		}
 		body.Body = strings.TrimSpace(body.Body)
+		body.AttachmentPath = strings.TrimSpace(body.AttachmentPath)
+		body.AttachmentMime = strings.TrimSpace(body.AttachmentMime)
 		if body.Body == "" && body.AttachmentPath == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body or attachment_path is required"})
+			return
+		}
+		if len([]rune(body.Body)) > maxBodyLen {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body is too long"})
+			return
+		}
+		if len(body.AttachmentPath) > maxAttachmentPath {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "attachment_path is too long"})
+			return
+		}
+		if len(body.AttachmentMime) > maxAttachmentMime {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "attachment_mime is too long"})
 			return
 		}
 
@@ -208,13 +260,24 @@ func MarkReadHandler(db *sql.DB) http.HandlerFunc {
 		}
 		// An empty body is valid: it just means "mark read up to now".
 		if r.ContentLength > 0 {
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			if !decodeJSON(w, r, &body) {
 				return
 			}
 		}
+		at := strings.TrimSpace(body.At)
+		if at != "" {
+			// Accept RFC3339 with optional sub-second precision. Reject anything
+			// unparseable so we never store garbage in last_read_at, which is
+			// compared as a string for unread-count ordering.
+			if _, err := time.Parse(time.RFC3339Nano, at); err != nil {
+				if _, err2 := time.Parse(time.RFC3339, at); err2 != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid at timestamp (expected RFC3339)"})
+					return
+				}
+			}
+		}
 
-		if err := MarkRead(db, convID, user.ID, strings.TrimSpace(body.At)); err != nil {
+		if err := MarkRead(db, convID, user.ID, at); err != nil {
 			if errors.Is(err, ErrNotMember) {
 				notFound(w)
 				return

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -191,9 +191,18 @@ func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
-// PostMessageHandler appends a message to a conversation and returns the
-// inserted row decrypted.
+// PostMessageHandler appends a message to a conversation, broadcasts it on
+// the SSE hub for any live subscriber, and fans webpush notifications out to
+// every recipient who is not currently subscribed via SSE.
 func PostMessageHandler(db *sql.DB) http.HandlerFunc {
+	return postMessageHandler(db, DefaultHub(), defaultPushSender(db), false /* notify async */)
+}
+
+// postMessageHandler is the testable inner constructor. When notifySync is
+// true the webpush fan-out runs inline so tests can assert on it after
+// ServeHTTP returns; in production it runs in a goroutine so a slow push
+// gateway cannot stall the HTTP response.
+func postMessageHandler(db *sql.DB, hub *Hub, sender PushSenderFunc, notifySync bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
 		convID, ok := parseConvID(r)
@@ -240,6 +249,25 @@ func PostMessageHandler(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to post message"})
 			return
 		}
+
+		// Publish to any live SSE subscribers first so they see the message
+		// without waiting for the webpush round trip.
+		if hub != nil {
+			hub.Publish(convID, Event{Type: EventMessageNew, Data: map[string]any{"message": msg}})
+		}
+
+		// Fan webpush out to recipients who are not currently on SSE. Done
+		// after the DB write and hub publish so the recipient cannot get a
+		// notification for a message that failed to persist.
+		if sender != nil {
+			senderName := senderDisplayName(user)
+			if notifySync {
+				notifyOfflineRecipients(db, hub, sender, convID, msg, senderName)
+			} else {
+				go notifyOfflineRecipients(db, hub, sender, convID, msg, senderName)
+			}
+		}
+
 		writeJSON(w, http.StatusCreated, map[string]any{"message": msg})
 	}
 }

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -2,17 +2,22 @@ package familychat
 
 import (
 	"context"
+	"crypto/ecdh"
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/Robin831/Hytte/internal/push"
 	"github.com/go-chi/chi/v5"
 	_ "modernc.org/sqlite"
 )
@@ -662,5 +667,242 @@ func TestDeleteConversationHandler_NonMember(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// addPushTables creates the vapid_keys and push_subscriptions tables on a
+// test DB that was originally built without them. Used by the push fan-out
+// tests below.
+func addPushTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`
+		CREATE TABLE vapid_keys (
+			id          INTEGER PRIMARY KEY,
+			public_key  TEXT NOT NULL,
+			private_key TEXT NOT NULL
+		);
+		CREATE TABLE push_subscriptions (
+			id         INTEGER PRIMARY KEY,
+			user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			endpoint   TEXT NOT NULL,
+			p256dh     TEXT NOT NULL,
+			auth       TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT '',
+			UNIQUE(user_id, endpoint)
+		);
+	`); err != nil {
+		t.Fatalf("add push tables: %v", err)
+	}
+}
+
+func TestPostMessageHandler_NotifiesOnlyOfflineRecipients(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com") // sender
+	makeUser(t, db, 2, "bob@example.com")   // online via SSE
+	makeUser(t, db, 3, "carol@example.com") // offline
+	convID := seedConversation(t, db, 1, "Family", 2, 3)
+
+	hub := NewHub()
+	// Bob is live on SSE — fan-out must skip him.
+	bobSub := hub.Subscribe(2, convID)
+	defer hub.Unsubscribe(convID, bobSub)
+	// Drain Bob's events so the hub buffer cannot fill mid-test.
+	go func() {
+		for range bobSub.Events() {
+		}
+	}()
+
+	type call struct {
+		userID  int64
+		payload []byte
+	}
+	var mu sync.Mutex
+	var calls []call
+	sender := func(userID int64, payload []byte) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, call{userID: userID, payload: append([]byte(nil), payload...)})
+		return nil
+	}
+
+	handler := postMessageHandler(db, hub, sender, true /* notifySync */)
+
+	idStr := strconv.FormatInt(convID, 10)
+	payloadStr := `{"body":"hello family"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payloadStr)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 push call (offline recipient), got %d", len(calls))
+	}
+	if calls[0].userID != 3 {
+		t.Fatalf("push went to user %d, want 3 (offline recipient)", calls[0].userID)
+	}
+
+	var note push.Notification
+	if err := json.Unmarshal(calls[0].payload, &note); err != nil {
+		t.Fatalf("decode push payload: %v", err)
+	}
+	// withUser builds users with Name="Test"; that's the sender's display name.
+	if note.Title != "Test" {
+		t.Errorf("title = %q, want %q", note.Title, "Test")
+	}
+	if note.Body != "hello family" {
+		t.Errorf("body = %q, want %q", note.Body, "hello family")
+	}
+	wantTag := fmt.Sprintf("familychat-%d", convID)
+	if note.Tag != wantTag {
+		t.Errorf("tag = %q, want %q", note.Tag, wantTag)
+	}
+}
+
+func TestPostMessageHandler_TruncatesLongBodyInPush(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	var captured []byte
+	sender := func(userID int64, payload []byte) error {
+		captured = append([]byte(nil), payload...)
+		return nil
+	}
+	handler := postMessageHandler(db, NewHub(), sender, true)
+
+	long := strings.Repeat("a", 200)
+	idStr := strconv.FormatInt(convID, 10)
+	payloadStr := fmt.Sprintf(`{"body":%q}`, long)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payloadStr)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if captured == nil {
+		t.Fatal("push sender was not called")
+	}
+	var note push.Notification
+	if err := json.Unmarshal(captured, &note); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if len([]rune(note.Body)) > notificationBodyLimit+1 {
+		t.Errorf("body rune length = %d, want at most %d (limit + ellipsis)", len([]rune(note.Body)), notificationBodyLimit+1)
+	}
+	if !strings.HasSuffix(note.Body, "…") {
+		t.Errorf("expected ellipsis on truncated body, got %q", note.Body)
+	}
+}
+
+func TestPostMessageHandler_StaleSubscriptionRemovedOn410(t *testing.T) {
+	db := setupTestDB(t)
+	addPushTables(t, db)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// A push endpoint that signals the subscription is gone. The internal/push
+	// package is responsible for deleting the row when this happens; this test
+	// verifies the family-chat fan-out exercises that path end to end.
+	var hitsMu sync.Mutex
+	var hits int
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitsMu.Lock()
+		hits++
+		hitsMu.Unlock()
+		w.WriteHeader(http.StatusGone)
+	}))
+	defer ts.Close()
+
+	// Real P-256 keypair so the encryption step succeeds before the HTTP layer.
+	curve := ecdh.P256()
+	priv, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	p256dh := base64.RawURLEncoding.EncodeToString(priv.PublicKey().Bytes())
+	authSecret := base64.RawURLEncoding.EncodeToString(make([]byte, 16))
+	if _, err := push.SaveSubscription(db, 2, ts.URL, p256dh, authSecret); err != nil {
+		t.Fatalf("save subscription: %v", err)
+	}
+
+	sender := func(userID int64, payload []byte) error {
+		_, err := push.SendToUser(db, ts.Client(), userID, payload)
+		return err
+	}
+	handler := postMessageHandler(db, NewHub(), sender, true)
+
+	idStr := strconv.FormatInt(convID, 10)
+	payloadStr := `{"body":"hi"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payloadStr)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	hitsMu.Lock()
+	gotHits := hits
+	hitsMu.Unlock()
+	if gotHits == 0 {
+		t.Fatal("test push endpoint received no requests")
+	}
+
+	var remaining int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM push_subscriptions WHERE user_id = ?`, int64(2)).Scan(&remaining); err != nil {
+		t.Fatalf("count subs: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("expected stale subscription deleted after 410 Gone, still have %d", remaining)
+	}
+}
+
+func TestPostMessageHandler_SkipsPushWhenAllRecipientsOnline(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	hub := NewHub()
+	bobSub := hub.Subscribe(2, convID)
+	defer hub.Unsubscribe(convID, bobSub)
+	go func() {
+		for range bobSub.Events() {
+		}
+	}()
+
+	var calls int
+	sender := func(userID int64, payload []byte) error {
+		calls++
+		return nil
+	}
+	handler := postMessageHandler(db, hub, sender, true)
+
+	idStr := strconv.FormatInt(convID, 10)
+	payloadStr := `{"body":"yo"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payloadStr)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
+	}
+	if calls != 0 {
+		t.Errorf("expected no push (every recipient on SSE), got %d", calls)
 	}
 }

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -562,6 +562,91 @@ func TestDeleteConversationHandler_NonOwnerMember(t *testing.T) {
 	}
 }
 
+func TestCreateConversationHandler_NameTooLong(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+
+	longName := strings.Repeat("a", maxNameLen+1)
+	payload := fmt.Sprintf(`{"name":%q}`, longName)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestCreateConversationHandler_InvalidMemberID(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+
+	payload := `{"name":"Family","member_user_ids":[0]}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestPostMessageHandler_BodyTooLong(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	longBody := strings.Repeat("x", maxBodyLen+1)
+	payload := fmt.Sprintf(`{"body":%q}`, longBody)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestListMessagesHandler_LimitTooLarge(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	url := fmt.Sprintf("/api/familychat/conversations/%s/messages?limit=%d", idStr, maxMsgLimit+1)
+	req := withUser(httptest.NewRequest("GET", url, nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestMarkReadHandler_InvalidTimestamp(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	payload := `{"at":"not-a-real-timestamp"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/read", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	MarkReadHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestDeleteConversationHandler_NonMember(t *testing.T) {
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com")

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -1,0 +1,581 @@
+package familychat
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/go-chi/chi/v5"
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-key-for-familychat-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
+		t.Fatalf("enable fk: %v", err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE users (
+			id         INTEGER PRIMARY KEY,
+			email      TEXT UNIQUE NOT NULL,
+			name       TEXT NOT NULL,
+			picture    TEXT NOT NULL DEFAULT '',
+			google_id  TEXT UNIQUE NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			is_admin   INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE family_chat_conversations (
+			id              INTEGER PRIMARY KEY,
+			name            TEXT NOT NULL DEFAULT '',
+			owner_user_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			created_at      TEXT NOT NULL DEFAULT '',
+			last_message_at TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE family_chat_members (
+			conversation_id INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
+			user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			joined_at       TEXT NOT NULL DEFAULT '',
+			last_read_at    TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (conversation_id, user_id)
+		);
+		CREATE TABLE family_chat_messages (
+			id              INTEGER PRIMARY KEY,
+			conversation_id INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
+			sender_user_id  INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			body            TEXT NOT NULL DEFAULT '',
+			attachment_path TEXT NOT NULL DEFAULT '',
+			attachment_mime TEXT NOT NULL DEFAULT '',
+			created_at      TEXT NOT NULL DEFAULT ''
+		);
+	`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+func makeUser(t *testing.T, db *sql.DB, id int64, email string) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO users (id, email, name, google_id) VALUES (?, ?, ?, ?)`,
+		id, email, email, fmt.Sprintf("google-%d", id),
+	); err != nil {
+		t.Fatalf("insert user %d: %v", id, err)
+	}
+}
+
+func withUser(r *http.Request, userID int64) *http.Request {
+	user := &auth.User{ID: userID, Email: fmt.Sprintf("u%d@example.com", userID), Name: "Test"}
+	return r.WithContext(auth.ContextWithUser(r.Context(), user))
+}
+
+func withChiParam(r *http.Request, key, value string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, value)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+// seedConversation creates a conversation owned by ownerID with extra members
+// listed in members. Returns the conversation ID.
+func seedConversation(t *testing.T, db *sql.DB, ownerID int64, name string, members ...int64) int64 {
+	t.Helper()
+	c, err := CreateConversation(db, ownerID, name, members)
+	if err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+	return c.ID
+}
+
+func TestListConversationsHandler_OnlyOwnMemberships(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+
+	// alice + bob conversation; carol is excluded.
+	seedConversation(t, db, 1, "Alice/Bob", 2)
+	// bob owns a chat with carol; alice should not see it.
+	seedConversation(t, db, 2, "Bob/Carol", 3)
+
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations", nil), 1)
+	rec := httptest.NewRecorder()
+	ListConversationsHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Conversations []Conversation `json:"conversations"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Conversations) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(body.Conversations))
+	}
+	if body.Conversations[0].Name != "Alice/Bob" {
+		t.Errorf("unexpected name: %q", body.Conversations[0].Name)
+	}
+}
+
+func TestCreateConversationHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+
+	payload := `{"name":"Family","member_user_ids":[2]}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Conversation Conversation `json:"conversation"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Conversation.Name != "Family" {
+		t.Errorf("name = %q", body.Conversation.Name)
+	}
+	if len(body.Conversation.MemberIDs) != 2 {
+		t.Errorf("expected 2 members, got %d: %v", len(body.Conversation.MemberIDs), body.Conversation.MemberIDs)
+	}
+}
+
+func TestCreateConversationHandler_MissingName(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(`{"name":""}`)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestGetConversationHandler_MemberAndNonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Member (bob, id=2) sees 200.
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr, nil), 2)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	GetConversationHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("member: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Non-member (carol, id=3) sees 404.
+	req = withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr, nil), 3)
+	req = withChiParam(req, "id", idStr)
+	rec = httptest.NewRecorder()
+	GetConversationHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("non-member: expected 404, got %d", rec.Code)
+	}
+}
+
+func TestGetConversationHandler_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/9999", nil), 1)
+	req = withChiParam(req, "id", "9999")
+	rec := httptest.NewRecorder()
+	GetConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestPostMessageHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	idStr := strconv.FormatInt(convID, 10)
+	payload := `{"body":"hello there"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Message Message `json:"message"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Message.Body != "hello there" {
+		t.Errorf("body = %q", body.Message.Body)
+	}
+	if body.Message.SenderUserID != 1 {
+		t.Errorf("sender = %d", body.Message.SenderUserID)
+	}
+
+	// Stored body should be encrypted (prefixed with enc:).
+	var stored string
+	if err := db.QueryRow(`SELECT body FROM family_chat_messages WHERE id = ?`, body.Message.ID).Scan(&stored); err != nil {
+		t.Fatalf("read stored body: %v", err)
+	}
+	if !strings.HasPrefix(stored, "enc:") {
+		t.Errorf("body not encrypted at rest: %q", stored)
+	}
+}
+
+func TestPostMessageHandler_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(`{"body":"sneaky"}`)), 3)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-member, got %d", rec.Code)
+	}
+
+	// No row should have been written.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ?`, convID).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("non-member message persisted (%d rows)", count)
+	}
+}
+
+func TestPostMessageHandler_EmptyBodyRejected(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(`{"body":""}`)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestListMessagesHandler_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+	if _, err := CreateMessage(db, convID, 1, "hi", "", ""); err != nil {
+		t.Fatalf("seed message: %v", err)
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages", nil), 3)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestListMessagesHandler_PaginationWithSince(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Seed 7 messages.
+	const total = 7
+	for i := 1; i <= total; i++ {
+		if _, err := CreateMessage(db, convID, 1, fmt.Sprintf("msg %d", i), "", ""); err != nil {
+			t.Fatalf("seed message %d: %v", i, err)
+		}
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+
+	// Page 1: limit=3, no since -> newest 3 messages, ids 7..5.
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages?limit=3", nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("page1: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Messages []Message `json:"messages"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode page1: %v", err)
+	}
+	if len(body.Messages) != 3 {
+		t.Fatalf("page1 len = %d", len(body.Messages))
+	}
+	if body.Messages[0].ID != 7 || body.Messages[2].ID != 5 {
+		t.Errorf("page1 ids = %d..%d, want 7..5", body.Messages[0].ID, body.Messages[2].ID)
+	}
+
+	page1IDs := []int64{body.Messages[0].ID, body.Messages[1].ID, body.Messages[2].ID}
+
+	// Page 2: limit=10 to fetch everything; ids should be 7..1 in order.
+	req = withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages?limit=10", nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec = httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("full: expected 200, got %d", rec.Code)
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode full: %v", err)
+	}
+	if len(body.Messages) != total {
+		t.Fatalf("full len = %d, want %d", len(body.Messages), total)
+	}
+	for i, want := range []int64{7, 6, 5, 4, 3, 2, 1} {
+		if body.Messages[i].ID != want {
+			t.Errorf("full[%d] = %d, want %d", i, body.Messages[i].ID, want)
+		}
+	}
+
+	// since filter: since=4 returns the 3 messages with id > 4 (i.e. 7,6,5).
+	req = withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages?since=4&limit=10", nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec = httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("since: expected 200, got %d", rec.Code)
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode since: %v", err)
+	}
+	if len(body.Messages) != 3 {
+		t.Fatalf("since len = %d, want 3", len(body.Messages))
+	}
+	for i, want := range []int64{7, 6, 5} {
+		if body.Messages[i].ID != want {
+			t.Errorf("since[%d] = %d, want %d", i, body.Messages[i].ID, want)
+		}
+	}
+
+	// Walking forward with `since` (incremental load scenario): the
+	// first page returns newest k messages. After a new message is posted,
+	// querying with since=<highest seen id> returns only the new message.
+	highestSeen := page1IDs[0]
+	if _, err := CreateMessage(db, convID, 1, "after page1", "", ""); err != nil {
+		t.Fatalf("seed new message: %v", err)
+	}
+	url := fmt.Sprintf("/api/familychat/conversations/%s/messages?since=%d&limit=10", idStr, highestSeen)
+	req = withUser(httptest.NewRequest("GET", url, nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec = httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("incremental: expected 200, got %d", rec.Code)
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode incremental: %v", err)
+	}
+	if len(body.Messages) != 1 {
+		t.Fatalf("incremental len = %d, want 1", len(body.Messages))
+	}
+	if body.Messages[0].Body != "after page1" {
+		t.Errorf("incremental body = %q", body.Messages[0].Body)
+	}
+}
+
+func TestMarkReadHandler(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Alice posts 3 messages; Bob should see unread_count=3 before MarkRead.
+	for i := 0; i < 3; i++ {
+		if _, err := CreateMessage(db, convID, 1, fmt.Sprintf("msg %d", i), "", ""); err != nil {
+			t.Fatalf("seed message: %v", err)
+		}
+	}
+
+	// Sanity check the unread count before MarkRead.
+	c, err := GetConversation(db, convID, 2)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if c.UnreadCount != 3 {
+		t.Errorf("unread before MarkRead = %d, want 3", c.UnreadCount)
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+
+	// Bob marks read with an explicit far-future watermark so we are not
+	// vulnerable to millisecond-precision ties between CreateMessage and the
+	// implicit "now" in MarkRead.
+	payload := `{"at":"9999-12-31T23:59:59.999Z"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/read", strings.NewReader(payload)), 2)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	MarkReadHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Now Bob's view should show unread_count = 0.
+	c, err = GetConversation(db, convID, 2)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if c.UnreadCount != 0 {
+		t.Errorf("unread after MarkRead = %d, want 0", c.UnreadCount)
+	}
+}
+
+func TestMarkReadHandler_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/read", nil), 3)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	MarkReadHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestDeleteConversationHandler_OwnerSucceeds(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Seed a message so cascade can be verified.
+	if _, err := CreateMessage(db, convID, 1, "soon to die", "", ""); err != nil {
+		t.Fatalf("seed message: %v", err)
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/familychat/conversations/"+idStr, nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	DeleteConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Conversation row, members, and messages must all be gone.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_conversations WHERE id = ?`, convID).Scan(&n); err != nil {
+		t.Fatalf("count conv: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("conversation row still present (n=%d)", n)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_members WHERE conversation_id = ?`, convID).Scan(&n); err != nil {
+		t.Fatalf("count members: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("member rows not cascaded (n=%d)", n)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ?`, convID).Scan(&n); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("message rows not cascaded (n=%d)", n)
+	}
+}
+
+func TestDeleteConversationHandler_NonOwnerMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Bob is a member but not the owner — DELETE must 404.
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/familychat/conversations/"+idStr, nil), 2)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	DeleteConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Conversation must still exist.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_conversations WHERE id = ?`, convID).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("conversation should still exist (n=%d)", n)
+	}
+}
+
+func TestDeleteConversationHandler_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/familychat/conversations/"+idStr, nil), 3)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	DeleteConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}

--- a/internal/familychat/hub.go
+++ b/internal/familychat/hub.go
@@ -30,9 +30,12 @@ const (
 // Subscriber is a single SSE client subscription. The channel is buffered so
 // a publisher can fan out without blocking on a slow consumer; if the buffer
 // fills up the publish for that Subscriber is dropped (the client will pick
-// up the next event or reconnect).
+// up the next event or reconnect). The userID is recorded so callers fanning
+// out external notifications (e.g. webpush) can skip recipients who are
+// already live on SSE.
 type Subscriber struct {
-	ch chan Event
+	userID int64
+	ch     chan Event
 }
 
 // SubscriberBufferSize is the per-Subscriber channel buffer. Sized to absorb
@@ -54,17 +57,35 @@ func NewHub() *Hub {
 	}
 }
 
-// Subscribe registers a new Subscriber for the given conversation and returns
-// it. The caller must Unsubscribe when finished, typically via defer.
-func (h *Hub) Subscribe(convID int64) *Subscriber {
+// Subscribe registers a new Subscriber for the given user and conversation
+// and returns it. The caller must Unsubscribe when finished, typically via
+// defer. The userID is stored on the Subscriber so other code paths (such as
+// the webpush fan-out for incoming messages) can ask whether a user already
+// has a live SSE stream open.
+func (h *Hub) Subscribe(userID, convID int64) *Subscriber {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	s := &Subscriber{ch: make(chan Event, SubscriberBufferSize)}
+	s := &Subscriber{userID: userID, ch: make(chan Event, SubscriberBufferSize)}
 	if h.subs[convID] == nil {
 		h.subs[convID] = make(map[*Subscriber]struct{})
 	}
 	h.subs[convID][s] = struct{}{}
 	return s
+}
+
+// HasSubscriber reports whether userID currently has any live SSE
+// subscription for convID. Used by the message-post fan-out to decide
+// whether a recipient also needs a webpush notification (they do not if
+// they already have a streaming connection).
+func (h *Hub) HasSubscriber(userID, convID int64) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for s := range h.subs[convID] {
+		if s.userID == userID {
+			return true
+		}
+	}
+	return false
 }
 
 // Unsubscribe removes the Subscriber and closes its channel. Idempotent and

--- a/internal/familychat/hub_test.go
+++ b/internal/familychat/hub_test.go
@@ -38,9 +38,9 @@ func recvWithin(t *testing.T, sub *Subscriber, d time.Duration) Event {
 
 func TestHub_PublishFanout(t *testing.T) {
 	h := NewHub()
-	a := h.Subscribe(42)
+	a := h.Subscribe(1, 42)
 	defer h.Unsubscribe(42, a)
-	b := h.Subscribe(42)
+	b := h.Subscribe(2, 42)
 	defer h.Unsubscribe(42, b)
 
 	h.Publish(42, Event{Type: EventMessageNew, Data: map[string]any{"id": 1}})
@@ -54,9 +54,9 @@ func TestHub_PublishFanout(t *testing.T) {
 
 func TestHub_IsolationBetweenConvs(t *testing.T) {
 	h := NewHub()
-	a := h.Subscribe(1)
+	a := h.Subscribe(10, 1)
 	defer h.Unsubscribe(1, a)
-	b := h.Subscribe(2)
+	b := h.Subscribe(11, 2)
 	defer h.Unsubscribe(2, b)
 
 	h.Publish(2, Event{Type: EventMessageNew, Data: map[string]any{"v": "for-b"}})
@@ -77,8 +77,8 @@ func TestHub_IsolationBetweenConvs(t *testing.T) {
 
 func TestHub_UnsubscribeCleanup(t *testing.T) {
 	h := NewHub()
-	a := h.Subscribe(7)
-	b := h.Subscribe(7)
+	a := h.Subscribe(1, 7)
+	b := h.Subscribe(2, 7)
 
 	if got := h.subscriberCount(7); got != 2 {
 		t.Fatalf("expected 2 subscribers, got %d", got)
@@ -114,13 +114,13 @@ func TestHub_UnsubscribeUnknownSubscriberNoPanic(t *testing.T) {
 	// Unsubscribe with a nil subscriber and one from an unknown conversation
 	// should both be no-ops.
 	h.Unsubscribe(9, nil)
-	stranger := &Subscriber{ch: make(chan Event, 1)}
+	stranger := &Subscriber{userID: 1, ch: make(chan Event, 1)}
 	h.Unsubscribe(9, stranger)
 }
 
 func TestHub_SlowSubscriberDoesNotBlock(t *testing.T) {
 	h := NewHub()
-	slow := h.Subscribe(3)
+	slow := h.Subscribe(1, 3)
 	defer h.Unsubscribe(3, slow)
 
 	// Saturate the slow subscriber's buffer so any further publish would
@@ -130,7 +130,7 @@ func TestHub_SlowSubscriberDoesNotBlock(t *testing.T) {
 	}
 
 	// Add a fast subscriber with an empty buffer.
-	fast := h.Subscribe(3)
+	fast := h.Subscribe(2, 3)
 	defer h.Unsubscribe(3, fast)
 
 	// Publish must return promptly even though slow is full.

--- a/internal/familychat/notify.go
+++ b/internal/familychat/notify.go
@@ -1,0 +1,102 @@
+package familychat
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/push"
+)
+
+// PushSenderFunc delivers a marshaled webpush payload to every push
+// subscription owned by userID. Production implementations are expected to
+// clean up subscriptions that respond with 410 Gone (the internal/push
+// package's SendToUser already does this). Returning an error does not stop
+// the wider fan-out: the caller logs and continues.
+type PushSenderFunc func(userID int64, payload []byte) error
+
+// defaultPushSender returns a PushSenderFunc backed by the internal/push
+// package and the shared push HTTP client. Stale (410 Gone / 404 Not Found)
+// subscriptions are deleted automatically by push.SendToUser.
+func defaultPushSender(db *sql.DB) PushSenderFunc {
+	return func(userID int64, payload []byte) error {
+		_, err := push.SendToUser(db, push.DefaultHTTPClient, userID, payload)
+		return err
+	}
+}
+
+// notificationBodyLimit caps the message preview surfaced in the push
+// notification body so the banner stays within typical OS limits.
+const notificationBodyLimit = 80
+
+// truncate clips s to at most n runes (not bytes), appending an ellipsis
+// when truncation occurs so the recipient can tell the message continues.
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
+}
+
+// notifyOfflineRecipients fans out a webpush notification to every member of
+// convID except the sender who is not currently subscribed via SSE for that
+// conversation. Per-recipient errors are logged and swallowed so one stale
+// or slow subscription cannot block delivery to the others. Returns once
+// every recipient has been processed.
+func notifyOfflineRecipients(db *sql.DB, hub *Hub, sender PushSenderFunc, convID int64, msg *Message, senderName string) {
+	if msg == nil {
+		return
+	}
+	members, err := listMemberIDs(db, convID)
+	if err != nil {
+		log.Printf("familychat: notify: list members conv=%d: %v", convID, err)
+		return
+	}
+
+	body := truncate(msg.Body, notificationBodyLimit)
+	if body == "" && msg.AttachmentPath != "" {
+		body = "Sent an attachment"
+	}
+	note := push.Notification{
+		Title: senderName,
+		Body:  body,
+		URL:   fmt.Sprintf("/familychat/%d", convID),
+		Tag:   fmt.Sprintf("familychat-%d", convID),
+	}
+	payload, err := json.Marshal(note)
+	if err != nil {
+		log.Printf("familychat: notify: marshal payload conv=%d: %v", convID, err)
+		return
+	}
+
+	for _, uid := range members {
+		if uid == msg.SenderUserID {
+			continue
+		}
+		if hub.HasSubscriber(uid, convID) {
+			continue
+		}
+		if err := sender(uid, payload); err != nil {
+			log.Printf("familychat: notify: send to user=%d conv=%d: %v", uid, convID, err)
+		}
+	}
+}
+
+// senderDisplayName returns a friendly label for the message sender. It
+// prefers the stored name and falls back to the email address (used by the
+// rare account with an empty display name).
+func senderDisplayName(u *auth.User) string {
+	if u == nil {
+		return ""
+	}
+	if u.Name != "" {
+		return u.Name
+	}
+	return u.Email
+}

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -1,0 +1,420 @@
+// Package familychat implements the REST handlers and storage for the Family
+// Chat feature. Conversations live in family_chat_conversations, membership in
+// family_chat_members, and messages in family_chat_messages. Message bodies
+// and attachment paths are encrypted at rest via internal/encryption.
+package familychat
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+// timeFormat is a fixed-width UTC timestamp with millisecond precision so
+// that string comparisons sort chronologically.
+const timeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+// Conversation is a single family chat conversation as returned to the client.
+type Conversation struct {
+	ID            int64   `json:"id"`
+	Name          string  `json:"name"`
+	OwnerUserID   int64   `json:"owner_user_id"`
+	CreatedAt     string  `json:"created_at"`
+	LastMessageAt string  `json:"last_message_at"`
+	UnreadCount   int64   `json:"unread_count"`
+	MemberIDs     []int64 `json:"member_ids"`
+}
+
+// Message is a single chat message returned to the client. Body and
+// AttachmentPath are returned in plaintext after decryption.
+type Message struct {
+	ID             int64  `json:"id"`
+	ConversationID int64  `json:"conversation_id"`
+	SenderUserID   int64  `json:"sender_user_id"`
+	Body           string `json:"body"`
+	AttachmentPath string `json:"attachment_path,omitempty"`
+	AttachmentMime string `json:"attachment_mime,omitempty"`
+	CreatedAt      string `json:"created_at"`
+}
+
+// ErrNotMember is returned when the requesting user is not a member of the
+// target conversation. Handlers convert this into 404 to avoid leaking the
+// existence of conversations the user is not part of.
+var ErrNotMember = errors.New("familychat: not a member")
+
+// IsMember reports whether userID belongs to convID.
+func IsMember(db *sql.DB, convID, userID int64) (bool, error) {
+	var one int
+	err := db.QueryRow(
+		`SELECT 1 FROM family_chat_members WHERE conversation_id = ? AND user_id = ?`,
+		convID, userID,
+	).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ListConversations returns every conversation the user belongs to, newest
+// activity first. The unread_count for each conversation is computed against
+// the member's last_read_at watermark.
+func ListConversations(db *sql.DB, userID int64) ([]Conversation, error) {
+	rows, err := db.Query(
+		`SELECT c.id, c.name, c.owner_user_id, c.created_at, c.last_message_at, m.last_read_at
+		 FROM family_chat_conversations c
+		 JOIN family_chat_members m ON m.conversation_id = c.id
+		 WHERE m.user_id = ?
+		 ORDER BY CASE WHEN c.last_message_at = '' THEN c.created_at ELSE c.last_message_at END DESC, c.id DESC`,
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type convoRow struct {
+		c          Conversation
+		lastReadAt string
+	}
+	var rowsBuf []convoRow
+	for rows.Next() {
+		var cr convoRow
+		if err := rows.Scan(&cr.c.ID, &cr.c.Name, &cr.c.OwnerUserID, &cr.c.CreatedAt, &cr.c.LastMessageAt, &cr.lastReadAt); err != nil {
+			return nil, err
+		}
+		rowsBuf = append(rowsBuf, cr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]Conversation, 0, len(rowsBuf))
+	for _, cr := range rowsBuf {
+		members, err := listMemberIDs(db, cr.c.ID)
+		if err != nil {
+			return nil, err
+		}
+		unread, err := unreadCount(db, cr.c.ID, userID, cr.lastReadAt)
+		if err != nil {
+			return nil, err
+		}
+		cr.c.MemberIDs = members
+		cr.c.UnreadCount = unread
+		out = append(out, cr.c)
+	}
+	return out, nil
+}
+
+// CreateConversation inserts a new conversation owned by ownerID and adds
+// every user in memberIDs (plus the owner) as a member. Duplicate or invalid
+// member IDs are silently coalesced.
+func CreateConversation(db *sql.DB, ownerID int64, name string, memberIDs []int64) (*Conversation, error) {
+	now := time.Now().UTC().Format(timeFormat)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.Exec(
+		`INSERT INTO family_chat_conversations (name, owner_user_id, created_at, last_message_at) VALUES (?, ?, ?, ?)`,
+		name, ownerID, now, "",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert conversation: %w", err)
+	}
+	convID, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("last insert id: %w", err)
+	}
+
+	seen := map[int64]struct{}{ownerID: {}}
+	if _, err := tx.Exec(
+		`INSERT INTO family_chat_members (conversation_id, user_id, joined_at, last_read_at) VALUES (?, ?, ?, ?)`,
+		convID, ownerID, now, "",
+	); err != nil {
+		return nil, fmt.Errorf("insert owner member: %w", err)
+	}
+	for _, uid := range memberIDs {
+		if uid <= 0 {
+			continue
+		}
+		if _, dup := seen[uid]; dup {
+			continue
+		}
+		seen[uid] = struct{}{}
+		if _, err := tx.Exec(
+			`INSERT INTO family_chat_members (conversation_id, user_id, joined_at, last_read_at) VALUES (?, ?, ?, ?)`,
+			convID, uid, now, "",
+		); err != nil {
+			return nil, fmt.Errorf("insert member %d: %w", uid, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return GetConversation(db, convID, ownerID)
+}
+
+// GetConversation returns the conversation if userID is a member, otherwise
+// returns ErrNotMember (handlers map to 404).
+func GetConversation(db *sql.DB, convID, userID int64) (*Conversation, error) {
+	ok, err := IsMember(db, convID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNotMember
+	}
+
+	var c Conversation
+	var lastReadAt string
+	err = db.QueryRow(
+		`SELECT c.id, c.name, c.owner_user_id, c.created_at, c.last_message_at, m.last_read_at
+		 FROM family_chat_conversations c
+		 JOIN family_chat_members m ON m.conversation_id = c.id
+		 WHERE c.id = ? AND m.user_id = ?`,
+		convID, userID,
+	).Scan(&c.ID, &c.Name, &c.OwnerUserID, &c.CreatedAt, &c.LastMessageAt, &lastReadAt)
+	if err != nil {
+		return nil, err
+	}
+
+	c.MemberIDs, err = listMemberIDs(db, convID)
+	if err != nil {
+		return nil, err
+	}
+	c.UnreadCount, err = unreadCount(db, convID, userID, lastReadAt)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// DeleteConversation removes the conversation, but only if userID is its
+// owner. Non-owners (including other members) receive ErrNotMember so the
+// existence of conversations they do not own is not leaked.
+func DeleteConversation(db *sql.DB, convID, userID int64) error {
+	res, err := db.Exec(
+		`DELETE FROM family_chat_conversations WHERE id = ? AND owner_user_id = ?`,
+		convID, userID,
+	)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrNotMember
+	}
+	return nil
+}
+
+// ListMessages returns up to limit messages from convID, newest-first.
+// If since > 0, only messages with id > since are returned (still newest-first)
+// — this lets the client poll for new messages incrementally.
+func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message, error) {
+	ok, err := IsMember(db, convID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNotMember
+	}
+
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+
+	var (
+		rows     *sql.Rows
+		queryErr error
+	)
+	if since > 0 {
+		rows, queryErr = db.Query(
+			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at
+			 FROM family_chat_messages
+			 WHERE conversation_id = ? AND id > ?
+			 ORDER BY id DESC
+			 LIMIT ?`,
+			convID, since, limit,
+		)
+	} else {
+		rows, queryErr = db.Query(
+			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at
+			 FROM family_chat_messages
+			 WHERE conversation_id = ?
+			 ORDER BY id DESC
+			 LIMIT ?`,
+			convID, limit,
+		)
+	}
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer rows.Close()
+
+	out := []Message{}
+	for rows.Next() {
+		var m Message
+		if err := rows.Scan(&m.ID, &m.ConversationID, &m.SenderUserID, &m.Body, &m.AttachmentPath, &m.AttachmentMime, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		if m.Body, err = encryption.DecryptField(m.Body); err != nil {
+			return nil, fmt.Errorf("decrypt body: %w", err)
+		}
+		if m.AttachmentPath, err = encryption.DecryptField(m.AttachmentPath); err != nil {
+			return nil, fmt.Errorf("decrypt attachment path: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CreateMessage inserts a new message authored by senderID into convID,
+// touches the conversation's last_message_at, and returns the inserted row
+// in plaintext form. Returns ErrNotMember if the sender is not a member.
+func CreateMessage(db *sql.DB, convID, senderID int64, body, attachmentPath, attachmentMime string) (*Message, error) {
+	ok, err := IsMember(db, convID, senderID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNotMember
+	}
+
+	encBody, err := encryption.EncryptField(body)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt body: %w", err)
+	}
+	encPath, err := encryption.EncryptField(attachmentPath)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt attachment path: %w", err)
+	}
+	now := time.Now().UTC().Format(timeFormat)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.Exec(
+		`INSERT INTO family_chat_messages (conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		convID, senderID, encBody, encPath, attachmentMime, now,
+	)
+	if err != nil {
+		return nil, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(
+		`UPDATE family_chat_conversations SET last_message_at = ? WHERE id = ?`,
+		now, convID,
+	); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &Message{
+		ID:             id,
+		ConversationID: convID,
+		SenderUserID:   senderID,
+		Body:           body,
+		AttachmentPath: attachmentPath,
+		AttachmentMime: attachmentMime,
+		CreatedAt:      now,
+	}, nil
+}
+
+// MarkRead sets the requesting member's last_read_at to at. Returns
+// ErrNotMember if the user is not a member of convID.
+func MarkRead(db *sql.DB, convID, userID int64, at string) error {
+	if at == "" {
+		at = time.Now().UTC().Format(timeFormat)
+	}
+	res, err := db.Exec(
+		`UPDATE family_chat_members SET last_read_at = ? WHERE conversation_id = ? AND user_id = ?`,
+		at, convID, userID,
+	)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrNotMember
+	}
+	return nil
+}
+
+// listMemberIDs returns every user_id in convID sorted ascending. Sorting
+// gives the JSON response a stable order regardless of insertion order.
+func listMemberIDs(db *sql.DB, convID int64) ([]int64, error) {
+	rows, err := db.Query(
+		`SELECT user_id FROM family_chat_members WHERE conversation_id = ?`,
+		convID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []int64{}
+	for rows.Next() {
+		var uid int64
+		if err := rows.Scan(&uid); err != nil {
+			return nil, err
+		}
+		out = append(out, uid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+// unreadCount returns the number of messages in convID newer than lastReadAt
+// that were not authored by userID. An empty lastReadAt counts every message
+// from someone other than the user.
+func unreadCount(db *sql.DB, convID, userID int64, lastReadAt string) (int64, error) {
+	var count int64
+	if lastReadAt == "" {
+		err := db.QueryRow(
+			`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ? AND sender_user_id <> ?`,
+			convID, userID,
+		).Scan(&count)
+		return count, err
+	}
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ? AND sender_user_id <> ? AND created_at > ?`,
+		convID, userID, lastReadAt,
+	).Scan(&count)
+	return count, err
+}

--- a/internal/familychat/stream.go
+++ b/internal/familychat/stream.go
@@ -18,12 +18,6 @@ import (
 // connection.
 const heartbeatInterval = 30 * time.Second
 
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
-}
-
 // StreamHandler returns an SSE handler at
 // GET /api/familychat/conversations/{id}/stream that pushes message_new,
 // message_deleted, and read_receipt events as they are published into hub.

--- a/internal/familychat/stream.go
+++ b/internal/familychat/stream.go
@@ -69,7 +69,7 @@ func StreamHandler(hub *Hub, membership MembershipFn) http.HandlerFunc {
 		w.Header().Set("X-Accel-Buffering", "no")
 		flusher.Flush()
 
-		sub := hub.Subscribe(convID)
+		sub := hub.Subscribe(user.ID, convID)
 		defer hub.Unsubscribe(convID, sub)
 
 		ticker := time.NewTicker(heartbeatInterval)


### PR DESCRIPTION
## Changes

- **Family Chat: webpush on incoming message** - When a new message arrives and a recipient does not currently have a live SSE stream open for the conversation, a webpush notification is sent so their device wakes up. The notification uses the sender's display name as the title, the first ~80 chars of the message as the body, and a `familychat-<conversation_id>` tag so a second message replaces the first banner instead of stacking. Stale (410 Gone) push subscriptions are removed automatically. (Hytte-6clp)

## Original Issue (feature): Family Chat: webpush on incoming message

Part of the Family Chat chain seeded from Suggestions id=145. See that suggestion's plan in the Suggestions page for the full architecture, trust model, and phase plan. Trust model: at-rest encryption with the server holding the key (same as Notes), NOT Signal-style E2EE.

This bead is step 4/7: Webpush of the chain.

## Scope

When a message arrives for a recipient who is NOT currently subscribed via SSE for that conversation, send a webpush notification so the kid's phone wakes up.

### Implementation

- In the POST /messages handler (after hub publish), iterate the conversation's members minus the sender. For each member:
    - Check if the SSE hub has an active subscription for that user × conversation. If yes, skip (live delivery handled).
    - If no, look up webpush subscriptions in the existing `push_subscriptions` table.
    - Send a notification with title = sender's display name, body = first ~80 chars of decrypted message body (truncated), tag = `familychat-<conversation_id>` (so a second message replaces the first instead of stacking).
- Reuse `internal/push/` package and existing VAPID setup. No new keys needed.
- Errors per subscription are logged, not propagated; one stale subscription must not block the others.

### Tests

- `handlers_test.go` extended: post a message while one recipient is SSE-subscribed and one is not; assert push fires only for the offline recipient (mock the push send).
- 410 Gone on a push subscription removes it from the table.

### Acceptance

- `make build`, `make test ./internal/familychat/...` pass.
- Offline kid receives a notification when parent sends a message.
- Tag collapsing works (second message replaces banner instead of stacking).
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-6clp | Branch: forge/Hytte-6clp
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->