### PR TITLE
Stride: workout_context note labels confuse evaluator — read as plan not as executed (Hytte-qdqz)

### DIFF
--- a/changelog.d/Hytte-qdqz.md
+++ b/changelog.d/Hytte-qdqz.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Stride: workout context now framed as a post-workout report** - The synthesized note that the Stride nightly evaluator sees for each workout now starts with "Runner's post-workout report —" and labels the structured speed segments as "Executed splits:" instead of "Plan:". This stops the evaluator from misreading after-the-fact context as a prescribed plan and comparing actual lap data against it as a target. The same helper powers the "What coach saw" panel on the Stride page, so the new wording appears there as well. (Hytte-qdqz)

--- a/internal/stride/evaluate_test.go
+++ b/internal/stride/evaluate_test.go
@@ -466,3 +466,84 @@ func TestParseEvalResponse_RestDayCompliance(t *testing.T) {
 	}
 }
 
+// --- appendWorkoutContextNote ---
+
+func TestAppendWorkoutContextNote_FramesAsPostWorkoutReport(t *testing.T) {
+	db := setupTestDB(t)
+
+	const workoutID = int64(600)
+	if _, err := db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (?, 1, 'running', '2026-04-08T07:00:00Z', 'append-ctx-hash', '2026-04-08T08:00:00Z')
+	`, workoutID); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	feelEnc, err := encryption.EncryptField("Tough but controlled")
+	if err != nil {
+		t.Fatalf("encrypt feel: %v", err)
+	}
+	// Encode the speed plan with a non-empty entry so summarizeSpeedPlan emits
+	// the new "Executed splits:" label and we can assert against it.
+	planEnc, err := encryption.EncryptField(`[{"kind":"steady","speed_kmph":10,"duration_sec":1800,"repeats":1,"same_as_previous":false}]`)
+	if err != nil {
+		t.Fatalf("encrypt plan: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO workout_context (workout_id, surface, run_type, hr_source, feel_notes, speed_plan, completed_at)
+		 VALUES (?, ?, ?, ?, ?, ?, '')`,
+		workoutID, "Treadmill", "long", "chest", feelEnc, planEnc,
+	); err != nil {
+		t.Fatalf("insert workout_context: %v", err)
+	}
+
+	workout := training.Workout{ID: workoutID, UserID: 1, Sport: "running", StartedAt: "2026-04-08T07:00:00Z"}
+	got := appendWorkoutContextNote(db, workout, "2026-04-08", nil)
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one synthetic note appended, got %d", len(got))
+	}
+	note := got[0]
+	if !strings.Contains(note.Content, "Runner's post-workout report") {
+		t.Errorf("note content missing post-workout framing, got %q", note.Content)
+	}
+	if !strings.Contains(note.Content, "Executed splits:") {
+		t.Errorf("note content missing 'Executed splits:' prefix, got %q", note.Content)
+	}
+	if strings.Contains(note.Content, "Plan:") {
+		t.Errorf("note content must not include 'Plan:' prefix (misleads evaluator), got %q", note.Content)
+	}
+	if !strings.Contains(note.Content, "Feel notes: Tough but controlled") {
+		t.Errorf("note content missing feel notes, got %q", note.Content)
+	}
+	if note.Scope != NoteScopeNightly {
+		t.Errorf("expected nightly scope on synthetic note, got %q", note.Scope)
+	}
+	if note.TargetDate != "2026-04-08" {
+		t.Errorf("expected target_date=2026-04-08, got %q", note.TargetDate)
+	}
+}
+
+func TestAppendWorkoutContextNote_NoContextLeavesNotesUnchanged(t *testing.T) {
+	db := setupTestDB(t)
+
+	const workoutID = int64(601)
+	if _, err := db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, fit_file_hash, created_at)
+		VALUES (?, 1, 'running', '2026-04-09T07:00:00Z', 'append-ctx-none', '2026-04-09T08:00:00Z')
+	`, workoutID); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	original := []Note{{ID: 1, Content: "Pre-existing note", TargetDate: "2026-04-09"}}
+	workout := training.Workout{ID: workoutID, UserID: 1, Sport: "running"}
+	got := appendWorkoutContextNote(db, workout, "2026-04-09", original)
+
+	if len(got) != 1 {
+		t.Fatalf("expected notes unchanged when no context row exists, got %d", len(got))
+	}
+	if got[0].Content != "Pre-existing note" {
+		t.Errorf("expected original note preserved, got %q", got[0].Content)
+	}
+}
+

--- a/internal/training/prompt_workout_context.go
+++ b/internal/training/prompt_workout_context.go
@@ -144,6 +144,10 @@ func isTreadmillSurface(surface string) bool {
 // stride note string (feel notes + structured plan summary). Returns empty
 // when there is nothing useful to surface. Used by the nightly stride
 // evaluation to fold per-workout context into the notes that go to Claude.
+//
+// The note is framed as a post-workout self-report so the Stride evaluator
+// reads the structured speed data as what the runner actually executed —
+// not as a prescribed plan to be measured against.
 func FormatWorkoutContextNote(ctx *WorkoutContext) string {
 	if ctx == nil {
 		return ""
@@ -153,7 +157,7 @@ func FormatWorkoutContextNote(ctx *WorkoutContext) string {
 		parts = append(parts, "Feel notes: "+notes)
 	}
 	if summary := summarizeSpeedPlan(ctx.SpeedPlan); summary != "" {
-		parts = append(parts, "Plan: "+summary)
+		parts = append(parts, "Executed splits: "+summary)
 	}
 	if ctx.Surface != "" || ctx.RunType != "" || ctx.HRSource != "" {
 		var meta []string
@@ -170,7 +174,10 @@ func FormatWorkoutContextNote(ctx *WorkoutContext) string {
 			parts = append(parts, "Context: "+strings.Join(meta, ", "))
 		}
 	}
-	return strings.Join(parts, " | ")
+	if len(parts) == 0 {
+		return ""
+	}
+	return "Runner's post-workout report — " + strings.Join(parts, " | ")
 }
 
 // summarizeSpeedPlan condenses a SpeedSegment plan into a one-line summary,

--- a/internal/training/prompt_workout_context_test.go
+++ b/internal/training/prompt_workout_context_test.go
@@ -1,0 +1,83 @@
+package training
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatWorkoutContextNote_PostWorkoutFraming(t *testing.T) {
+	ctx := &WorkoutContext{
+		Surface:   "Treadmill",
+		RunType:   "long",
+		HRSource:  "chest",
+		FeelNotes: "Legs heavy in last 10 min",
+		SpeedPlan: []SpeedSegment{
+			{Kind: "steady", SpeedKmph: 10.0, DurationSec: 1800, Repeats: 1},
+		},
+	}
+
+	got := FormatWorkoutContextNote(ctx)
+
+	if !strings.Contains(got, "Runner's post-workout report —") {
+		t.Errorf("expected post-workout framing prefix, got %q", got)
+	}
+	if !strings.Contains(got, "Executed splits:") {
+		t.Errorf("expected 'Executed splits:' prefix for speed plan, got %q", got)
+	}
+	if strings.Contains(got, "Plan:") {
+		t.Errorf("output must not contain the 'Plan:' prefix (would mislead the evaluator), got %q", got)
+	}
+	if !strings.Contains(got, "Feel notes: Legs heavy") {
+		t.Errorf("expected feel notes to be preserved, got %q", got)
+	}
+	if !strings.Contains(got, "surface=Treadmill") {
+		t.Errorf("expected surface metadata, got %q", got)
+	}
+	if !strings.Contains(got, "run_type=long") {
+		t.Errorf("expected run_type metadata, got %q", got)
+	}
+}
+
+func TestFormatWorkoutContextNote_OnlySpeedPlan(t *testing.T) {
+	ctx := &WorkoutContext{
+		SpeedPlan: []SpeedSegment{
+			{Kind: "work", SpeedKmph: 14.0, DurationSec: 300, Repeats: 4},
+		},
+	}
+
+	got := FormatWorkoutContextNote(ctx)
+
+	if !strings.Contains(got, "Runner's post-workout report —") {
+		t.Errorf("expected post-workout framing prefix when only speed plan is set, got %q", got)
+	}
+	if !strings.Contains(got, "Executed splits:") {
+		t.Errorf("expected 'Executed splits:' prefix, got %q", got)
+	}
+	if strings.Contains(got, "Plan:") {
+		t.Errorf("output must not contain the 'Plan:' prefix, got %q", got)
+	}
+}
+
+func TestFormatWorkoutContextNote_OnlyFeelNotes(t *testing.T) {
+	ctx := &WorkoutContext{FeelNotes: "Great session"}
+	got := FormatWorkoutContextNote(ctx)
+	if !strings.Contains(got, "Runner's post-workout report —") {
+		t.Errorf("expected post-workout framing prefix, got %q", got)
+	}
+	if !strings.Contains(got, "Feel notes: Great session") {
+		t.Errorf("expected feel notes content, got %q", got)
+	}
+}
+
+func TestFormatWorkoutContextNote_NilReturnsEmpty(t *testing.T) {
+	if got := FormatWorkoutContextNote(nil); got != "" {
+		t.Errorf("expected empty string for nil context, got %q", got)
+	}
+}
+
+func TestFormatWorkoutContextNote_EmptyReturnsEmpty(t *testing.T) {
+	ctx := &WorkoutContext{}
+	if got := FormatWorkoutContextNote(ctx); got != "" {
+		t.Errorf("expected empty string when no fields populated, got %q", got)
+	}
+}


### PR DESCRIPTION
## Changes

- **Stride: workout context now framed as a post-workout report** - The synthesized note that the Stride nightly evaluator sees for each workout now starts with "Runner's post-workout report —" and labels the structured speed segments as "Executed splits:" instead of "Plan:". This stops the evaluator from misreading after-the-fact context as a prescribed plan and comparing actual lap data against it as a target. The same helper powers the "What coach saw" panel on the Stride page, so the new wording appears there as well. (Hytte-qdqz)

## Original Issue (bug): Stride: workout_context note labels confuse evaluator — read as plan not as executed

The workout-context modal is filled out AFTER a workout to record what actually happened: how it felt, the surface, the run type, and the structured speed/duration splits the user actually executed. That context is then synthesised into a Note for the Stride nightly evaluator (via `internal/stride/evaluate.go:appendWorkoutContextNote` → `training.FormatWorkoutContextNote`).

The current format uses the prefix **`Plan:`** for the speed segments:

    Feel notes: ... | Plan: 10 km/h × 30 min | Context: surface=Treadmill, run_type=long, hr_source=chest

`Plan:` is a loaded word — the evaluator reads it as "this is the prescribed workout" instead of "this is what the runner actually did". The evaluator then ends up complaining the runner didn't follow a plan that was never prescribed, or compares actual lap data against the "plan" as if it were a target.

## Fix

`internal/training/prompt_workout_context.go` `FormatWorkoutContextNote`:

- Replace `"Plan: "` prefix with something that frames the data as a post-workout report. Suggestions:
    - `"Executed splits: "` — clearest signal that this is what the runner did, not a prescription
    - `"Actual structure: "` — alternative phrasing
    - `"Splits (actual): "` — short, unambiguous
- Add a small framing line at the start of the note so the evaluator anchors on the whole block as a runner self-report. Suggested:
    - Prefix everything with `"Runner's post-workout report — "` (so the whole note reads: `"Runner's post-workout report — Feel notes: ... | Executed splits: ... | Context: ..."`)
- Update `appendWorkoutContextNote` if it adds any additional framing; align so the evaluator can't misread.

If you keep `Plan:` for backward-compat reasons (e.g. UI elsewhere reuses the string), explicitly mark the note in the evaluator's prompt builder as "user-reported, post-workout" — but the simpler and cleaner fix is just changing the prefix.

## Also: update the inline panel on the Stride page (Hytte-ajpg)

That panel uses the same `FormatWorkoutContextNote` helper. Fixing the prefix once benefits both surfaces. Verify the panel renders cleanly with the new wording — it shouldn't need separate handling since it's just displaying the formatted note.

## Tests

- `prompt_workout_context_test.go` (if it exists, else create): assert the new prefix is in the output and that `Plan:` is NOT.
- `evaluate_test.go`: at least one test that exercises `appendWorkoutContextNote` and asserts the final note contains the unambiguous "post-workout" framing.

## Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build` all pass.
- Stride evaluator no longer treats the workout context as a prescribed plan; spot-check by saving a context modal and reading the resulting evaluation's reasoning.
- Stride page's "What coach saw" panel renders with the new wording.
- Changelog fragment in changelog.d/ (category: Changed).

## Reference

- internal/training/prompt_workout_context.go:147 — `FormatWorkoutContextNote`, the function to update.
- internal/training/prompt_workout_context.go:152 — current `"Plan: "+summary` line.
- internal/stride/evaluate.go:996 — `appendWorkoutContextNote`, the consumer that wraps the formatted string into a Note for the prompt.
- Hytte-ajpg — the inline-on-Stride-page panel that consumes the same helper.


---
Bead: Hytte-qdqz | Branch: forge/Hytte-qdqz
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->