### PR TITLE
Pokémon: schema + Norges Bank EUR/NOK rate sync (Hytte-8pzb)

### DIFF
--- a/changelog.d/Hytte-8pzb.md
+++ b/changelog.d/Hytte-8pzb.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon Collection: schema + EUR/NOK rate sync** - Added schema for `pokemon_sets`, `pokemon_cards`, `pokemon_card_variants`, `pokemon_collections`, and `currency_rates`, a new `pokemon` feature flag (off by default), and a daily Norges Bank EUR/NOK sync that fires at 06:00 Europe/Oslo so the Pokémon Collection can convert prices to NOK without hitting the API on every page load. (Hytte-8pzb)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -356,10 +356,13 @@ func main() {
 	// a rate available, then ticks daily. Failures are logged; downstream
 	// readers fall back to the latest stored rate.
 	go func() {
-		oslo, err := time.LoadLocation("Europe/Oslo")
+		loc, err := time.LoadLocation("Europe/Oslo")
 		if err != nil {
-			log.Printf("currency: failed to load Europe/Oslo timezone: %v", err)
-			return
+			// Missing tzdata shouldn't disable the sync entirely — fall back
+			// to UTC so the daily tick still fires (just shifted by Oslo's
+			// UTC offset). Downstream code only needs a fresh-ish rate.
+			log.Printf("currency: failed to load Europe/Oslo timezone, falling back to UTC: %v", err)
+			loc = time.UTC
 		}
 		startupCtx, startupCancel := context.WithTimeout(notifCtx, 30*time.Second)
 		if err := currency.SyncEURNOK(startupCtx, database); err != nil {
@@ -368,7 +371,7 @@ func main() {
 		startupCancel()
 
 		for {
-			next := currency.NextDailyRun(time.Now(), oslo)
+			next := currency.NextDailyRun(time.Now(), loc)
 			timer := time.NewTimer(time.Until(next))
 			select {
 			case <-notifCtx.Done():

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Robin831/Hytte/internal/allowance"
 	"github.com/Robin831/Hytte/internal/api"
 	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/currency"
 	"github.com/Robin831/Hytte/internal/daemon"
 	"github.com/Robin831/Hytte/internal/db"
 	"github.com/Robin831/Hytte/internal/push"
@@ -346,6 +347,41 @@ func main() {
 					}
 				}
 				log.Printf("stride: weekly plan generation complete (%d users)", len(userIDs))
+			}
+		}
+	}()
+
+	// Daily EUR/NOK rate sync from Norges Bank at 06:00 Europe/Oslo
+	// (Hytte-8pzb). Runs a best-effort fetch at startup so a fresh deploy has
+	// a rate available, then ticks daily. Failures are logged; downstream
+	// readers fall back to the latest stored rate.
+	go func() {
+		oslo, err := time.LoadLocation("Europe/Oslo")
+		if err != nil {
+			log.Printf("currency: failed to load Europe/Oslo timezone: %v", err)
+			return
+		}
+		startupCtx, startupCancel := context.WithTimeout(notifCtx, 30*time.Second)
+		if err := currency.SyncEURNOK(startupCtx, database); err != nil {
+			log.Printf("currency: startup EUR/NOK sync failed: %v", err)
+		}
+		startupCancel()
+
+		for {
+			next := currency.NextDailyRun(time.Now(), oslo)
+			timer := time.NewTimer(time.Until(next))
+			select {
+			case <-notifCtx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+				syncCtx, syncCancel := context.WithTimeout(notifCtx, 30*time.Second)
+				if err := currency.SyncEURNOK(syncCtx, database); err != nil {
+					log.Printf("currency: scheduled EUR/NOK sync failed: %v", err)
+				} else {
+					log.Println("currency: EUR/NOK rate synced")
+				}
+				syncCancel()
 			}
 		}
 	}()

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -36,6 +36,7 @@ var FeatureDefaults = map[string]bool{
 	"grocery":          false,
 	"homework":         false,
 	"regnemester":      false,
+	"pokemon":          false,
 }
 
 // FeatureKeys is a sorted list of all known feature keys, used for stable

--- a/internal/currency/currency.go
+++ b/internal/currency/currency.go
@@ -30,6 +30,17 @@ var httpClient = &http.Client{Timeout: 30 * time.Second}
 // overrideURL, when non-empty, replaces norgesBankEURNOKURL. Used by tests.
 var overrideURL string
 
+// maxResponseBytes caps the response body fed to the CSV parser. The real
+// Norges Bank response is well under 1 KB; 1 MiB leaves comfortable headroom
+// while bounding memory if the upstream misbehaves.
+const maxResponseBytes int64 = 1 << 20
+
+// maxErrorBodyBytes caps how much of an HTTP error body we include in the
+// returned error message. Truncation is intentional here (it's only for
+// diagnostics), so the parser uses io.LimitedReader with limit+1 to detect
+// and signal overflow rather than silently swallow it.
+const maxErrorBodyBytes int64 = 1024
+
 // SyncEURNOK fetches the latest EUR/NOK observation from Norges Bank and
 // upserts a row into currency_rates keyed by (pair, observed). Calling it
 // multiple times on the same observation date is idempotent — the row is
@@ -51,13 +62,22 @@ func SyncEURNOK(ctx context.Context, db *sql.DB) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("norges bank: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		limited := &io.LimitedReader{R: resp.Body, N: maxErrorBodyBytes + 1}
+		body, _ := io.ReadAll(limited)
+		truncated := ""
+		if int64(len(body)) > maxErrorBodyBytes {
+			body = body[:maxErrorBodyBytes]
+			truncated = " (truncated)"
+		}
+		return fmt.Errorf("norges bank: HTTP %d: %s%s", resp.StatusCode, strings.TrimSpace(string(body)), truncated)
 	}
 
-	observed, rate, err := parseEURNOKCSV(resp.Body)
+	observed, rate, err := parseEURNOKCSV(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		return fmt.Errorf("parse norges bank csv: %w", err)
+	}
+	if rate <= 0 {
+		return fmt.Errorf("norges bank: invalid rate %v for %s", rate, PairEURNOK)
 	}
 
 	_, err = db.ExecContext(ctx, `

--- a/internal/currency/currency.go
+++ b/internal/currency/currency.go
@@ -1,0 +1,149 @@
+// Package currency syncs daily exchange rates from Norges Bank and exposes
+// helpers for downstream readers (Pokémon Collection NOK conversion etc.).
+package currency
+
+import (
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// PairEURNOK is the canonical pair key stored in currency_rates for the
+// EUR→NOK reference rate.
+const PairEURNOK = "EUR/NOK"
+
+// norgesBankEURNOKURL is the public Norges Bank API endpoint that returns the
+// most recent EUR/NOK observation as semicolon-separated CSV with Norwegian
+// decimal commas.
+const norgesBankEURNOKURL = "https://data.norges-bank.no/api/data/EXR/B.EUR.NOK.SP?lastNObservations=1&format=csv-no-utf8"
+
+// httpClient is the HTTP client used for upstream requests. Tests can replace
+// it (typically together with overrideURL) to point at a httptest server.
+var httpClient = &http.Client{Timeout: 30 * time.Second}
+
+// overrideURL, when non-empty, replaces norgesBankEURNOKURL. Used by tests.
+var overrideURL string
+
+// SyncEURNOK fetches the latest EUR/NOK observation from Norges Bank and
+// upserts a row into currency_rates keyed by (pair, observed). Calling it
+// multiple times on the same observation date is idempotent — the row is
+// replaced with a fresh rate and fetched_at value.
+func SyncEURNOK(ctx context.Context, db *sql.DB) error {
+	url := norgesBankEURNOKURL
+	if overrideURL != "" {
+		url = overrideURL
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build norges bank request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch norges bank: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("norges bank: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	observed, rate, err := parseEURNOKCSV(resp.Body)
+	if err != nil {
+		return fmt.Errorf("parse norges bank csv: %w", err)
+	}
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO currency_rates (pair, rate, observed, fetched_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(pair, observed) DO UPDATE SET
+			rate       = excluded.rate,
+			fetched_at = excluded.fetched_at
+	`, PairEURNOK, rate, observed, time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("upsert currency_rates: %w", err)
+	}
+	return nil
+}
+
+// LatestRate returns the most recent rate stored for pair, along with the
+// observation date it was recorded for. Returns sql.ErrNoRows wrapped in a
+// descriptive error if no rate exists yet.
+func LatestRate(ctx context.Context, db *sql.DB, pair string) (rate float64, observed time.Time, err error) {
+	var observedStr string
+	err = db.QueryRowContext(ctx, `
+		SELECT rate, observed
+		FROM currency_rates
+		WHERE pair = ?
+		ORDER BY observed DESC
+		LIMIT 1
+	`, pair).Scan(&rate, &observedStr)
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("query latest rate for %s: %w", pair, err)
+	}
+	observed, err = time.Parse("2006-01-02", observedStr)
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("parse observed date %q: %w", observedStr, err)
+	}
+	return rate, observed, nil
+}
+
+// parseEURNOKCSV extracts the observation date and rate from a Norges Bank
+// csv-no-utf8 response. The format is semicolon-separated with a header row;
+// the relevant columns are TIME_PERIOD (observation date, ISO 8601) and
+// OBS_VALUE (decimal with a Norwegian comma separator).
+func parseEURNOKCSV(r io.Reader) (observed string, rate float64, err error) {
+	reader := csv.NewReader(r)
+	reader.Comma = ';'
+	reader.FieldsPerRecord = -1
+	reader.LazyQuotes = true
+
+	header, err := reader.Read()
+	if err != nil {
+		return "", 0, fmt.Errorf("read csv header: %w", err)
+	}
+
+	timeIdx, valueIdx := -1, -1
+	for i, col := range header {
+		switch strings.TrimSpace(strings.ToUpper(col)) {
+		case "TIME_PERIOD":
+			timeIdx = i
+		case "OBS_VALUE":
+			valueIdx = i
+		}
+	}
+	if timeIdx < 0 || valueIdx < 0 {
+		return "", 0, fmt.Errorf("missing TIME_PERIOD/OBS_VALUE columns in header %v", header)
+	}
+
+	row, err := reader.Read()
+	if err != nil {
+		return "", 0, fmt.Errorf("read csv row: %w", err)
+	}
+	if timeIdx >= len(row) || valueIdx >= len(row) {
+		return "", 0, fmt.Errorf("short csv row: have %d columns, need %d", len(row), max(timeIdx, valueIdx)+1)
+	}
+
+	observed = strings.TrimSpace(row[timeIdx])
+	if _, perr := time.Parse("2006-01-02", observed); perr != nil {
+		return "", 0, fmt.Errorf("parse observed date %q: %w", observed, perr)
+	}
+
+	// Norges Bank csv-no-utf8 uses Norwegian decimal commas (e.g. "11,4567").
+	// Strip thousand separators (space) before swapping the comma for a dot.
+	raw := strings.TrimSpace(row[valueIdx])
+	raw = strings.ReplaceAll(raw, " ", "")
+	raw = strings.Replace(raw, ",", ".", 1)
+	rate, err = strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return "", 0, fmt.Errorf("parse rate %q: %w", row[valueIdx], err)
+	}
+	return observed, rate, nil
+}

--- a/internal/currency/currency_test.go
+++ b/internal/currency/currency_test.go
@@ -1,0 +1,208 @@
+package currency
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(`
+		CREATE TABLE currency_rates (
+			pair       TEXT NOT NULL,
+			rate       REAL NOT NULL,
+			observed   TEXT NOT NULL,
+			fetched_at TIMESTAMP NOT NULL,
+			PRIMARY KEY(pair, observed)
+		);
+	`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+// fixtureCSV is a minimal Norges Bank csv-no-utf8 response with the columns
+// we rely on (TIME_PERIOD, OBS_VALUE) plus a handful of the surrounding
+// metadata columns the real upstream emits.
+const fixtureCSV = "FREQ;Frequency;BASE_CUR;Base Currency;QUOTE_CUR;Quote Currency;TENOR;Tenor;DECIMALS;CALCULATED;UNIT_MULT;COLLECTION;TIME_PERIOD;OBS_VALUE\n" +
+	"B;Forretningsdag;EUR;Euro;NOK;Norske kroner;SP;Spot;4;false;0;A;2026-05-14;11,4567\n"
+
+func startFixtureServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func withOverrideURL(t *testing.T, url string) {
+	t.Helper()
+	prev := overrideURL
+	overrideURL = url
+	t.Cleanup(func() { overrideURL = prev })
+}
+
+func TestSyncEURNOK_InsertsRow(t *testing.T) {
+	db := setupTestDB(t)
+	srv := startFixtureServer(t, fixtureCSV)
+	withOverrideURL(t, srv.URL)
+
+	ctx := context.Background()
+	if err := SyncEURNOK(ctx, db); err != nil {
+		t.Fatalf("SyncEURNOK: %v", err)
+	}
+
+	var pair, observed string
+	var rate float64
+	var fetchedAt time.Time
+	if err := db.QueryRowContext(ctx,
+		`SELECT pair, rate, observed, fetched_at FROM currency_rates`).
+		Scan(&pair, &rate, &observed, &fetchedAt); err != nil {
+		t.Fatalf("query inserted row: %v", err)
+	}
+	if pair != PairEURNOK {
+		t.Errorf("pair = %q, want %q", pair, PairEURNOK)
+	}
+	if observed != "2026-05-14" {
+		t.Errorf("observed = %q, want 2026-05-14", observed)
+	}
+	if rate != 11.4567 {
+		t.Errorf("rate = %v, want 11.4567", rate)
+	}
+	if fetchedAt.IsZero() {
+		t.Errorf("fetched_at should not be zero")
+	}
+}
+
+func TestSyncEURNOK_IdempotentSameDay(t *testing.T) {
+	db := setupTestDB(t)
+	srv := startFixtureServer(t, fixtureCSV)
+	withOverrideURL(t, srv.URL)
+
+	ctx := context.Background()
+	if err := SyncEURNOK(ctx, db); err != nil {
+		t.Fatalf("first SyncEURNOK: %v", err)
+	}
+	if err := SyncEURNOK(ctx, db); err != nil {
+		t.Fatalf("second SyncEURNOK: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM currency_rates`).Scan(&n); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("row count = %d, want 1 (upsert should not duplicate the same observed date)", n)
+	}
+}
+
+func TestSyncEURNOK_UpstreamError(t *testing.T) {
+	db := setupTestDB(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	withOverrideURL(t, srv.URL)
+
+	if err := SyncEURNOK(context.Background(), db); err == nil {
+		t.Fatal("expected error on HTTP 500, got nil")
+	}
+}
+
+func TestLatestRate_PicksMostRecent(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	insertRate(t, db, "EUR/NOK", 11.0000, "2026-05-12", now)
+	insertRate(t, db, "EUR/NOK", 11.5000, "2026-05-14", now)
+	insertRate(t, db, "EUR/NOK", 11.2500, "2026-05-13", now)
+
+	rate, observed, err := LatestRate(ctx, db, "EUR/NOK")
+	if err != nil {
+		t.Fatalf("LatestRate: %v", err)
+	}
+	if rate != 11.5000 {
+		t.Errorf("rate = %v, want 11.5000", rate)
+	}
+	want := time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC)
+	if !observed.Equal(want) {
+		t.Errorf("observed = %v, want %v", observed, want)
+	}
+}
+
+func TestLatestRate_Missing(t *testing.T) {
+	db := setupTestDB(t)
+	_, _, err := LatestRate(context.Background(), db, "EUR/NOK")
+	if err == nil {
+		t.Fatal("expected error when no rates exist, got nil")
+	}
+}
+
+func TestParseEURNOKCSV_RejectsBadDate(t *testing.T) {
+	bad := "TIME_PERIOD;OBS_VALUE\n" +
+		"not-a-date;11,4567\n"
+	_, _, err := parseEURNOKCSV(strings.NewReader(bad))
+	if err == nil {
+		t.Fatal("expected error for invalid date, got nil")
+	}
+}
+
+func TestNextDailyRun(t *testing.T) {
+	oslo, err := time.LoadLocation("Europe/Oslo")
+	if err != nil {
+		t.Fatalf("load Oslo: %v", err)
+	}
+	cases := []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "before 06:00 returns today",
+			now:  time.Date(2026, 5, 14, 5, 59, 59, 0, oslo),
+			want: time.Date(2026, 5, 14, 6, 0, 0, 0, oslo),
+		},
+		{
+			name: "after 06:00 returns tomorrow",
+			now:  time.Date(2026, 5, 14, 6, 0, 1, 0, oslo),
+			want: time.Date(2026, 5, 15, 6, 0, 0, 0, oslo),
+		},
+		{
+			name: "midnight returns today",
+			now:  time.Date(2026, 5, 14, 0, 0, 0, 0, oslo),
+			want: time.Date(2026, 5, 14, 6, 0, 0, 0, oslo),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NextDailyRun(tc.now, oslo)
+			if !got.Equal(tc.want) {
+				t.Errorf("NextDailyRun(%v) = %v, want %v", tc.now, got, tc.want)
+			}
+		})
+	}
+}
+
+func insertRate(t *testing.T, db *sql.DB, pair string, rate float64, observed string, fetched time.Time) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO currency_rates (pair, rate, observed, fetched_at) VALUES (?, ?, ?, ?)`,
+		pair, rate, observed, fetched,
+	); err != nil {
+		t.Fatalf("insert rate: %v", err)
+	}
+}

--- a/internal/currency/currency_test.go
+++ b/internal/currency/currency_test.go
@@ -18,6 +18,10 @@ func setupTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
+	// Each sql.DB connection to ":memory:" opens its own private in-memory
+	// database in modernc.org/sqlite, so unbounded pooling causes flakiness
+	// (writes on one conn aren't visible on another). Pin to a single conn.
+	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { db.Close() })
 	if _, err := db.Exec(`
 		CREATE TABLE currency_rates (
@@ -158,6 +162,26 @@ func TestParseEURNOKCSV_RejectsBadDate(t *testing.T) {
 	_, _, err := parseEURNOKCSV(strings.NewReader(bad))
 	if err == nil {
 		t.Fatal("expected error for invalid date, got nil")
+	}
+}
+
+func TestSyncEURNOK_RejectsNonPositiveRate(t *testing.T) {
+	db := setupTestDB(t)
+	// Norges Bank should never serve a zero rate, but if it ever does we
+	// must not store it — downstream NOK conversion would produce zeros.
+	zeroCSV := "TIME_PERIOD;OBS_VALUE\n2026-05-14;0,0000\n"
+	srv := startFixtureServer(t, zeroCSV)
+	withOverrideURL(t, srv.URL)
+
+	if err := SyncEURNOK(context.Background(), db); err == nil {
+		t.Fatal("expected error for zero rate, got nil")
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM currency_rates`).Scan(&n); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("row count = %d, want 0 (invalid rate should not be persisted)", n)
 	}
 }
 

--- a/internal/currency/scheduler.go
+++ b/internal/currency/scheduler.go
@@ -1,0 +1,21 @@
+package currency
+
+import "time"
+
+// NextDailyRun returns the next time the EUR/NOK sync should fire (daily at
+// 06:00 in the given location). If today's 06:00 is still in the future, that
+// instant is returned; otherwise the next day's 06:00 is returned. The result
+// is constructed via time.Date in loc on every call so DST transitions in the
+// target zone are handled correctly.
+func NextDailyRun(now time.Time, loc *time.Location) time.Time {
+	if loc == nil {
+		loc = time.UTC
+	}
+	now = now.In(loc)
+	todayRun := time.Date(now.Year(), now.Month(), now.Day(), 6, 0, 0, 0, loc)
+	if now.Before(todayRun) {
+		return todayRun
+	}
+	tomorrow := now.AddDate(0, 0, 1)
+	return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 6, 0, 0, 0, loc)
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1625,6 +1625,65 @@ func createSchema(db *sql.DB) error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_task_notes_task ON task_notes(task_id, created_at);
 
+	-- Pokémon Collection (Hytte-8pzb): per-kid collection of TCG cards with
+	-- pricing in EUR (converted to NOK via currency_rates at read time).
+	CREATE TABLE IF NOT EXISTS pokemon_sets (
+		id            TEXT PRIMARY KEY,
+		name          TEXT NOT NULL,
+		series        TEXT NOT NULL,
+		release_date  TEXT NOT NULL,
+		total_cards   INTEGER NOT NULL DEFAULT 0,
+		symbol_url    TEXT NOT NULL DEFAULT '',
+		logo_url      TEXT NOT NULL DEFAULT '',
+		synced_at     TIMESTAMP NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS pokemon_cards (
+		id              TEXT PRIMARY KEY,
+		set_id          TEXT NOT NULL REFERENCES pokemon_sets(id) ON DELETE CASCADE,
+		name            TEXT NOT NULL,
+		collector_no    TEXT NOT NULL,
+		rarity          TEXT NOT NULL DEFAULT '',
+		image_small_url TEXT NOT NULL DEFAULT '',
+		image_large_url TEXT NOT NULL DEFAULT '',
+		synced_at       TIMESTAMP NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_pokemon_cards_set ON pokemon_cards(set_id, collector_no);
+	CREATE INDEX IF NOT EXISTS idx_pokemon_cards_name ON pokemon_cards(name);
+
+	CREATE TABLE IF NOT EXISTS pokemon_card_variants (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		card_id     TEXT NOT NULL REFERENCES pokemon_cards(id) ON DELETE CASCADE,
+		kind        TEXT NOT NULL,
+		price_eur   REAL NOT NULL DEFAULT 0,
+		price_at    TIMESTAMP,
+		UNIQUE(card_id, kind)
+	);
+
+	CREATE TABLE IF NOT EXISTS pokemon_collections (
+		id            INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		card_id       TEXT NOT NULL REFERENCES pokemon_cards(id) ON DELETE CASCADE,
+		variant_id    INTEGER NOT NULL REFERENCES pokemon_card_variants(id) ON DELETE CASCADE,
+		quantity      INTEGER NOT NULL DEFAULT 1,
+		condition     TEXT NOT NULL DEFAULT '',
+		acquired_at   TIMESTAMP NOT NULL,
+		notes_enc     TEXT,
+		UNIQUE(user_id, card_id, variant_id)
+	);
+	CREATE INDEX IF NOT EXISTS idx_pokemon_collections_user ON pokemon_collections(user_id);
+
+	-- currency_rates (Hytte-8pzb): daily reference exchange rates, sourced
+	-- from Norges Bank. observed is the observation date (YYYY-MM-DD) reported
+	-- by the upstream; fetched_at is the wall clock time of the local upsert.
+	CREATE TABLE IF NOT EXISTS currency_rates (
+		pair       TEXT NOT NULL,
+		rate       REAL NOT NULL,
+		observed   TEXT NOT NULL,
+		fetched_at TIMESTAMP NOT NULL,
+		PRIMARY KEY(pair, observed)
+	);
+
 	`
 
 	_, err := db.Exec(schema)


### PR DESCRIPTION
## Changes

- **Pokémon Collection: schema + EUR/NOK rate sync** - Added schema for `pokemon_sets`, `pokemon_cards`, `pokemon_card_variants`, `pokemon_collections`, and `currency_rates`, a new `pokemon` feature flag (off by default), and a daily Norges Bank EUR/NOK sync that fires at 06:00 Europe/Oslo so the Pokémon Collection can convert prices to NOK without hitting the API on every page load. (Hytte-8pzb)

## Original Issue (feature): Pokémon: schema + Norges Bank EUR/NOK rate sync

Part of the Pokémon Collection chain seeded from Suggestions id=146. See that suggestion's plan for the full architecture, data sources (pokemontcg.io + Norges Bank EUR/NOK), and scope decisions (per-kid collections, NOK only, variants from day 1, local image cache).

This bead is step 1/7: Schema + currency rate of the chain.

## Scope

### Schema (internal/db/db.go createSchema)

    CREATE TABLE IF NOT EXISTS pokemon_sets (
      id            TEXT PRIMARY KEY,
      name          TEXT NOT NULL,
      series        TEXT NOT NULL,
      release_date  TEXT NOT NULL,
      total_cards   INTEGER NOT NULL DEFAULT 0,
      symbol_url    TEXT NOT NULL DEFAULT '',
      logo_url      TEXT NOT NULL DEFAULT '',
      synced_at     TIMESTAMP NOT NULL
    );

    CREATE TABLE IF NOT EXISTS pokemon_cards (
      id              TEXT PRIMARY KEY,
      set_id          TEXT NOT NULL REFERENCES pokemon_sets(id) ON DELETE CASCADE,
      name            TEXT NOT NULL,
      collector_no    TEXT NOT NULL,
      rarity          TEXT NOT NULL DEFAULT '',
      image_small_url TEXT NOT NULL DEFAULT '',
      image_large_url TEXT NOT NULL DEFAULT '',
      synced_at       TIMESTAMP NOT NULL
    );
    CREATE INDEX IF NOT EXISTS idx_pokemon_cards_set ON pokemon_cards(set_id, collector_no);
    CREATE INDEX IF NOT EXISTS idx_pokemon_cards_name ON pokemon_cards(name);

    CREATE TABLE IF NOT EXISTS pokemon_card_variants (
      id          INTEGER PRIMARY KEY AUTOINCREMENT,
      card_id     TEXT NOT NULL REFERENCES pokemon_cards(id) ON DELETE CASCADE,
      kind        TEXT NOT NULL,
      price_eur   REAL NOT NULL DEFAULT 0,
      price_at    TIMESTAMP,
      UNIQUE(card_id, kind)
    );

    CREATE TABLE IF NOT EXISTS pokemon_collections (
      id            INTEGER PRIMARY KEY AUTOINCREMENT,
      user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
      card_id       TEXT NOT NULL REFERENCES pokemon_cards(id) ON DELETE CASCADE,
      variant_id    INTEGER NOT NULL REFERENCES pokemon_card_variants(id) ON DELETE CASCADE,
      quantity      INTEGER NOT NULL DEFAULT 1,
      condition     TEXT NOT NULL DEFAULT '',
      acquired_at   TIMESTAMP NOT NULL,
      notes_enc     TEXT,
      UNIQUE(user_id, card_id, variant_id)
    );
    CREATE INDEX IF NOT EXISTS idx_pokemon_collections_user ON pokemon_collections(user_id);

    CREATE TABLE IF NOT EXISTS currency_rates (
      pair       TEXT NOT NULL,
      rate       REAL NOT NULL,
      observed   TEXT NOT NULL,
      fetched_at TIMESTAMP NOT NULL,
      PRIMARY KEY(pair, observed)
    );

### Feature flag

Add `"pokemon": false` to `FeatureDefaults` in `internal/auth/features.go:11`.

### Norges Bank daily rate fetch

- New package `internal/currency/` with a `SyncEURNOK(ctx, db)` function that fetches `https://data.norges-bank.no/api/data/EXR/B.EUR.NOK.SP?lastNObservations=1&format=csv-no-utf8` and upserts a `currency_rates` row keyed by `('EUR/NOK', <observed_date>)`.
- Scheduler goroutine in `cmd/server/main.go` mirroring Stride's daily pattern: fire at 06:00 Europe/Oslo every day. Tolerate failures by logging and reusing the latest known rate.
- Helper `LatestRate(ctx, db, pair string) (rate float64, observed time.Time, err error)` for downstream readers.

### Tests

- `currency_test.go` mocks the Norges Bank response (CSV fixture), asserts row inserted, asserts second call same-day is idempotent.

### Acceptance

- `make build`, `make test` pass.
- Schema applied at startup.
- After one scheduled tick, `SELECT * FROM currency_rates` shows a row for today's EUR/NOK.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-8pzb | Branch: forge/Hytte-8pzb
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->