### PR TITLE
Tasks: frontend page + routing + sidebar + i18n (Hytte-kq6d)

### DIFF
--- a/changelog.d/Hytte-kq6d.md
+++ b/changelog.d/Hytte-kq6d.md
@@ -1,0 +1,2 @@
+category: Added
+- **Tasks page (frontend)** - Added a new Tasks page where users with the `tasks` feature flag can capture quick to-dos with built-in `work`/`personal` chips or free-text tags, expand a card to edit the body and attach chronological notes, archive/unarchive tasks, and filter the list by tag. Routed at `/tasks` with a `ListTodo` sidebar entry, full i18n in en/nb/th, and a small `GET /api/tasks/{id}/notes` backend endpoint to power the notes list. (Hytte-kq6d)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -406,6 +406,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/tasks", tasks.CreateHandler(db))
 				r.Patch("/tasks/{id}", tasks.UpdateHandler(db))
 				r.Delete("/tasks/{id}", tasks.DeleteHandler(db))
+				r.Get("/tasks/{id}/notes", tasks.ListNotesHandler(db))
 				r.Post("/tasks/{id}/notes", tasks.AddNoteHandler(db))
 				r.Delete("/tasks/{id}/notes/{note_id}", tasks.DeleteNoteHandler(db))
 			})

--- a/internal/tasks/handlers.go
+++ b/internal/tasks/handlers.go
@@ -175,6 +175,31 @@ func DeleteHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
+// ListNotesHandler returns every note attached to a task in chronological order.
+func ListNotesHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		taskID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid task ID"})
+			return
+		}
+
+		notes, err := ListNotes(db, taskID, user.ID)
+		if err != nil {
+			if errors.Is(err, ErrTaskNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+				return
+			}
+			log.Printf("tasks: list notes failed: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list notes"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"notes": notes})
+	}
+}
+
 // AddNoteHandler appends a note to a task.
 func AddNoteHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/tasks/handlers_test.go
+++ b/internal/tasks/handlers_test.go
@@ -220,6 +220,56 @@ func TestDeleteHandler_NotFoundForOtherUser(t *testing.T) {
 	}
 }
 
+func TestListNotesHandler_ReturnsChronological(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Owner", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := AddNote(db, task.ID, 1, "first"); err != nil {
+		t.Fatalf("add note: %v", err)
+	}
+	if _, err := AddNote(db, task.ID, 1, "second"); err != nil {
+		t.Fatalf("add note: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("GET", "/api/tasks/"+idStr+"/notes", nil), 1)
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	ListNotesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Notes []TaskNote `json:"notes"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Notes) != 2 {
+		t.Fatalf("expected 2 notes, got %d", len(body.Notes))
+	}
+	if body.Notes[0].Content != "first" || body.Notes[1].Content != "second" {
+		t.Errorf("unexpected ordering: %+v", body.Notes)
+	}
+}
+
+func TestListNotesHandler_TaskOwnedByAnotherUser(t *testing.T) {
+	db := setupTestDB(t)
+	task, err := CreateTask(db, 1, "Owner", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	idStr := strconv.FormatInt(task.ID, 10)
+	req := withUser(httptest.NewRequest("GET", "/api/tasks/"+idStr+"/notes", nil), 2)
+	req = withChiParams(req, map[string]string{"id": idStr})
+	rec := httptest.NewRecorder()
+	ListNotesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
 func TestAddNoteHandler_Success(t *testing.T) {
 	db := setupTestDB(t)
 	task, err := CreateTask(db, 1, "Owner", "", nil)

--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -8,6 +8,7 @@
     "calendar": "Calendar",
     "webhooks": "Webhooks",
     "notes": "Notes",
+    "tasks": "Tasks",
     "chat": "Chat",
     "training": "Training",
     "lactate": "Lactate",

--- a/web/public/locales/en/tasks.json
+++ b/web/public/locales/en/tasks.json
@@ -1,0 +1,53 @@
+{
+  "pageTitle": "Tasks",
+  "inputPlaceholder": "What needs doing?",
+  "addTask": "Add task",
+  "tags": {
+    "label": "Tags",
+    "work": "work",
+    "personal": "personal",
+    "addCustom": "Add tag",
+    "customPlaceholder": "Add a tag…"
+  },
+  "filter": {
+    "label": "Filter by tag",
+    "clearLabel": "Clear tag filter"
+  },
+  "showArchived": "Show archived",
+  "archivedLabel": "Archived",
+  "archive": "Archive",
+  "unarchive": "Unarchive",
+  "delete": "Delete",
+  "expand": "Expand task",
+  "collapse": "Collapse task",
+  "body": {
+    "label": "Details",
+    "placeholder": "Add more detail…"
+  },
+  "notes": {
+    "heading": "Notes",
+    "badge_one": "+{{count}} note",
+    "badge_other": "+{{count}} notes",
+    "composerPlaceholder": "Add a note…",
+    "add": "Add note",
+    "delete": "Delete note",
+    "empty": "No notes yet."
+  },
+  "empty": {
+    "active": "No tasks yet. Add one above to get started.",
+    "archived": "Nothing archived yet.",
+    "filtered": "No tasks match the selected tag."
+  },
+  "time": {
+    "created": "Created {{relative}}",
+    "updated": "Updated {{relative}}",
+    "justNow": "just now"
+  },
+  "errors": {
+    "failedToLoad": "Failed to load tasks",
+    "failedToCreate": "Failed to create task",
+    "failedToUpdate": "Failed to update task",
+    "failedToAddNote": "Failed to add note",
+    "failedToLoadNotes": "Failed to load notes"
+  }
+}

--- a/web/public/locales/en/tasks.json
+++ b/web/public/locales/en/tasks.json
@@ -7,7 +7,8 @@
     "work": "work",
     "personal": "personal",
     "addCustom": "Add tag",
-    "customPlaceholder": "Add a tag…"
+    "customPlaceholder": "Add a tag…",
+    "removeTag": "Remove tag {{tag}}"
   },
   "filter": {
     "label": "Filter by tag",

--- a/web/public/locales/nb/common.json
+++ b/web/public/locales/nb/common.json
@@ -8,6 +8,7 @@
     "calendar": "Kalender",
     "webhooks": "Webhooks",
     "notes": "Notater",
+    "tasks": "Oppgaver",
     "chat": "Chat",
     "training": "Trening",
     "lactate": "Laktat",

--- a/web/public/locales/nb/tasks.json
+++ b/web/public/locales/nb/tasks.json
@@ -7,7 +7,8 @@
     "work": "jobb",
     "personal": "personlig",
     "addCustom": "Legg til etikett",
-    "customPlaceholder": "Legg til en etikett…"
+    "customPlaceholder": "Legg til en etikett…",
+    "removeTag": "Fjern etikett {{tag}}"
   },
   "filter": {
     "label": "Filtrer etter etikett",

--- a/web/public/locales/nb/tasks.json
+++ b/web/public/locales/nb/tasks.json
@@ -1,0 +1,53 @@
+{
+  "pageTitle": "Oppgaver",
+  "inputPlaceholder": "Hva må gjøres?",
+  "addTask": "Legg til oppgave",
+  "tags": {
+    "label": "Etiketter",
+    "work": "jobb",
+    "personal": "personlig",
+    "addCustom": "Legg til etikett",
+    "customPlaceholder": "Legg til en etikett…"
+  },
+  "filter": {
+    "label": "Filtrer etter etikett",
+    "clearLabel": "Fjern etikettfilter"
+  },
+  "showArchived": "Vis arkiverte",
+  "archivedLabel": "Arkivert",
+  "archive": "Arkiver",
+  "unarchive": "Gjenopprett",
+  "delete": "Slett",
+  "expand": "Utvid oppgave",
+  "collapse": "Lukk oppgave",
+  "body": {
+    "label": "Detaljer",
+    "placeholder": "Legg til flere detaljer…"
+  },
+  "notes": {
+    "heading": "Notater",
+    "badge_one": "+{{count}} notat",
+    "badge_other": "+{{count}} notater",
+    "composerPlaceholder": "Legg til et notat…",
+    "add": "Legg til notat",
+    "delete": "Slett notat",
+    "empty": "Ingen notater enda."
+  },
+  "empty": {
+    "active": "Ingen oppgaver enda. Legg til en over for å komme i gang.",
+    "archived": "Ingenting arkivert enda.",
+    "filtered": "Ingen oppgaver matcher den valgte etiketten."
+  },
+  "time": {
+    "created": "Opprettet {{relative}}",
+    "updated": "Oppdatert {{relative}}",
+    "justNow": "akkurat nå"
+  },
+  "errors": {
+    "failedToLoad": "Kunne ikke laste oppgaver",
+    "failedToCreate": "Kunne ikke opprette oppgave",
+    "failedToUpdate": "Kunne ikke oppdatere oppgave",
+    "failedToAddNote": "Kunne ikke legge til notat",
+    "failedToLoadNotes": "Kunne ikke laste notater"
+  }
+}

--- a/web/public/locales/th/common.json
+++ b/web/public/locales/th/common.json
@@ -8,6 +8,7 @@
     "calendar": "ปฏิทิน",
     "webhooks": "เว็บฮุค",
     "notes": "บันทึก",
+    "tasks": "งาน",
     "chat": "แชท",
     "training": "การฝึกซ้อม",
     "lactate": "แลคเตท",

--- a/web/public/locales/th/tasks.json
+++ b/web/public/locales/th/tasks.json
@@ -7,7 +7,8 @@
     "work": "งาน",
     "personal": "ส่วนตัว",
     "addCustom": "เพิ่มแท็ก",
-    "customPlaceholder": "เพิ่มแท็ก…"
+    "customPlaceholder": "เพิ่มแท็ก…",
+    "removeTag": "ลบแท็ก {{tag}}"
   },
   "filter": {
     "label": "กรองตามแท็ก",

--- a/web/public/locales/th/tasks.json
+++ b/web/public/locales/th/tasks.json
@@ -1,0 +1,53 @@
+{
+  "pageTitle": "งาน",
+  "inputPlaceholder": "ต้องทำอะไรบ้าง?",
+  "addTask": "เพิ่มงาน",
+  "tags": {
+    "label": "แท็ก",
+    "work": "งาน",
+    "personal": "ส่วนตัว",
+    "addCustom": "เพิ่มแท็ก",
+    "customPlaceholder": "เพิ่มแท็ก…"
+  },
+  "filter": {
+    "label": "กรองตามแท็ก",
+    "clearLabel": "ล้างตัวกรองแท็ก"
+  },
+  "showArchived": "แสดงที่เก็บถาวร",
+  "archivedLabel": "เก็บถาวรแล้ว",
+  "archive": "เก็บถาวร",
+  "unarchive": "ยกเลิกเก็บถาวร",
+  "delete": "ลบ",
+  "expand": "ขยายงาน",
+  "collapse": "ย่องาน",
+  "body": {
+    "label": "รายละเอียด",
+    "placeholder": "เพิ่มรายละเอียด…"
+  },
+  "notes": {
+    "heading": "บันทึก",
+    "badge_one": "+{{count}} บันทึก",
+    "badge_other": "+{{count}} บันทึก",
+    "composerPlaceholder": "เพิ่มบันทึก…",
+    "add": "เพิ่มบันทึก",
+    "delete": "ลบบันทึก",
+    "empty": "ยังไม่มีบันทึก"
+  },
+  "empty": {
+    "active": "ยังไม่มีงาน เพิ่มงานด้านบนเพื่อเริ่มต้น",
+    "archived": "ยังไม่มีงานที่เก็บถาวร",
+    "filtered": "ไม่มีงานที่ตรงกับแท็กที่เลือก"
+  },
+  "time": {
+    "created": "สร้างเมื่อ {{relative}}",
+    "updated": "อัปเดตเมื่อ {{relative}}",
+    "justNow": "เมื่อสักครู่"
+  },
+  "errors": {
+    "failedToLoad": "ไม่สามารถโหลดงาน",
+    "failedToCreate": "ไม่สามารถสร้างงาน",
+    "failedToUpdate": "ไม่สามารถอัปเดตงาน",
+    "failedToAddNote": "ไม่สามารถเพิ่มบันทึก",
+    "failedToLoadNotes": "ไม่สามารถโหลดบันทึก"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import Weather from './pages/Weather'
 import CalendarPage from './pages/CalendarPage'
 import Webhooks from './pages/Webhooks'
 import Notes from './pages/Notes'
+import Tasks from './pages/Tasks'
 import Links from './pages/Links'
 import LactateTests from './pages/LactateTests'
 import LactateNewTest from './pages/LactateNewTest'
@@ -109,6 +110,14 @@ function MainLayout() {
             element={
               <FeatureRoute feature="notes">
                 <Notes />
+              </FeatureRoute>
+            }
+          />
+          <Route
+            path="/tasks"
+            element={
+              <FeatureRoute feature="tasks">
+                <Tasks />
               </FeatureRoute>
             }
           />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -35,6 +35,7 @@ import {
   ShoppingCart,
   BookOpen,
   ClipboardList,
+  ListTodo,
   Calculator,
   Lightbulb,
 } from 'lucide-react'
@@ -63,6 +64,7 @@ const navItems: NavItem[] = [
   { to: '/calendar', icon: <Calendar size={20} />, label: 'nav.calendar', requiresAuth: true, feature: 'calendar' },
   { to: '/webhooks', icon: <Webhook size={20} />, label: 'nav.webhooks', requiresAuth: true, feature: 'webhooks' },
   { to: '/notes', icon: <FileText size={20} />, label: 'nav.notes', requiresAuth: true, feature: 'notes' },
+  { to: '/tasks', icon: <ListTodo size={20} />, label: 'nav.tasks', requiresAuth: true, feature: 'tasks' },
   { to: '/vault', icon: <Lock size={20} />, label: 'nav.vault', requiresAuth: true, feature: 'vault' },
   { to: '/chat', icon: <MessageSquare size={20} />, label: 'nav.chat', requiresAuth: true, feature: 'chat' },
   { to: '/training', icon: <Dumbbell size={20} />, label: 'nav.training', requiresAuth: true, feature: 'training' },

--- a/web/src/i18next.d.ts
+++ b/web/src/i18next.d.ts
@@ -6,6 +6,7 @@ import type infraEn from '../public/locales/en/infra.json'
 import type kioskEn from '../public/locales/en/kiosk.json'
 import type lactateEn from '../public/locales/en/lactate.json'
 import type notesEn from '../public/locales/en/notes.json'
+import type tasksEn from '../public/locales/en/tasks.json'
 import type settingsEn from '../public/locales/en/settings.json'
 import type trainingEn from '../public/locales/en/training.json'
 import type transitEn from '../public/locales/en/transit.json'
@@ -37,6 +38,7 @@ declare module 'i18next' {
       kiosk: typeof kioskEn
       lactate: typeof lactateEn
       notes: typeof notesEn
+      tasks: typeof tasksEn
       settings: typeof settingsEn
       training: typeof trainingEn
       transit: typeof transitEn

--- a/web/src/pages/Tasks.test.tsx
+++ b/web/src/pages/Tasks.test.tsx
@@ -1,0 +1,297 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Tasks from './Tasks'
+
+const TRANSLATIONS: Record<string, string> = {
+  'pageTitle': 'Tasks',
+  'inputPlaceholder': 'What needs doing?',
+  'addTask': 'Add task',
+  'tags.label': 'Tags',
+  'tags.work': 'work',
+  'tags.personal': 'personal',
+  'tags.addCustom': 'Add tag',
+  'tags.customPlaceholder': 'Add a tag…',
+  'filter.label': 'Filter by tag',
+  'filter.clearLabel': 'Clear tag filter',
+  'showArchived': 'Show archived',
+  'archivedLabel': 'Archived',
+  'archive': 'Archive',
+  'unarchive': 'Unarchive',
+  'delete': 'Delete',
+  'expand': 'Expand task',
+  'collapse': 'Collapse task',
+  'body.label': 'Details',
+  'body.placeholder': 'Add more detail…',
+  'notes.heading': 'Notes',
+  'notes.composerPlaceholder': 'Add a note…',
+  'notes.add': 'Add note',
+  'notes.delete': 'Delete note',
+  'notes.empty': 'No notes yet.',
+  'empty.active': 'No tasks yet. Add one above to get started.',
+  'empty.archived': 'Nothing archived yet.',
+  'empty.filtered': 'No tasks match the selected tag.',
+  'time.justNow': 'just now',
+  'errors.failedToLoad': 'Failed to load tasks',
+  'errors.failedToCreate': 'Failed to create task',
+  'errors.failedToUpdate': 'Failed to update task',
+  'errors.failedToAddNote': 'Failed to add note',
+  'errors.failedToLoadNotes': 'Failed to load notes',
+}
+
+function mockT(key: string, opts?: Record<string, string | number>): string {
+  if (key === 'notes.badge') return `+${opts?.count ?? 0} notes`
+  if (key === 'time.created') return `Created ${opts?.relative ?? ''}`
+  if (key === 'time.updated') return `Updated ${opts?.relative ?? ''}`
+  return TRANSLATIONS[key] ?? key
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockT,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+function makeTask(overrides: Partial<{
+  id: number
+  title: string
+  body: string
+  tags: string[]
+  archived: boolean
+  note_count: number
+  created_at: string
+  updated_at: string
+}> = {}) {
+  const now = '2026-05-14T10:00:00Z'
+  return {
+    id: 1,
+    user_id: 1,
+    title: 'Test task',
+    body: '',
+    archived: false,
+    created_at: now,
+    updated_at: now,
+    tags: [] as string[],
+    note_count: 0,
+    ...overrides,
+  }
+}
+
+type TaskShape = ReturnType<typeof makeTask>
+
+function tasksResponse(tasks: TaskShape[]) {
+  return { ok: true, json: () => Promise.resolve({ tasks }) }
+}
+
+function notesResponse(notes: Array<{ id: number; task_id: number; content: string; created_at: string }>) {
+  return { ok: true, json: () => Promise.resolve({ notes }) }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <Tasks />
+    </MemoryRouter>,
+  )
+}
+
+describe('Tasks – initial load', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('shows empty state when no tasks', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(tasksResponse([]))))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('No tasks yet. Add one above to get started.')).toBeInTheDocument()
+    })
+  })
+
+  it('renders tasks returned by the API', async () => {
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve(tasksResponse([makeTask({ title: 'Buy bread' })])),
+    ))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Buy bread')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('Tasks – create flow', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('creates a task and prepends it to the list', async () => {
+    const created = makeTask({ id: 2, title: 'New task', tags: ['work'] })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(tasksResponse([]))
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ task: created }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('No tasks yet. Add one above to get started.')).toBeInTheDocument())
+
+    const input = screen.getByPlaceholderText('What needs doing?')
+    fireEvent.change(input, { target: { value: 'New task' } })
+
+    // Tap the built-in "work" chip so the POST body contains it.
+    fireEvent.click(screen.getByRole('button', { name: 'work' }))
+
+    fireEvent.click(screen.getByLabelText('Add task'))
+
+    await waitFor(() => {
+      expect(screen.getByText('New task')).toBeInTheDocument()
+    })
+
+    const postCall = fetchMock.mock.calls.find(call => call[0] === '/api/tasks' && call[1]?.method === 'POST')
+    expect(postCall).toBeDefined()
+    expect(JSON.parse(postCall![1].body as string)).toEqual({ title: 'New task', tags: ['work'] })
+  })
+
+  it('attaches a custom tag entered with Enter', async () => {
+    const created = makeTask({ id: 3, title: 'Plant trees', tags: ['garden'] })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(tasksResponse([]))
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ task: created }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByPlaceholderText('What needs doing?')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByPlaceholderText('What needs doing?'), { target: { value: 'Plant trees' } })
+
+    const customTagInput = screen.getByPlaceholderText('Add a tag…')
+    fireEvent.change(customTagInput, { target: { value: 'garden' } })
+    fireEvent.keyDown(customTagInput, { key: 'Enter', code: 'Enter' })
+
+    fireEvent.click(screen.getByLabelText('Add task'))
+
+    await waitFor(() => {
+      const postCall = fetchMock.mock.calls.find(call => call[0] === '/api/tasks' && call[1]?.method === 'POST')
+      expect(postCall).toBeDefined()
+      expect(JSON.parse(postCall![1].body as string).tags).toEqual(['garden'])
+    })
+  })
+})
+
+describe('Tasks – tag filter', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('filters the visible list when a tag chip is clicked', async () => {
+    const taskA = makeTask({ id: 1, title: 'Email Alice', tags: ['work'] })
+    const taskB = makeTask({ id: 2, title: 'Walk the dog', tags: ['personal'] })
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(tasksResponse([taskA, taskB]))))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Email Alice')).toBeInTheDocument())
+    expect(screen.getByText('Walk the dog')).toBeInTheDocument()
+
+    // Click the filter chip group's "work" — there are multiple "work" buttons
+    // (composer toggle + filter chip). Find the filter group specifically.
+    const filterGroup = screen.getByRole('group', { name: 'Filter by tag' })
+    fireEvent.click(within(filterGroup).getByRole('button', { name: 'work' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Walk the dog')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Email Alice')).toBeInTheDocument()
+  })
+})
+
+describe('Tasks – archive toggle', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('archives a task via PATCH and dims/removes the card', async () => {
+    const task = makeTask({ id: 7, title: 'Renew passport' })
+    const archived = { ...task, archived: true, archived_at: '2026-05-14T11:00:00Z' }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(tasksResponse([task]))   // initial load (archived=false)
+      .mockResolvedValueOnce(notesResponse([]))       // notes lookup on expand
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ task: archived }) }) // PATCH
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Renew passport')).toBeInTheDocument())
+
+    // Expand
+    fireEvent.click(screen.getByRole('button', { name: 'Expand task' }))
+    await waitFor(() => expect(screen.getByText('No notes yet.')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /Archive/ }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Renew passport')).not.toBeInTheDocument()
+    })
+
+    const patchCall = fetchMock.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].startsWith('/api/tasks/7') && call[1]?.method === 'PATCH',
+    )
+    expect(patchCall).toBeDefined()
+    expect(JSON.parse(patchCall![1].body as string)).toEqual({ archived: true })
+  })
+
+  it('renders an archived task with dim style when Show archived is on', async () => {
+    const archived = makeTask({ id: 9, title: 'Old task', archived: true })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(tasksResponse([]))           // initial active list
+      .mockResolvedValueOnce(tasksResponse([archived]))   // after toggle
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('No tasks yet. Add one above to get started.')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText('Show archived'))
+
+    await waitFor(() => expect(screen.getByText('Old task')).toBeInTheDocument())
+    const card = screen.getByTestId('task-card-9')
+    expect(card.className).toMatch(/opacity-60/)
+  })
+})
+
+describe('Tasks – add note', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('adds a note to an expanded task', async () => {
+    const task = makeTask({ id: 5, title: 'Pack for trip' })
+    const newNote = { id: 100, task_id: 5, content: 'Charger', created_at: '2026-05-14T12:00:00Z' }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(tasksResponse([task]))   // initial load
+      .mockResolvedValueOnce(notesResponse([]))       // notes list (empty)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ note: newNote }) }) // POST note
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pack for trip')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand task' }))
+    await waitFor(() => expect(screen.getByText('No notes yet.')).toBeInTheDocument())
+
+    const composer = screen.getByPlaceholderText('Add a note…')
+    fireEvent.change(composer, { target: { value: 'Charger' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Charger')).toBeInTheDocument()
+    })
+
+    const postCall = fetchMock.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0] === '/api/tasks/5/notes' && call[1]?.method === 'POST',
+    )
+    expect(postCall).toBeDefined()
+    expect(JSON.parse(postCall![1].body as string)).toEqual({ content: 'Charger' })
+  })
+})
+
+describe('Tasks – failure paths', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('shows an alert when the initial load fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false })))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to load tasks')
+    })
+  })
+})

--- a/web/src/pages/Tasks.test.tsx
+++ b/web/src/pages/Tasks.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Tasks from './Tasks'

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -192,7 +192,7 @@ export default function Tasks() {
       })
       if (!res.ok) throw new Error(t('errors.failedToUpdate'))
       const data: { task: Task } = await res.json()
-      setTasks(prev => prev.map(t => t.id === data.task.id ? data.task : t))
+      setTasks(prev => prev.map(existing => existing.id === data.task.id ? data.task : existing))
     } catch (err) {
       setError(err instanceof Error ? err.message : t('errors.failedToUpdate'))
     }
@@ -212,9 +212,9 @@ export default function Tasks() {
       // Remove from view if it no longer matches the showArchived filter.
       setTasks(prev => {
         if (data.task.archived === showArchived) {
-          return prev.map(t => t.id === data.task.id ? data.task : t)
+          return prev.map(existing => existing.id === data.task.id ? data.task : existing)
         }
-        return prev.filter(t => t.id !== data.task.id)
+        return prev.filter(existing => existing.id !== data.task.id)
       })
       if (data.task.archived !== showArchived) {
         setExpandedId(prev => prev === data.task.id ? null : prev)
@@ -241,8 +241,8 @@ export default function Tasks() {
         [task.id]: [...(prev[task.id] ?? []), data.note],
       }))
       setNoteDrafts(prev => ({ ...prev, [task.id]: '' }))
-      setTasks(prev => prev.map(t =>
-        t.id === task.id ? { ...t, note_count: t.note_count + 1 } : t,
+      setTasks(prev => prev.map(existing =>
+        existing.id === task.id ? { ...existing, note_count: existing.note_count + 1 } : existing,
       ))
     } catch (err) {
       setError(err instanceof Error ? err.message : t('errors.failedToAddNote'))
@@ -310,10 +310,10 @@ export default function Tasks() {
                     : 'bg-gray-800 text-gray-400 hover:text-white'
                 }`}
               >
-                {t(`tags.${tag}` as never)}
+                {tag === 'work' ? t('tags.work') : t('tags.personal')}
               </button>
             ))}
-            {selectedTags.filter(tag => !BUILT_IN_TAGS.includes(tag as typeof BUILT_IN_TAGS[number])).map(tag => (
+            {selectedTags.filter(tag => !(BUILT_IN_TAGS as readonly string[]).includes(tag)).map(tag => (
               <span
                 key={tag}
                 className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-blue-600 text-white"

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -1,0 +1,526 @@
+import { useState, useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Plus,
+  X,
+  ChevronDown,
+  ChevronUp,
+  Archive,
+  ArchiveRestore,
+} from 'lucide-react'
+
+interface Task {
+  id: number
+  user_id: number
+  title: string
+  body: string
+  archived: boolean
+  created_at: string
+  updated_at: string
+  archived_at?: string | null
+  tags: string[]
+  note_count: number
+}
+
+interface TaskNote {
+  id: number
+  task_id: number
+  content: string
+  created_at: string
+}
+
+const BUILT_IN_TAGS = ['work', 'personal'] as const
+
+function formatRelative(iso: string, language: string, justNow: string): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const now = Date.now()
+  const diffSec = Math.round((then - now) / 1000)
+  const abs = Math.abs(diffSec)
+  const rtf = new Intl.RelativeTimeFormat(language, { numeric: 'auto' })
+  if (abs < 30) return justNow
+  if (abs < 60) return rtf.format(diffSec, 'second')
+  if (abs < 60 * 60) return rtf.format(Math.round(diffSec / 60), 'minute')
+  if (abs < 60 * 60 * 24) return rtf.format(Math.round(diffSec / 3600), 'hour')
+  if (abs < 60 * 60 * 24 * 7) return rtf.format(Math.round(diffSec / 86400), 'day')
+  if (abs < 60 * 60 * 24 * 30) return rtf.format(Math.round(diffSec / (86400 * 7)), 'week')
+  if (abs < 60 * 60 * 24 * 365) return rtf.format(Math.round(diffSec / (86400 * 30)), 'month')
+  return rtf.format(Math.round(diffSec / (86400 * 365)), 'year')
+}
+
+function formatAbsolute(iso: string, language: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat(language, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(d)
+}
+
+export default function Tasks() {
+  const { t, i18n } = useTranslation('tasks')
+
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [showArchived, setShowArchived] = useState(false)
+  const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null)
+  const [expandedId, setExpandedId] = useState<number | null>(null)
+
+  // Composer state
+  const [newTaskTitle, setNewTaskTitle] = useState('')
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [customTagInput, setCustomTagInput] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  // Expanded-card cache: task ID -> notes loaded from API.
+  const [notesById, setNotesById] = useState<Record<number, TaskNote[]>>({})
+  const [notesLoadingId, setNotesLoadingId] = useState<number | null>(null)
+  const [noteDrafts, setNoteDrafts] = useState<Record<number, string>>({})
+  const [bodyDrafts, setBodyDrafts] = useState<Record<number, string>>({})
+
+  useEffect(() => {
+    const controller = new AbortController()
+    ;(async () => {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/tasks?archived=${showArchived ? 'true' : 'false'}`, {
+          credentials: 'include',
+          signal: controller.signal,
+        })
+        if (!res.ok) throw new Error(t('errors.failedToLoad'))
+        const data: { tasks?: Task[] } = await res.json()
+        setTasks(data.tasks ?? [])
+        setError('')
+      } catch (err) {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          setError(err.message)
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    })()
+    return () => { controller.abort() }
+  }, [showArchived, t])
+
+  const allTags = useMemo(() => {
+    const set = new Set<string>()
+    tasks.forEach(task => task.tags.forEach(tag => set.add(tag)))
+    return Array.from(set).sort()
+  }, [tasks])
+
+  const visibleTasks = useMemo(() => {
+    if (!activeTagFilter) return tasks
+    return tasks.filter(task => task.tags.includes(activeTagFilter))
+  }, [tasks, activeTagFilter])
+
+  function toggleTag(tag: string) {
+    setSelectedTags(prev => prev.includes(tag) ? prev.filter(x => x !== tag) : [...prev, tag])
+  }
+
+  function handleCustomTagKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      const value = customTagInput.trim()
+      if (value && !selectedTags.includes(value)) {
+        setSelectedTags(prev => [...prev, value])
+      }
+      setCustomTagInput('')
+    }
+  }
+
+  async function submitNewTask(e: React.FormEvent) {
+    e.preventDefault()
+    const title = newTaskTitle.trim()
+    if (!title || submitting) return
+    setSubmitting(true)
+    setError('')
+    try {
+      const res = await fetch('/api/tasks', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, tags: selectedTags }),
+      })
+      if (!res.ok) {
+        let msg = t('errors.failedToCreate')
+        try { const data = await res.json(); msg = data.error ?? msg } catch { /* non-JSON body */ }
+        throw new Error(msg)
+      }
+      const data: { task: Task } = await res.json()
+      setTasks(prev => [data.task, ...prev])
+      setNewTaskTitle('')
+      setSelectedTags([])
+      setCustomTagInput('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('errors.failedToCreate'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function toggleExpanded(task: Task) {
+    if (expandedId === task.id) {
+      setExpandedId(null)
+      return
+    }
+    setExpandedId(task.id)
+    setBodyDrafts(prev => prev[task.id] !== undefined ? prev : { ...prev, [task.id]: task.body })
+    if (notesById[task.id]) return
+    setNotesLoadingId(task.id)
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/notes`, { credentials: 'include' })
+      if (!res.ok) throw new Error(t('errors.failedToLoadNotes'))
+      const data: { notes?: TaskNote[] } = await res.json()
+      setNotesById(prev => ({ ...prev, [task.id]: data.notes ?? [] }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('errors.failedToLoadNotes'))
+    } finally {
+      setNotesLoadingId(null)
+    }
+  }
+
+  async function saveBody(task: Task) {
+    const draft = bodyDrafts[task.id] ?? ''
+    if (draft === task.body) return
+    try {
+      const res = await fetch(`/api/tasks/${task.id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: draft }),
+      })
+      if (!res.ok) throw new Error(t('errors.failedToUpdate'))
+      const data: { task: Task } = await res.json()
+      setTasks(prev => prev.map(t => t.id === data.task.id ? data.task : t))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('errors.failedToUpdate'))
+    }
+  }
+
+  async function toggleArchive(task: Task) {
+    const nextArchived = !task.archived
+    try {
+      const res = await fetch(`/api/tasks/${task.id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ archived: nextArchived }),
+      })
+      if (!res.ok) throw new Error(t('errors.failedToUpdate'))
+      const data: { task: Task } = await res.json()
+      // Remove from view if it no longer matches the showArchived filter.
+      setTasks(prev => {
+        if (data.task.archived === showArchived) {
+          return prev.map(t => t.id === data.task.id ? data.task : t)
+        }
+        return prev.filter(t => t.id !== data.task.id)
+      })
+      if (data.task.archived !== showArchived) {
+        setExpandedId(prev => prev === data.task.id ? null : prev)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('errors.failedToUpdate'))
+    }
+  }
+
+  async function addNote(task: Task) {
+    const content = (noteDrafts[task.id] ?? '').trim()
+    if (!content) return
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/notes`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      })
+      if (!res.ok) throw new Error(t('errors.failedToAddNote'))
+      const data: { note: TaskNote } = await res.json()
+      setNotesById(prev => ({
+        ...prev,
+        [task.id]: [...(prev[task.id] ?? []), data.note],
+      }))
+      setNoteDrafts(prev => ({ ...prev, [task.id]: '' }))
+      setTasks(prev => prev.map(t =>
+        t.id === task.id ? { ...t, note_count: t.note_count + 1 } : t,
+      ))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('errors.failedToAddNote'))
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+        <header className="flex items-center justify-between gap-2">
+          <h1 className="text-2xl font-semibold">{t('pageTitle')}</h1>
+          <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={e => {
+                setShowArchived(e.target.checked)
+                setExpandedId(null)
+              }}
+              className="rounded border-gray-700 bg-gray-800"
+              aria-label={t('showArchived')}
+            />
+            <span>{t('showArchived')}</span>
+          </label>
+        </header>
+
+        {error && (
+          <div role="alert" className="px-3 py-2 bg-red-900/40 border border-red-800 text-red-300 text-sm rounded">
+            {error}
+          </div>
+        )}
+
+        {/* Composer */}
+        <form onSubmit={submitNewTask} className="space-y-2 p-3 bg-gray-800/40 border border-gray-800 rounded-lg">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={newTaskTitle}
+              onChange={e => setNewTaskTitle(e.target.value)}
+              placeholder={t('inputPlaceholder')}
+              aria-label={t('inputPlaceholder')}
+              className="flex-1 min-w-0 px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+            />
+            <button
+              type="submit"
+              disabled={submitting || !newTaskTitle.trim()}
+              className="flex items-center gap-1 px-3 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-default text-white rounded text-sm transition-colors cursor-pointer shrink-0"
+              aria-label={t('addTask')}
+            >
+              <Plus size={16} />
+              <span className="hidden sm:inline">{t('addTask')}</span>
+            </button>
+          </div>
+
+          <div className="flex flex-wrap gap-1.5 items-center">
+            <span className="text-xs text-gray-500 mr-1">{t('tags.label')}:</span>
+            {BUILT_IN_TAGS.map(tag => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleTag(tag)}
+                className={`px-2 py-0.5 rounded-full text-xs transition-colors cursor-pointer ${
+                  selectedTags.includes(tag)
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-800 text-gray-400 hover:text-white'
+                }`}
+              >
+                {t(`tags.${tag}` as never)}
+              </button>
+            ))}
+            {selectedTags.filter(tag => !BUILT_IN_TAGS.includes(tag as typeof BUILT_IN_TAGS[number])).map(tag => (
+              <span
+                key={tag}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-blue-600 text-white"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => toggleTag(tag)}
+                  className="hover:text-gray-200 cursor-pointer"
+                  aria-label={`Remove tag ${tag}`}
+                >
+                  <X size={10} />
+                </button>
+              </span>
+            ))}
+            <input
+              type="text"
+              value={customTagInput}
+              onChange={e => setCustomTagInput(e.target.value)}
+              onKeyDown={handleCustomTagKeyDown}
+              placeholder={t('tags.customPlaceholder')}
+              aria-label={t('tags.addCustom')}
+              className="flex-1 min-w-[120px] px-2 py-0.5 bg-transparent border border-gray-700 rounded-full text-xs text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+            />
+          </div>
+        </form>
+
+        {/* Tag filter chips */}
+        {allTags.length > 0 && (
+          <div
+            className="flex flex-wrap gap-1.5"
+            role="group"
+            aria-label={t('filter.label')}
+          >
+            {allTags.map(tag => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => setActiveTagFilter(activeTagFilter === tag ? null : tag)}
+                className={`px-2 py-0.5 rounded-full text-xs transition-colors cursor-pointer ${
+                  activeTagFilter === tag
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-800 text-gray-400 hover:text-white'
+                }`}
+                aria-pressed={activeTagFilter === tag}
+              >
+                {tag}
+              </button>
+            ))}
+            {activeTagFilter && (
+              <button
+                type="button"
+                onClick={() => setActiveTagFilter(null)}
+                className="px-2 py-0.5 rounded-full text-xs bg-gray-800 text-gray-400 hover:text-white transition-colors cursor-pointer"
+                aria-label={t('filter.clearLabel')}
+              >
+                <X size={12} />
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Task list */}
+        <ul className="space-y-2" aria-busy={loading}>
+          {!loading && visibleTasks.length === 0 && (
+            <li className="px-3 py-6 text-center text-gray-500 text-sm">
+              {activeTagFilter
+                ? t('empty.filtered')
+                : showArchived
+                  ? t('empty.archived')
+                  : t('empty.active')}
+            </li>
+          )}
+          {visibleTasks.map(task => {
+            const isExpanded = expandedId === task.id
+            const cardDim = task.archived ? 'opacity-60' : ''
+            return (
+              <li
+                key={task.id}
+                className={`bg-gray-800/40 border border-gray-800 rounded-lg ${cardDim}`}
+                data-testid={`task-card-${task.id}`}
+                data-archived={task.archived ? 'true' : 'false'}
+              >
+                <button
+                  type="button"
+                  onClick={() => toggleExpanded(task)}
+                  aria-expanded={isExpanded}
+                  aria-label={isExpanded ? t('collapse') : t('expand')}
+                  className="w-full text-left px-3 py-2.5 flex items-start gap-2 hover:bg-gray-800/60 transition-colors cursor-pointer"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <p className="text-sm font-medium text-white">{task.title}</p>
+                      {task.archived && (
+                        <span className="px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wide bg-gray-700 text-gray-400">
+                          {t('archivedLabel')}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-1.5 mt-1 items-center">
+                      {task.tags.map(tag => (
+                        <span
+                          key={tag}
+                          className="px-1.5 py-0.5 bg-gray-700 text-gray-300 text-[10px] rounded-full"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                      {task.note_count > 0 && (
+                        <span className="text-[10px] text-gray-400">
+                          {t('notes.badge', { count: task.note_count })}
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-gray-500">
+                      <span title={formatAbsolute(task.created_at, i18n.language)}>
+                        {t('time.created', { relative: formatRelative(task.created_at, i18n.language, t('time.justNow')) })}
+                      </span>
+                      <span title={formatAbsolute(task.updated_at, i18n.language)}>
+                        {t('time.updated', { relative: formatRelative(task.updated_at, i18n.language, t('time.justNow')) })}
+                      </span>
+                    </div>
+                  </div>
+                  <span className="text-gray-400 shrink-0 mt-1">
+                    {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                  </span>
+                </button>
+
+                {isExpanded && (
+                  <div className="px-3 pb-3 pt-1 border-t border-gray-800 space-y-3">
+                    <div>
+                      <label className="block text-xs text-gray-400 mb-1" htmlFor={`task-body-${task.id}`}>
+                        {t('body.label')}
+                      </label>
+                      <textarea
+                        id={`task-body-${task.id}`}
+                        rows={3}
+                        value={bodyDrafts[task.id] ?? task.body}
+                        onChange={e => setBodyDrafts(prev => ({ ...prev, [task.id]: e.target.value }))}
+                        onBlur={() => saveBody(task)}
+                        placeholder={t('body.placeholder')}
+                        className="w-full px-2 py-1.5 bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-blue-500 resize-y"
+                      />
+                    </div>
+
+                    <div>
+                      <h3 className="text-xs text-gray-400 mb-1">{t('notes.heading')}</h3>
+                      <ul className="space-y-1.5">
+                        {notesLoadingId === task.id && !notesById[task.id] && (
+                          <li className="text-xs text-gray-500">…</li>
+                        )}
+                        {(notesById[task.id] ?? []).length === 0 && notesLoadingId !== task.id && (
+                          <li className="text-xs text-gray-500">{t('notes.empty')}</li>
+                        )}
+                        {(notesById[task.id] ?? []).map(note => (
+                          <li key={note.id} className="px-2 py-1.5 bg-gray-900/60 border border-gray-800 rounded text-xs text-gray-200">
+                            <p className="whitespace-pre-wrap break-words">{note.content}</p>
+                            <p className="text-[10px] text-gray-500 mt-0.5" title={formatAbsolute(note.created_at, i18n.language)}>
+                              {formatRelative(note.created_at, i18n.language, t('time.justNow'))}
+                            </p>
+                          </li>
+                        ))}
+                      </ul>
+
+                      <div className="mt-2 flex gap-2">
+                        <input
+                          type="text"
+                          value={noteDrafts[task.id] ?? ''}
+                          onChange={e => setNoteDrafts(prev => ({ ...prev, [task.id]: e.target.value }))}
+                          onKeyDown={e => {
+                            if (e.key === 'Enter') {
+                              e.preventDefault()
+                              addNote(task)
+                            }
+                          }}
+                          placeholder={t('notes.composerPlaceholder')}
+                          aria-label={t('notes.composerPlaceholder')}
+                          className="flex-1 min-w-0 px-2 py-1.5 bg-gray-900 border border-gray-700 rounded text-xs text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => addNote(task)}
+                          disabled={!(noteDrafts[task.id] ?? '').trim()}
+                          className="px-2 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-default text-white rounded text-xs transition-colors cursor-pointer"
+                        >
+                          {t('notes.add')}
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="flex justify-end">
+                      <button
+                        type="button"
+                        onClick={() => toggleArchive(task)}
+                        className="flex items-center gap-1 px-2 py-1 text-xs text-gray-400 hover:text-white hover:bg-gray-800 rounded transition-colors cursor-pointer"
+                      >
+                        {task.archived ? <ArchiveRestore size={14} /> : <Archive size={14} />}
+                        <span>{task.archived ? t('unarchive') : t('archive')}</span>
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -148,7 +148,9 @@ export default function Tasks() {
         throw new Error(msg)
       }
       const data: { task: Task } = await res.json()
-      setTasks(prev => [data.task, ...prev])
+      if (!showArchived) {
+        setTasks(prev => [data.task, ...prev])
+      }
       setNewTaskTitle('')
       setSelectedTags([])
       setCustomTagInput('')
@@ -167,6 +169,7 @@ export default function Tasks() {
     setExpandedId(task.id)
     setBodyDrafts(prev => prev[task.id] !== undefined ? prev : { ...prev, [task.id]: task.body })
     if (notesById[task.id]) return
+    setError('')
     setNotesLoadingId(task.id)
     try {
       const res = await fetch(`/api/tasks/${task.id}/notes`, { credentials: 'include' })
@@ -183,6 +186,7 @@ export default function Tasks() {
   async function saveBody(task: Task) {
     const draft = bodyDrafts[task.id] ?? ''
     if (draft === task.body) return
+    setError('')
     try {
       const res = await fetch(`/api/tasks/${task.id}`, {
         method: 'PATCH',
@@ -200,6 +204,7 @@ export default function Tasks() {
 
   async function toggleArchive(task: Task) {
     const nextArchived = !task.archived
+    setError('')
     try {
       const res = await fetch(`/api/tasks/${task.id}`, {
         method: 'PATCH',
@@ -227,6 +232,7 @@ export default function Tasks() {
   async function addNote(task: Task) {
     const content = (noteDrafts[task.id] ?? '').trim()
     if (!content) return
+    setError('')
     try {
       const res = await fetch(`/api/tasks/${task.id}/notes`, {
         method: 'POST',
@@ -323,7 +329,7 @@ export default function Tasks() {
                   type="button"
                   onClick={() => toggleTag(tag)}
                   className="hover:text-gray-200 cursor-pointer"
-                  aria-label={`Remove tag ${tag}`}
+                  aria-label={t('tags.removeTag', { tag })}
                 >
                   <X size={10} />
                 </button>


### PR DESCRIPTION
## Changes

- **Tasks page (frontend)** - Added a new Tasks page where users with the `tasks` feature flag can capture quick to-dos with built-in `work`/`personal` chips or free-text tags, expand a card to edit the body and attach chronological notes, archive/unarchive tasks, and filter the list by tag. Routed at `/tasks` with a `ListTodo` sidebar entry, full i18n in en/nb/th, and a small `GET /api/tasks/{id}/notes` backend endpoint to power the notes list. (Hytte-kq6d)

## Original Issue (feature): Tasks: frontend page + routing + sidebar + i18n

Part of the Task list chain seeded from Suggestions id=141 (step 2/2: Frontend). See that suggestion's plan for the full design.

Frontend slice of the Tasks page. Depends on the backend that landed in the previous chain link. See Suggestions id=141 plan for full design.

## Scope

### web/src/pages/Tasks.tsx

- Top: text input "What needs doing?" + tag chips (built-in: work, personal; custom tags entered free-text). Submit creates the task.
- List view: tasks rendered as cards. Each card shows title, created/updated timestamps (relative + tooltip absolute), tag chips, "+N notes" badge.
- Expand a card to reveal: body editor, notes list (chronological), add-note composer, "Archive" / "Unarchive" toggle.
- "Show archived" toggle at the top of the list. Archived tasks rendered with a dim style.
- Tag filter chips: click a tag chip to filter the visible list.
- All API calls via plain `fetch` to /api/tasks endpoints with credentials: 'include'.
- Mobile-first per CLAUDE.md — single column at 375px, tag chips wrap.

### Routing + Sidebar

- Add `/tasks` route in `web/src/App.tsx` inside `<ProtectedRoute>`.
- Sidebar entry in `web/src/components/Sidebar.tsx` using `ListTodo` Lucide icon, gated on the `tasks` user_features flag (same pattern as other feature-gated nav entries).

### i18n

- New namespace `tasks` in `web/public/locales/{en,nb,th}/tasks.json`.
- Keys: page title, input placeholder, tag-chip labels (built-in work / personal), archive toggle, archived label, empty state, note composer placeholder, timestamps formatting.
- `Intl.DateTimeFormat` uses `i18n.language` per CLAUDE.md convention.

### Tests

- `Tasks.test.tsx`: render with mocked fetch responses. Cover create flow, tag attach, archive toggle, note add, filter chip, archive-visible toggle.

### Acceptance

- `npm run lint`, `npm run build`, `npm test -- --run src/pages/Tasks` pass.
- User with the `tasks` flag can: create a task, tag it, add notes, archive it, see it under "Show archived". User without the flag has no nav entry.
- Mobile at 375px works (no horizontal scroll).
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-kq6d | Branch: forge/Hytte-kq6d
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->