### PR TITLE
Pokémon: REST handlers (sets, cards, collection, search) (Hytte-l9op)

### DIFF
--- a/changelog.d/Hytte-l9op.md
+++ b/changelog.d/Hytte-l9op.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon Collection REST API** - New endpoints under `/api/pokemon/*` for listing sets, browsing cards in a set, autocomplete search by collector number or name fragment, and per-user collection CRUD. Variant prices are returned in both EUR and NOK using the latest cached Norges Bank rate; an `X-Pokemon-Rate-Missing` header signals when no rate is available. All endpoints are gated by the `pokemon` feature flag. (Hytte-l9op)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -405,6 +405,18 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Delete("/notes/{id}", notes.DeleteHandler(db))
 			})
 
+			// Pokémon Collection — gated by "pokemon" feature.
+			r.Group(func(r chi.Router) {
+				r.Use(auth.RequireFeature(db, "pokemon"))
+				r.Get("/pokemon/sets", pokemon.ListSetsHandler(db))
+				r.Get("/pokemon/sets/{id}/cards", pokemon.ListSetCardsHandler(db))
+				r.Get("/pokemon/cards/search", pokemon.SearchCardsHandler(db))
+				r.Post("/pokemon/collection", pokemon.UpsertCollectionHandler(db))
+				r.Patch("/pokemon/collection/{id}", pokemon.UpdateCollectionHandler(db))
+				r.Delete("/pokemon/collection/{id}", pokemon.DeleteCollectionHandler(db))
+				r.Get("/pokemon/collection/missing", pokemon.MissingFromSetHandler(db))
+			})
+
 			// Tasks — gated by "tasks" feature.
 			r.Group(func(r chi.Router) {
 				r.Use(auth.RequireFeature(db, "tasks"))

--- a/internal/pokemon/handlers.go
+++ b/internal/pokemon/handlers.go
@@ -29,10 +29,6 @@ const defaultListLimit = 50
 // list endpoints stay snappy when the upper bound is tight.
 const maxListLimit = 50
 
-// maxSetCardsLimit caps the per-set cards listing. A single set is typically
-// 200–300 cards, so the limit is intentionally generous.
-const maxSetCardsLimit = 500
-
 // allowedConditions enumerates the grades we accept for a collection row.
 // An empty string is also permitted (callers may not yet have graded the card).
 var allowedConditions = map[string]bool{
@@ -136,7 +132,7 @@ func decodeBody(w http.ResponseWriter, r *http.Request, dst any) bool {
 // parseLimit reads ?limit= with a default and cap. Returns the default when
 // the parameter is missing or invalid (to keep the API forgiving for
 // hand-crafted URLs).
-func parseLimit(r *http.Request, def, max int) int {
+func parseLimit(r *http.Request, def, upper int) int {
 	q := strings.TrimSpace(r.URL.Query().Get("limit"))
 	if q == "" {
 		return def
@@ -145,8 +141,8 @@ func parseLimit(r *http.Request, def, max int) int {
 	if err != nil || n <= 0 {
 		return def
 	}
-	if n > max {
-		return max
+	if n > upper {
+		return upper
 	}
 	return n
 }
@@ -166,10 +162,14 @@ func parseOffset(r *http.Request) int {
 
 // loadRate fetches the latest EUR/NOK rate. When no rate is available it
 // returns ok=false so callers can flag the response with the
-// X-Pokemon-Rate-Missing header.
+// X-Pokemon-Rate-Missing header. Unexpected (non sql.ErrNoRows) errors are
+// logged so a misconfigured DB or schema mismatch is visible in operations.
 func loadRate(r *http.Request, db *sql.DB) (rate float64, ok bool) {
 	rate, _, err := currency.LatestRate(r.Context(), db, currency.PairEURNOK)
 	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			log.Printf("pokemon: load EUR/NOK rate: %v", err)
+		}
 		return 0, false
 	}
 	return rate, true
@@ -371,17 +371,18 @@ func UpsertCollectionHandler(db *sql.DB) http.HandlerFunc {
 		now := time.Now().UTC()
 		// Determine whether an existing row already covers (user, card, variant) so
 		// we can return the correct status code (200 vs 201) and re-read the row.
-		var existingID int64
+		// We only care whether a row exists, not its id, so EXISTS() is enough.
+		var rowExists bool
 		err = db.QueryRowContext(r.Context(),
-			`SELECT id FROM pokemon_collections WHERE user_id = ? AND card_id = ? AND variant_id = ?`,
+			`SELECT EXISTS(SELECT 1 FROM pokemon_collections WHERE user_id = ? AND card_id = ? AND variant_id = ?)`,
 			user.ID, body.CardID, body.VariantID,
-		).Scan(&existingID)
-		isNew := errors.Is(err, sql.ErrNoRows)
-		if err != nil && !isNew {
+		).Scan(&rowExists)
+		if err != nil {
 			log.Printf("pokemon: lookup collection: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to upsert collection")
 			return
 		}
+		isNew := !rowExists
 
 		_, err = db.ExecContext(r.Context(), `
 			INSERT INTO pokemon_collections (user_id, card_id, variant_id, quantity, condition, acquired_at, notes_enc)
@@ -571,15 +572,16 @@ func MissingFromSetHandler(db *sql.DB) http.HandlerFunc {
 }
 
 // loadCardsForSet hydrates every card in a set with its variants and owner
-// flags for the given user.
+// flags for the given user. A set is bounded by its printed total, so no
+// pagination is applied here — silently truncating would hide cards from a
+// caller building a "what's missing?" view.
 func loadCardsForSet(r *http.Request, db *sql.DB, userID int64, setID string) ([]CardDTO, error) {
 	cardRows, err := db.QueryContext(r.Context(), `
 		SELECT id, set_id, name, collector_no, rarity, image_small_url, image_large_url
 		FROM pokemon_cards
 		WHERE set_id = ?
 		ORDER BY CAST(collector_no AS INTEGER), collector_no
-		LIMIT ?
-	`, setID, maxSetCardsLimit)
+	`, setID)
 	if err != nil {
 		return nil, err
 	}
@@ -788,8 +790,11 @@ func encryptNotes(plain string) (any, error) {
 }
 
 // decryptNotes returns the plaintext notes for a nullable encrypted column.
-// Legacy plaintext values are returned as-is with a log warning, matching the
-// rest of the codebase's tolerant decryption strategy.
+// On decrypt failure it returns an empty string and logs a warning: returning
+// the raw column value would leak ciphertext (or legacy plaintext from another
+// user) into the API response, which the Warden rules explicitly forbid. This
+// feature is new and has never stored plaintext, so there is no legacy path
+// to preserve.
 func decryptNotes(enc sql.NullString) string {
 	if !enc.Valid || enc.String == "" {
 		return ""
@@ -797,7 +802,7 @@ func decryptNotes(enc sql.NullString) string {
 	plain, err := encryption.DecryptField(enc.String)
 	if err != nil {
 		log.Printf("pokemon: decrypt notes: %v", err)
-		return enc.String
+		return ""
 	}
 	return plain
 }

--- a/internal/pokemon/handlers.go
+++ b/internal/pokemon/handlers.go
@@ -1,0 +1,803 @@
+package pokemon
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/currency"
+	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/go-chi/chi/v5"
+)
+
+// maxBodySize caps request bodies for collection write endpoints. Notes are
+// short free-text fields; 16 KB leaves room for long parent annotations
+// without exposing the decoder to unbounded streams.
+const maxBodySize = 16 << 10
+
+// defaultListLimit is the default page size for set/search/card listings.
+const defaultListLimit = 50
+
+// maxListLimit caps the explicit ?limit= a caller may request. The search and
+// list endpoints stay snappy when the upper bound is tight.
+const maxListLimit = 50
+
+// maxSetCardsLimit caps the per-set cards listing. A single set is typically
+// 200–300 cards, so the limit is intentionally generous.
+const maxSetCardsLimit = 500
+
+// allowedConditions enumerates the grades we accept for a collection row.
+// An empty string is also permitted (callers may not yet have graded the card).
+var allowedConditions = map[string]bool{
+	"":                  true,
+	"mint":              true,
+	"near_mint":         true,
+	"lightly_played":    true,
+	"moderately_played": true,
+	"heavily_played":    true,
+	"damaged":           true,
+}
+
+// collectorNumberPattern matches a collector-number query like "25" or
+// "025/195". The slash form lets callers paste the printed "n/total" notation
+// straight from a card.
+var collectorNumberPattern = regexp.MustCompile(`^\d+(/\d+)?$`)
+
+// SetDTO is the JSON shape used by /api/pokemon/sets.
+type SetDTO struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Series      string `json:"series"`
+	ReleaseDate string `json:"release_date"`
+	TotalCards  int    `json:"total_cards"`
+	SymbolURL   string `json:"symbol_url"`
+	LogoURL     string `json:"logo_url"`
+}
+
+// VariantDTO is the JSON shape of a card variant, including ownership state
+// for the current user. Quantity, Condition, Notes are zero values when the
+// user does not own the variant.
+type VariantDTO struct {
+	ID         int64    `json:"id"`
+	Kind       string   `json:"kind"`
+	PriceEUR   float64  `json:"price_eur"`
+	PriceNOK   *float64 `json:"price_nok"`
+	PriceAt    *string  `json:"price_at,omitempty"`
+	Owned      bool     `json:"owned"`
+	OwnedID    *int64   `json:"owned_id,omitempty"`
+	Quantity   int      `json:"quantity"`
+	Condition  string   `json:"condition,omitempty"`
+	Notes      string   `json:"notes,omitempty"`
+	AcquiredAt *string  `json:"acquired_at,omitempty"`
+}
+
+// CardDTO is the JSON shape returned for any card listing.
+type CardDTO struct {
+	ID            string       `json:"id"`
+	SetID         string       `json:"set_id"`
+	SetName       string       `json:"set_name,omitempty"`
+	Name          string       `json:"name"`
+	CollectorNo   string       `json:"collector_no"`
+	Rarity        string       `json:"rarity"`
+	ImageSmallURL string       `json:"image_small_url"`
+	ImageLargeURL string       `json:"image_large_url"`
+	Variants      []VariantDTO `json:"variants"`
+}
+
+// CollectionRow is the JSON shape for collection CRUD responses. Timestamps
+// are returned as the database-stored string (RFC3339-style) so we don't have
+// to translate between driver representations on every read.
+type CollectionRow struct {
+	ID         int64  `json:"id"`
+	UserID     int64  `json:"user_id"`
+	CardID     string `json:"card_id"`
+	VariantID  int64  `json:"variant_id"`
+	Quantity   int    `json:"quantity"`
+	Condition  string `json:"condition"`
+	Notes      string `json:"notes,omitempty"`
+	AcquiredAt string `json:"acquired_at"`
+}
+
+func respondJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("pokemon: encode response: %v", err)
+	}
+}
+
+func respondError(w http.ResponseWriter, status int, msg string) {
+	respondJSON(w, status, map[string]string{"error": msg})
+}
+
+// decodeBody decodes r.Body into dst after capping the body at limit bytes.
+// Returns false and writes the appropriate error response on failure.
+func decodeBody(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			respondError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return false
+		}
+		respondError(w, http.StatusBadRequest, "invalid JSON")
+		return false
+	}
+	return true
+}
+
+// parseLimit reads ?limit= with a default and cap. Returns the default when
+// the parameter is missing or invalid (to keep the API forgiving for
+// hand-crafted URLs).
+func parseLimit(r *http.Request, def, max int) int {
+	q := strings.TrimSpace(r.URL.Query().Get("limit"))
+	if q == "" {
+		return def
+	}
+	n, err := strconv.Atoi(q)
+	if err != nil || n <= 0 {
+		return def
+	}
+	if n > max {
+		return max
+	}
+	return n
+}
+
+// parseOffset reads ?offset= with a 0 default.
+func parseOffset(r *http.Request) int {
+	q := strings.TrimSpace(r.URL.Query().Get("offset"))
+	if q == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(q)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// loadRate fetches the latest EUR/NOK rate. When no rate is available it
+// returns ok=false so callers can flag the response with the
+// X-Pokemon-Rate-Missing header.
+func loadRate(r *http.Request, db *sql.DB) (rate float64, ok bool) {
+	rate, _, err := currency.LatestRate(r.Context(), db, currency.PairEURNOK)
+	if err != nil {
+		return 0, false
+	}
+	return rate, true
+}
+
+// applyNOK fills the price_nok field on every variant when the rate is
+// available, and sets the X-Pokemon-Rate-Missing header otherwise. The header
+// must be set before the response body is written.
+func applyNOK(w http.ResponseWriter, cards []CardDTO, rate float64, rateOK bool) {
+	if !rateOK {
+		w.Header().Set("X-Pokemon-Rate-Missing", "1")
+		return
+	}
+	for ci := range cards {
+		for vi := range cards[ci].Variants {
+			nok := cards[ci].Variants[vi].PriceEUR * rate
+			cards[ci].Variants[vi].PriceNOK = &nok
+		}
+	}
+}
+
+// ListSetsHandler returns the catalogue of sets, ordered newest-first and
+// optionally filtered by series via ?era=<name>.
+func ListSetsHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		era := strings.TrimSpace(r.URL.Query().Get("era"))
+		limit := parseLimit(r, defaultListLimit, maxListLimit)
+		offset := parseOffset(r)
+
+		var (
+			rows *sql.Rows
+			err  error
+		)
+		if era != "" {
+			rows, err = db.QueryContext(r.Context(), `
+				SELECT id, name, series, release_date, total_cards, symbol_url, logo_url
+				FROM pokemon_sets
+				WHERE series = ?
+				ORDER BY release_date DESC, id DESC
+				LIMIT ? OFFSET ?
+			`, era, limit, offset)
+		} else {
+			rows, err = db.QueryContext(r.Context(), `
+				SELECT id, name, series, release_date, total_cards, symbol_url, logo_url
+				FROM pokemon_sets
+				ORDER BY release_date DESC, id DESC
+				LIMIT ? OFFSET ?
+			`, limit, offset)
+		}
+		if err != nil {
+			log.Printf("pokemon: list sets: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to list sets")
+			return
+		}
+		defer rows.Close()
+
+		sets := make([]SetDTO, 0)
+		for rows.Next() {
+			var s SetDTO
+			if err := rows.Scan(&s.ID, &s.Name, &s.Series, &s.ReleaseDate, &s.TotalCards, &s.SymbolURL, &s.LogoURL); err != nil {
+				log.Printf("pokemon: scan set: %v", err)
+				respondError(w, http.StatusInternalServerError, "failed to list sets")
+				return
+			}
+			sets = append(sets, s)
+		}
+		if err := rows.Err(); err != nil {
+			log.Printf("pokemon: iterate sets: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to list sets")
+			return
+		}
+
+		respondJSON(w, http.StatusOK, map[string]any{"sets": sets})
+	}
+}
+
+// ListSetCardsHandler returns every card in a set with variants and per-user
+// ownership flags. Caller must be authenticated; the URL must contain {id}.
+func ListSetCardsHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		setID := strings.TrimSpace(chi.URLParam(r, "id"))
+		if setID == "" {
+			respondError(w, http.StatusBadRequest, "set id is required")
+			return
+		}
+
+		cards, err := loadCardsForSet(r, db, user.ID, setID)
+		if err != nil {
+			log.Printf("pokemon: list set cards: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to list cards")
+			return
+		}
+
+		rate, ok := loadRate(r, db)
+		applyNOK(w, cards, rate, ok)
+		respondJSON(w, http.StatusOK, map[string]any{"cards": cards})
+	}
+}
+
+// SearchCardsHandler powers autocomplete by collector number or name fragment.
+// The query parameter is ?q=<text>. The optional ?limit= caps the response at
+// up to 50 cards.
+func SearchCardsHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		q := strings.TrimSpace(r.URL.Query().Get("q"))
+		if q == "" {
+			respondJSON(w, http.StatusOK, map[string]any{"cards": []CardDTO{}})
+			return
+		}
+		limit := parseLimit(r, defaultListLimit, maxListLimit)
+
+		cards, err := searchCards(r, db, user.ID, q, limit)
+		if err != nil {
+			log.Printf("pokemon: search cards: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to search cards")
+			return
+		}
+
+		rate, ok := loadRate(r, db)
+		applyNOK(w, cards, rate, ok)
+		respondJSON(w, http.StatusOK, map[string]any{"cards": cards})
+	}
+}
+
+// UpsertCollectionHandler inserts or updates a collection row for the current
+// user. The (user_id, card_id, variant_id) tuple is unique, so calling this
+// endpoint twice with the same payload updates instead of duplicating.
+func UpsertCollectionHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		var body struct {
+			CardID    string `json:"card_id"`
+			VariantID int64  `json:"variant_id"`
+			Quantity  int    `json:"quantity"`
+			Condition string `json:"condition"`
+			Notes     string `json:"notes"`
+		}
+		if !decodeBody(w, r, &body) {
+			return
+		}
+		body.CardID = strings.TrimSpace(body.CardID)
+		body.Condition = strings.TrimSpace(body.Condition)
+		if body.CardID == "" || body.VariantID == 0 {
+			respondError(w, http.StatusBadRequest, "card_id and variant_id are required")
+			return
+		}
+		if body.Quantity < 0 {
+			respondError(w, http.StatusBadRequest, "quantity must be non-negative")
+			return
+		}
+		if body.Quantity == 0 {
+			body.Quantity = 1
+		}
+		if !allowedConditions[body.Condition] {
+			respondError(w, http.StatusBadRequest, "invalid condition")
+			return
+		}
+
+		// Verify the variant belongs to the card so the FK relationship is
+		// well-formed before we encrypt + write.
+		var variantCard string
+		err := db.QueryRowContext(r.Context(),
+			`SELECT card_id FROM pokemon_card_variants WHERE id = ?`, body.VariantID,
+		).Scan(&variantCard)
+		if errors.Is(err, sql.ErrNoRows) {
+			respondError(w, http.StatusNotFound, "variant not found")
+			return
+		}
+		if err != nil {
+			log.Printf("pokemon: lookup variant: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to verify variant")
+			return
+		}
+		if variantCard != body.CardID {
+			respondError(w, http.StatusBadRequest, "variant does not belong to card")
+			return
+		}
+
+		notesEnc, err := encryptNotes(body.Notes)
+		if err != nil {
+			log.Printf("pokemon: encrypt notes: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to encrypt notes")
+			return
+		}
+		now := time.Now().UTC()
+		// Determine whether an existing row already covers (user, card, variant) so
+		// we can return the correct status code (200 vs 201) and re-read the row.
+		var existingID int64
+		err = db.QueryRowContext(r.Context(),
+			`SELECT id FROM pokemon_collections WHERE user_id = ? AND card_id = ? AND variant_id = ?`,
+			user.ID, body.CardID, body.VariantID,
+		).Scan(&existingID)
+		isNew := errors.Is(err, sql.ErrNoRows)
+		if err != nil && !isNew {
+			log.Printf("pokemon: lookup collection: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to upsert collection")
+			return
+		}
+
+		_, err = db.ExecContext(r.Context(), `
+			INSERT INTO pokemon_collections (user_id, card_id, variant_id, quantity, condition, acquired_at, notes_enc)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(user_id, card_id, variant_id) DO UPDATE SET
+				quantity   = excluded.quantity,
+				condition  = excluded.condition,
+				notes_enc  = excluded.notes_enc
+		`, user.ID, body.CardID, body.VariantID, body.Quantity, body.Condition, now, notesEnc)
+		if err != nil {
+			log.Printf("pokemon: upsert collection: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to upsert collection")
+			return
+		}
+
+		row, err := loadCollectionRow(r, db, user.ID, body.CardID, body.VariantID)
+		if err != nil {
+			log.Printf("pokemon: reload collection: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to read collection")
+			return
+		}
+		status := http.StatusOK
+		if isNew {
+			status = http.StatusCreated
+		}
+		respondJSON(w, status, map[string]any{"item": row})
+	}
+}
+
+// UpdateCollectionHandler patches an existing collection row. Only fields
+// present in the request body are updated. The row must belong to the
+// authenticated user.
+func UpdateCollectionHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil || id <= 0 {
+			respondError(w, http.StatusBadRequest, "invalid collection id")
+			return
+		}
+		var body struct {
+			Quantity  *int    `json:"quantity"`
+			Condition *string `json:"condition"`
+			Notes     *string `json:"notes"`
+		}
+		if !decodeBody(w, r, &body) {
+			return
+		}
+
+		// Read-modify-write under the user_id scope to enforce ownership.
+		// A row that does not exist or belongs to another user looks the same
+		// to the caller: 404.
+		var existing CollectionRow
+		var encNotes sql.NullString
+		err = db.QueryRowContext(r.Context(), `
+			SELECT id, user_id, card_id, variant_id, quantity, condition, acquired_at, notes_enc
+			FROM pokemon_collections
+			WHERE id = ? AND user_id = ?
+		`, id, user.ID).Scan(&existing.ID, &existing.UserID, &existing.CardID, &existing.VariantID,
+			&existing.Quantity, &existing.Condition, &existing.AcquiredAt, &encNotes)
+		if errors.Is(err, sql.ErrNoRows) {
+			respondError(w, http.StatusNotFound, "collection item not found")
+			return
+		}
+		if err != nil {
+			log.Printf("pokemon: load collection: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to load collection")
+			return
+		}
+		existing.Notes = decryptNotes(encNotes)
+
+		if body.Quantity != nil {
+			if *body.Quantity < 0 {
+				respondError(w, http.StatusBadRequest, "quantity must be non-negative")
+				return
+			}
+			existing.Quantity = *body.Quantity
+		}
+		if body.Condition != nil {
+			cond := strings.TrimSpace(*body.Condition)
+			if !allowedConditions[cond] {
+				respondError(w, http.StatusBadRequest, "invalid condition")
+				return
+			}
+			existing.Condition = cond
+		}
+		if body.Notes != nil {
+			existing.Notes = *body.Notes
+		}
+
+		notesEnc, err := encryptNotes(existing.Notes)
+		if err != nil {
+			log.Printf("pokemon: encrypt notes: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to encrypt notes")
+			return
+		}
+		if _, err := db.ExecContext(r.Context(), `
+			UPDATE pokemon_collections
+			SET quantity = ?, condition = ?, notes_enc = ?
+			WHERE id = ? AND user_id = ?
+		`, existing.Quantity, existing.Condition, notesEnc, id, user.ID); err != nil {
+			log.Printf("pokemon: update collection: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to update collection")
+			return
+		}
+
+		respondJSON(w, http.StatusOK, map[string]any{"item": existing})
+	}
+}
+
+// DeleteCollectionHandler removes a collection row owned by the current user.
+// Returns 204 on success, 404 when the row does not exist or belongs to a
+// different user.
+func DeleteCollectionHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil || id <= 0 {
+			respondError(w, http.StatusBadRequest, "invalid collection id")
+			return
+		}
+		res, err := db.ExecContext(r.Context(),
+			`DELETE FROM pokemon_collections WHERE id = ? AND user_id = ?`,
+			id, user.ID,
+		)
+		if err != nil {
+			log.Printf("pokemon: delete collection: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete collection")
+			return
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			respondError(w, http.StatusNotFound, "collection item not found")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// MissingFromSetHandler returns the cards in a set that the current user does
+// not yet own (no variant present in their collection). Useful for "what's
+// left to find?" UIs.
+func MissingFromSetHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		setID := strings.TrimSpace(r.URL.Query().Get("set_id"))
+		if setID == "" {
+			respondError(w, http.StatusBadRequest, "set_id is required")
+			return
+		}
+		cards, err := loadCardsForSet(r, db, user.ID, setID)
+		if err != nil {
+			log.Printf("pokemon: missing-from-set: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to list cards")
+			return
+		}
+		missing := make([]CardDTO, 0, len(cards))
+		for _, c := range cards {
+			owned := false
+			for _, v := range c.Variants {
+				if v.Owned {
+					owned = true
+					break
+				}
+			}
+			if !owned {
+				missing = append(missing, c)
+			}
+		}
+
+		rate, ok := loadRate(r, db)
+		applyNOK(w, missing, rate, ok)
+		respondJSON(w, http.StatusOK, map[string]any{"cards": missing})
+	}
+}
+
+// loadCardsForSet hydrates every card in a set with its variants and owner
+// flags for the given user.
+func loadCardsForSet(r *http.Request, db *sql.DB, userID int64, setID string) ([]CardDTO, error) {
+	cardRows, err := db.QueryContext(r.Context(), `
+		SELECT id, set_id, name, collector_no, rarity, image_small_url, image_large_url
+		FROM pokemon_cards
+		WHERE set_id = ?
+		ORDER BY CAST(collector_no AS INTEGER), collector_no
+		LIMIT ?
+	`, setID, maxSetCardsLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer cardRows.Close()
+
+	cards := make([]CardDTO, 0)
+	cardIndex := make(map[string]int)
+	for cardRows.Next() {
+		var c CardDTO
+		if err := cardRows.Scan(&c.ID, &c.SetID, &c.Name, &c.CollectorNo, &c.Rarity, &c.ImageSmallURL, &c.ImageLargeURL); err != nil {
+			return nil, err
+		}
+		c.Variants = []VariantDTO{}
+		cardIndex[c.ID] = len(cards)
+		cards = append(cards, c)
+	}
+	if err := cardRows.Err(); err != nil {
+		return nil, err
+	}
+	if len(cards) == 0 {
+		return cards, nil
+	}
+	return hydrateVariants(r, db, userID, cards, cardIndex)
+}
+
+// searchCards executes either a collector-number or name-fragment lookup.
+func searchCards(r *http.Request, db *sql.DB, userID int64, q string, limit int) ([]CardDTO, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if collectorNumberPattern.MatchString(q) {
+		// "025/195" → split into number and total; "025" → number only.
+		numPart := q
+		totalPart := ""
+		if idx := strings.Index(q, "/"); idx >= 0 {
+			numPart = q[:idx]
+			totalPart = q[idx+1:]
+		}
+		numInt, _ := strconv.Atoi(numPart)
+		if totalPart != "" {
+			totalInt, _ := strconv.Atoi(totalPart)
+			rows, err = db.QueryContext(r.Context(), `
+				SELECT c.id, c.set_id, s.name, c.name, c.collector_no, c.rarity, c.image_small_url, c.image_large_url
+				FROM pokemon_cards c
+				JOIN pokemon_sets s ON s.id = c.set_id
+				WHERE CAST(c.collector_no AS INTEGER) = ?
+				  AND s.total_cards = ?
+				ORDER BY s.release_date DESC, c.id
+				LIMIT ?
+			`, numInt, totalInt, limit)
+		} else {
+			rows, err = db.QueryContext(r.Context(), `
+				SELECT c.id, c.set_id, s.name, c.name, c.collector_no, c.rarity, c.image_small_url, c.image_large_url
+				FROM pokemon_cards c
+				JOIN pokemon_sets s ON s.id = c.set_id
+				WHERE CAST(c.collector_no AS INTEGER) = ?
+				ORDER BY s.release_date DESC, c.id
+				LIMIT ?
+			`, numInt, limit)
+		}
+	} else {
+		// Name fragment: case-insensitive LIKE with %fragment%.
+		pattern := "%" + strings.ToLower(q) + "%"
+		rows, err = db.QueryContext(r.Context(), `
+			SELECT c.id, c.set_id, s.name, c.name, c.collector_no, c.rarity, c.image_small_url, c.image_large_url
+			FROM pokemon_cards c
+			JOIN pokemon_sets s ON s.id = c.set_id
+			WHERE LOWER(c.name) LIKE ?
+			ORDER BY s.release_date DESC, c.id
+			LIMIT ?
+		`, pattern, limit)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cards := make([]CardDTO, 0)
+	cardIndex := make(map[string]int)
+	for rows.Next() {
+		var c CardDTO
+		if err := rows.Scan(&c.ID, &c.SetID, &c.SetName, &c.Name, &c.CollectorNo, &c.Rarity, &c.ImageSmallURL, &c.ImageLargeURL); err != nil {
+			return nil, err
+		}
+		c.Variants = []VariantDTO{}
+		cardIndex[c.ID] = len(cards)
+		cards = append(cards, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(cards) == 0 {
+		return cards, nil
+	}
+	return hydrateVariants(r, db, userID, cards, cardIndex)
+}
+
+// hydrateVariants fetches every variant for the cards in cardIndex and merges
+// ownership data from pokemon_collections for the given user.
+func hydrateVariants(r *http.Request, db *sql.DB, userID int64, cards []CardDTO, cardIndex map[string]int) ([]CardDTO, error) {
+	ids := make([]any, 0, len(cardIndex))
+	placeholders := make([]string, 0, len(cardIndex))
+	for id := range cardIndex {
+		ids = append(ids, id)
+		placeholders = append(placeholders, "?")
+	}
+	query := `
+		SELECT v.id, v.card_id, v.kind, v.price_eur, v.price_at,
+		       c.id, c.quantity, c.condition, c.acquired_at, c.notes_enc
+		FROM pokemon_card_variants v
+		LEFT JOIN pokemon_collections c
+		  ON c.variant_id = v.id AND c.user_id = ?
+		WHERE v.card_id IN (` + strings.Join(placeholders, ",") + `)
+		ORDER BY v.card_id, v.kind
+	`
+	args := append([]any{userID}, ids...)
+	rows, err := db.QueryContext(r.Context(), query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			vID         int64
+			cardID      string
+			kind        string
+			priceEUR    float64
+			priceAt     sql.NullString
+			collID      sql.NullInt64
+			collQty     sql.NullInt64
+			collCond    sql.NullString
+			collAcq     sql.NullString
+			collNotesEn sql.NullString
+		)
+		if err := rows.Scan(&vID, &cardID, &kind, &priceEUR, &priceAt,
+			&collID, &collQty, &collCond, &collAcq, &collNotesEn); err != nil {
+			return nil, err
+		}
+		idx, ok := cardIndex[cardID]
+		if !ok {
+			continue
+		}
+		v := VariantDTO{
+			ID:       vID,
+			Kind:     kind,
+			PriceEUR: priceEUR,
+		}
+		if priceAt.Valid && priceAt.String != "" {
+			ts := priceAt.String
+			v.PriceAt = &ts
+		}
+		if collID.Valid {
+			id := collID.Int64
+			v.Owned = true
+			v.OwnedID = &id
+			if collQty.Valid {
+				v.Quantity = int(collQty.Int64)
+			}
+			if collCond.Valid {
+				v.Condition = collCond.String
+			}
+			if collAcq.Valid && collAcq.String != "" {
+				ts := collAcq.String
+				v.AcquiredAt = &ts
+			}
+			v.Notes = decryptNotes(collNotesEn)
+		}
+		cards[idx].Variants = append(cards[idx].Variants, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return cards, nil
+}
+
+// loadCollectionRow re-reads a single collection row after an upsert so the
+// response reflects the persisted state (including the generated id and
+// acquired_at timestamp).
+func loadCollectionRow(r *http.Request, db *sql.DB, userID int64, cardID string, variantID int64) (*CollectionRow, error) {
+	var row CollectionRow
+	var encNotes sql.NullString
+	err := db.QueryRowContext(r.Context(), `
+		SELECT id, user_id, card_id, variant_id, quantity, condition, acquired_at, notes_enc
+		FROM pokemon_collections
+		WHERE user_id = ? AND card_id = ? AND variant_id = ?
+	`, userID, cardID, variantID).Scan(
+		&row.ID, &row.UserID, &row.CardID, &row.VariantID,
+		&row.Quantity, &row.Condition, &row.AcquiredAt, &encNotes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	row.Notes = decryptNotes(encNotes)
+	return &row, nil
+}
+
+// encryptNotes encrypts plaintext notes for storage. Empty notes are stored
+// as NULL so the column remains queryable for "has notes" filters.
+func encryptNotes(plain string) (any, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return encryption.EncryptField(plain)
+}
+
+// decryptNotes returns the plaintext notes for a nullable encrypted column.
+// Legacy plaintext values are returned as-is with a log warning, matching the
+// rest of the codebase's tolerant decryption strategy.
+func decryptNotes(enc sql.NullString) string {
+	if !enc.Valid || enc.String == "" {
+		return ""
+	}
+	plain, err := encryption.DecryptField(enc.String)
+	if err != nil {
+		log.Printf("pokemon: decrypt notes: %v", err)
+		return enc.String
+	}
+	return plain
+}

--- a/internal/pokemon/handlers_test.go
+++ b/internal/pokemon/handlers_test.go
@@ -1,0 +1,719 @@
+package pokemon
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/go-chi/chi/v5"
+)
+
+// seedUser inserts a user with the given id+email and enables the pokemon
+// feature for them. Returns a *auth.User suitable for injecting into a
+// request context.
+func seedUser(t *testing.T, db *sql.DB, id int64, email string) *auth.User {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO users (id, email, name, google_id)
+		VALUES (?, ?, ?, ?)
+	`, id, email, email, email); err != nil {
+		t.Fatalf("seed user %d: %v", id, err)
+	}
+	if err := auth.SetUserFeature(db, id, "pokemon", true); err != nil {
+		t.Fatalf("enable pokemon feature for %d: %v", id, err)
+	}
+	return &auth.User{ID: id, Email: email, Name: email}
+}
+
+// seedCatalogue inserts two sets, four cards, and their variants. The base
+// fixture is shared across most tests so we can exercise filtering, ordering,
+// and ownership without rewriting it each time.
+func seedCatalogue(t *testing.T, db *sql.DB) {
+	t.Helper()
+	now := time.Now().UTC()
+	sets := []struct {
+		id, name, series, releaseDate string
+		total                         int
+	}{
+		{"sv1", "Scarlet & Violet Base", "Scarlet & Violet", "2023/03/31", 198},
+		{"swsh1", "Sword & Shield Base", "Sword & Shield", "2020/02/07", 202},
+	}
+	for _, s := range sets {
+		if _, err := db.Exec(`
+			INSERT INTO pokemon_sets (id, name, series, release_date, total_cards, symbol_url, logo_url, synced_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`, s.id, s.name, s.series, s.releaseDate, s.total, "", "", now); err != nil {
+			t.Fatalf("seed set %s: %v", s.id, err)
+		}
+	}
+
+	cards := []struct {
+		id, setID, name, collectorNo, rarity string
+	}{
+		{"sv1-25", "sv1", "Pikachu", "025", "Common"},
+		{"sv1-100", "sv1", "Eevee", "100", "Common"},
+		{"swsh1-1", "swsh1", "Celebi V", "001", "Rare Holo V"},
+		{"swsh1-25", "swsh1", "Pikachu V", "025", "Rare Holo V"},
+	}
+	for _, c := range cards {
+		if _, err := db.Exec(`
+			INSERT INTO pokemon_cards (id, set_id, name, collector_no, rarity, image_small_url, image_large_url, synced_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`, c.id, c.setID, c.name, c.collectorNo, c.rarity, "", "", now); err != nil {
+			t.Fatalf("seed card %s: %v", c.id, err)
+		}
+	}
+
+	variants := []struct {
+		cardID, kind string
+		eur          float64
+	}{
+		{"sv1-25", "normal", 10.0},
+		{"sv1-25", "reverse_holofoil", 14.5},
+		{"sv1-100", "normal", 2.5},
+		{"swsh1-1", "normal", 25.0},
+		{"swsh1-25", "normal", 8.0},
+	}
+	for _, v := range variants {
+		if _, err := db.Exec(`
+			INSERT INTO pokemon_card_variants (card_id, kind, price_eur, price_at)
+			VALUES (?, ?, ?, ?)
+		`, v.cardID, v.kind, v.eur, now); err != nil {
+			t.Fatalf("seed variant %s/%s: %v", v.cardID, v.kind, err)
+		}
+	}
+}
+
+// seedRate inserts a single EUR/NOK rate row dated to today.
+func seedRate(t *testing.T, db *sql.DB, rate float64) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO currency_rates (pair, rate, observed, fetched_at)
+		VALUES (?, ?, ?, ?)
+	`, "EUR/NOK", rate, time.Now().UTC().Format("2006-01-02"), time.Now().UTC()); err != nil {
+		t.Fatalf("seed rate: %v", err)
+	}
+}
+
+// variantID returns the auto-generated row id for a given card/kind pair.
+func variantID(t *testing.T, db *sql.DB, cardID, kind string) int64 {
+	t.Helper()
+	var id int64
+	if err := db.QueryRow(
+		`SELECT id FROM pokemon_card_variants WHERE card_id = ? AND kind = ?`,
+		cardID, kind,
+	).Scan(&id); err != nil {
+		t.Fatalf("lookup variant %s/%s: %v", cardID, kind, err)
+	}
+	return id
+}
+
+// asUser injects the authenticated user (and feature map for pokemon=true)
+// into the request context.
+func asUser(r *http.Request, u *auth.User) *http.Request {
+	ctx := auth.ContextWithUser(r.Context(), u)
+	return r.WithContext(ctx)
+}
+
+// asChi attaches chi URL params for handlers that read chi.URLParam.
+func asChi(r *http.Request, kv map[string]string) *http.Request {
+	rctx := chi.NewRouteContext()
+	for k, v := range kv {
+		rctx.URLParams.Add(k, v)
+	}
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+func decode[T any](t *testing.T, rec *httptest.ResponseRecorder) T {
+	t.Helper()
+	var out T
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v (body=%q)", err, rec.Body.String())
+	}
+	return out
+}
+
+// --- ListSetsHandler ----------------------------------------------------------
+
+func TestListSetsHandler_NewestFirst(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets", nil), u)
+	rec := httptest.NewRecorder()
+	ListSetsHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Sets []SetDTO `json:"sets"`
+	}](t, rec)
+	if len(body.Sets) != 2 {
+		t.Fatalf("expected 2 sets, got %d", len(body.Sets))
+	}
+	if body.Sets[0].ID != "sv1" {
+		t.Errorf("expected newest set first, got %q", body.Sets[0].ID)
+	}
+}
+
+func TestListSetsHandler_FilterByEra(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets?era=Sword+%26+Shield", nil), u)
+	rec := httptest.NewRecorder()
+	ListSetsHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Sets []SetDTO `json:"sets"`
+	}](t, rec)
+	if len(body.Sets) != 1 || body.Sets[0].ID != "swsh1" {
+		t.Errorf("expected only swsh1, got %+v", body.Sets)
+	}
+}
+
+func TestListSetsHandler_LimitOffset(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets?limit=1&offset=1", nil), u)
+	rec := httptest.NewRecorder()
+	ListSetsHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := decode[struct {
+		Sets []SetDTO `json:"sets"`
+	}](t, rec)
+	if len(body.Sets) != 1 || body.Sets[0].ID != "swsh1" {
+		t.Errorf("expected second set after offset, got %+v", body.Sets)
+	}
+}
+
+// --- ListSetCardsHandler ------------------------------------------------------
+
+func TestListSetCardsHandler_Success_WithNOK(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	seedRate(t, db, 11.5)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asChi(asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets/sv1/cards", nil), u),
+		map[string]string{"id": "sv1"})
+	rec := httptest.NewRecorder()
+	ListSetCardsHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("X-Pokemon-Rate-Missing") != "" {
+		t.Errorf("expected no rate-missing header, got %q", rec.Header().Get("X-Pokemon-Rate-Missing"))
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	if len(body.Cards) != 2 {
+		t.Fatalf("expected 2 cards in sv1, got %d", len(body.Cards))
+	}
+	// Cards are ordered by collector_no — Pikachu (25) before Eevee (100).
+	if body.Cards[0].CollectorNo != "025" {
+		t.Errorf("expected collector_no 025 first, got %q", body.Cards[0].CollectorNo)
+	}
+	// Normal variant of Pikachu costs 10 EUR; with rate 11.5 → 115 NOK.
+	for _, v := range body.Cards[0].Variants {
+		if v.Kind != "normal" {
+			continue
+		}
+		if v.PriceNOK == nil {
+			t.Fatalf("expected non-nil price_nok for normal variant")
+		}
+		if got := *v.PriceNOK; got != 115.0 {
+			t.Errorf("expected price_nok=115.0, got %v", got)
+		}
+	}
+}
+
+func TestListSetCardsHandler_MissingRate(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asChi(asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets/sv1/cards", nil), u),
+		map[string]string{"id": "sv1"})
+	rec := httptest.NewRecorder()
+	ListSetCardsHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Header().Get("X-Pokemon-Rate-Missing") != "1" {
+		t.Errorf("expected X-Pokemon-Rate-Missing=1 header, got %q", rec.Header().Get("X-Pokemon-Rate-Missing"))
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	for _, c := range body.Cards {
+		for _, v := range c.Variants {
+			if v.PriceNOK != nil {
+				t.Errorf("expected price_nok=nil when rate missing, got %v", *v.PriceNOK)
+			}
+		}
+	}
+}
+
+func TestListSetCardsHandler_OwnedFlag(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+	pikachuNormal := variantID(t, db, "sv1-25", "normal")
+	if _, err := db.Exec(`
+		INSERT INTO pokemon_collections (user_id, card_id, variant_id, quantity, condition, acquired_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, u.ID, "sv1-25", pikachuNormal, 3, "near_mint", time.Now().UTC()); err != nil {
+		t.Fatalf("seed collection: %v", err)
+	}
+
+	req := asChi(asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets/sv1/cards", nil), u),
+		map[string]string{"id": "sv1"})
+	rec := httptest.NewRecorder()
+	ListSetCardsHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	gotOwned := false
+	for _, c := range body.Cards {
+		for _, v := range c.Variants {
+			if v.ID == pikachuNormal {
+				if !v.Owned || v.Quantity != 3 || v.Condition != "near_mint" {
+					t.Errorf("expected owned variant with quantity=3, got %+v", v)
+				}
+				gotOwned = true
+			} else if v.Owned {
+				t.Errorf("unexpected owned flag on variant %d", v.ID)
+			}
+		}
+	}
+	if !gotOwned {
+		t.Errorf("expected to find owned variant in response")
+	}
+}
+
+// --- SearchCardsHandler -------------------------------------------------------
+
+func TestSearchCardsHandler_ByCollectorNumber(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	// "025/198" matches Pikachu in sv1 (total=198) but not Pikachu V in swsh1 (total=202).
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/cards/search?q=025/198", nil), u)
+	rec := httptest.NewRecorder()
+	SearchCardsHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	if len(body.Cards) != 1 || body.Cards[0].ID != "sv1-25" {
+		t.Errorf("expected single sv1-25 hit, got %+v", body.Cards)
+	}
+}
+
+func TestSearchCardsHandler_ByCollectorNumberOnly(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	// "025" without total — should return both Pikachus across sets.
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/cards/search?q=025", nil), u)
+	rec := httptest.NewRecorder()
+	SearchCardsHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	if len(body.Cards) != 2 {
+		t.Errorf("expected 2 cards with collector_no 25, got %d", len(body.Cards))
+	}
+}
+
+func TestSearchCardsHandler_ByNameFragment(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/cards/search?q=pika", nil), u)
+	rec := httptest.NewRecorder()
+	SearchCardsHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	if len(body.Cards) != 2 {
+		t.Fatalf("expected 2 Pikachu hits, got %d", len(body.Cards))
+	}
+	for _, c := range body.Cards {
+		if !strings.Contains(strings.ToLower(c.Name), "pikachu") {
+			t.Errorf("unexpected hit %q", c.Name)
+		}
+	}
+}
+
+func TestSearchCardsHandler_EmptyQuery(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/cards/search?q=", nil), u)
+	rec := httptest.NewRecorder()
+	SearchCardsHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	if len(body.Cards) != 0 {
+		t.Errorf("expected empty result for empty query, got %d cards", len(body.Cards))
+	}
+}
+
+// --- Collection CRUD ----------------------------------------------------------
+
+func TestUpsertCollectionHandler_CreatesAndUpdates(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+	vid := variantID(t, db, "sv1-25", "normal")
+
+	// First call creates → 201.
+	payload := map[string]any{
+		"card_id":    "sv1-25",
+		"variant_id": vid,
+		"quantity":   2,
+		"condition":  "near_mint",
+		"notes":      "first booster",
+	}
+	rec := callJSON(t, http.MethodPost, "/api/pokemon/collection", payload, u, nil, UpsertCollectionHandler(db))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 on create, got %d: %s", rec.Code, rec.Body.String())
+	}
+	created := decode[struct {
+		Item CollectionRow `json:"item"`
+	}](t, rec)
+	if created.Item.Quantity != 2 || created.Item.Condition != "near_mint" || created.Item.Notes != "first booster" {
+		t.Errorf("unexpected created row: %+v", created.Item)
+	}
+	if created.Item.ID == 0 {
+		t.Errorf("expected non-zero id, got %d", created.Item.ID)
+	}
+
+	// Verify notes are encrypted at rest.
+	var stored sql.NullString
+	if err := db.QueryRow(`SELECT notes_enc FROM pokemon_collections WHERE id = ?`, created.Item.ID).Scan(&stored); err != nil {
+		t.Fatalf("read notes_enc: %v", err)
+	}
+	if !stored.Valid || stored.String == "first booster" {
+		t.Errorf("notes_enc should be encrypted, got valid=%v string=%q", stored.Valid, stored.String)
+	}
+	plain, err := encryption.DecryptField(stored.String)
+	if err != nil || plain != "first booster" {
+		t.Errorf("decrypt mismatch: plain=%q err=%v", plain, err)
+	}
+
+	// Second call updates → 200 (same unique tuple).
+	payload["quantity"] = 5
+	payload["notes"] = "updated note"
+	rec = callJSON(t, http.MethodPost, "/api/pokemon/collection", payload, u, nil, UpsertCollectionHandler(db))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on update, got %d: %s", rec.Code, rec.Body.String())
+	}
+	updated := decode[struct {
+		Item CollectionRow `json:"item"`
+	}](t, rec)
+	if updated.Item.Quantity != 5 || updated.Item.Notes != "updated note" {
+		t.Errorf("unexpected updated row: %+v", updated.Item)
+	}
+	if updated.Item.ID != created.Item.ID {
+		t.Errorf("expected same id after update, got %d vs %d", updated.Item.ID, created.Item.ID)
+	}
+}
+
+func TestUpsertCollectionHandler_VariantMismatch(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+	otherVID := variantID(t, db, "sv1-100", "normal")
+
+	payload := map[string]any{
+		"card_id":    "sv1-25",
+		"variant_id": otherVID,
+		"quantity":   1,
+	}
+	rec := callJSON(t, http.MethodPost, "/api/pokemon/collection", payload, u, nil, UpsertCollectionHandler(db))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for mismatched variant, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpsertCollectionHandler_InvalidCondition(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+	vid := variantID(t, db, "sv1-25", "normal")
+
+	payload := map[string]any{
+		"card_id":    "sv1-25",
+		"variant_id": vid,
+		"quantity":   1,
+		"condition":  "perfect",
+	}
+	rec := callJSON(t, http.MethodPost, "/api/pokemon/collection", payload, u, nil, UpsertCollectionHandler(db))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid condition, got %d", rec.Code)
+	}
+}
+
+func TestUpdateCollectionHandler_OwnerScopedAndPartial(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	uA := seedUser(t, db, 1, "a@example.com")
+	uB := seedUser(t, db, 2, "b@example.com")
+	vid := variantID(t, db, "sv1-25", "normal")
+
+	// User A creates a row.
+	rec := callJSON(t, http.MethodPost, "/api/pokemon/collection", map[string]any{
+		"card_id":    "sv1-25",
+		"variant_id": vid,
+		"quantity":   1,
+		"condition":  "mint",
+		"notes":      "hers",
+	}, uA, nil, UpsertCollectionHandler(db))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create as A: %d %s", rec.Code, rec.Body.String())
+	}
+	rowA := decode[struct {
+		Item CollectionRow `json:"item"`
+	}](t, rec).Item
+
+	// User B tries to update A's row → 404.
+	rec = callJSON(t, http.MethodPatch, "/api/pokemon/collection/"+strconv.FormatInt(rowA.ID, 10),
+		map[string]any{"quantity": 99}, uB, map[string]string{"id": strconv.FormatInt(rowA.ID, 10)},
+		UpdateCollectionHandler(db))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 cross-user, got %d", rec.Code)
+	}
+
+	// User A partial-updates only condition. Quantity and notes untouched.
+	rec = callJSON(t, http.MethodPatch, "/api/pokemon/collection/"+strconv.FormatInt(rowA.ID, 10),
+		map[string]any{"condition": "lightly_played"}, uA, map[string]string{"id": strconv.FormatInt(rowA.ID, 10)},
+		UpdateCollectionHandler(db))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	patched := decode[struct {
+		Item CollectionRow `json:"item"`
+	}](t, rec).Item
+	if patched.Condition != "lightly_played" || patched.Quantity != 1 || patched.Notes != "hers" {
+		t.Errorf("partial update mismatched: %+v", patched)
+	}
+}
+
+func TestDeleteCollectionHandler_OwnerScoped(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	uA := seedUser(t, db, 1, "a@example.com")
+	uB := seedUser(t, db, 2, "b@example.com")
+	vid := variantID(t, db, "sv1-25", "normal")
+
+	rec := callJSON(t, http.MethodPost, "/api/pokemon/collection", map[string]any{
+		"card_id":    "sv1-25",
+		"variant_id": vid,
+		"quantity":   1,
+	}, uA, nil, UpsertCollectionHandler(db))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create as A: %d", rec.Code)
+	}
+	rowA := decode[struct {
+		Item CollectionRow `json:"item"`
+	}](t, rec).Item
+	idStr := strconv.FormatInt(rowA.ID, 10)
+
+	// B cannot delete A's row.
+	rec = callJSON(t, http.MethodDelete, "/api/pokemon/collection/"+idStr, nil, uB,
+		map[string]string{"id": idStr}, DeleteCollectionHandler(db))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 cross-user delete, got %d", rec.Code)
+	}
+
+	// A can delete → 204.
+	rec = callJSON(t, http.MethodDelete, "/api/pokemon/collection/"+idStr, nil, uA,
+		map[string]string{"id": idStr}, DeleteCollectionHandler(db))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
+	}
+
+	// Second delete → 404 (row is gone).
+	rec = callJSON(t, http.MethodDelete, "/api/pokemon/collection/"+idStr, nil, uA,
+		map[string]string{"id": idStr}, DeleteCollectionHandler(db))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 second delete, got %d", rec.Code)
+	}
+}
+
+// --- MissingFromSetHandler ----------------------------------------------------
+
+func TestMissingFromSetHandler_ExcludesOwned(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	seedRate(t, db, 11.5)
+	u := seedUser(t, db, 1, "a@example.com")
+	vid := variantID(t, db, "sv1-25", "normal")
+	if _, err := db.Exec(`
+		INSERT INTO pokemon_collections (user_id, card_id, variant_id, quantity, condition, acquired_at)
+		VALUES (?, ?, ?, 1, '', ?)
+	`, u.ID, "sv1-25", vid, time.Now().UTC()); err != nil {
+		t.Fatalf("seed collection: %v", err)
+	}
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/collection/missing?set_id=sv1", nil), u)
+	rec := httptest.NewRecorder()
+	MissingFromSetHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	if len(body.Cards) != 1 || body.Cards[0].ID != "sv1-100" {
+		t.Errorf("expected only sv1-100 missing, got %+v", body.Cards)
+	}
+}
+
+func TestMissingFromSetHandler_RequiresSetID(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/collection/missing", nil), u)
+	rec := httptest.NewRecorder()
+	MissingFromSetHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+// --- Feature-flag enforcement -------------------------------------------------
+
+// TestFeatureFlagEnforcement_All wires every endpoint through the real
+// auth.RequireAuth + auth.RequireFeature middleware and asserts that a user
+// without the pokemon flag is denied across the board. This is the end-to-end
+// proof that the feature gate is wired correctly.
+func TestFeatureFlagEnforcement_All(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+
+	// Create a non-admin user WITHOUT the pokemon feature.
+	if _, err := db.Exec(`
+		INSERT INTO users (id, email, name, google_id)
+		VALUES (1, 'a@example.com', 'A', 'a-google')
+	`); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	// Provision a session so RequireAuth resolves the user.
+	token, _, err := auth.CreateSession(db, 1)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAuth(db))
+		r.Use(auth.WithFeatures(db))
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireFeature(db, "pokemon"))
+			r.Get("/api/pokemon/sets", ListSetsHandler(db))
+			r.Get("/api/pokemon/sets/{id}/cards", ListSetCardsHandler(db))
+			r.Get("/api/pokemon/cards/search", SearchCardsHandler(db))
+			r.Post("/api/pokemon/collection", UpsertCollectionHandler(db))
+			r.Patch("/api/pokemon/collection/{id}", UpdateCollectionHandler(db))
+			r.Delete("/api/pokemon/collection/{id}", DeleteCollectionHandler(db))
+			r.Get("/api/pokemon/collection/missing", MissingFromSetHandler(db))
+		})
+	})
+
+	calls := []struct {
+		method, path string
+	}{
+		{http.MethodGet, "/api/pokemon/sets"},
+		{http.MethodGet, "/api/pokemon/sets/sv1/cards"},
+		{http.MethodGet, "/api/pokemon/cards/search?q=pika"},
+		{http.MethodPost, "/api/pokemon/collection"},
+		{http.MethodPatch, "/api/pokemon/collection/1"},
+		{http.MethodDelete, "/api/pokemon/collection/1"},
+		{http.MethodGet, "/api/pokemon/collection/missing?set_id=sv1"},
+	}
+	for _, c := range calls {
+		req := httptest.NewRequest(c.method, c.path, strings.NewReader(`{}`))
+		req.AddCookie(&http.Cookie{Name: "session", Value: token})
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s %s: expected 403 without pokemon flag, got %d (%s)",
+				c.method, c.path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// callJSON encodes payload as JSON, attaches the user + optional chi params,
+// and runs the handler against the resulting request/recorder pair.
+func callJSON(t *testing.T, method, path string, payload any, user *auth.User, params map[string]string, h http.HandlerFunc) *httptest.ResponseRecorder {
+	t.Helper()
+	var body *bytes.Buffer
+	if payload != nil {
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		body = bytes.NewBuffer(raw)
+	} else {
+		body = bytes.NewBuffer(nil)
+	}
+	req := httptest.NewRequest(method, path, body)
+	req.Header.Set("Content-Type", "application/json")
+	if user != nil {
+		req = asUser(req, user)
+	}
+	if len(params) > 0 {
+		req = asChi(req, params)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}

--- a/internal/pokemon/sync_test.go
+++ b/internal/pokemon/sync_test.go
@@ -19,6 +19,7 @@ import (
 
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-key-for-pokemon-tests")
 	d, err := db.Init(":memory:")
 	if err != nil {
 		t.Fatalf("init test db: %v", err)

--- a/internal/pokemon/sync_test.go
+++ b/internal/pokemon/sync_test.go
@@ -15,11 +15,14 @@ import (
 	"time"
 
 	"github.com/Robin831/Hytte/internal/db"
+	"github.com/Robin831/Hytte/internal/encryption"
 )
 
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	t.Setenv("ENCRYPTION_KEY", "test-key-for-pokemon-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
 	d, err := db.Init(":memory:")
 	if err != nil {
 		t.Fatalf("init test db: %v", err)


### PR DESCRIPTION
## Changes

- **Pokémon Collection REST API** - New endpoints under `/api/pokemon/*` for listing sets, browsing cards in a set, autocomplete search by collector number or name fragment, and per-user collection CRUD. Variant prices are returned in both EUR and NOK using the latest cached Norges Bank rate; an `X-Pokemon-Rate-Missing` header signals when no rate is available. All endpoints are gated by the `pokemon` feature flag. (Hytte-l9op)

## Original Issue (feature): Pokémon: REST handlers (sets, cards, collection, search)

Part of the Pokémon Collection chain seeded from Suggestions id=146. See that suggestion's plan for the full architecture, data sources (pokemontcg.io + Norges Bank EUR/NOK), and scope decisions (per-kid collections, NOK only, variants from day 1, local image cache).

This bead is step 3/7: REST handlers of the chain.

## Scope

REST handlers in `internal/pokemon/handlers.go` wired in `internal/api/router.go` inside `RequireAuth` + `RequireFeature(db, "pokemon")`.

### Endpoints

- GET /api/pokemon/sets?era=<series>&limit=<n>&offset=<n>
    - Returns sets, optionally filtered by series name (e.g. "Scarlet & Violet").
    - Default behaviour: newest sets first.
- GET /api/pokemon/sets/{id}/cards
    - Returns cards for the set with: card metadata, variants (each with `price_eur` and the computed `price_nok`), owned flag per variant for the current user.
- GET /api/pokemon/cards/search?q=<text>&limit=<n>
    - Autocomplete by collector number ("025/195") OR name fragment ("pika").
    - Returns up to 50 cards with their variants.
- POST /api/pokemon/collection
    - Body: { card_id, variant_id, quantity, condition, notes }. Upsert.
- PATCH /api/pokemon/collection/{id}
    - Update quantity / condition / notes.
- DELETE /api/pokemon/collection/{id}
    - Remove ownership.
- GET /api/pokemon/collection/missing?set_id=<id>
    - Returns cards in the set the current user does NOT own.

### NOK conversion

- At handler boundary, fetch `LatestRate("EUR/NOK")` (from currency package). For each variant: `price_nok = price_eur * rate`. Include both in the JSON response so the frontend has flexibility.
- If no rate is cached, return `price_nok = null` and a header `X-Pokemon-Rate-Missing: 1` so the UI can warn.

### Tests

- `handlers_test.go` covers each endpoint success, cross-user isolation, feature flag enforcement, NOK conversion math, missing-rate fallback.

### Acceptance

- `make build`, `make test ./internal/pokemon/...` pass.
- Without the `pokemon` flag, all endpoints return 403.
- With the flag, list + search + collection CRUD work end-to-end against a seeded DB.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-l9op | Branch: forge/Hytte-l9op
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->