### PR TITLE
Tasks: schema + backend handlers + feature flag (Hytte-u49p)

### DIFF
--- a/changelog.d/Hytte-u49p.md
+++ b/changelog.d/Hytte-u49p.md
@@ -1,0 +1,2 @@
+category: Added
+- **Tasks backend foundation** - Added schema (`tasks`, `task_tags`, `task_tag_assignments`, `task_notes`), the `tasks` feature flag (default off), and `/api/tasks` REST endpoints (list/create/patch/delete plus per-task notes) gated by `RequireFeature("tasks")`. Title, body, tag labels and note content are encrypted at rest. (Hytte-u49p)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Robin831/Hytte/internal/stars"
 	"github.com/Robin831/Hytte/internal/stride"
 	"github.com/Robin831/Hytte/internal/suggestions"
+	"github.com/Robin831/Hytte/internal/tasks"
 	"github.com/Robin831/Hytte/internal/training"
 	"github.com/Robin831/Hytte/internal/vault"
 	"github.com/Robin831/Hytte/internal/transit"
@@ -396,6 +397,17 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Get("/notes/{id}", notes.GetHandler(db))
 				r.Put("/notes/{id}", notes.UpdateHandler(db))
 				r.Delete("/notes/{id}", notes.DeleteHandler(db))
+			})
+
+			// Tasks — gated by "tasks" feature.
+			r.Group(func(r chi.Router) {
+				r.Use(auth.RequireFeature(db, "tasks"))
+				r.Get("/tasks", tasks.ListHandler(db))
+				r.Post("/tasks", tasks.CreateHandler(db))
+				r.Patch("/tasks/{id}", tasks.UpdateHandler(db))
+				r.Delete("/tasks/{id}", tasks.DeleteHandler(db))
+				r.Post("/tasks/{id}/notes", tasks.AddNoteHandler(db))
+				r.Delete("/tasks/{id}/notes/{note_id}", tasks.DeleteNoteHandler(db))
 			})
 
 			// Calendar — Google Calendar integration, gated by "calendar" feature.

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -13,6 +13,7 @@ var FeatureDefaults = map[string]bool{
 	"weather":    true,
 	"calendar":   true,
 	"notes":      false,
+	"tasks":      false,
 	"links":      false,
 	"training":   false,
 	"lactate":    false,

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1589,6 +1589,41 @@ func createSchema(db *sql.DB) error {
 		completed_at TEXT NOT NULL DEFAULT ''
 	);
 
+	-- Tasks (Hytte-u49p): lightweight task list with optional notes/tags.
+	-- title_enc, body_enc, label_enc, content_enc are AES-256-GCM ciphertext.
+	CREATE TABLE IF NOT EXISTS tasks (
+		id            INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		title_enc     TEXT NOT NULL,
+		body_enc      TEXT NOT NULL DEFAULT '',
+		archived      INTEGER NOT NULL DEFAULT 0,
+		created_at    TIMESTAMP NOT NULL,
+		updated_at    TIMESTAMP NOT NULL,
+		archived_at   TIMESTAMP
+	);
+	CREATE INDEX IF NOT EXISTS idx_tasks_user_archived ON tasks(user_id, archived);
+
+	CREATE TABLE IF NOT EXISTS task_tags (
+		id         INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		label_enc  TEXT NOT NULL,
+		UNIQUE(user_id, label_enc)
+	);
+
+	CREATE TABLE IF NOT EXISTS task_tag_assignments (
+		task_id  INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+		tag_id   INTEGER NOT NULL REFERENCES task_tags(id) ON DELETE CASCADE,
+		PRIMARY KEY (task_id, tag_id)
+	);
+
+	CREATE TABLE IF NOT EXISTS task_notes (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		task_id     INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+		content_enc TEXT NOT NULL,
+		created_at  TIMESTAMP NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_task_notes_task ON task_notes(task_id, created_at);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1607,8 +1607,9 @@ func createSchema(db *sql.DB) error {
 		id         INTEGER PRIMARY KEY AUTOINCREMENT,
 		user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 		label_enc  TEXT NOT NULL,
-		UNIQUE(user_id, label_enc)
+		label_hmac TEXT NOT NULL DEFAULT ''
 	);
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_task_tags_user_label_hmac ON task_tags(user_id, label_hmac) WHERE label_hmac != '';
 
 	CREATE TABLE IF NOT EXISTS task_tag_assignments (
 		task_id  INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
@@ -2320,6 +2321,22 @@ func createSchema(db *sql.DB) error {
 		if _, err := db.Exec(`ALTER TABLE math_sessions ADD COLUMN best_streak INTEGER NOT NULL DEFAULT 0`); err != nil {
 			return fmt.Errorf("add math_sessions best_streak column: %w", err)
 		}
+	}
+
+	// Add label_hmac to task_tags (Hytte-u49p): deterministic per-user lookup key
+	// so concurrent tag creates hit the unique index rather than inserting duplicate
+	// encrypted rows (random nonces make label_enc non-deterministic).
+	var hasTaskTagLabelHmac int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('task_tags') WHERE name = 'label_hmac'`).Scan(&hasTaskTagLabelHmac); err != nil {
+		return fmt.Errorf("check task_tags label_hmac column: %w", err)
+	}
+	if hasTaskTagLabelHmac == 0 {
+		if _, err := db.Exec(`ALTER TABLE task_tags ADD COLUMN label_hmac TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add task_tags label_hmac column: %w", err)
+		}
+	}
+	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_task_tags_user_label_hmac ON task_tags(user_id, label_hmac) WHERE label_hmac != ''`); err != nil {
+		return fmt.Errorf("create task_tags label_hmac index: %w", err)
 	}
 
 	return nil

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -3,6 +3,7 @@ package encryption
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -222,6 +223,21 @@ func DecryptLenient(value string) string {
 		return ""
 	}
 	return result
+}
+
+// HMACField returns a deterministic hex-encoded HMAC-SHA256 of value scoped to
+// userID. Use it as a stable lookup key for fields that are stored encrypted
+// with a random nonce (where the same plaintext produces different ciphertexts).
+// The HMAC key is derived from the encryption key so it cannot be computed
+// without access to the key material.
+func HMACField(userID int64, value string) (string, error) {
+	key, err := getEncryptionKey()
+	if err != nil {
+		return "", err
+	}
+	h := hmac.New(sha256.New, key)
+	fmt.Fprintf(h, "%d:%s", userID, value)
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // Decrypt decrypts a base64-encoded AES-256-GCM ciphertext back to

--- a/internal/tasks/handlers.go
+++ b/internal/tasks/handlers.go
@@ -13,12 +13,36 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// maxTaskBodySize caps the JSON payload accepted by task write endpoints. Tasks
+// are short user notes — 64 KB is plenty for title + body + tag list and stops
+// a misbehaving client from streaming an unbounded body into the decoder.
+const maxTaskBodySize = 64 << 10
+
+// maxTaskNoteBodySize is the upper bound for a single note body.
+const maxTaskNoteBodySize = 64 << 10
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		log.Printf("tasks: writeJSON encode error: %v", err)
 	}
+}
+
+// decodeJSONBody decodes r.Body into dst after capping the body at limit bytes.
+// It writes the appropriate HTTP response and returns false on error.
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, limit int64, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+			return false
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return false
+	}
+	return true
 }
 
 // ListHandler returns the authenticated user's tasks, filtered by archived state.
@@ -57,8 +81,7 @@ func CreateHandler(db *sql.DB) http.HandlerFunc {
 			Body  string   `json:"body"`
 			Tags  []string `json:"tags"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		if !decodeJSONBody(w, r, maxTaskBodySize, &body) {
 			return
 		}
 
@@ -96,8 +119,7 @@ func UpdateHandler(db *sql.DB) http.HandlerFunc {
 			Tags     *[]string `json:"tags"`
 			Archived *bool     `json:"archived"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		if !decodeJSONBody(w, r, maxTaskBodySize, &body) {
 			return
 		}
 
@@ -167,8 +189,7 @@ func AddNoteHandler(db *sql.DB) http.HandlerFunc {
 		var body struct {
 			Content string `json:"content"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		if !decodeJSONBody(w, r, maxTaskNoteBodySize, &body) {
 			return
 		}
 		if strings.TrimSpace(body.Content) == "" {

--- a/internal/tasks/handlers.go
+++ b/internal/tasks/handlers.go
@@ -1,0 +1,224 @@
+package tasks
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("tasks: writeJSON encode error: %v", err)
+	}
+}
+
+// ListHandler returns the authenticated user's tasks, filtered by archived state.
+// Defaults to archived=false when the query parameter is missing.
+func ListHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		archived := false
+		if q := r.URL.Query().Get("archived"); q != "" {
+			parsed, err := strconv.ParseBool(q)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "archived must be a boolean"})
+				return
+			}
+			archived = parsed
+		}
+
+		items, err := ListTasks(db, user.ID, archived)
+		if err != nil {
+			log.Printf("tasks: list failed: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list tasks"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"tasks": items})
+	}
+}
+
+// CreateHandler creates a new task. Title is required.
+func CreateHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		var body struct {
+			Title string   `json:"title"`
+			Body  string   `json:"body"`
+			Tags  []string `json:"tags"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+
+		body.Title = strings.TrimSpace(body.Title)
+		if body.Title == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "title is required"})
+			return
+		}
+
+		task, err := CreateTask(db, user.ID, body.Title, body.Body, body.Tags)
+		if err != nil {
+			log.Printf("tasks: create failed: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create task"})
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"task": task})
+	}
+}
+
+// UpdateHandler applies a partial update to a task. Fields omitted from the
+// request body are left unchanged.
+func UpdateHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid task ID"})
+			return
+		}
+
+		var body struct {
+			Title    *string   `json:"title"`
+			Body     *string   `json:"body"`
+			Tags     *[]string `json:"tags"`
+			Archived *bool     `json:"archived"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+
+		if body.Title != nil {
+			trimmed := strings.TrimSpace(*body.Title)
+			if trimmed == "" {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "title must not be empty"})
+				return
+			}
+			body.Title = &trimmed
+		}
+
+		task, err := UpdateTask(db, id, user.ID, TaskUpdate{
+			Title:    body.Title,
+			Body:     body.Body,
+			Tags:     body.Tags,
+			Archived: body.Archived,
+		})
+		if err != nil {
+			if errors.Is(err, ErrTaskNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+				return
+			}
+			log.Printf("tasks: update failed: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update task"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"task": task})
+	}
+}
+
+// DeleteHandler deletes a task and its cascaded children.
+func DeleteHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid task ID"})
+			return
+		}
+
+		if err := DeleteTask(db, id, user.ID); err != nil {
+			if errors.Is(err, ErrTaskNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+				return
+			}
+			log.Printf("tasks: delete failed: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete task"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+}
+
+// AddNoteHandler appends a note to a task.
+func AddNoteHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		taskID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid task ID"})
+			return
+		}
+
+		var body struct {
+			Content string `json:"content"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+		if strings.TrimSpace(body.Content) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "content is required"})
+			return
+		}
+
+		note, err := AddNote(db, taskID, user.ID, body.Content)
+		if err != nil {
+			if errors.Is(err, ErrTaskNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+				return
+			}
+			log.Printf("tasks: add note failed: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to add note"})
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"note": note})
+	}
+}
+
+// DeleteNoteHandler removes a note from a task.
+func DeleteNoteHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		taskID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid task ID"})
+			return
+		}
+		noteID, err := strconv.ParseInt(chi.URLParam(r, "note_id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid note ID"})
+			return
+		}
+
+		if err := DeleteNote(db, taskID, noteID, user.ID); err != nil {
+			if errors.Is(err, ErrTaskNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+				return
+			}
+			if errors.Is(err, ErrNoteNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "task note not found"})
+				return
+			}
+			log.Printf("tasks: delete note failed: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete note"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+}

--- a/internal/tasks/handlers_test.go
+++ b/internal/tasks/handlers_test.go
@@ -1,0 +1,318 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+func withUser(r *http.Request, userID int64) *http.Request {
+	user := &auth.User{ID: userID, Email: "test@example.com", Name: "Test"}
+	ctx := auth.ContextWithUser(r.Context(), user)
+	return r.WithContext(ctx)
+}
+
+func withChiParams(r *http.Request, kv map[string]string) *http.Request {
+	rctx := chi.NewRouteContext()
+	for k, v := range kv {
+		rctx.URLParams.Add(k, v)
+	}
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestCreateHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	payload := `{"title":"Buy bread","body":"sourdough","tags":["shopping"]}`
+	req := withUser(httptest.NewRequest("POST", "/api/tasks", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Task Task `json:"task"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Task.Title != "Buy bread" || body.Task.Body != "sourdough" {
+		t.Errorf("task = %+v", body.Task)
+	}
+}
+
+func TestCreateHandler_MissingTitle(t *testing.T) {
+	db := setupTestDB(t)
+	req := withUser(httptest.NewRequest("POST", "/api/tasks", strings.NewReader(`{"title":"   "}`)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestCreateHandler_InvalidJSON(t *testing.T) {
+	db := setupTestDB(t)
+	req := withUser(httptest.NewRequest("POST", "/api/tasks", strings.NewReader("not json")), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestListHandler_FilterByArchived(t *testing.T) {
+	db := setupTestDB(t)
+	active, err := CreateTask(db, 1, "Active", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	archived, err := CreateTask(db, 1, "Archived", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	on := true
+	if _, err := UpdateTask(db, archived.ID, 1, TaskUpdate{Archived: &on}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	for _, tc := range []struct {
+		query   string
+		wantID  int64
+		wantLen int
+	}{
+		{"", active.ID, 1},
+		{"archived=false", active.ID, 1},
+		{"archived=true", archived.ID, 1},
+	} {
+		req := withUser(httptest.NewRequest("GET", "/api/tasks?"+tc.query, nil), 1)
+		rec := httptest.NewRecorder()
+		ListHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("query %q: status = %d", tc.query, rec.Code)
+		}
+		var body struct {
+			Tasks []Task `json:"tasks"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(body.Tasks) != tc.wantLen {
+			t.Errorf("query %q: got %d tasks, want %d", tc.query, len(body.Tasks), tc.wantLen)
+		}
+		if len(body.Tasks) > 0 && body.Tasks[0].ID != tc.wantID {
+			t.Errorf("query %q: got id %d, want %d", tc.query, body.Tasks[0].ID, tc.wantID)
+		}
+	}
+}
+
+func TestListHandler_InvalidArchivedParam(t *testing.T) {
+	db := setupTestDB(t)
+	req := withUser(httptest.NewRequest("GET", "/api/tasks?archived=maybe", nil), 1)
+	rec := httptest.NewRecorder()
+	ListHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestUpdateHandler_PartialPatch(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Old", "old body", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("PATCH", "/api/tasks/"+idStr, strings.NewReader(`{"body":"new body"}`)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	UpdateHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Task Task `json:"task"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Task.Title != "Old" {
+		t.Errorf("title should be unchanged, got %q", body.Task.Title)
+	}
+	if body.Task.Body != "new body" {
+		t.Errorf("body = %q, want %q", body.Task.Body, "new body")
+	}
+}
+
+func TestUpdateHandler_EmptyTitleRejected(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Title", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("PATCH", "/api/tasks/"+idStr, strings.NewReader(`{"title":"   "}`)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	UpdateHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestUpdateHandler_NotFoundForOtherUser(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Mine", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("PATCH", "/api/tasks/"+idStr, strings.NewReader(`{"title":"hacked"}`)), 2)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	UpdateHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestDeleteHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Delete me", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/tasks/"+idStr, nil), 1)
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	DeleteHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestDeleteHandler_NotFoundForOtherUser(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Hers", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/tasks/"+idStr, nil), 2)
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	DeleteHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestAddNoteHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Owner", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("POST", "/api/tasks/"+idStr+"/notes", strings.NewReader(`{"content":"hello"}`)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	AddNoteHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAddNoteHandler_EmptyContent(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Owner", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("POST", "/api/tasks/"+idStr+"/notes", strings.NewReader(`{"content":"   "}`)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	AddNoteHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestAddNoteHandler_TaskOwnedByAnotherUser(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Owner", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("POST", "/api/tasks/"+idStr+"/notes", strings.NewReader(`{"content":"hi"}`)), 2)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	AddNoteHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestDeleteNoteHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Owner", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	note, err := AddNote(db, task.ID, 1, "Goodbye")
+	if err != nil {
+		t.Fatalf("add note: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	noteStr := strconv.FormatInt(note.ID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/tasks/"+idStr+"/notes/"+noteStr, nil), 1)
+	req = withChiParams(req, map[string]string{"id": idStr, "note_id": noteStr})
+	rec := httptest.NewRecorder()
+	DeleteNoteHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestDeleteNoteHandler_NoteFromOtherTask(t *testing.T) {
+	db := setupTestDB(t)
+	t1, err := CreateTask(db, 1, "One", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t2, err := CreateTask(db, 1, "Two", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	note, err := AddNote(db, t1.ID, 1, "for t1")
+	if err != nil {
+		t.Fatalf("add note: %v", err)
+	}
+	t2Str := strconv.FormatInt(t2.ID, 10)
+	noteStr := strconv.FormatInt(note.ID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/tasks/"+t2Str+"/notes/"+noteStr, nil), 1)
+	req = withChiParams(req, map[string]string{"id": t2Str, "note_id": noteStr})
+	rec := httptest.NewRecorder()
+	DeleteNoteHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}

--- a/internal/tasks/models.go
+++ b/internal/tasks/models.go
@@ -1,0 +1,568 @@
+package tasks
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+// Task is a single user-owned task with optional tags and notes.
+type Task struct {
+	ID         int64      `json:"id"`
+	UserID     int64      `json:"user_id"`
+	Title      string     `json:"title"`
+	Body       string     `json:"body"`
+	Archived   bool       `json:"archived"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+	ArchivedAt *time.Time `json:"archived_at,omitempty"`
+	Tags       []string   `json:"tags"`
+	NoteCount  int        `json:"note_count"`
+}
+
+// TaskTag is a per-user tag label used to group tasks.
+type TaskTag struct {
+	ID     int64  `json:"id"`
+	UserID int64  `json:"user_id"`
+	Label  string `json:"label"`
+}
+
+// TaskNote is a free-text note attached to a task.
+type TaskNote struct {
+	ID        int64     `json:"id"`
+	TaskID    int64     `json:"task_id"`
+	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ErrTaskNotFound signals that no task matched the requested ID + user pair.
+var ErrTaskNotFound = errors.New("task not found")
+
+// ErrNoteNotFound signals that no note matched the requested task + note IDs.
+var ErrNoteNotFound = errors.New("task note not found")
+
+// formatTimestamp renders a time.Time for storage in a TIMESTAMP column.
+// The codebase historically stores times as RFC3339 strings; this keeps the
+// roundtrip predictable across the modernc.org/sqlite driver and tests.
+func formatTimestamp(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// parseTimestamp parses a database-stored timestamp back to time.Time. It is
+// permissive about the exact RFC3339 sub-format (with or without sub-second
+// precision) so callers do not need to track which writer produced the value.
+func parseTimestamp(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, errors.New("empty time string")
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05.999999999-07:00", "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognised timestamp %q", s)
+}
+
+// CreateTask inserts a new task and, if tags are provided, upserts and assigns them.
+func CreateTask(db *sql.DB, userID int64, title, body string, tags []string) (*Task, error) {
+	now := time.Now().UTC()
+	encTitle, err := encryption.EncryptField(title)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt title: %w", err)
+	}
+	encBody, err := encryption.EncryptField(body)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt body: %w", err)
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	nowStr := formatTimestamp(now)
+	res, err := tx.Exec(
+		`INSERT INTO tasks (user_id, title_enc, body_enc, archived, created_at, updated_at)
+		 VALUES (?, ?, ?, 0, ?, ?)`,
+		userID, encTitle, encBody, nowStr, nowStr,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert task: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("last insert id: %w", err)
+	}
+
+	if err := setTaskTags(tx, userID, id, tags); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return GetTask(db, id, userID)
+}
+
+// GetTask returns a single task scoped to the owner, with its tags and note count.
+func GetTask(db *sql.DB, id, userID int64) (*Task, error) {
+	var (
+		t          Task
+		encTitle   string
+		encBody    string
+		archived   int
+		createdAt  string
+		updatedAt  string
+		archivedAt sql.NullString
+	)
+	err := db.QueryRow(
+		`SELECT id, user_id, title_enc, body_enc, archived, created_at, updated_at, archived_at
+		 FROM tasks WHERE id = ? AND user_id = ?`,
+		id, userID,
+	).Scan(&t.ID, &t.UserID, &encTitle, &encBody, &archived, &createdAt, &updatedAt, &archivedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrTaskNotFound
+		}
+		return nil, err
+	}
+
+	if t.Title, err = encryption.DecryptField(encTitle); err != nil {
+		return nil, fmt.Errorf("decrypt title: %w", err)
+	}
+	if t.Body, err = encryption.DecryptField(encBody); err != nil {
+		return nil, fmt.Errorf("decrypt body: %w", err)
+	}
+	t.Archived = archived != 0
+	if t.CreatedAt, err = parseTimestamp(createdAt); err != nil {
+		return nil, fmt.Errorf("parse created_at: %w", err)
+	}
+	if t.UpdatedAt, err = parseTimestamp(updatedAt); err != nil {
+		return nil, fmt.Errorf("parse updated_at: %w", err)
+	}
+	if archivedAt.Valid && archivedAt.String != "" {
+		v, perr := parseTimestamp(archivedAt.String)
+		if perr != nil {
+			return nil, fmt.Errorf("parse archived_at: %w", perr)
+		}
+		t.ArchivedAt = &v
+	}
+
+	tags, err := listTagsForTask(db, id)
+	if err != nil {
+		return nil, err
+	}
+	t.Tags = tags
+
+	count, err := countNotesForTask(db, id)
+	if err != nil {
+		return nil, err
+	}
+	t.NoteCount = count
+
+	return &t, nil
+}
+
+// ListTasks returns all tasks for the user filtered by archived state.
+func ListTasks(db *sql.DB, userID int64, archived bool) ([]Task, error) {
+	archInt := 0
+	if archived {
+		archInt = 1
+	}
+	rows, err := db.Query(
+		`SELECT id, user_id, title_enc, body_enc, archived, created_at, updated_at, archived_at
+		 FROM tasks WHERE user_id = ? AND archived = ?
+		 ORDER BY updated_at DESC`,
+		userID, archInt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tasks []Task
+	for rows.Next() {
+		var (
+			t          Task
+			encTitle   string
+			encBody    string
+			arch       int
+			createdAt  string
+			updatedAt  string
+			archivedAt sql.NullString
+		)
+		if err := rows.Scan(&t.ID, &t.UserID, &encTitle, &encBody, &arch, &createdAt, &updatedAt, &archivedAt); err != nil {
+			return nil, err
+		}
+		if t.Title, err = encryption.DecryptField(encTitle); err != nil {
+			return nil, fmt.Errorf("decrypt title: %w", err)
+		}
+		if t.Body, err = encryption.DecryptField(encBody); err != nil {
+			return nil, fmt.Errorf("decrypt body: %w", err)
+		}
+		t.Archived = arch != 0
+		if t.CreatedAt, err = parseTimestamp(createdAt); err != nil {
+			return nil, fmt.Errorf("parse created_at: %w", err)
+		}
+		if t.UpdatedAt, err = parseTimestamp(updatedAt); err != nil {
+			return nil, fmt.Errorf("parse updated_at: %w", err)
+		}
+		if archivedAt.Valid && archivedAt.String != "" {
+			v, perr := parseTimestamp(archivedAt.String)
+			if perr != nil {
+				return nil, fmt.Errorf("parse archived_at: %w", perr)
+			}
+			t.ArchivedAt = &v
+		}
+		tasks = append(tasks, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	for i := range tasks {
+		tags, err := listTagsForTask(db, tasks[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		tasks[i].Tags = tags
+		count, err := countNotesForTask(db, tasks[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		tasks[i].NoteCount = count
+	}
+
+	if tasks == nil {
+		tasks = []Task{}
+	}
+	return tasks, nil
+}
+
+// TaskUpdate is a partial update payload. Nil pointers leave the corresponding
+// column untouched.
+type TaskUpdate struct {
+	Title    *string
+	Body     *string
+	Tags     *[]string
+	Archived *bool
+}
+
+// UpdateTask applies the given partial update to a task scoped to the user.
+func UpdateTask(db *sql.DB, id, userID int64, upd TaskUpdate) (*Task, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var currentArchived int
+	if err := tx.QueryRow(`SELECT archived FROM tasks WHERE id = ? AND user_id = ?`, id, userID).Scan(&currentArchived); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrTaskNotFound
+		}
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	nowStr := formatTimestamp(now)
+	setClauses := []string{"updated_at = ?"}
+	args := []any{nowStr}
+
+	if upd.Title != nil {
+		enc, err := encryption.EncryptField(*upd.Title)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt title: %w", err)
+		}
+		setClauses = append(setClauses, "title_enc = ?")
+		args = append(args, enc)
+	}
+	if upd.Body != nil {
+		enc, err := encryption.EncryptField(*upd.Body)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt body: %w", err)
+		}
+		setClauses = append(setClauses, "body_enc = ?")
+		args = append(args, enc)
+	}
+	if upd.Archived != nil {
+		newArchived := 0
+		if *upd.Archived {
+			newArchived = 1
+		}
+		setClauses = append(setClauses, "archived = ?")
+		args = append(args, newArchived)
+		// Set archived_at when flipping to archived; clear it when unarchiving.
+		if newArchived == 1 && currentArchived == 0 {
+			setClauses = append(setClauses, "archived_at = ?")
+			args = append(args, nowStr)
+		} else if newArchived == 0 && currentArchived == 1 {
+			setClauses = append(setClauses, "archived_at = NULL")
+		}
+	}
+
+	args = append(args, id, userID)
+	query := fmt.Sprintf("UPDATE tasks SET %s WHERE id = ? AND user_id = ?", strings.Join(setClauses, ", "))
+	res, err := tx.Exec(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("update task: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return nil, ErrTaskNotFound
+	}
+
+	if upd.Tags != nil {
+		if err := setTaskTags(tx, userID, id, *upd.Tags); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return GetTask(db, id, userID)
+}
+
+// DeleteTask removes a task and (via ON DELETE CASCADE) its tag assignments and notes.
+func DeleteTask(db *sql.DB, id, userID int64) error {
+	res, err := db.Exec(`DELETE FROM tasks WHERE id = ? AND user_id = ?`, id, userID)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrTaskNotFound
+	}
+	return nil
+}
+
+// AddNote appends a free-text note to an existing task. The task must belong
+// to the given user — returns ErrTaskNotFound otherwise.
+func AddNote(db *sql.DB, taskID, userID int64, content string) (*TaskNote, error) {
+	if err := ensureTaskOwned(db, taskID, userID); err != nil {
+		return nil, err
+	}
+	enc, err := encryption.EncryptField(content)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt note content: %w", err)
+	}
+	now := time.Now().UTC()
+	res, err := db.Exec(
+		`INSERT INTO task_notes (task_id, content_enc, created_at) VALUES (?, ?, ?)`,
+		taskID, enc, formatTimestamp(now),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert note: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("last insert id: %w", err)
+	}
+	return &TaskNote{ID: id, TaskID: taskID, Content: content, CreatedAt: now}, nil
+}
+
+// DeleteNote removes a note owned by the given user (via the task ownership check).
+func DeleteNote(db *sql.DB, taskID, noteID, userID int64) error {
+	if err := ensureTaskOwned(db, taskID, userID); err != nil {
+		return err
+	}
+	res, err := db.Exec(`DELETE FROM task_notes WHERE id = ? AND task_id = ?`, noteID, taskID)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNoteNotFound
+	}
+	return nil
+}
+
+// ListNotes returns every note attached to a task, oldest first.
+func ListNotes(db *sql.DB, taskID, userID int64) ([]TaskNote, error) {
+	if err := ensureTaskOwned(db, taskID, userID); err != nil {
+		return nil, err
+	}
+	rows, err := db.Query(
+		`SELECT id, task_id, content_enc, created_at FROM task_notes WHERE task_id = ? ORDER BY created_at`,
+		taskID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var notes []TaskNote
+	for rows.Next() {
+		var (
+			n         TaskNote
+			enc       string
+			createdAt string
+		)
+		if err := rows.Scan(&n.ID, &n.TaskID, &enc, &createdAt); err != nil {
+			return nil, err
+		}
+		if n.Content, err = encryption.DecryptField(enc); err != nil {
+			return nil, fmt.Errorf("decrypt note content: %w", err)
+		}
+		if n.CreatedAt, err = parseTimestamp(createdAt); err != nil {
+			return nil, fmt.Errorf("parse note created_at: %w", err)
+		}
+		notes = append(notes, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if notes == nil {
+		notes = []TaskNote{}
+	}
+	return notes, nil
+}
+
+// ensureTaskOwned returns ErrTaskNotFound if the task does not exist or is not
+// owned by the given user. Used as a guard before mutating task children.
+func ensureTaskOwned(db *sql.DB, taskID, userID int64) error {
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE id = ? AND user_id = ?`, taskID, userID).Scan(&n); err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrTaskNotFound
+	}
+	return nil
+}
+
+// setTaskTags replaces the tag set for a task. New labels are upserted into
+// task_tags (reusing existing IDs when a plaintext label already exists for
+// the user); removed labels are unlinked. The encryption nonce is random, so
+// uniqueness is enforced in Go by decrypting and comparing plaintexts rather
+// than relying on the UNIQUE(user_id, label_enc) constraint.
+func setTaskTags(tx *sql.Tx, userID, taskID int64, tags []string) error {
+	if _, err := tx.Exec(`DELETE FROM task_tag_assignments WHERE task_id = ?`, taskID); err != nil {
+		return fmt.Errorf("clear tag assignments: %w", err)
+	}
+
+	if len(tags) == 0 {
+		return nil
+	}
+
+	// Build a map of plaintext label -> tag ID for this user's existing tags.
+	existing, err := loadUserTags(tx, userID)
+	if err != nil {
+		return err
+	}
+
+	for _, raw := range tags {
+		label := strings.TrimSpace(raw)
+		if label == "" {
+			continue
+		}
+		tagID, ok := existing[label]
+		if !ok {
+			enc, err := encryption.EncryptField(label)
+			if err != nil {
+				return fmt.Errorf("encrypt tag label: %w", err)
+			}
+			res, err := tx.Exec(`INSERT INTO task_tags (user_id, label_enc) VALUES (?, ?)`, userID, enc)
+			if err != nil {
+				return fmt.Errorf("insert tag: %w", err)
+			}
+			tagID, err = res.LastInsertId()
+			if err != nil {
+				return fmt.Errorf("last insert id: %w", err)
+			}
+			existing[label] = tagID
+		}
+		if _, err := tx.Exec(`INSERT OR IGNORE INTO task_tag_assignments (task_id, tag_id) VALUES (?, ?)`, taskID, tagID); err != nil {
+			return fmt.Errorf("assign tag: %w", err)
+		}
+	}
+	return nil
+}
+
+// loadUserTags returns a plaintext label -> tag ID map for the given user.
+func loadUserTags(tx *sql.Tx, userID int64) (map[string]int64, error) {
+	rows, err := tx.Query(`SELECT id, label_enc FROM task_tags WHERE user_id = ?`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]int64)
+	for rows.Next() {
+		var (
+			id  int64
+			enc string
+		)
+		if err := rows.Scan(&id, &enc); err != nil {
+			return nil, err
+		}
+		label, err := encryption.DecryptField(enc)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt tag label: %w", err)
+		}
+		// Last one wins if duplicates leak through (e.g. legacy plaintext).
+		out[label] = id
+	}
+	return out, rows.Err()
+}
+
+// listTagsForTask returns the decrypted, sorted tag labels for a task.
+func listTagsForTask(db *sql.DB, taskID int64) ([]string, error) {
+	rows, err := db.Query(
+		`SELECT t.label_enc FROM task_tags t
+		 JOIN task_tag_assignments a ON a.tag_id = t.id
+		 WHERE a.task_id = ?`,
+		taskID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var labels []string
+	for rows.Next() {
+		var enc string
+		if err := rows.Scan(&enc); err != nil {
+			return nil, err
+		}
+		label, err := encryption.DecryptField(enc)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt tag label: %w", err)
+		}
+		labels = append(labels, label)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Strings(labels)
+	if labels == nil {
+		labels = []string{}
+	}
+	return labels, nil
+}
+
+func countNotesForTask(db *sql.DB, taskID int64) (int, error) {
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM task_notes WHERE task_id = ?`, taskID).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}

--- a/internal/tasks/models.go
+++ b/internal/tasks/models.go
@@ -47,10 +47,11 @@ var ErrTaskNotFound = errors.New("task not found")
 var ErrNoteNotFound = errors.New("task note not found")
 
 // formatTimestamp renders a time.Time for storage in a TIMESTAMP column.
-// The codebase historically stores times as RFC3339 strings; this keeps the
-// roundtrip predictable across the modernc.org/sqlite driver and tests.
+// RFC3339 (second precision, always UTC "Z" suffix) produces a fixed-width
+// string so ORDER BY updated_at sorts correctly in SQLite without mixed
+// fractional-second widths breaking lexicographic order.
 func formatTimestamp(t time.Time) string {
-	return t.UTC().Format(time.RFC3339Nano)
+	return t.UTC().Format(time.RFC3339)
 }
 
 // parseTimestamp parses a database-stored timestamp back to time.Time. It is
@@ -471,11 +472,11 @@ func ensureTaskOwned(db *sql.DB, taskID, userID int64) error {
 	return nil
 }
 
-// setTaskTags replaces the tag set for a task. New labels are upserted into
-// task_tags (reusing existing IDs when a plaintext label already exists for
-// the user); removed labels are unlinked. The encryption nonce is random, so
-// uniqueness is enforced in Go by decrypting and comparing plaintexts rather
-// than relying on the UNIQUE(user_id, label_enc) constraint.
+// setTaskTags replaces the tag set for a task. Each label is upserted via
+// INSERT OR IGNORE keyed on the deterministic (user_id, label_hmac) unique
+// index, so concurrent creates for the same label collide on the index rather
+// than inserting duplicate encrypted rows (which would differ in ciphertext due
+// to the random AES-GCM nonce).
 func setTaskTags(tx *sql.Tx, userID, taskID int64, tags []string) error {
 	if _, err := tx.Exec(`DELETE FROM task_tag_assignments WHERE task_id = ?`, taskID); err != nil {
 		return fmt.Errorf("clear tag assignments: %w", err)
@@ -485,65 +486,46 @@ func setTaskTags(tx *sql.Tx, userID, taskID int64, tags []string) error {
 		return nil
 	}
 
-	// Build a map of plaintext label -> tag ID for this user's existing tags.
-	existing, err := loadUserTags(tx, userID)
-	if err != nil {
-		return err
-	}
-
 	for _, raw := range tags {
 		label := strings.TrimSpace(raw)
 		if label == "" {
 			continue
 		}
-		tagID, ok := existing[label]
-		if !ok {
-			enc, err := encryption.EncryptField(label)
-			if err != nil {
-				return fmt.Errorf("encrypt tag label: %w", err)
-			}
-			res, err := tx.Exec(`INSERT INTO task_tags (user_id, label_enc) VALUES (?, ?)`, userID, enc)
-			if err != nil {
-				return fmt.Errorf("insert tag: %w", err)
-			}
-			tagID, err = res.LastInsertId()
-			if err != nil {
-				return fmt.Errorf("last insert id: %w", err)
-			}
-			existing[label] = tagID
+
+		hmacVal, err := encryption.HMACField(userID, label)
+		if err != nil {
+			return fmt.Errorf("hmac tag label: %w", err)
 		}
-		if _, err := tx.Exec(`INSERT OR IGNORE INTO task_tag_assignments (task_id, tag_id) VALUES (?, ?)`, taskID, tagID); err != nil {
+		enc, err := encryption.EncryptField(label)
+		if err != nil {
+			return fmt.Errorf("encrypt tag label: %w", err)
+		}
+
+		// INSERT OR IGNORE: if a concurrent request already created this tag the
+		// unique (user_id, label_hmac) index rejects the duplicate silently.
+		if _, err := tx.Exec(
+			`INSERT OR IGNORE INTO task_tags (user_id, label_enc, label_hmac) VALUES (?, ?, ?)`,
+			userID, enc, hmacVal,
+		); err != nil {
+			return fmt.Errorf("upsert tag: %w", err)
+		}
+
+		var tagID int64
+		if err := tx.QueryRow(
+			`SELECT id FROM task_tags WHERE user_id = ? AND label_hmac = ?`,
+			userID, hmacVal,
+		).Scan(&tagID); err != nil {
+			return fmt.Errorf("lookup tag: %w", err)
+		}
+
+		if _, err := tx.Exec(
+			`INSERT OR IGNORE INTO task_tag_assignments (task_id, tag_id) VALUES (?, ?)`,
+			taskID, tagID,
+		); err != nil {
 			return fmt.Errorf("assign tag: %w", err)
 		}
 	}
 	return nil
-}
-
-// loadUserTags returns a plaintext label -> tag ID map for the given user.
-func loadUserTags(tx *sql.Tx, userID int64) (map[string]int64, error) {
-	rows, err := tx.Query(`SELECT id, label_enc FROM task_tags WHERE user_id = ?`, userID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	out := make(map[string]int64)
-	for rows.Next() {
-		var (
-			id  int64
-			enc string
-		)
-		if err := rows.Scan(&id, &enc); err != nil {
-			return nil, err
-		}
-		label, err := encryption.DecryptField(enc)
-		if err != nil {
-			return nil, fmt.Errorf("decrypt tag label: %w", err)
-		}
-		// Last one wins if duplicates leak through (e.g. legacy plaintext).
-		out[label] = id
-	}
-	return out, rows.Err()
 }
 
 // listTagsForTask returns the decrypted, sorted tag labels for a task.

--- a/internal/tasks/models.go
+++ b/internal/tasks/models.go
@@ -171,15 +171,20 @@ func GetTask(db *sql.DB, id, userID int64) (*Task, error) {
 }
 
 // ListTasks returns all tasks for the user filtered by archived state.
+// Tag labels and note counts are fetched in two batched queries (not per-task)
+// to keep the cost at O(1) database round-trips.
 func ListTasks(db *sql.DB, userID int64, archived bool) ([]Task, error) {
 	archInt := 0
 	if archived {
 		archInt = 1
 	}
+	// updated_at DESC is the user-facing ordering; id DESC breaks ties so the
+	// order is deterministic even when two tasks share an updated_at value
+	// (e.g. seeded fixtures or rapid back-to-back writes).
 	rows, err := db.Query(
 		`SELECT id, user_id, title_enc, body_enc, archived, created_at, updated_at, archived_at
 		 FROM tasks WHERE user_id = ? AND archived = ?
-		 ORDER BY updated_at DESC`,
+		 ORDER BY updated_at DESC, id DESC`,
 		userID, archInt,
 	)
 	if err != nil {
@@ -187,7 +192,11 @@ func ListTasks(db *sql.DB, userID int64, archived bool) ([]Task, error) {
 	}
 	defer rows.Close()
 
-	var tasks []Task
+	var (
+		tasks   []Task
+		ids     []int64
+		indexBy = map[int64]int{}
+	)
 	for rows.Next() {
 		var (
 			t          Task
@@ -221,28 +230,41 @@ func ListTasks(db *sql.DB, userID int64, archived bool) ([]Task, error) {
 			}
 			t.ArchivedAt = &v
 		}
+		t.Tags = []string{}
+		indexBy[t.ID] = len(tasks)
 		tasks = append(tasks, t)
+		ids = append(ids, t.ID)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
-	for i := range tasks {
-		tags, err := listTagsForTask(db, tasks[i].ID)
-		if err != nil {
-			return nil, err
-		}
-		tasks[i].Tags = tags
-		count, err := countNotesForTask(db, tasks[i].ID)
-		if err != nil {
-			return nil, err
-		}
-		tasks[i].NoteCount = count
+	if len(tasks) == 0 {
+		return []Task{}, nil
 	}
 
-	if tasks == nil {
-		tasks = []Task{}
+	// Batched tag fetch: one query for all tasks in the page.
+	tagMap, err := listTagsForTasks(db, ids)
+	if err != nil {
+		return nil, err
 	}
+	for taskID, labels := range tagMap {
+		if i, ok := indexBy[taskID]; ok {
+			tasks[i].Tags = labels
+		}
+	}
+
+	// Batched note-count fetch: one COUNT(*) GROUP BY task_id query.
+	countMap, err := countNotesForTasks(db, ids)
+	if err != nil {
+		return nil, err
+	}
+	for taskID, n := range countMap {
+		if i, ok := indexBy[taskID]; ok {
+			tasks[i].NoteCount = n
+		}
+	}
+
 	return tasks, nil
 }
 
@@ -401,7 +423,7 @@ func ListNotes(db *sql.DB, taskID, userID int64) ([]TaskNote, error) {
 		return nil, err
 	}
 	rows, err := db.Query(
-		`SELECT id, task_id, content_enc, created_at FROM task_notes WHERE task_id = ? ORDER BY created_at`,
+		`SELECT id, task_id, content_enc, created_at FROM task_notes WHERE task_id = ? ORDER BY created_at, id`,
 		taskID,
 	)
 	if err != nil {
@@ -565,4 +587,90 @@ func countNotesForTask(db *sql.DB, taskID int64) (int, error) {
 		return 0, err
 	}
 	return n, nil
+}
+
+// listTagsForTasks returns decrypted, sorted tag labels keyed by task ID for
+// the given set of tasks. It runs a single query against task_tag_assignments
+// joined with task_tags, avoiding the per-task N+1 pattern in listTagsForTask.
+func listTagsForTasks(db *sql.DB, taskIDs []int64) (map[int64][]string, error) {
+	out := map[int64][]string{}
+	if len(taskIDs) == 0 {
+		return out, nil
+	}
+	placeholders := make([]string, len(taskIDs))
+	args := make([]any, len(taskIDs))
+	for i, id := range taskIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := fmt.Sprintf(
+		`SELECT a.task_id, t.label_enc
+		 FROM task_tag_assignments a
+		 JOIN task_tags t ON t.id = a.tag_id
+		 WHERE a.task_id IN (%s)`,
+		strings.Join(placeholders, ","),
+	)
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			taskID int64
+			enc    string
+		)
+		if err := rows.Scan(&taskID, &enc); err != nil {
+			return nil, err
+		}
+		label, err := encryption.DecryptField(enc)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt tag label: %w", err)
+		}
+		out[taskID] = append(out[taskID], label)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	for taskID := range out {
+		sort.Strings(out[taskID])
+	}
+	return out, nil
+}
+
+// countNotesForTasks returns a task_id -> note count map fetched in a single
+// GROUP BY query.
+func countNotesForTasks(db *sql.DB, taskIDs []int64) (map[int64]int, error) {
+	out := map[int64]int{}
+	if len(taskIDs) == 0 {
+		return out, nil
+	}
+	placeholders := make([]string, len(taskIDs))
+	args := make([]any, len(taskIDs))
+	for i, id := range taskIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := fmt.Sprintf(
+		`SELECT task_id, COUNT(*) FROM task_notes WHERE task_id IN (%s) GROUP BY task_id`,
+		strings.Join(placeholders, ","),
+	)
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			taskID int64
+			n      int
+		)
+		if err := rows.Scan(&taskID, &n); err != nil {
+			return nil, err
+		}
+		out[taskID] = n
+	}
+	return out, rows.Err()
 }

--- a/internal/tasks/models_test.go
+++ b/internal/tasks/models_test.go
@@ -1,0 +1,458 @@
+package tasks
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+	_ "modernc.org/sqlite"
+)
+
+const schemaSQL = `
+CREATE TABLE users (
+	id         INTEGER PRIMARY KEY,
+	email      TEXT UNIQUE NOT NULL,
+	name       TEXT NOT NULL,
+	picture    TEXT NOT NULL DEFAULT '',
+	google_id  TEXT UNIQUE NOT NULL,
+	created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+	is_admin   INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE tasks (
+	id            INTEGER PRIMARY KEY AUTOINCREMENT,
+	user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	title_enc     TEXT NOT NULL,
+	body_enc      TEXT NOT NULL DEFAULT '',
+	archived      INTEGER NOT NULL DEFAULT 0,
+	created_at    TIMESTAMP NOT NULL,
+	updated_at    TIMESTAMP NOT NULL,
+	archived_at   TIMESTAMP
+);
+CREATE INDEX idx_tasks_user_archived ON tasks(user_id, archived);
+CREATE TABLE task_tags (
+	id         INTEGER PRIMARY KEY AUTOINCREMENT,
+	user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	label_enc  TEXT NOT NULL,
+	UNIQUE(user_id, label_enc)
+);
+CREATE TABLE task_tag_assignments (
+	task_id  INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+	tag_id   INTEGER NOT NULL REFERENCES task_tags(id) ON DELETE CASCADE,
+	PRIMARY KEY (task_id, tag_id)
+);
+CREATE TABLE task_notes (
+	id          INTEGER PRIMARY KEY AUTOINCREMENT,
+	task_id     INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+	content_enc TEXT NOT NULL,
+	created_at  TIMESTAMP NOT NULL
+);
+CREATE INDEX idx_task_notes_task ON task_notes(task_id, created_at);
+`
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-key-for-tasks-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
+		t.Fatalf("enable fk: %v", err)
+	}
+	if _, err := db.Exec(schemaSQL); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if _, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'a@example.com', 'Alice', 'g1'), (2, 'b@example.com', 'Bob', 'g2')`); err != nil {
+		t.Fatalf("insert users: %v", err)
+	}
+	return db
+}
+
+func TestCreateAndGetTask(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Buy milk", "2 percent", []string{"shopping", "home"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if task.Title != "Buy milk" {
+		t.Errorf("title = %q, want %q", task.Title, "Buy milk")
+	}
+	if task.Body != "2 percent" {
+		t.Errorf("body = %q, want %q", task.Body, "2 percent")
+	}
+	if task.Archived {
+		t.Error("new task should not be archived")
+	}
+	if len(task.Tags) != 2 {
+		t.Errorf("tags len = %d, want 2", len(task.Tags))
+	}
+	if task.NoteCount != 0 {
+		t.Errorf("note count = %d, want 0", task.NoteCount)
+	}
+
+	got, err := GetTask(db, task.ID, 1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ID != task.ID || got.Title != "Buy milk" {
+		t.Errorf("get mismatch: %+v", got)
+	}
+}
+
+func TestGetTask_NotFoundForOtherUser(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Private", "secret", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := GetTask(db, task.ID, 2); !errors.Is(err, ErrTaskNotFound) {
+		t.Errorf("expected ErrTaskNotFound, got %v", err)
+	}
+}
+
+func TestListTasks_ActiveAndArchived(t *testing.T) {
+	db := setupTestDB(t)
+
+	active, err := CreateTask(db, 1, "Active", "", nil)
+	if err != nil {
+		t.Fatalf("create active: %v", err)
+	}
+	archived, err := CreateTask(db, 1, "Archived", "", nil)
+	if err != nil {
+		t.Fatalf("create archived: %v", err)
+	}
+	val := true
+	if _, err := UpdateTask(db, archived.ID, 1, TaskUpdate{Archived: &val}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	activeList, err := ListTasks(db, 1, false)
+	if err != nil {
+		t.Fatalf("list active: %v", err)
+	}
+	if len(activeList) != 1 || activeList[0].ID != active.ID {
+		t.Errorf("active list = %+v, want single active task", activeList)
+	}
+
+	archivedList, err := ListTasks(db, 1, true)
+	if err != nil {
+		t.Fatalf("list archived: %v", err)
+	}
+	if len(archivedList) != 1 || archivedList[0].ID != archived.ID {
+		t.Errorf("archived list = %+v, want single archived task", archivedList)
+	}
+	if archivedList[0].ArchivedAt == nil {
+		t.Error("archived_at should be set after archiving")
+	}
+}
+
+func TestUpdateTask_PartialFields(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Original", "original body", []string{"old"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	newTitle := "Renamed"
+	updated, err := UpdateTask(db, task.ID, 1, TaskUpdate{Title: &newTitle})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Title != "Renamed" {
+		t.Errorf("title = %q, want %q", updated.Title, "Renamed")
+	}
+	if updated.Body != "original body" {
+		t.Errorf("body should be unchanged, got %q", updated.Body)
+	}
+	if len(updated.Tags) != 1 || updated.Tags[0] != "old" {
+		t.Errorf("tags should be unchanged, got %v", updated.Tags)
+	}
+}
+
+func TestUpdateTask_ArchiveUnarchiveSetsArchivedAt(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Toggle", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	on := true
+	archived, err := UpdateTask(db, task.ID, 1, TaskUpdate{Archived: &on})
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	if !archived.Archived || archived.ArchivedAt == nil {
+		t.Errorf("archive: archived=%v archived_at=%v", archived.Archived, archived.ArchivedAt)
+	}
+
+	off := false
+	unarchived, err := UpdateTask(db, task.ID, 1, TaskUpdate{Archived: &off})
+	if err != nil {
+		t.Fatalf("unarchive: %v", err)
+	}
+	if unarchived.Archived || unarchived.ArchivedAt != nil {
+		t.Errorf("unarchive: archived=%v archived_at=%v", unarchived.Archived, unarchived.ArchivedAt)
+	}
+}
+
+func TestUpdateTask_OtherUserGetsNotFound(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Mine", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	newTitle := "Hacked"
+	_, err = UpdateTask(db, task.ID, 2, TaskUpdate{Title: &newTitle})
+	if !errors.Is(err, ErrTaskNotFound) {
+		t.Errorf("expected ErrTaskNotFound, got %v", err)
+	}
+}
+
+func TestDeleteTask_CascadesNotesAndAssignments(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Cascade", "", []string{"alpha"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := AddNote(db, task.ID, 1, "Note content"); err != nil {
+		t.Fatalf("add note: %v", err)
+	}
+
+	if err := DeleteTask(db, task.ID, 1); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	var assignmentCount, noteCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM task_tag_assignments WHERE task_id = ?`, task.ID).Scan(&assignmentCount); err != nil {
+		t.Fatalf("count assignments: %v", err)
+	}
+	if assignmentCount != 0 {
+		t.Errorf("assignments = %d, want 0", assignmentCount)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM task_notes WHERE task_id = ?`, task.ID).Scan(&noteCount); err != nil {
+		t.Fatalf("count notes: %v", err)
+	}
+	if noteCount != 0 {
+		t.Errorf("notes = %d, want 0", noteCount)
+	}
+
+	// The tag itself is kept for reuse.
+	var tagCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM task_tags WHERE user_id = 1`).Scan(&tagCount); err != nil {
+		t.Fatalf("count tags: %v", err)
+	}
+	if tagCount != 1 {
+		t.Errorf("tags = %d, want 1 (preserved for reuse)", tagCount)
+	}
+}
+
+func TestAddNoteAndDeleteNote(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Owner", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	note, err := AddNote(db, task.ID, 1, "First note")
+	if err != nil {
+		t.Fatalf("add note: %v", err)
+	}
+	if note.Content != "First note" {
+		t.Errorf("note content = %q", note.Content)
+	}
+
+	notes, err := ListNotes(db, task.ID, 1)
+	if err != nil {
+		t.Fatalf("list notes: %v", err)
+	}
+	if len(notes) != 1 || notes[0].Content != "First note" {
+		t.Errorf("list = %+v", notes)
+	}
+
+	if err := DeleteNote(db, task.ID, note.ID, 1); err != nil {
+		t.Fatalf("delete note: %v", err)
+	}
+
+	notes, err = ListNotes(db, task.ID, 1)
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	if len(notes) != 0 {
+		t.Errorf("expected empty notes after delete, got %v", notes)
+	}
+}
+
+func TestAddNote_TaskOwnedByOtherUser(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Theirs", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_, err = AddNote(db, task.ID, 2, "Sneaky")
+	if !errors.Is(err, ErrTaskNotFound) {
+		t.Errorf("expected ErrTaskNotFound, got %v", err)
+	}
+}
+
+func TestDeleteNote_WrongUser(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Owner", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	note, err := AddNote(db, task.ID, 1, "Mine")
+	if err != nil {
+		t.Fatalf("add note: %v", err)
+	}
+	if err := DeleteNote(db, task.ID, note.ID, 2); !errors.Is(err, ErrTaskNotFound) {
+		t.Errorf("expected ErrTaskNotFound, got %v", err)
+	}
+}
+
+func TestTagsReusedAcrossTasks(t *testing.T) {
+	db := setupTestDB(t)
+
+	t1, err := CreateTask(db, 1, "First", "", []string{"shared", "one"})
+	if err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	t2, err := CreateTask(db, 1, "Second", "", []string{"shared", "two"})
+	if err != nil {
+		t.Fatalf("create second: %v", err)
+	}
+
+	// Three distinct tag rows: "shared", "one", "two".
+	var tagCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM task_tags WHERE user_id = 1`).Scan(&tagCount); err != nil {
+		t.Fatalf("count tags: %v", err)
+	}
+	if tagCount != 3 {
+		t.Errorf("task_tags rows = %d, want 3", tagCount)
+	}
+
+	// Same tag_id must back the "shared" label on both tasks.
+	var sharedTagID1, sharedTagID2 int64
+	row := db.QueryRow(
+		`SELECT a.tag_id FROM task_tag_assignments a
+		 JOIN task_tags t ON t.id = a.tag_id
+		 WHERE a.task_id = ? AND t.user_id = 1
+		 ORDER BY a.tag_id`,
+		t1.ID,
+	)
+	if err := row.Scan(&sharedTagID1); err != nil {
+		t.Fatalf("scan tag id 1: %v", err)
+	}
+	row = db.QueryRow(
+		`SELECT a.tag_id FROM task_tag_assignments a
+		 JOIN task_tags t ON t.id = a.tag_id
+		 WHERE a.task_id = ? AND t.user_id = 1
+		 ORDER BY a.tag_id`,
+		t2.ID,
+	)
+	if err := row.Scan(&sharedTagID2); err != nil {
+		t.Fatalf("scan tag id 2: %v", err)
+	}
+	// Since the lowest-ID tag is "shared" (inserted first), both should match.
+	if sharedTagID1 != sharedTagID2 {
+		t.Errorf("expected shared tag to be reused (id1=%d id2=%d)", sharedTagID1, sharedTagID2)
+	}
+}
+
+func TestCrossUserIsolation(t *testing.T) {
+	db := setupTestDB(t)
+
+	a, err := CreateTask(db, 1, "Alice task", "", nil)
+	if err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	if _, err := CreateTask(db, 2, "Bob task", "", nil); err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+
+	bobList, err := ListTasks(db, 2, false)
+	if err != nil {
+		t.Fatalf("list bob: %v", err)
+	}
+	for _, task := range bobList {
+		if task.ID == a.ID {
+			t.Errorf("bob should not see alice's task %d", a.ID)
+		}
+	}
+
+	if err := DeleteTask(db, a.ID, 2); !errors.Is(err, ErrTaskNotFound) {
+		t.Errorf("bob deleting alice's task: expected ErrTaskNotFound, got %v", err)
+	}
+}
+
+func TestEncryptionRoundTrip_RawDBIsCiphertext(t *testing.T) {
+	db := setupTestDB(t)
+
+	task, err := CreateTask(db, 1, "Sensitive title", "Sensitive body", []string{"private"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := AddNote(db, task.ID, 1, "Confidential"); err != nil {
+		t.Fatalf("add note: %v", err)
+	}
+
+	var rawTitle, rawBody string
+	if err := db.QueryRow(`SELECT title_enc, body_enc FROM tasks WHERE id = ?`, task.ID).Scan(&rawTitle, &rawBody); err != nil {
+		t.Fatalf("raw select tasks: %v", err)
+	}
+	if !strings.HasPrefix(rawTitle, "enc:") || strings.Contains(rawTitle, "Sensitive title") {
+		t.Errorf("title_enc should be ciphertext, got %q", rawTitle)
+	}
+	if !strings.HasPrefix(rawBody, "enc:") || strings.Contains(rawBody, "Sensitive body") {
+		t.Errorf("body_enc should be ciphertext, got %q", rawBody)
+	}
+
+	var rawLabel string
+	if err := db.QueryRow(`SELECT label_enc FROM task_tags WHERE user_id = 1`).Scan(&rawLabel); err != nil {
+		t.Fatalf("raw select tag: %v", err)
+	}
+	if !strings.HasPrefix(rawLabel, "enc:") || strings.Contains(rawLabel, "private") {
+		t.Errorf("label_enc should be ciphertext, got %q", rawLabel)
+	}
+
+	var rawNote string
+	if err := db.QueryRow(`SELECT content_enc FROM task_notes WHERE task_id = ?`, task.ID).Scan(&rawNote); err != nil {
+		t.Fatalf("raw select note: %v", err)
+	}
+	if !strings.HasPrefix(rawNote, "enc:") || strings.Contains(rawNote, "Confidential") {
+		t.Errorf("content_enc should be ciphertext, got %q", rawNote)
+	}
+
+	// GetTask must return plaintext.
+	got, err := GetTask(db, task.ID, 1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "Sensitive title" || got.Body != "Sensitive body" {
+		t.Errorf("decrypted task mismatch: %+v", got)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "private" {
+		t.Errorf("decrypted tags: %v", got.Tags)
+	}
+	notes, err := ListNotes(db, task.ID, 1)
+	if err != nil {
+		t.Fatalf("list notes: %v", err)
+	}
+	if len(notes) != 1 || notes[0].Content != "Confidential" {
+		t.Errorf("decrypted note: %+v", notes)
+	}
+}

--- a/internal/tasks/models_test.go
+++ b/internal/tasks/models_test.go
@@ -6,73 +6,33 @@ import (
 	"strings"
 	"testing"
 
+	hyttedb "github.com/Robin831/Hytte/internal/db"
 	"github.com/Robin831/Hytte/internal/encryption"
-	_ "modernc.org/sqlite"
 )
 
-const schemaSQL = `
-CREATE TABLE users (
-	id         INTEGER PRIMARY KEY,
-	email      TEXT UNIQUE NOT NULL,
-	name       TEXT NOT NULL,
-	picture    TEXT NOT NULL DEFAULT '',
-	google_id  TEXT UNIQUE NOT NULL,
-	created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-	is_admin   INTEGER NOT NULL DEFAULT 0
-);
-CREATE TABLE tasks (
-	id            INTEGER PRIMARY KEY AUTOINCREMENT,
-	user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-	title_enc     TEXT NOT NULL,
-	body_enc      TEXT NOT NULL DEFAULT '',
-	archived      INTEGER NOT NULL DEFAULT 0,
-	created_at    TIMESTAMP NOT NULL,
-	updated_at    TIMESTAMP NOT NULL,
-	archived_at   TIMESTAMP
-);
-CREATE INDEX idx_tasks_user_archived ON tasks(user_id, archived);
-CREATE TABLE task_tags (
-	id         INTEGER PRIMARY KEY AUTOINCREMENT,
-	user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-	label_enc  TEXT NOT NULL,
-	UNIQUE(user_id, label_enc)
-);
-CREATE TABLE task_tag_assignments (
-	task_id  INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-	tag_id   INTEGER NOT NULL REFERENCES task_tags(id) ON DELETE CASCADE,
-	PRIMARY KEY (task_id, tag_id)
-);
-CREATE TABLE task_notes (
-	id          INTEGER PRIMARY KEY AUTOINCREMENT,
-	task_id     INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-	content_enc TEXT NOT NULL,
-	created_at  TIMESTAMP NOT NULL
-);
-CREATE INDEX idx_task_notes_task ON task_notes(task_id, created_at);
-`
-
+// setupTestDB creates an in-memory database that uses the real createSchema()
+// (via db.Init) so the test schema cannot drift from production. The connection
+// pool is pinned to a single connection because each new connection opened
+// against a `:memory:` DSN gets its own private database, which causes flaky
+// "no such table" errors.
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	t.Setenv("ENCRYPTION_KEY", "test-key-for-tasks-tests")
 	encryption.ResetEncryptionKey()
 	t.Cleanup(func() { encryption.ResetEncryptionKey() })
 
-	db, err := sql.Open("sqlite", ":memory:")
+	d, err := hyttedb.Init(":memory:")
 	if err != nil {
-		t.Fatalf("open db: %v", err)
+		t.Fatalf("init db: %v", err)
 	}
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		t.Fatalf("enable fk: %v", err)
-	}
-	if _, err := db.Exec(schemaSQL); err != nil {
-		t.Fatalf("create schema: %v", err)
-	}
-	t.Cleanup(func() { db.Close() })
+	d.SetMaxOpenConns(1)
+	d.SetMaxIdleConns(1)
+	t.Cleanup(func() { d.Close() })
 
-	if _, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'a@example.com', 'Alice', 'g1'), (2, 'b@example.com', 'Bob', 'g2')`); err != nil {
+	if _, err := d.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (1, 'a@example.com', 'Alice', 'g1'), (2, 'b@example.com', 'Bob', 'g2')`); err != nil {
 		t.Fatalf("insert users: %v", err)
 	}
-	return db
+	return d
 }
 
 func TestCreateAndGetTask(t *testing.T) {


### PR DESCRIPTION
## Changes

- **Tasks backend foundation** - Added schema (`tasks`, `task_tags`, `task_tag_assignments`, `task_notes`), the `tasks` feature flag (default off), and `/api/tasks` REST endpoints (list/create/patch/delete plus per-task notes) gated by `RequireFeature("tasks")`. Title, body, tag labels and note content are encrypted at rest. (Hytte-u49p)

## Original Issue (feature): Tasks: schema + backend handlers + feature flag

Part of the Task list chain seeded from Suggestions id=141 (step 1/2: Backend foundation). See that suggestion's plan for the full design.

Backend foundation for the Tasks page. See Suggestions id=141 in the Suggestions page for the full plan; this slice is the schema + handlers + feature flag (no frontend).

## Scope

### Schema (internal/db/db.go createSchema)

    CREATE TABLE IF NOT EXISTS tasks (
      id            INTEGER PRIMARY KEY AUTOINCREMENT,
      user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
      title_enc     TEXT NOT NULL,
      body_enc      TEXT NOT NULL DEFAULT '',
      archived      INTEGER NOT NULL DEFAULT 0,
      created_at    TIMESTAMP NOT NULL,
      updated_at    TIMESTAMP NOT NULL,
      archived_at   TIMESTAMP
    );
    CREATE INDEX IF NOT EXISTS idx_tasks_user_archived ON tasks(user_id, archived);

    CREATE TABLE IF NOT EXISTS task_tags (
      id         INTEGER PRIMARY KEY AUTOINCREMENT,
      user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
      label_enc  TEXT NOT NULL,        -- encrypted (so custom tag names stay private)
      UNIQUE(user_id, label_enc)
    );

    CREATE TABLE IF NOT EXISTS task_tag_assignments (
      task_id  INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
      tag_id   INTEGER NOT NULL REFERENCES task_tags(id) ON DELETE CASCADE,
      PRIMARY KEY (task_id, tag_id)
    );

    CREATE TABLE IF NOT EXISTS task_notes (
      id          INTEGER PRIMARY KEY AUTOINCREMENT,
      task_id     INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
      content_enc TEXT NOT NULL,
      created_at  TIMESTAMP NOT NULL
    );
    CREATE INDEX IF NOT EXISTS idx_task_notes_task ON task_notes(task_id, created_at);

### Feature flag

Add `"tasks": false` to `FeatureDefaults` in `internal/auth/features.go:11`.

### Package internal/tasks/

- `models.go`: Task, TaskTag, TaskNote structs + DB helpers using `encryption.EncryptField` / `DecryptField` for title/body/tag label/note content. Mirror the pattern in `internal/notes/`.
- `handlers.go`:
    - GET /api/tasks?archived=<bool> → list user's tasks with tags and note counts.
    - POST /api/tasks → body { title, body?, tags? } → create.
    - PATCH /api/tasks/{id} → body { title?, body?, tags?, archived? } → update.
    - DELETE /api/tasks/{id} → delete cascade.
    - POST /api/tasks/{id}/notes → body { content } → add a note.
    - DELETE /api/tasks/{id}/notes/{note_id} → remove note.
- All endpoints gated by `auth.RequireFeature(db, "tasks")` and `RequireAuth`.

### Tests

- `handlers_test.go` with `:memory:` SQLite. Cover: create, list (active vs archived), update, archive/unarchive, notes CRUD, tag reuse across tasks, cross-user isolation (user A cannot see/mutate user B's tasks).
- Round-trip encryption: SELECT directly against the DB shows ciphertext, GetTask returns plaintext.

### Wiring

Register routes in `internal/api/router.go` inside the existing `RequireAuth` group, wrapped in `RequireFeature(db, "tasks")`.

### Acceptance

- `make build`, `make test`, `go vet ./...` pass.
- Hitting any /api/tasks endpoint without the feature flag returns 403.
- Hitting with the flag works as specified above.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-u49p | Branch: forge/Hytte-u49p
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->