### PR TITLE
Pokémon: per-kid gating + sidebar entry + i18n + smoke (Hytte-mec4)

### DIFF
--- a/changelog.d/Hytte-mec4.md
+++ b/changelog.d/Hytte-mec4.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon nav entry and smoke coverage** - The Pokémon Collection feature is now reachable from the sidebar (Sparkles icon, gated on the `pokemon` user feature so each kid can have an independent setting). Added `nav.pokemon` to all three locales (en, nb, th) and a Go test that proves toggling the `pokemon` flag for one kid does not affect the other, plus a Vitest+RTL smoke test that drives the full end-to-end flow (sets browser → set detail → mark a card owned → owned count increments). (Hytte-mec4)

--- a/internal/pokemon/handlers_test.go
+++ b/internal/pokemon/handlers_test.go
@@ -761,6 +761,113 @@ func TestFeatureFlagEnforcement_All(t *testing.T) {
 	}
 }
 
+// TestFeatureFlagEnforcement_PerKid asserts the pokemon flag is independent
+// per user — toggling it for kid A must not change the gate for kid B. Kids
+// are normal users, so the existing user_features mechanism gives us this for
+// free; this test guards against future regressions that would conflate them.
+func TestFeatureFlagEnforcement_PerKid(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+
+	if _, err := db.Exec(`
+		INSERT INTO users (id, email, name, google_id) VALUES (1, 'kid-a@example.com', 'Kid A', 'g-kid-a');
+		INSERT INTO users (id, email, name, google_id) VALUES (2, 'kid-b@example.com', 'Kid B', 'g-kid-b');
+	`); err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+
+	// Kid A has pokemon enabled; Kid B does not.
+	if err := auth.SetUserFeature(db, 1, "pokemon", true); err != nil {
+		t.Fatalf("enable pokemon for kid A: %v", err)
+	}
+	if err := auth.SetUserFeature(db, 2, "pokemon", false); err != nil {
+		t.Fatalf("disable pokemon for kid B: %v", err)
+	}
+
+	featsA, err := auth.GetUserFeatures(db, 1, false)
+	if err != nil {
+		t.Fatalf("get features A: %v", err)
+	}
+	featsB, err := auth.GetUserFeatures(db, 2, false)
+	if err != nil {
+		t.Fatalf("get features B: %v", err)
+	}
+	if !featsA["pokemon"] {
+		t.Errorf("kid A should have pokemon enabled, got %v", featsA["pokemon"])
+	}
+	if featsB["pokemon"] {
+		t.Errorf("kid B should have pokemon disabled, got %v", featsB["pokemon"])
+	}
+
+	tokenA, _, err := auth.CreateSession(db, 1)
+	if err != nil {
+		t.Fatalf("create session A: %v", err)
+	}
+	tokenB, _, err := auth.CreateSession(db, 2)
+	if err != nil {
+		t.Fatalf("create session B: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAuth(db))
+		r.Use(auth.WithFeatures(db))
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireFeature(db, "pokemon"))
+			r.Get("/api/pokemon/sets", ListSetsHandler(db))
+		})
+	})
+
+	// Kid A: pokemon=true → 200.
+	reqA := httptest.NewRequest(http.MethodGet, "/api/pokemon/sets", nil)
+	reqA.AddCookie(&http.Cookie{Name: "session", Value: tokenA})
+	recA := httptest.NewRecorder()
+	r.ServeHTTP(recA, reqA)
+	if recA.Code != http.StatusOK {
+		t.Errorf("kid A expected 200 with pokemon enabled, got %d (%s)", recA.Code, recA.Body.String())
+	}
+
+	// Kid B: pokemon=false → 403.
+	reqB := httptest.NewRequest(http.MethodGet, "/api/pokemon/sets", nil)
+	reqB.AddCookie(&http.Cookie{Name: "session", Value: tokenB})
+	recB := httptest.NewRecorder()
+	r.ServeHTTP(recB, reqB)
+	if recB.Code != http.StatusForbidden {
+		t.Errorf("kid B expected 403 with pokemon disabled, got %d (%s)", recB.Code, recB.Body.String())
+	}
+
+	// Flip kid B on — kid A's gate should be unaffected.
+	if err := auth.SetUserFeature(db, 2, "pokemon", true); err != nil {
+		t.Fatalf("re-enable pokemon for kid B: %v", err)
+	}
+	reqB2 := httptest.NewRequest(http.MethodGet, "/api/pokemon/sets", nil)
+	reqB2.AddCookie(&http.Cookie{Name: "session", Value: tokenB})
+	recB2 := httptest.NewRecorder()
+	r.ServeHTTP(recB2, reqB2)
+	if recB2.Code != http.StatusOK {
+		t.Errorf("kid B expected 200 after enabling pokemon, got %d (%s)", recB2.Code, recB2.Body.String())
+	}
+
+	// Toggle kid A off — kid B should remain enabled.
+	if err := auth.SetUserFeature(db, 1, "pokemon", false); err != nil {
+		t.Fatalf("disable pokemon for kid A: %v", err)
+	}
+	reqA2 := httptest.NewRequest(http.MethodGet, "/api/pokemon/sets", nil)
+	reqA2.AddCookie(&http.Cookie{Name: "session", Value: tokenA})
+	recA2 := httptest.NewRecorder()
+	r.ServeHTTP(recA2, reqA2)
+	if recA2.Code != http.StatusForbidden {
+		t.Errorf("kid A expected 403 after disabling pokemon, got %d (%s)", recA2.Code, recA2.Body.String())
+	}
+	reqB3 := httptest.NewRequest(http.MethodGet, "/api/pokemon/sets", nil)
+	reqB3.AddCookie(&http.Cookie{Name: "session", Value: tokenB})
+	recB3 := httptest.NewRecorder()
+	r.ServeHTTP(recB3, reqB3)
+	if recB3.Code != http.StatusOK {
+		t.Errorf("kid B should still be 200 after toggling kid A, got %d (%s)", recB3.Code, recB3.Body.String())
+	}
+}
+
 // callJSON encodes payload as JSON, attaches the user + optional chi params,
 // and runs the handler against the resulting request/recorder pair.
 func callJSON(t *testing.T, method, path string, payload any, user *auth.User, params map[string]string, h http.HandlerFunc) *httptest.ResponseRecorder {

--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -35,7 +35,8 @@
     "homework": "Homework",
     "homeworkReview": "Homework Review",
     "regnemester": "Regnemester",
-    "suggestions": "Suggestions"
+    "suggestions": "Suggestions",
+    "pokemon": "Pokémon"
   },
   "actions": {
     "save": "Save",

--- a/web/public/locales/nb/common.json
+++ b/web/public/locales/nb/common.json
@@ -35,7 +35,8 @@
     "homework": "Lekser",
     "homeworkReview": "Lekseoversikt",
     "regnemester": "Regnemester",
-    "suggestions": "Forslag"
+    "suggestions": "Forslag",
+    "pokemon": "Pokémon"
   },
   "actions": {
     "save": "Lagre",

--- a/web/public/locales/th/common.json
+++ b/web/public/locales/th/common.json
@@ -35,7 +35,8 @@
     "homework": "\u0e01\u0e32\u0e23\u0e1a\u0e49\u0e32\u0e19",
     "homeworkReview": "\u0e15\u0e23\u0e27\u0e08\u0e2a\u0e2d\u0e1a\u0e01\u0e32\u0e23\u0e1a\u0e49\u0e32\u0e19",
     "regnemester": "เกมคณิตศาสตร์",
-    "suggestions": "ข้อเสนอแนะ"
+    "suggestions": "ข้อเสนอแนะ",
+    "pokemon": "โปเกมอน"
   },
   "actions": {
     "save": "บันทึก",

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -38,6 +38,7 @@ import {
   ListTodo,
   Calculator,
   Lightbulb,
+  Sparkles,
 } from 'lucide-react'
 import type { ParseKeys } from 'i18next'
 import { useTranslation } from 'react-i18next'
@@ -84,6 +85,7 @@ const navItems: NavItem[] = [
   { to: '/grocery', icon: <ShoppingCart size={20} />, label: 'nav.grocery', requiresAuth: true, feature: 'grocery' },
   { to: '/wordfeud', icon: <Gamepad2 size={20} />, label: 'nav.wordfeud', requiresAuth: true, feature: 'wordfeud' },
   { to: '/math', icon: <Calculator size={20} />, label: 'nav.regnemester', requiresAuth: true, feature: 'regnemester' },
+  { to: '/pokemon', icon: <Sparkles size={20} />, label: 'nav.pokemon', requiresAuth: true, feature: 'pokemon' },
   { to: '/homework', icon: <BookOpen size={20} />, label: 'nav.homework', requiresAuth: true, feature: 'homework', familyRole: 'child' },
   { to: '/homework/review', icon: <ClipboardList size={20} />, label: 'nav.homeworkReview', requiresAuth: true, feature: 'homework', familyRole: 'parent' },
   { to: '/forge/mezzanine', icon: <Hammer size={20} />, label: 'nav.forge', requiresAuth: true, requireAdmin: true },

--- a/web/src/pages/PokemonSmoke.test.tsx
+++ b/web/src/pages/PokemonSmoke.test.tsx
@@ -1,0 +1,251 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import PokemonSets from './PokemonSets'
+import PokemonSet from './PokemonSet'
+
+// End-to-end smoke flow for the Pokémon collection feature: open the sets
+// browser → click a set → mark a card owned → verify the owned count
+// increments. fetch is mocked per-URL so the flow runs entirely in-memory.
+
+const TRANSLATIONS: Record<string, string> = {
+  pageTitle: 'Pokémon Sets',
+  retry: 'Retry',
+  showOlder: 'Show older sets',
+  hideOlder: 'Hide older sets',
+  'errors.failedToLoad': 'Failed to load Pokémon sets',
+  'errors.markFailed': 'Failed to mark card as owned',
+  'errors.unmarkFailed': 'Failed to unmark card',
+  'detail.back': 'Back to sets',
+  'detail.ownership': 'Owned',
+  'detail.setValue': 'Set value',
+  'detail.totalCards': 'Total cards',
+  'detail.filter': 'Filter cards',
+  'detail.filters.all': 'All',
+  'detail.filters.owned': 'Owned only',
+  'detail.filters.missing': 'Missing only',
+  'detail.empty': 'No cards match this filter.',
+  'detail.close': 'Close detail',
+  'detail.variant': 'Variant',
+  'detail.quantity': 'Quantity',
+  'detail.increaseQuantity': 'Increase quantity',
+  'detail.decreaseQuantity': 'Decrease quantity',
+  'detail.condition': 'Condition',
+  'detail.notes': 'Notes',
+  'detail.notesPlaceholder': 'Notes',
+  'detail.markOwned': 'Mark as owned',
+  'detail.update': 'Update',
+  'detail.unmark': 'Remove from collection',
+  'condition.unset': 'Unspecified',
+  'condition.mint': 'Mint',
+  'condition.near_mint': 'Near mint',
+  'condition.lightly_played': 'Lightly played',
+  'condition.moderately_played': 'Moderately played',
+  'condition.heavily_played': 'Heavily played',
+  'condition.damaged': 'Damaged',
+  'variantKind.normal': 'Normal',
+  'variantKind.reverse_holofoil': 'Reverse holo',
+  'toast.marked': 'Added to collection',
+  'toast.unmarked': 'Removed from collection',
+  'addCard.openLabel': 'Add a card to your collection',
+}
+
+function mockT(
+  key: string,
+  opts?: Record<string, string | number> & { defaultValue?: string },
+): string {
+  if (key === 'tile.ownership')
+    return `${opts?.owned ?? 0} / ${opts?.total ?? 0} — ${opts?.percent ?? 0}%`
+  if (key === 'tile.openSet') return `Open ${opts?.name ?? ''}`
+  if (key === 'tile.openCard') return `Open ${opts?.name ?? ''} (#${opts?.number ?? ''})`
+  if (key === 'tile.collectorNo') return `#${opts?.number ?? ''}`
+  if (key === 'tile.totalCards') {
+    const count = Number(opts?.count ?? 0)
+    return count === 1 ? `${count} card` : `${count} cards`
+  }
+  if (key === 'detail.ownedOf') return `${opts?.owned ?? 0} / ${opts?.total ?? 0}`
+  if (key.startsWith('variantKind.')) return TRANSLATIONS[key] ?? opts?.defaultValue ?? key
+  return TRANSLATIONS[key] ?? key
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockT,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// formatDate pulls in the real i18n bootstrap (HttpBackend), which would
+// thrash the test env. Stub it down to a static language so the module loads
+// without network IO.
+vi.mock('../i18n', () => ({
+  default: { language: 'en' },
+}))
+
+interface FetchInit {
+  method?: string
+  body?: BodyInit | null
+}
+
+interface PokemonResponse {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}
+
+function jsonResponse(body: unknown, status = 200): PokemonResponse {
+  return {
+    ok: status < 400,
+    status,
+    json: () => Promise.resolve(body),
+  }
+}
+
+function makeFetchMock() {
+  // Pikachu owns nothing initially. The POST handler flips ownership for
+  // subsequent /cards reads (in case the page reloads) — but the page also
+  // updates state optimistically, so the in-memory flag is just for safety.
+  let owned = false
+
+  return vi.fn((url: string, init?: FetchInit) => {
+    // 1) Sets browser list endpoint with pagination.
+    if (url.startsWith('/api/pokemon/sets?')) {
+      return Promise.resolve(
+        jsonResponse({
+          sets: [
+            {
+              id: 'sv1',
+              name: 'Scarlet & Violet Base',
+              series: 'Scarlet & Violet',
+              release_date: '2023/03/31',
+              total_cards: 1,
+              symbol_url: '',
+              logo_url: '',
+              owned_count: owned ? 1 : 0,
+            },
+          ],
+        }),
+      )
+    }
+
+    // 2) Set detail (cards in set) endpoint.
+    if (url === '/api/pokemon/sets/sv1/cards') {
+      return Promise.resolve(
+        jsonResponse({
+          set: {
+            id: 'sv1',
+            name: 'Scarlet & Violet Base',
+            series: 'Scarlet & Violet',
+            release_date: '2023/03/31',
+            total_cards: 1,
+            symbol_url: '',
+            logo_url: '',
+            owned_count: owned ? 1 : 0,
+          },
+          cards: [
+            {
+              id: 'sv1-1',
+              set_id: 'sv1',
+              name: 'Pikachu',
+              collector_no: '001',
+              rarity: 'Common',
+              image_small_url: '',
+              image_large_url: '',
+              variants: [
+                {
+                  id: 1,
+                  kind: 'normal',
+                  price_eur: 10,
+                  price_nok: 100,
+                  owned,
+                  owned_id: owned ? 42 : null,
+                  quantity: owned ? 1 : 0,
+                  condition: '',
+                  notes: '',
+                  acquired_at: null,
+                },
+              ],
+            },
+          ],
+        }),
+      )
+    }
+
+    // 3) Mark-owned mutation.
+    if (url === '/api/pokemon/collection' && init?.method === 'POST') {
+      owned = true
+      return Promise.resolve(
+        jsonResponse(
+          {
+            item: {
+              id: 42,
+              quantity: 1,
+              condition: '',
+              notes: '',
+              acquired_at: new Date('2026-01-01T00:00:00Z').toISOString(),
+            },
+          },
+          201,
+        ),
+      )
+    }
+
+    return Promise.resolve(jsonResponse({}, 404))
+  })
+}
+
+function renderApp() {
+  return render(
+    <MemoryRouter initialEntries={['/pokemon']}>
+      <Routes>
+        <Route path="/pokemon" element={<PokemonSets />} />
+        <Route path="/pokemon/sets/:id" element={<PokemonSet />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('Pokémon smoke flow', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('opens the sets browser, navigates to a set, and marks a card owned', async () => {
+    const fetchMock = makeFetchMock()
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderApp()
+
+    // 1) Sets browser renders the set tile.
+    const setLink = await screen.findByRole('link', { name: 'Open Scarlet & Violet Base' })
+    expect(setLink).toHaveAttribute('href', '/pokemon/sets/sv1')
+
+    // 2) Click into the set detail page.
+    fireEvent.click(setLink)
+
+    // 3) Wait for the card grid and confirm the starting count is 0 / 1.
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+    expect(screen.getByTestId('owned-count')).toHaveTextContent('0 / 1')
+
+    // 4) Open the detail panel and click "Mark as owned".
+    fireEvent.click(screen.getByTestId('card-tile-sv1-1'))
+    const markButton = await screen.findByRole('button', { name: 'Mark as owned' })
+    fireEvent.click(markButton)
+
+    // 5) The owned count should increment to 1 / 1 and the tile should report
+    //    aria-pressed=true.
+    await waitFor(() => expect(screen.getByTestId('owned-count')).toHaveTextContent('1 / 1'))
+    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('aria-pressed', 'true')
+
+    // 6) The POST went out with the expected payload.
+    const post = fetchMock.mock.calls.find(([url, init]) =>
+      url === '/api/pokemon/collection' && (init as FetchInit | undefined)?.method === 'POST',
+    )
+    expect(post).toBeTruthy()
+    const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
+    expect(body).toMatchObject({ card_id: 'sv1-1', variant_id: 1, quantity: 1 })
+  })
+})


### PR DESCRIPTION
## Changes

- **Pokémon nav entry and smoke coverage** - The Pokémon Collection feature is now reachable from the sidebar (Sparkles icon, gated on the `pokemon` user feature so each kid can have an independent setting). Added `nav.pokemon` to all three locales (en, nb, th) and a Go test that proves toggling the `pokemon` flag for one kid does not affect the other, plus a Vitest+RTL smoke test that drives the full end-to-end flow (sets browser → set detail → mark a card owned → owned count increments). (Hytte-mec4)

## Original Issue (chore): Pokémon: per-kid gating + sidebar entry + i18n + smoke

Part of the Pokémon Collection chain seeded from Suggestions id=146. See that suggestion's plan for the full architecture, data sources (pokemontcg.io + Norges Bank EUR/NOK), and scope decisions (per-kid collections, NOK only, variants from day 1, local image cache).

This bead is step 7/7: Polish of the chain.

## Scope

Final polish slice.

### Per-kid gating

- The `pokemon` feature flag must be settable per-kid. Use the existing user_features mechanism — kids are normal users in the system. Verify in handler tests.

### Sidebar entry

- `web/src/components/Sidebar.tsx` adds an entry with the `Sparkles` (or `Layers` — implementer's choice; `Sparkles` reads more playful for kids) Lucide icon. Gated on `user_features.pokemon`. Navigates to `/pokemon` (the sets browser).

### i18n

- New namespace `pokemon` in `web/public/locales/{en,nb,th}/pokemon.json`.
- Cover all visible strings: nav label, page titles, "Show older sets", set headers (e.g. "Owned: {{count}} / {{total}}"), filter toggles, add-card placeholder, variant picker labels, toast messages, error states.
- Card and set NAMES stay verbatim — no translation. Only the UI chrome translates.
- `Intl.NumberFormat` uses `i18n.language` for NOK formatting.

### Smoke

- One Vitest+RTL smoke test that drives: open Pokémon → click a set → mark a card owned → verify owned count increments. Mocks fetch responses.

### Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build`, `npm test` pass.
- Both kids can have independent Pokémon flag settings (verify by toggling in Admin → user features).
- All three locales have the new namespace.
- Mobile 375px works end-to-end.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-mec4 | Branch: forge/Hytte-mec4
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->