### PR TITLE
Pokémon Phase 2: backend scan endpoint via Claude vision (Hytte-sud5)

### DIFF
--- a/changelog.d/Hytte-sud5.md
+++ b/changelog.d/Hytte-sud5.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon card vision scan endpoint** - `POST /api/pokemon/scan` accepts a multipart image upload, runs it through Claude vision to identify the set and collector number, and returns matched card candidates with EUR/NOK pricing. Admin-gated and behind the `pokemon` feature flag. (Hytte-sud5)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -415,6 +415,11 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Patch("/pokemon/collection/{id}", pokemon.UpdateCollectionHandler(db))
 				r.Delete("/pokemon/collection/{id}", pokemon.DeleteCollectionHandler(db))
 				r.Get("/pokemon/collection/missing", pokemon.MissingFromSetHandler(db))
+				// Vision scan (Phase 2) is admin-only on top of the feature gate.
+				// The Claude CLI call lives behind RequireAdmin so non-admin kids
+				// can still browse and edit their collection without exposing the
+				// vision endpoint, which costs money to run.
+				r.With(auth.RequireAdmin()).Post("/pokemon/scan", pokemon.ScanHandler(db))
 			})
 
 			// Tasks — gated by "tasks" feature.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -405,22 +405,8 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Delete("/notes/{id}", notes.DeleteHandler(db))
 			})
 
-			// Pokémon Collection — gated by "pokemon" feature.
-			r.Group(func(r chi.Router) {
-				r.Use(auth.RequireFeature(db, "pokemon"))
-				r.Get("/pokemon/sets", pokemon.ListSetsHandler(db))
-				r.Get("/pokemon/sets/{id}/cards", pokemon.ListSetCardsHandler(db))
-				r.Get("/pokemon/cards/search", pokemon.SearchCardsHandler(db))
-				r.Post("/pokemon/collection", pokemon.UpsertCollectionHandler(db))
-				r.Patch("/pokemon/collection/{id}", pokemon.UpdateCollectionHandler(db))
-				r.Delete("/pokemon/collection/{id}", pokemon.DeleteCollectionHandler(db))
-				r.Get("/pokemon/collection/missing", pokemon.MissingFromSetHandler(db))
-				// Vision scan (Phase 2) is admin-only on top of the feature gate.
-				// The Claude CLI call lives behind RequireAdmin so non-admin kids
-				// can still browse and edit their collection without exposing the
-				// vision endpoint, which costs money to run.
-				r.With(auth.RequireAdmin()).Post("/pokemon/scan", pokemon.ScanHandler(db))
-			})
+			// Pokémon Collection — gated by "pokemon" feature (routes in pokemon.RegisterRoutes).
+			pokemon.RegisterRoutes(r, db)
 
 			// Tasks — gated by "tasks" feature.
 			r.Group(func(r chi.Router) {

--- a/internal/pokemon/handlers.go
+++ b/internal/pokemon/handlers.go
@@ -105,6 +105,25 @@ type CollectionRow struct {
 	AcquiredAt string `json:"acquired_at"`
 }
 
+// RegisterRoutes mounts all Pokémon Collection routes on r under the "pokemon"
+// feature gate. It is called by both the production API router and tests so
+// both exercise the same middleware chain — if the gate or admin check changes
+// here, the tests automatically reflect that change.
+func RegisterRoutes(r chi.Router, db *sql.DB) {
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireFeature(db, "pokemon"))
+		r.Get("/pokemon/sets", ListSetsHandler(db))
+		r.Get("/pokemon/sets/{id}/cards", ListSetCardsHandler(db))
+		r.Get("/pokemon/cards/search", SearchCardsHandler(db))
+		r.Post("/pokemon/collection", UpsertCollectionHandler(db))
+		r.Patch("/pokemon/collection/{id}", UpdateCollectionHandler(db))
+		r.Delete("/pokemon/collection/{id}", DeleteCollectionHandler(db))
+		r.Get("/pokemon/collection/missing", MissingFromSetHandler(db))
+		// Vision scan: admin-only on top of the feature gate.
+		r.With(auth.RequireAdmin()).Post("/pokemon/scan", ScanHandler(db))
+	})
+}
+
 func respondJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/internal/pokemon/scan.go
+++ b/internal/pokemon/scan.go
@@ -41,6 +41,46 @@ var scanAllowedMIMETypes = map[string]bool{
 	"image/heif": true,
 }
 
+// heifBrands is the set of ISOBMFF "ftyp" brand codes that identify a HEIC or
+// HEIF still image. http.DetectContentType does not recognise either format
+// (it returns application/octet-stream), so detectImageMIME falls back to this
+// table when the standard sniffer can't classify the bytes.
+var heifBrands = map[string]string{
+	"heic": "image/heic",
+	"heix": "image/heic",
+	"heim": "image/heic",
+	"heis": "image/heic",
+	"hevc": "image/heic",
+	"hevx": "image/heic",
+	"hevm": "image/heic",
+	"hevs": "image/heic",
+	"mif1": "image/heif",
+	"msf1": "image/heif",
+	"heif": "image/heif",
+}
+
+// detectImageMIME classifies the first bytes of an upload. It defers to
+// http.DetectContentType for the common cases (JPEG, PNG, WebP, …) and only
+// reaches into the HEIF/HEIC ftyp box if the stdlib sniffer fell back to the
+// generic application/octet-stream. The buffer must contain at least 12 bytes
+// to identify HEIC/HEIF; shorter slices simply return the stdlib result.
+func detectImageMIME(buf []byte) string {
+	mime := http.DetectContentType(buf)
+	if mime != "application/octet-stream" {
+		return mime
+	}
+	if len(buf) < 12 {
+		return mime
+	}
+	if string(buf[4:8]) != "ftyp" {
+		return mime
+	}
+	if heif, ok := heifBrands[strings.ToLower(string(buf[8:12]))]; ok {
+		return heif
+	}
+	return mime
+}
+
 // scanPrompt is the exact prompt sent to Claude. It asks for STRICT JSON so
 // the response can be parsed without an LLM-grade post-processor.
 const scanPrompt = `You will be shown a single Pokémon TCG card photo. Identify two things:
@@ -118,20 +158,32 @@ func ScanHandler(db *sql.DB) http.HandlerFunc {
 			respondError(w, http.StatusBadRequest, "failed to read image")
 			return
 		}
-		mime := http.DetectContentType(sniff[:n])
+		mime := detectImageMIME(sniff[:n])
 		if !scanAllowedMIMETypes[mime] {
 			respondError(w, http.StatusBadRequest, "unsupported image type")
 			return
 		}
 
-		tmp, err := os.CreateTemp("", "pokemon-scan-*")
+		// Create a per-scan directory under the OS temp root and place the
+		// image inside it. The Claude wrapper grants Read access to the
+		// containing directory (via --add-dir), so isolating each scan in its
+		// own folder ensures Claude cannot see any other temp files. The
+		// directory and its contents are removed at the end of the request.
+		tmpDir, err := os.MkdirTemp("", "pokemon-scan-*")
+		if err != nil {
+			log.Printf("pokemon: create temp dir: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to create temp dir")
+			return
+		}
+		defer os.RemoveAll(tmpDir)
+
+		tmp, err := os.CreateTemp(tmpDir, "image-*")
 		if err != nil {
 			log.Printf("pokemon: create temp file: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to create temp file")
 			return
 		}
 		tmpPath := tmp.Name()
-		defer os.Remove(tmpPath)
 
 		if _, err := tmp.Write(sniff[:n]); err != nil {
 			tmp.Close()

--- a/internal/pokemon/scan.go
+++ b/internal/pokemon/scan.go
@@ -132,10 +132,12 @@ func ScanHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		r.Body = http.MaxBytesReader(w, r.Body, scanParseFormBytes)
 		if err := r.ParseMultipartForm(scanParseFormBytes); err != nil {
 			respondError(w, http.StatusBadRequest, "failed to parse multipart form")
 			return
 		}
+		defer r.MultipartForm.RemoveAll()
 
 		file, header, err := r.FormFile("image")
 		if err != nil {
@@ -348,15 +350,17 @@ func findScanCandidates(ctx context.Context, db *sql.DB, userID int64, result *c
 			if err != nil {
 				return nil, "", fmt.Errorf("set name lookup: %w", err)
 			}
+			defer rows.Close()
 			for rows.Next() {
 				var id string
 				if err := rows.Scan(&id); err != nil {
-					rows.Close()
 					return nil, "", fmt.Errorf("scan set id: %w", err)
 				}
 				setFilter = append(setFilter, id)
 			}
-			rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, "", fmt.Errorf("set name rows: %w", err)
+			}
 			setLabel = name
 		}
 	}

--- a/internal/pokemon/scan.go
+++ b/internal/pokemon/scan.go
@@ -1,0 +1,487 @@
+package pokemon
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+// scanMaxImageBytes caps the uploaded image size at 5 MB. Anything larger is
+// rejected with 400 — Pokémon card photos from a phone camera fit well within
+// this even at the highest quality settings.
+const scanMaxImageBytes = 5 << 20
+
+// scanParseFormBytes is the multipart parser limit. It sits slightly above the
+// per-image cap so a request that includes only the image field never trips
+// before scanMaxImageBytes is enforced on the file itself.
+const scanParseFormBytes = 10 << 20
+
+// scanConfidenceThreshold is the floor below which a Claude response is
+// treated as "could not read the card" — we then return matched:false rather
+// than running a doomed DB lookup.
+const scanConfidenceThreshold = 0.4
+
+// scanAllowedMIMETypes whitelists the image types we accept. The list is kept
+// tight because Claude's Read tool needs to be able to view the file.
+var scanAllowedMIMETypes = map[string]bool{
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/webp": true,
+	"image/heic": true,
+	"image/heif": true,
+}
+
+// scanPrompt is the exact prompt sent to Claude. It asks for STRICT JSON so
+// the response can be parsed without an LLM-grade post-processor.
+const scanPrompt = `You will be shown a single Pokémon TCG card photo. Identify two things:
+1. The set, by reading the small set symbol on the bottom-right of the card AND any visible set name printed near it.
+2. The collector number on the bottom-left, in the format "025/195" (numerator/denominator).
+
+Respond as STRICT JSON, no markdown fence, no prose:
+{
+  "set_name": "...",         // best guess for the set's English name
+  "set_id_hint": "...",      // optional pokemontcg.io set id if recognised (e.g. "sv4"), otherwise empty
+  "collector_number": "...", // exact string from the card, e.g. "025/195"
+  "confidence": 0.95         // 0.0-1.0; 0 means you can't read the card
+}`
+
+// claudeScanResult mirrors the STRICT JSON shape we ask Claude to return.
+type claudeScanResult struct {
+	SetName         string  `json:"set_name"`
+	SetIDHint       string  `json:"set_id_hint"`
+	CollectorNumber string  `json:"collector_number"`
+	Confidence      float64 `json:"confidence"`
+}
+
+// ScanCandidate is a single matched card the scan endpoint returns. Score is
+// currently the same as the model's confidence — over time we can refine it
+// per-candidate (e.g. lower when only the set_name matched fuzzily).
+type ScanCandidate struct {
+	Card  CardDTO `json:"card"`
+	Set   *SetDTO `json:"set,omitempty"`
+	Score float64 `json:"score"`
+}
+
+// scanRunPromptFn is the package-level seam used by ScanHandler to invoke
+// Claude. Tests override it to stub out the CLI call without touching the
+// real claude binary.
+var scanRunPromptFn = func(ctx context.Context, cfg *training.ClaudeConfig, prompt, imagePath string) (string, error) {
+	return training.RunPromptWithImage(ctx, cfg, prompt, imagePath)
+}
+
+// ScanHandler accepts a multipart upload with a single `image` part, runs the
+// photo through Claude vision, and returns the matched card (or a low-
+// confidence marker). The handler is admin-gated and feature-gated at the
+// router level — it does no further auth checks here beyond reading the user
+// for Claude config lookup.
+func ScanHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+
+		if err := r.ParseMultipartForm(scanParseFormBytes); err != nil {
+			respondError(w, http.StatusBadRequest, "failed to parse multipart form")
+			return
+		}
+
+		file, header, err := r.FormFile("image")
+		if err != nil {
+			respondError(w, http.StatusBadRequest, "image is required")
+			return
+		}
+		defer file.Close()
+
+		if header.Size > scanMaxImageBytes {
+			respondError(w, http.StatusBadRequest, "image too large (max 5 MB)")
+			return
+		}
+
+		// Sniff the content type from the first 512 bytes. The reported
+		// form Content-Type is attacker-controlled; the actual byte pattern
+		// is what Claude's Read tool will see.
+		sniff := make([]byte, 512)
+		n, err := io.ReadFull(file, sniff)
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			respondError(w, http.StatusBadRequest, "failed to read image")
+			return
+		}
+		mime := http.DetectContentType(sniff[:n])
+		if !scanAllowedMIMETypes[mime] {
+			respondError(w, http.StatusBadRequest, "unsupported image type")
+			return
+		}
+
+		tmp, err := os.CreateTemp("", "pokemon-scan-*")
+		if err != nil {
+			log.Printf("pokemon: create temp file: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to create temp file")
+			return
+		}
+		tmpPath := tmp.Name()
+		defer os.Remove(tmpPath)
+
+		if _, err := tmp.Write(sniff[:n]); err != nil {
+			tmp.Close()
+			log.Printf("pokemon: write sniffed bytes: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to buffer image")
+			return
+		}
+		// Enforce the 5 MB cap on the streaming copy too — a client could
+		// have lied about Size via the multipart header.
+		remaining := int64(scanMaxImageBytes) - int64(n)
+		if remaining > 0 {
+			written, err := io.Copy(tmp, io.LimitReader(file, remaining+1))
+			if err != nil {
+				tmp.Close()
+				log.Printf("pokemon: copy upload to temp: %v", err)
+				respondError(w, http.StatusInternalServerError, "failed to buffer image")
+				return
+			}
+			if written > remaining {
+				tmp.Close()
+				respondError(w, http.StatusBadRequest, "image too large (max 5 MB)")
+				return
+			}
+		}
+		if err := tmp.Close(); err != nil {
+			log.Printf("pokemon: close temp file: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to save image")
+			return
+		}
+
+		cfg, err := training.LoadClaudeConfig(db, user.ID)
+		if err != nil {
+			log.Printf("pokemon: load claude config: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to load claude config")
+			return
+		}
+		if !cfg.Enabled {
+			respondError(w, http.StatusBadRequest, "claude is not enabled for this user")
+			return
+		}
+
+		raw, err := scanRunPromptFn(r.Context(), cfg, scanPrompt, tmpPath)
+		if err != nil {
+			log.Printf("pokemon: claude scan: %v", err)
+			respondError(w, http.StatusBadGateway, "vision call failed")
+			return
+		}
+
+		result, parseErr := parseClaudeScanResult(raw)
+		if parseErr != nil {
+			respondJSON(w, http.StatusOK, map[string]any{
+				"matched":    false,
+				"confidence": 0.0,
+				"reason":     fmt.Sprintf("could not parse vision response: %v", parseErr),
+			})
+			return
+		}
+		if result.Confidence < scanConfidenceThreshold {
+			respondJSON(w, http.StatusOK, map[string]any{
+				"matched":    false,
+				"confidence": result.Confidence,
+				"reason":     "low confidence",
+			})
+			return
+		}
+
+		candidates, reason, err := findScanCandidates(r.Context(), db, user.ID, result)
+		if err != nil {
+			log.Printf("pokemon: find scan candidates: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to look up card")
+			return
+		}
+
+		rate, rateOK := loadRate(r, db)
+		if len(candidates) == 0 {
+			respondJSON(w, http.StatusOK, map[string]any{
+				"matched":    false,
+				"confidence": result.Confidence,
+				"reason":     reason,
+			})
+			return
+		}
+
+		// Apply EUR→NOK to each candidate card. We reuse the same helper that
+		// the listing endpoints use so prices stay consistent across the API.
+		if rateOK {
+			cards := make([]CardDTO, len(candidates))
+			for i := range candidates {
+				cards[i] = candidates[i].Card
+			}
+			applyNOK(w, cards, rate, rateOK)
+			for i := range candidates {
+				candidates[i].Card = cards[i]
+			}
+		} else {
+			w.Header().Set("X-Pokemon-Rate-Missing", "1")
+		}
+
+		respondJSON(w, http.StatusOK, map[string]any{
+			"matched":    true,
+			"confidence": result.Confidence,
+			"candidates": candidates,
+		})
+	}
+}
+
+// parseClaudeScanResult unmarshals the Claude response into claudeScanResult,
+// tolerating a stray markdown code fence the model occasionally adds despite
+// being asked not to.
+func parseClaudeScanResult(raw string) (*claudeScanResult, error) {
+	trimmed := strings.TrimSpace(raw)
+	// Strip ```json … ``` fences if present.
+	if strings.HasPrefix(trimmed, "```") {
+		trimmed = strings.TrimPrefix(trimmed, "```json")
+		trimmed = strings.TrimPrefix(trimmed, "```")
+		trimmed = strings.TrimSuffix(trimmed, "```")
+		trimmed = strings.TrimSpace(trimmed)
+	}
+	var res claudeScanResult
+	if err := json.Unmarshal([]byte(trimmed), &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// findScanCandidates resolves the Claude-identified set + collector number to
+// one or more catalogue cards. Match priority follows the bead spec: explicit
+// pokemontcg.io set id hint first, then case-insensitive set name substring,
+// then unfiltered. The returned reason is included in matched:false responses
+// so the UI can surface why nothing came back.
+func findScanCandidates(ctx context.Context, db *sql.DB, userID int64, result *claudeScanResult) ([]ScanCandidate, string, error) {
+	collector := strings.TrimSpace(result.CollectorNumber)
+	if collector == "" {
+		return nil, "no collector number identified", nil
+	}
+
+	var setFilter []string
+	var setLabel string
+
+	if hint := strings.TrimSpace(result.SetIDHint); hint != "" {
+		var exists string
+		err := db.QueryRowContext(ctx,
+			`SELECT id FROM pokemon_sets WHERE id = ?`, hint,
+		).Scan(&exists)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			// Hint didn't match the catalogue; fall through to name match.
+		case err != nil:
+			return nil, "", fmt.Errorf("set id lookup: %w", err)
+		default:
+			setFilter = []string{exists}
+			setLabel = exists
+		}
+	}
+
+	if len(setFilter) == 0 {
+		if name := strings.TrimSpace(result.SetName); name != "" {
+			rows, err := db.QueryContext(ctx,
+				`SELECT id FROM pokemon_sets WHERE LOWER(name) LIKE LOWER(?)`,
+				"%"+name+"%",
+			)
+			if err != nil {
+				return nil, "", fmt.Errorf("set name lookup: %w", err)
+			}
+			for rows.Next() {
+				var id string
+				if err := rows.Scan(&id); err != nil {
+					rows.Close()
+					return nil, "", fmt.Errorf("scan set id: %w", err)
+				}
+				setFilter = append(setFilter, id)
+			}
+			rows.Close()
+			setLabel = name
+		}
+	}
+
+	cards, err := loadScanCards(ctx, db, userID, collector, setFilter)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if len(cards) == 0 {
+		label := setLabel
+		if label == "" {
+			label = "any set"
+		}
+		return nil, fmt.Sprintf("no card matches set '%s' collector '%s'", label, collector), nil
+	}
+
+	out := make([]ScanCandidate, 0, len(cards))
+	for i := range cards {
+		card := cards[i]
+		set, err := loadSetByID(ctx, db, userID, card.SetID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, "", fmt.Errorf("load set %s: %w", card.SetID, err)
+		}
+		out = append(out, ScanCandidate{
+			Card:  card,
+			Set:   set,
+			Score: result.Confidence,
+		})
+	}
+	return out, "", nil
+}
+
+// loadScanCards fetches cards matching the collector number, optionally
+// restricted to one or more set ids. Variants and ownership flags are
+// hydrated the same way as the other listing endpoints.
+func loadScanCards(ctx context.Context, db *sql.DB, userID int64, collector string, setIDs []string) ([]CardDTO, error) {
+	query := `
+		SELECT c.id, c.set_id, c.name, c.collector_no, c.rarity, c.image_small_url, c.image_large_url
+		FROM pokemon_cards c
+		WHERE c.collector_no = ?
+	`
+	args := []any{collector}
+	if len(setIDs) > 0 {
+		placeholders := strings.Repeat("?,", len(setIDs))
+		placeholders = placeholders[:len(placeholders)-1]
+		query += " AND c.set_id IN (" + placeholders + ")"
+		for _, id := range setIDs {
+			args = append(args, id)
+		}
+	}
+	query += " ORDER BY c.set_id, c.id"
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cards := make([]CardDTO, 0)
+	cardIndex := make(map[string]int)
+	for rows.Next() {
+		var c CardDTO
+		if err := rows.Scan(&c.ID, &c.SetID, &c.Name, &c.CollectorNo, &c.Rarity, &c.ImageSmallURL, &c.ImageLargeURL); err != nil {
+			return nil, err
+		}
+		c.Variants = []VariantDTO{}
+		cardIndex[c.ID] = len(cards)
+		cards = append(cards, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(cards) == 0 {
+		return cards, nil
+	}
+	return hydrateVariantsCtx(ctx, db, userID, cards, cardIndex)
+}
+
+// loadSetByID is a context-aware variant of loadSet that does not depend on a
+// live *http.Request. The scan handler runs inside an HTTP context, but
+// helpers that only need a Context (e.g. background callers added later) can
+// reuse the same query without faking a request.
+func loadSetByID(ctx context.Context, db *sql.DB, userID int64, setID string) (*SetDTO, error) {
+	var s SetDTO
+	err := db.QueryRowContext(ctx, `
+		SELECT s.id, s.name, s.series, s.release_date, s.total_cards, s.symbol_url, s.logo_url,
+		       (SELECT COUNT(DISTINCT pc.card_id)
+		        FROM pokemon_collections pc
+		        JOIN pokemon_cards c ON c.id = pc.card_id
+		        WHERE c.set_id = s.id AND pc.user_id = ? AND pc.quantity > 0) AS owned_count
+		FROM pokemon_sets s
+		WHERE s.id = ?
+	`, userID, setID).Scan(&s.ID, &s.Name, &s.Series, &s.ReleaseDate, &s.TotalCards, &s.SymbolURL, &s.LogoURL, &s.OwnedCount)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// hydrateVariantsCtx is the context-only equivalent of hydrateVariants. The
+// existing helper takes *http.Request because every other caller already has
+// one; the scan handler does too but we want a callable seam for future
+// background scans.
+func hydrateVariantsCtx(ctx context.Context, db *sql.DB, userID int64, cards []CardDTO, cardIndex map[string]int) ([]CardDTO, error) {
+	ids := make([]any, 0, len(cardIndex))
+	placeholders := make([]string, 0, len(cardIndex))
+	for id := range cardIndex {
+		ids = append(ids, id)
+		placeholders = append(placeholders, "?")
+	}
+	query := `
+		SELECT v.id, v.card_id, v.kind, v.price_eur, v.price_at,
+		       c.id, c.quantity, c.condition, c.acquired_at, c.notes_enc
+		FROM pokemon_card_variants v
+		LEFT JOIN pokemon_collections c
+		  ON c.variant_id = v.id AND c.user_id = ?
+		WHERE v.card_id IN (` + strings.Join(placeholders, ",") + `)
+		ORDER BY v.card_id, v.kind
+	`
+	args := append([]any{userID}, ids...)
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			vID         int64
+			cardID      string
+			kind        string
+			priceEUR    float64
+			priceAt     sql.NullString
+			collID      sql.NullInt64
+			collQty     sql.NullInt64
+			collCond    sql.NullString
+			collAcq     sql.NullString
+			collNotesEn sql.NullString
+		)
+		if err := rows.Scan(&vID, &cardID, &kind, &priceEUR, &priceAt,
+			&collID, &collQty, &collCond, &collAcq, &collNotesEn); err != nil {
+			return nil, err
+		}
+		idx, ok := cardIndex[cardID]
+		if !ok {
+			continue
+		}
+		v := VariantDTO{
+			ID:       vID,
+			Kind:     kind,
+			PriceEUR: priceEUR,
+		}
+		if priceAt.Valid && priceAt.String != "" {
+			ts := priceAt.String
+			v.PriceAt = &ts
+		}
+		if collID.Valid {
+			id := collID.Int64
+			v.Owned = true
+			v.OwnedID = &id
+			if collQty.Valid {
+				v.Quantity = int(collQty.Int64)
+			}
+			if collCond.Valid {
+				v.Condition = collCond.String
+			}
+			if collAcq.Valid && collAcq.String != "" {
+				ts := collAcq.String
+				v.AcquiredAt = &ts
+			}
+			v.Notes = decryptNotes(collNotesEn)
+		}
+		cards[idx].Variants = append(cards[idx].Variants, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return cards, nil
+}

--- a/internal/pokemon/scan_test.go
+++ b/internal/pokemon/scan_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -335,6 +334,10 @@ func TestScanHandler_NoCardMatch(t *testing.T) {
 // BOTH RequireFeature(db, "pokemon") and RequireAdmin. A non-admin user with
 // the feature enabled must be denied; an admin without any explicit feature
 // flag must pass (admins bypass feature checks by design).
+//
+// The router is built using RegisterRoutes — the same helper that the
+// production API router calls — so this test would catch any accidental
+// removal of the feature gate or admin check from the shared registration code.
 func TestScanHandler_FeatureGateAndAdmin(t *testing.T) {
 	db := setupTestDB(t)
 	seedCatalogue(t, db)
@@ -371,13 +374,14 @@ func TestScanHandler_FeatureGateAndAdmin(t *testing.T) {
 
 	stubScanPrompt(t, `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"025","confidence":0.95}`, nil)
 
+	// Build the router using RegisterRoutes — the same function the production
+	// API router calls — so changes to the gate or admin check are caught here.
 	r := chi.NewRouter()
-	r.Group(func(r chi.Router) {
-		r.Use(auth.RequireAuth(db))
-		r.Use(auth.WithFeatures(db))
+	r.Route("/api", func(r chi.Router) {
 		r.Group(func(r chi.Router) {
-			r.Use(auth.RequireFeature(db, "pokemon"))
-			r.With(auth.RequireAdmin()).Post("/api/pokemon/scan", ScanHandler(db))
+			r.Use(auth.RequireAuth(db))
+			r.Use(auth.WithFeatures(db))
+			RegisterRoutes(r, db)
 		})
 	})
 
@@ -466,9 +470,9 @@ func TestParseClaudeScanResult(t *testing.T) {
 	}
 }
 
-// ensure we can encode/decode the candidate struct symmetrically. Cheap
-// sanity check that prevents API shape regressions if anyone re-orders the
-// struct fields.
+// TestScanCandidate_JSON verifies ScanCandidate round-trips through JSON
+// symmetrically. A change to any exported field name or type would break this
+// check and signal an API shape regression.
 func TestScanCandidate_JSON(t *testing.T) {
 	c := ScanCandidate{
 		Card:  CardDTO{ID: "sv1-25", SetID: "sv1", Name: "Pikachu", Variants: []VariantDTO{}},
@@ -479,8 +483,11 @@ func TestScanCandidate_JSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	wantSnippet := fmt.Sprintf(`"score":%v`, 0.91)
-	if !strings.Contains(string(out), wantSnippet) {
-		t.Errorf("expected %s in %s", wantSnippet, out)
+	var got ScanCandidate
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Card.ID != c.Card.ID || got.Score != c.Score || got.Set == nil || got.Set.ID != c.Set.ID {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, c)
 	}
 }

--- a/internal/pokemon/scan_test.go
+++ b/internal/pokemon/scan_test.go
@@ -1,0 +1,486 @@
+package pokemon
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/training"
+	"github.com/go-chi/chi/v5"
+)
+
+// pngMagic is the 8-byte signature that http.DetectContentType uses to
+// recognise image/png. Embedding it directly keeps the test fixtures byte-
+// exact and avoids needing a real PNG file on disk.
+var pngMagic = []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+// jpegMagic is the leading marker bytes for image/jpeg.
+var jpegMagic = []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+// enableClaudeForUser flips the per-user claude flag so the scan handler does
+// not bail with "claude is not enabled". The CLI path stays "claude" so the
+// real binary is never invoked — the test seam intercepts the call first.
+func enableClaudeForUser(t *testing.T, db *sql.DB, userID int64) {
+	t.Helper()
+	if err := auth.SetPreference(db, userID, "claude_enabled", "true"); err != nil {
+		t.Fatalf("enable claude: %v", err)
+	}
+}
+
+// stubScanPrompt replaces scanRunPromptFn with a fixed-response stub and
+// restores the original on cleanup. The returned counter tracks how many
+// times the stub was invoked, which lets tests assert that the DB lookup is
+// skipped when confidence is below the threshold.
+func stubScanPrompt(t *testing.T, response string, stubErr error) *atomic.Int32 {
+	t.Helper()
+	orig := scanRunPromptFn
+	calls := new(atomic.Int32)
+	scanRunPromptFn = func(_ context.Context, _ *training.ClaudeConfig, _, _ string) (string, error) {
+		calls.Add(1)
+		return response, stubErr
+	}
+	t.Cleanup(func() { scanRunPromptFn = orig })
+	return calls
+}
+
+// buildScanRequest creates a POST /api/pokemon/scan multipart/form-data
+// request with the supplied bytes attached as the `image` field. filename is
+// arbitrary; the handler sniffs the bytes for content-type detection.
+func buildScanRequest(t *testing.T, payload []byte, filename string) *http.Request {
+	t.Helper()
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	part, err := w.CreateFormFile("image", filename)
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := part.Write(payload); err != nil {
+		t.Fatalf("write form payload: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close multipart: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/pokemon/scan", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	return req
+}
+
+func TestScanHandler_MatchedCandidate(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	stubScanPrompt(t, `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"025","confidence":0.95}`, nil)
+
+	req := buildScanRequest(t, append(pngMagic, []byte("padding")...), "card.png")
+	req = asUser(req, u)
+	rec := httptest.NewRecorder()
+
+	ScanHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Matched    bool            `json:"matched"`
+		Confidence float64         `json:"confidence"`
+		Candidates []ScanCandidate `json:"candidates"`
+	}](t, rec)
+	if !body.Matched {
+		t.Fatalf("expected matched=true, got %+v", body)
+	}
+	if body.Confidence != 0.95 {
+		t.Errorf("expected confidence=0.95, got %v", body.Confidence)
+	}
+	if len(body.Candidates) != 1 || body.Candidates[0].Card.ID != "sv1-25" {
+		t.Errorf("expected single sv1-25 candidate, got %+v", body.Candidates)
+	}
+	if body.Candidates[0].Set == nil || body.Candidates[0].Set.ID != "sv1" {
+		t.Errorf("expected embedded set sv1, got %+v", body.Candidates[0].Set)
+	}
+}
+
+func TestScanHandler_LowConfidenceSkipsLookup(t *testing.T) {
+	db := setupTestDB(t)
+	// Intentionally do NOT seed cards — a DB lookup would error out if reached.
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	calls := stubScanPrompt(t, `{"set_name":"","set_id_hint":"","collector_number":"???","confidence":0.30}`, nil)
+
+	req := buildScanRequest(t, append(pngMagic, []byte("padding")...), "card.png")
+	req = asUser(req, u)
+	rec := httptest.NewRecorder()
+	ScanHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 even on low confidence, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Matched    bool    `json:"matched"`
+		Confidence float64 `json:"confidence"`
+		Reason     string  `json:"reason"`
+	}](t, rec)
+	if body.Matched {
+		t.Errorf("expected matched=false on low confidence, got true")
+	}
+	if body.Confidence != 0.30 {
+		t.Errorf("expected confidence=0.30, got %v", body.Confidence)
+	}
+	if body.Reason == "" {
+		t.Errorf("expected a reason string, got empty")
+	}
+	if calls.Load() != 1 {
+		t.Errorf("expected exactly one Claude call, got %d", calls.Load())
+	}
+}
+
+func TestScanHandler_MalformedJSON(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	stubScanPrompt(t, "I am not JSON", nil)
+
+	req := buildScanRequest(t, append(pngMagic, []byte("p")...), "card.png")
+	req = asUser(req, u)
+	rec := httptest.NewRecorder()
+	ScanHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 even on malformed JSON, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Matched bool   `json:"matched"`
+		Reason  string `json:"reason"`
+	}](t, rec)
+	if body.Matched {
+		t.Errorf("expected matched=false on malformed JSON, got true")
+	}
+	if !strings.Contains(body.Reason, "parse") {
+		t.Errorf("expected reason to mention parse failure, got %q", body.Reason)
+	}
+}
+
+func TestScanHandler_MultipleCandidates(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	// Both sv1-25 (Pikachu, 025) and swsh1-25 (Pikachu V, 025) share the same
+	// collector number. With no set hint and no set name match, both should
+	// come back as candidates.
+	stubScanPrompt(t, `{"set_name":"unknown set","set_id_hint":"","collector_number":"025","confidence":0.80}`, nil)
+
+	req := buildScanRequest(t, append(pngMagic, []byte("p")...), "card.png")
+	req = asUser(req, u)
+	rec := httptest.NewRecorder()
+	ScanHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Matched    bool            `json:"matched"`
+		Candidates []ScanCandidate `json:"candidates"`
+	}](t, rec)
+	if !body.Matched {
+		t.Fatalf("expected matched=true, got %+v", body)
+	}
+	if len(body.Candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(body.Candidates))
+	}
+	ids := map[string]bool{}
+	for _, c := range body.Candidates {
+		ids[c.Card.ID] = true
+	}
+	if !ids["sv1-25"] || !ids["swsh1-25"] {
+		t.Errorf("expected both Pikachu cards in candidates, got %v", ids)
+	}
+}
+
+func TestScanHandler_UnsupportedMIME(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	// Plain text gets sniffed as text/plain.
+	req := buildScanRequest(t, []byte("not an image"), "fake.png")
+	req = asUser(req, u)
+	rec := httptest.NewRecorder()
+	ScanHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestScanHandler_TooLarge(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	// 5 MB + 1 byte of JPEG-flavoured padding. Multipart parser still accepts
+	// the request (parser limit is 10 MB); the handler's own size check fires.
+	payload := append([]byte{}, jpegMagic...)
+	for len(payload) <= scanMaxImageBytes {
+		payload = append(payload, 0x00)
+	}
+
+	req := buildScanRequest(t, payload, "huge.jpg")
+	req = asUser(req, u)
+	rec := httptest.NewRecorder()
+	ScanHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestScanHandler_MissingFile(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	// Multipart body with no image part.
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	if err := w.WriteField("other", "value"); err != nil {
+		t.Fatalf("write field: %v", err)
+	}
+	w.Close()
+	req := httptest.NewRequest(http.MethodPost, "/api/pokemon/scan", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	req = asUser(req, u)
+	rec := httptest.NewRecorder()
+	ScanHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestScanHandler_StripsCodeFence(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	// Claude occasionally wraps the answer in a markdown fence despite the
+	// "no markdown fence" instruction. The handler must still parse this.
+	stubScanPrompt(t, "```json\n{\"set_name\":\"Scarlet & Violet Base\",\"set_id_hint\":\"sv1\",\"collector_number\":\"025\",\"confidence\":0.9}\n```", nil)
+
+	req := buildScanRequest(t, append(pngMagic, []byte("p")...), "card.png")
+	req = asUser(req, u)
+	rec := httptest.NewRecorder()
+	ScanHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Matched    bool            `json:"matched"`
+		Candidates []ScanCandidate `json:"candidates"`
+	}](t, rec)
+	if !body.Matched || len(body.Candidates) != 1 || body.Candidates[0].Card.ID != "sv1-25" {
+		t.Errorf("expected sv1-25 match through code fence, got %+v", body)
+	}
+}
+
+func TestScanHandler_NoCardMatch(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	stubScanPrompt(t, `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"999","confidence":0.92}`, nil)
+
+	req := buildScanRequest(t, append(pngMagic, []byte("p")...), "card.png")
+	req = asUser(req, u)
+	rec := httptest.NewRecorder()
+	ScanHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Matched    bool    `json:"matched"`
+		Confidence float64 `json:"confidence"`
+		Reason     string  `json:"reason"`
+	}](t, rec)
+	if body.Matched {
+		t.Errorf("expected matched=false when no card matches, got true")
+	}
+	if body.Confidence != 0.92 {
+		t.Errorf("expected confidence to pass through, got %v", body.Confidence)
+	}
+	if !strings.Contains(body.Reason, "collector '999'") {
+		t.Errorf("expected reason to include collector number, got %q", body.Reason)
+	}
+}
+
+// TestScanHandler_FeatureGateAndAdmin asserts the route is wired up behind
+// BOTH RequireFeature(db, "pokemon") and RequireAdmin. A non-admin user with
+// the feature enabled must be denied; an admin without any explicit feature
+// flag must pass (admins bypass feature checks by design).
+func TestScanHandler_FeatureGateAndAdmin(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+
+	// Non-admin kid with the pokemon feature ON but no admin flag.
+	if _, err := db.Exec(`
+		INSERT INTO users (id, email, name, google_id, is_admin)
+		VALUES (1, 'kid@example.com', 'Kid', 'g-kid', 0)
+	`); err != nil {
+		t.Fatalf("seed kid: %v", err)
+	}
+	if err := auth.SetUserFeature(db, 1, "pokemon", true); err != nil {
+		t.Fatalf("enable pokemon for kid: %v", err)
+	}
+	enableClaudeForUser(t, db, 1)
+
+	// Admin with no explicit pokemon flag — admins bypass feature checks.
+	if _, err := db.Exec(`
+		INSERT INTO users (id, email, name, google_id, is_admin)
+		VALUES (2, 'admin@example.com', 'Admin', 'g-admin', 1)
+	`); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+	enableClaudeForUser(t, db, 2)
+
+	kidToken, _, err := auth.CreateSession(db, 1)
+	if err != nil {
+		t.Fatalf("create kid session: %v", err)
+	}
+	adminToken, _, err := auth.CreateSession(db, 2)
+	if err != nil {
+		t.Fatalf("create admin session: %v", err)
+	}
+
+	stubScanPrompt(t, `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"025","confidence":0.95}`, nil)
+
+	r := chi.NewRouter()
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAuth(db))
+		r.Use(auth.WithFeatures(db))
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireFeature(db, "pokemon"))
+			r.With(auth.RequireAdmin()).Post("/api/pokemon/scan", ScanHandler(db))
+		})
+	})
+
+	makeReq := func(token string) *http.Request {
+		req := buildScanRequest(t, append(pngMagic, []byte("p")...), "card.png")
+		req.AddCookie(&http.Cookie{Name: "session", Value: token})
+		return req
+	}
+
+	// Kid (non-admin) with pokemon=true → 403 because RequireAdmin denies them.
+	recKid := httptest.NewRecorder()
+	r.ServeHTTP(recKid, makeReq(kidToken))
+	if recKid.Code != http.StatusForbidden {
+		t.Errorf("kid expected 403 on scan, got %d (%s)", recKid.Code, recKid.Body.String())
+	}
+
+	// Admin → 200.
+	recAdmin := httptest.NewRecorder()
+	r.ServeHTTP(recAdmin, makeReq(adminToken))
+	if recAdmin.Code != http.StatusOK {
+		t.Errorf("admin expected 200, got %d (%s)", recAdmin.Code, recAdmin.Body.String())
+	}
+
+	// User with no pokemon flag AND no admin flag → 403 from the feature gate.
+	if _, err := db.Exec(`
+		INSERT INTO users (id, email, name, google_id, is_admin)
+		VALUES (3, 'no-feat@example.com', 'NoFeat', 'g-nofeat', 0)
+	`); err != nil {
+		t.Fatalf("seed no-feat user: %v", err)
+	}
+	noFeatToken, _, err := auth.CreateSession(db, 3)
+	if err != nil {
+		t.Fatalf("create no-feat session: %v", err)
+	}
+	recNoFeat := httptest.NewRecorder()
+	r.ServeHTTP(recNoFeat, makeReq(noFeatToken))
+	if recNoFeat.Code != http.StatusForbidden {
+		t.Errorf("no-feat user expected 403, got %d (%s)", recNoFeat.Code, recNoFeat.Body.String())
+	}
+}
+
+// TestParseClaudeScanResult exercises the JSON parser directly against the
+// payload variants we expect to see in production: a strict object, an
+// accidental markdown fence, and a malformed string.
+func TestParseClaudeScanResult(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr bool
+		conf    float64
+	}{
+		{
+			name:    "strict json",
+			raw:     `{"set_name":"x","set_id_hint":"sv1","collector_number":"025","confidence":0.9}`,
+			wantErr: false,
+			conf:    0.9,
+		},
+		{
+			name:    "code fence",
+			raw:     "```json\n{\"set_name\":\"x\",\"set_id_hint\":\"sv1\",\"collector_number\":\"025\",\"confidence\":0.5}\n```",
+			wantErr: false,
+			conf:    0.5,
+		},
+		{
+			name:    "garbage",
+			raw:     "i give up",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := parseClaudeScanResult(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", r)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r.Confidence != tc.conf {
+				t.Errorf("expected confidence %v, got %v", tc.conf, r.Confidence)
+			}
+		})
+	}
+}
+
+// ensure we can encode/decode the candidate struct symmetrically. Cheap
+// sanity check that prevents API shape regressions if anyone re-orders the
+// struct fields.
+func TestScanCandidate_JSON(t *testing.T) {
+	c := ScanCandidate{
+		Card:  CardDTO{ID: "sv1-25", SetID: "sv1", Name: "Pikachu", Variants: []VariantDTO{}},
+		Set:   &SetDTO{ID: "sv1", Name: "SV Base"},
+		Score: 0.91,
+	}
+	out, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wantSnippet := fmt.Sprintf(`"score":%v`, 0.91)
+	if !strings.Contains(string(out), wantSnippet) {
+		t.Errorf("expected %s in %s", wantSnippet, out)
+	}
+}

--- a/internal/training/claude.go
+++ b/internal/training/claude.go
@@ -175,10 +175,15 @@ var runPromptWithImageFn = runPromptCLIWithImage
 // CLI and returns the text response. The image is referenced inside the prompt
 // so Claude's built-in Read tool can view it — this works around the fact that
 // `claude -p` in v2.1.x does not expose a dedicated `--image` flag. To allow
-// the Read tool to access the image, the temp directory containing it is
-// granted via `--add-dir` and tool permissions are bypassed for the call.
-// Callers are expected to write the image to a short-lived temp file under
-// /tmp and remove it after this returns.
+// the Read tool to access the image, the directory containing it is granted
+// via `--add-dir` and tool permissions are bypassed for the call.
+//
+// Security note: Read access is granted to filepath.Dir(imagePath), so callers
+// MUST place the image inside a dedicated per-call directory (e.g. via
+// os.MkdirTemp) that contains no other files. Passing a path whose parent is
+// a shared location like /tmp would expose every file in that directory to
+// Claude. The caller is responsible for removing the directory after this
+// returns.
 func RunPromptWithImage(ctx context.Context, cfg *ClaudeConfig, prompt, imagePath string) (string, error) {
 	return runPromptWithImageFn(ctx, cfg, prompt, imagePath)
 }

--- a/internal/training/claude.go
+++ b/internal/training/claude.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -164,6 +165,61 @@ type claudeJSONResponse struct {
 	Result    string `json:"result"`
 	SessionID string `json:"session_id"`
 	IsError   bool   `json:"is_error"`
+}
+
+// runPromptWithImageFn is the seam used by RunPromptWithImage. Tests override
+// this to stub out the CLI invocation.
+var runPromptWithImageFn = runPromptCLIWithImage
+
+// RunPromptWithImage sends a prompt plus a single image file path to the Claude
+// CLI and returns the text response. The image is referenced inside the prompt
+// so Claude's built-in Read tool can view it — this works around the fact that
+// `claude -p` in v2.1.x does not expose a dedicated `--image` flag. To allow
+// the Read tool to access the image, the temp directory containing it is
+// granted via `--add-dir` and tool permissions are bypassed for the call.
+// Callers are expected to write the image to a short-lived temp file under
+// /tmp and remove it after this returns.
+func RunPromptWithImage(ctx context.Context, cfg *ClaudeConfig, prompt, imagePath string) (string, error) {
+	return runPromptWithImageFn(ctx, cfg, prompt, imagePath)
+}
+
+func runPromptCLIWithImage(ctx context.Context, cfg *ClaudeConfig, prompt, imagePath string) (string, error) {
+	if !cfg.Enabled {
+		return "", fmt.Errorf("claude is not enabled")
+	}
+	if imagePath == "" {
+		return "", fmt.Errorf("image path is required")
+	}
+
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, DefaultCLITimeout)
+		defer cancel()
+	}
+
+	dir := filepath.Dir(imagePath)
+	augmented := fmt.Sprintf("Read the image at %s, then answer:\n\n%s", imagePath, prompt)
+
+	cmd := exec.CommandContext(ctx, cfg.CLIPath,
+		"--model", cfg.Model,
+		"-p", "-",
+		"--output-format", "json",
+		"--add-dir", dir,
+		"--allowedTools", "Read",
+		"--permission-mode", "bypassPermissions",
+	)
+	cmd.Stdin = strings.NewReader(augmented)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("claude CLI error: %w: %s", err, stderr.String())
+	}
+
+	text, _, err := parseClaudeCostEnvelope(stdout.Bytes())
+	return text, err
 }
 
 // RunPromptWithSession sends a prompt to the Claude CLI with optional session resumption.


### PR DESCRIPTION
## Changes

- **Pokémon card vision scan endpoint** - `POST /api/pokemon/scan` accepts a multipart image upload, runs it through Claude vision to identify the set and collector number, and returns matched card candidates with EUR/NOK pricing. Admin-gated and behind the `pokemon` feature flag. (Hytte-sud5)

## Original Issue (feature): Pokémon Phase 2: backend scan endpoint via Claude vision

Part of the Pokémon Collection chain seeded from Suggestions id=146, Phase 2 (scanning via Claude vision). Phase 1 chain (Hytte-8pzb → Hytte-mec4) is already merged. This bead is the backend half of Phase 2; the frontend live-scanner is the next link.

## Scope

### New endpoint

`POST /api/pokemon/scan` (admin-gated + `RequireFeature(db, "pokemon")`):

- Accepts a `multipart/form-data` body with a single image part named `image`.
- Size cap 5 MB. Only `image/jpeg`, `image/png`, `image/webp`, `image/heic`, `image/heif` MIME types accepted; reject everything else with 400.
- Writes the image to a temp file (`os.CreateTemp`), removes it after the Claude call regardless of outcome (no audit trail; no PII concerns).
- Builds the Claude prompt:

      You will be shown a single Pokémon TCG card photo. Identify two things:
      1. The set, by reading the small set symbol on the bottom-right of the card AND any visible set name printed near it.
      2. The collector number on the bottom-left, in the format "025/195" (numerator/denominator).

      Respond as STRICT JSON, no markdown fence, no prose:
      {
        "set_name": "...",         // best guess for the set's English name
        "set_id_hint": "...",      // optional pokemontcg.io set id if recognised (e.g. "sv4"), otherwise empty
        "collector_number": "...", // exact string from the card, e.g. "025/195"
        "confidence": 0.95         // 0.0-1.0; 0 means you can't read the card
      }

- Calls Claude with the image attached. Reuse `training.RunPrompt` if it already supports image input; otherwise add a sibling `training.RunPromptWithImage(ctx, cfg, prompt, imagePath) (string, error)` that shells out to the Claude CLI with the image attachment flag. Check the Claude CLI version's supported flags — `claude -p` accepts `--image <path>` in recent versions. Document the addition in `internal/training/claude.go`.
- Parse the JSON. If `confidence < 0.4` OR JSON is malformed → return 200 with `{matched: false, confidence: <value>, reason: "..."}`. Do NOT return 4xx — a low-confidence result is a valid outcome.
- If high confidence: look up the matching card. Match priority:
  1. If `set_id_hint` is set AND non-empty AND exists in `pokemon_sets`: filter by that set.
  2. Else if `set_name` matches a `pokemon_sets.name` (case-insensitive substring): filter by that set.
  3. Else: search all cards.
  Within the filtered scope, find a card whose `collector_no` equals `collector_number` (exact match). If multiple sets match the same collector number, return all candidates with `confidence` so the user picks.
- Response shape on success:

      {
        "matched": true,
        "confidence": 0.95,
        "candidates": [
          { "card": {<full card object with variants>}, "set": {<set object>}, "score": 0.95 }
        ]
      }

  On no match (but Claude was confident): `{matched: false, confidence: 0.92, reason: "no card matches set 'sv4' collector '025/195'"}`.

### Tests

- `internal/pokemon/scan_test.go`:
    - Multipart upload with a fake image — Claude mocked via the `runPromptFn`-style seam — asserts the matched card lookup works.
    - Confidence below threshold → `matched: false`, no DB lookup.
    - Malformed JSON from Claude → `matched: false` with reason.
    - Multi-candidate (same collector_number across sets) → returns all candidates.
    - Unsupported MIME type → 400.
    - Image > 5 MB → 400.
- Wire-up test asserting the route is registered behind `RequireFeature(db, "pokemon")`.

## Image handling

- Use `r.ParseMultipartForm(10 << 20)` (10 MB cap) and inspect the first `image` form file.
- Validate MIME by sniffing the first 512 bytes via `http.DetectContentType` rather than trusting the form's reported content-type.
- Write to a temp file with `os.CreateTemp("", "pokemon-scan-*")`, defer remove.
- Pass the temp file's path to the Claude wrapper.

## Acceptance

- `make build`, `make test`, `go vet ./...`, `npm run build` all pass.
- Hitting `POST /api/pokemon/scan` with a valid card image returns a matched candidate (verified manually with one known card image).
- Unsupported MIME returns 400.
- Low-confidence response is 200 with `matched: false`.
- Each scan creates and cleans up exactly one temp file.
- Changelog fragment in changelog.d/ (category: Added).

## Reference

- internal/training/claude.go — `RunPrompt`; extend for image input.
- internal/pokemon/handlers.go — existing handler pattern.
- internal/pokemon/models.go — card / variant / set struct shapes for the response.
- internal/api/router.go — admin-gated + feature-flag route registration pattern.
- The Phase 1 chain Hytte-8pzb → Hytte-mec4 for context.


---
Bead: Hytte-sud5 | Branch: forge/Hytte-sud5
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->