### PR TITLE
Pokémon: full-size lightbox with prev/next nav (tap-zones, keyboard, swipe) (Hytte-sevm)

### DIFF
--- a/changelog.d/Hytte-sevm.md
+++ b/changelog.d/Hytte-sevm.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon card lightbox** - Tap a card thumbnail on the Pokémon set detail page or in the add-card search to open a full-screen lightbox of the high-resolution image. Navigate adjacent cards with arrow keys, left/right tap zones, or horizontal swipe; the list wraps at the edges with a brief flash. Mark/remove owned and add-to-collection actions stay reachable in a bottom action bar inside the lightbox. (Hytte-sevm)

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -82,6 +82,7 @@
     "results": "Card results",
     "previewCard": "Preview {{name}} in full size",
     "cancel": "Cancel",
+    "alreadyOwnedShort": "Already owned",
     "variantPickerLabel": "Pick a variant for {{name}}",
     "variantPickerPrompt": "Pick a variant for {{name}}",
     "toast": {

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -63,6 +63,13 @@
     "marked": "Added to collection",
     "unmarked": "Removed from collection"
   },
+  "lightbox": {
+    "previousCard": "Previous card",
+    "nextCard": "Next card",
+    "close": "Close lightbox",
+    "wrappedToStart": "Wrapped to the first card",
+    "wrappedToEnd": "Wrapped to the last card"
+  },
   "addCard": {
     "openLabel": "Add a card to your collection",
     "dialogLabel": "Add a card",
@@ -73,6 +80,7 @@
     "searching": "Searching…",
     "noResults": "No cards match that search.",
     "results": "Card results",
+    "previewCard": "Preview {{name}} in full size",
     "cancel": "Cancel",
     "variantPickerLabel": "Pick a variant for {{name}}",
     "variantPickerPrompt": "Pick a variant for {{name}}",

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -82,6 +82,7 @@
     "results": "Kortresultater",
     "previewCard": "Forhåndsvis {{name}} i full størrelse",
     "cancel": "Avbryt",
+    "alreadyOwnedShort": "Allerede eid",
     "variantPickerLabel": "Velg variant for {{name}}",
     "variantPickerPrompt": "Velg variant for {{name}}",
     "toast": {

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -63,6 +63,13 @@
     "marked": "Lagt til i samlingen",
     "unmarked": "Fjernet fra samlingen"
   },
+  "lightbox": {
+    "previousCard": "Forrige kort",
+    "nextCard": "Neste kort",
+    "close": "Lukk lyskasse",
+    "wrappedToStart": "Hoppet til første kort",
+    "wrappedToEnd": "Hoppet til siste kort"
+  },
   "addCard": {
     "openLabel": "Legg til kort i samlingen",
     "dialogLabel": "Legg til kort",
@@ -73,6 +80,7 @@
     "searching": "Søker …",
     "noResults": "Ingen kort matcher søket.",
     "results": "Kortresultater",
+    "previewCard": "Forhåndsvis {{name}} i full størrelse",
     "cancel": "Avbryt",
     "variantPickerLabel": "Velg variant for {{name}}",
     "variantPickerPrompt": "Velg variant for {{name}}",

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -82,6 +82,7 @@
     "results": "ผลลัพธ์การ์ด",
     "previewCard": "ดู {{name}} ขนาดเต็ม",
     "cancel": "ยกเลิก",
+    "alreadyOwnedShort": "มีแล้ว",
     "variantPickerLabel": "เลือกชนิดสำหรับ {{name}}",
     "variantPickerPrompt": "เลือกชนิดสำหรับ {{name}}",
     "toast": {

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -63,6 +63,13 @@
     "marked": "เพิ่มเข้าคอลเลกชันแล้ว",
     "unmarked": "ลบออกจากคอลเลกชันแล้ว"
   },
+  "lightbox": {
+    "previousCard": "การ์ดก่อนหน้า",
+    "nextCard": "การ์ดถัดไป",
+    "close": "ปิดมุมมองเต็มจอ",
+    "wrappedToStart": "ย้อนไปการ์ดใบแรก",
+    "wrappedToEnd": "ข้ามไปการ์ดใบสุดท้าย"
+  },
   "addCard": {
     "openLabel": "เพิ่มการ์ดเข้าคอลเลกชัน",
     "dialogLabel": "เพิ่มการ์ด",
@@ -73,6 +80,7 @@
     "searching": "กำลังค้นหา…",
     "noResults": "ไม่พบการ์ดที่ตรงกับคำค้นหา",
     "results": "ผลลัพธ์การ์ด",
+    "previewCard": "ดู {{name}} ขนาดเต็ม",
     "cancel": "ยกเลิก",
     "variantPickerLabel": "เลือกชนิดสำหรับ {{name}}",
     "variantPickerPrompt": "เลือกชนิดสำหรับ {{name}}",

--- a/web/src/components/pokemon/AddCardPanel.test.tsx
+++ b/web/src/components/pokemon/AddCardPanel.test.tsx
@@ -362,6 +362,22 @@ describe('AddCardPanel — multi-variant picker', () => {
   })
 })
 
+describe('AddCardPanel — lightbox preview', () => {
+  it('clicking the result thumbnail opens the CardLightbox dialog', async () => {
+    const card = makeCard({ id: 'sv1-25', name: 'Pikachu' })
+    vi.stubGlobal('fetch', makeFetchMock([card]))
+
+    render(<AddCardPanel />)
+    openPanel()
+    fireEvent.change(screen.getByLabelText('Search cards'), { target: { value: 'pika' } })
+
+    fireEvent.click(await screen.findByTestId('add-card-preview-sv1-25'))
+
+    expect(await screen.findByRole('dialog', { name: 'Pikachu' })).toBeInTheDocument()
+    expect(screen.getByTestId('lightbox-prev-zone')).toBeInTheDocument()
+  })
+})
+
 describe('AddCardPanel — search error', () => {
   it('shows the failure message when the search endpoint errors', async () => {
     const fetchMock = makeFetchMock([], (url) => {

--- a/web/src/components/pokemon/AddCardPanel.tsx
+++ b/web/src/components/pokemon/AddCardPanel.tsx
@@ -7,6 +7,7 @@ import { useToast } from '../../hooks/useToast'
 import { formatNumber } from '../../utils/formatDate'
 import { useAuth } from '../../auth'
 import CardScanner from './CardScanner'
+import CardLightbox from './CardLightbox'
 
 interface Variant {
   id: number
@@ -62,6 +63,7 @@ export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
   const [variantCard, setVariantCard] = useState<Card | null>(null)
   const [adding, setAdding] = useState(false)
   const [scannerOpen, setScannerOpen] = useState(false)
+  const [lightboxStartIndex, setLightboxStartIndex] = useState<number | null>(null)
 
   const close = useCallback(() => {
     setIsOpen(false)
@@ -70,6 +72,7 @@ export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
     setResults([])
     setError('')
     setVariantCard(null)
+    setLightboxStartIndex(null)
   }, [])
 
   // Debounced autocomplete: each keystroke schedules a 200ms timer; the
@@ -220,16 +223,16 @@ export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
           )}
           {showResults && (
             <ul aria-label={t('addCard.results')}>
-              {results.map(card => {
+              {results.map((card, i) => {
                 const variant = card.variants[0]
                 return (
-                  <li key={card.id}>
+                  <li key={card.id} className="flex items-stretch border-b border-gray-800 last:border-b-0 hover:bg-gray-800/60">
                     <button
                       type="button"
-                      onClick={() => handleResultClick(card)}
-                      disabled={adding}
-                      data-testid={`add-card-result-${card.id}`}
-                      className="flex w-full items-center gap-3 px-3 py-2 hover:bg-gray-800/60 disabled:cursor-not-allowed text-left cursor-pointer border-b border-gray-800 last:border-b-0"
+                      onClick={() => setLightboxStartIndex(i)}
+                      aria-label={t('addCard.previewCard', { name: card.name })}
+                      data-testid={`add-card-preview-${card.id}`}
+                      className="shrink-0 flex items-center justify-center px-3 py-2 cursor-pointer"
                     >
                       <div className="h-14 w-10 shrink-0 flex items-center justify-center bg-gray-800/40 rounded overflow-hidden">
                         {card.image_small_url ? (
@@ -241,6 +244,14 @@ export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
                           />
                         ) : null}
                       </div>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleResultClick(card)}
+                      disabled={adding}
+                      data-testid={`add-card-result-${card.id}`}
+                      className="flex flex-1 min-w-0 items-center gap-3 pr-3 py-2 disabled:cursor-not-allowed text-left cursor-pointer"
+                    >
                       <div className="min-w-0 flex-1">
                         <p className="text-sm font-medium text-white truncate">{card.name}</p>
                         <p className="text-xs text-gray-500 truncate">
@@ -311,6 +322,68 @@ export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
             setResults([])
             setError('')
             setVariantCard(null)
+          }}
+        />
+      )}
+
+      {lightboxStartIndex != null && results.length > 0 && (
+        <CardLightbox
+          cards={results}
+          startIndex={lightboxStartIndex}
+          onClose={() => setLightboxStartIndex(null)}
+          showPrice
+          renderActionBar={(card) => {
+            const lightCard = card as Card
+            const ownedAlready = lightCard.variants.length === 1 && lightCard.variants[0]?.owned
+            return (
+              <div className="flex flex-wrap items-center gap-2 bg-gray-900/80 border border-gray-700 rounded-lg p-3 backdrop-blur-sm">
+                {lightCard.variants.length > 1 ? (
+                  <>
+                    <span className="text-xs text-gray-300 mr-1">
+                      {t('addCard.variantPickerPrompt', { name: lightCard.name })}
+                    </span>
+                    {lightCard.variants.map(v => (
+                      <button
+                        key={v.id}
+                        type="button"
+                        onClick={() => {
+                          if (v.owned) {
+                            showToast(t('addCard.toast.alreadyOwned', { name: lightCard.name }), 'warning')
+                            return
+                          }
+                          void addCard(lightCard, v.id)
+                        }}
+                        disabled={adding}
+                        data-testid={`lightbox-add-variant-${v.id}`}
+                        className="flex items-center gap-2 px-3 py-1.5 rounded border border-gray-700 hover:border-emerald-500 hover:bg-emerald-500/10 disabled:cursor-not-allowed text-sm text-white cursor-pointer"
+                      >
+                        <span>{t(`variantKind.${v.kind}`, { defaultValue: v.kind })}</span>
+                        {v.owned && <span className="text-xs text-emerald-400">✓</span>}
+                        <span className="text-xs text-gray-400">{formatNok(v.price_nok)}</span>
+                      </button>
+                    ))}
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const v = lightCard.variants[0]
+                      if (!v) return
+                      if (v.owned) {
+                        showToast(t('addCard.toast.alreadyOwned', { name: lightCard.name }), 'warning')
+                        return
+                      }
+                      void addCard(lightCard, v.id)
+                    }}
+                    disabled={adding || ownedAlready}
+                    data-testid="lightbox-add-card"
+                    className="flex items-center gap-2 px-3 py-1.5 rounded bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-sm text-white cursor-pointer"
+                  >
+                    {ownedAlready ? t('addCard.toast.alreadyOwned', { name: lightCard.name }) : t('detail.markOwned')}
+                  </button>
+                )}
+              </div>
+            )
           }}
         />
       )}

--- a/web/src/components/pokemon/AddCardPanel.tsx
+++ b/web/src/components/pokemon/AddCardPanel.tsx
@@ -378,7 +378,7 @@ export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
                     data-testid="lightbox-add-card"
                     className="flex items-center gap-2 px-3 py-1.5 rounded bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-sm text-white cursor-pointer"
                   >
-                    {ownedAlready ? t('addCard.toast.alreadyOwned', { name: card.name }) : t('detail.markOwned')}
+                    {ownedAlready ? t('addCard.alreadyOwnedShort') : t('detail.markOwned')}
                   </button>
                 )}
               </div>

--- a/web/src/components/pokemon/AddCardPanel.tsx
+++ b/web/src/components/pokemon/AddCardPanel.tsx
@@ -327,31 +327,30 @@ export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
       )}
 
       {lightboxStartIndex != null && results.length > 0 && (
-        <CardLightbox
+        <CardLightbox<Card>
           cards={results}
           startIndex={lightboxStartIndex}
           onClose={() => setLightboxStartIndex(null)}
           showPrice
           renderActionBar={(card) => {
-            const lightCard = card as Card
-            const ownedAlready = lightCard.variants.length === 1 && lightCard.variants[0]?.owned
+            const ownedAlready = card.variants.length === 1 && card.variants[0]?.owned
             return (
               <div className="flex flex-wrap items-center gap-2 bg-gray-900/80 border border-gray-700 rounded-lg p-3 backdrop-blur-sm">
-                {lightCard.variants.length > 1 ? (
+                {card.variants.length > 1 ? (
                   <>
                     <span className="text-xs text-gray-300 mr-1">
-                      {t('addCard.variantPickerPrompt', { name: lightCard.name })}
+                      {t('addCard.variantPickerPrompt', { name: card.name })}
                     </span>
-                    {lightCard.variants.map(v => (
+                    {card.variants.map(v => (
                       <button
                         key={v.id}
                         type="button"
                         onClick={() => {
                           if (v.owned) {
-                            showToast(t('addCard.toast.alreadyOwned', { name: lightCard.name }), 'warning')
+                            showToast(t('addCard.toast.alreadyOwned', { name: card.name }), 'warning')
                             return
                           }
-                          void addCard(lightCard, v.id)
+                          void addCard(card, v.id)
                         }}
                         disabled={adding}
                         data-testid={`lightbox-add-variant-${v.id}`}
@@ -367,19 +366,19 @@ export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
                   <button
                     type="button"
                     onClick={() => {
-                      const v = lightCard.variants[0]
+                      const v = card.variants[0]
                       if (!v) return
                       if (v.owned) {
-                        showToast(t('addCard.toast.alreadyOwned', { name: lightCard.name }), 'warning')
+                        showToast(t('addCard.toast.alreadyOwned', { name: card.name }), 'warning')
                         return
                       }
-                      void addCard(lightCard, v.id)
+                      void addCard(card, v.id)
                     }}
                     disabled={adding || ownedAlready}
                     data-testid="lightbox-add-card"
                     className="flex items-center gap-2 px-3 py-1.5 rounded bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-sm text-white cursor-pointer"
                   >
-                    {ownedAlready ? t('addCard.toast.alreadyOwned', { name: lightCard.name }) : t('detail.markOwned')}
+                    {ownedAlready ? t('addCard.toast.alreadyOwned', { name: card.name }) : t('detail.markOwned')}
                   </button>
                 )}
               </div>

--- a/web/src/components/pokemon/CardLightbox.test.tsx
+++ b/web/src/components/pokemon/CardLightbox.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import CardLightbox, { type LightboxCard } from './CardLightbox'
+
+const TRANSLATIONS: Record<string, string> = {
+  'lightbox.previousCard': 'Previous card',
+  'lightbox.nextCard': 'Next card',
+  'lightbox.close': 'Close lightbox',
+  'lightbox.wrappedToStart': 'Wrapped to the first card',
+  'lightbox.wrappedToEnd': 'Wrapped to the last card',
+  'detail.ownership': 'Owned',
+}
+
+function mockT(key: string, opts?: Record<string, string | number>): string {
+  if (key === 'tile.collectorNo') return `#${opts?.number ?? ''}`
+  return TRANSLATIONS[key] ?? key
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockT,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+vi.mock('../../i18n', () => ({
+  default: { language: 'en' },
+}))
+
+function makeCard(over: Partial<LightboxCard> = {}): LightboxCard {
+  return {
+    id: 'c0',
+    name: 'Card 0',
+    collector_no: '001',
+    set_id: 'sv1',
+    set_name: 'Test Set',
+    image_large_url: 'https://example.com/0.png',
+    variants: [{ price_eur: 1, price_nok: 10, owned: false }],
+    ...over,
+  }
+}
+
+const fixture: LightboxCard[] = [
+  makeCard({ id: 'c0', name: 'Card 0', image_large_url: 'https://example.com/0.png' }),
+  makeCard({ id: 'c1', name: 'Card 1', image_large_url: 'https://example.com/1.png' }),
+  makeCard({ id: 'c2', name: 'Card 2', image_large_url: 'https://example.com/2.png' }),
+]
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function getImage(): HTMLImageElement {
+  return screen.getByTestId('lightbox-image') as HTMLImageElement
+}
+
+describe('CardLightbox – initial render', () => {
+  it('renders the dialog at the start index with the correct image', () => {
+    const onClose = vi.fn()
+    render(<CardLightbox cards={fixture} startIndex={1} onClose={onClose} />)
+    const dialog = screen.getByRole('dialog', { name: 'Card 1' })
+    expect(dialog).toBeInTheDocument()
+    expect(getImage().src).toBe('https://example.com/1.png')
+  })
+})
+
+describe('CardLightbox – keyboard navigation', () => {
+  it('ArrowLeft moves to the previous card', () => {
+    render(<CardLightbox cards={fixture} startIndex={1} onClose={vi.fn()} />)
+    fireEvent.keyDown(document, { key: 'ArrowLeft' })
+    expect(getImage().src).toBe('https://example.com/0.png')
+  })
+
+  it('ArrowRight moves to the next card', () => {
+    render(<CardLightbox cards={fixture} startIndex={1} onClose={vi.fn()} />)
+    fireEvent.keyDown(document, { key: 'ArrowRight' })
+    expect(getImage().src).toBe('https://example.com/2.png')
+  })
+
+  it('Escape closes the lightbox', () => {
+    const onClose = vi.fn()
+    render(<CardLightbox cards={fixture} startIndex={1} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('CardLightbox – click navigation', () => {
+  it('clicking the image closes the lightbox', () => {
+    const onClose = vi.fn()
+    render(<CardLightbox cards={fixture} startIndex={1} onClose={onClose} />)
+    fireEvent.click(getImage())
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking the left tap-zone goes to the previous card', () => {
+    render(<CardLightbox cards={fixture} startIndex={1} onClose={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('lightbox-prev-zone'))
+    expect(getImage().src).toBe('https://example.com/0.png')
+  })
+
+  it('clicking the right tap-zone goes to the next card', () => {
+    render(<CardLightbox cards={fixture} startIndex={1} onClose={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('lightbox-next-zone'))
+    expect(getImage().src).toBe('https://example.com/2.png')
+  })
+
+  it('clicking the explicit close button closes the lightbox', () => {
+    const onClose = vi.fn()
+    render(<CardLightbox cards={fixture} startIndex={0} onClose={onClose} />)
+    fireEvent.click(screen.getByTestId('lightbox-close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('CardLightbox – wrap-around', () => {
+  it('past the last card wraps to the first', () => {
+    render(<CardLightbox cards={fixture} startIndex={2} onClose={vi.fn()} />)
+    fireEvent.keyDown(document, { key: 'ArrowRight' })
+    expect(getImage().src).toBe('https://example.com/0.png')
+  })
+
+  it('before the first card wraps to the last', () => {
+    render(<CardLightbox cards={fixture} startIndex={0} onClose={vi.fn()} />)
+    fireEvent.keyDown(document, { key: 'ArrowLeft' })
+    expect(getImage().src).toBe('https://example.com/2.png')
+  })
+})
+
+describe('CardLightbox – swipe', () => {
+  it('a left swipe past the threshold advances to the next card', () => {
+    vi.useFakeTimers()
+    try {
+      render(<CardLightbox cards={fixture} startIndex={1} onClose={vi.fn()} />)
+      const overlay = screen.getByTestId('card-lightbox')
+
+      fireEvent.touchStart(overlay, { touches: [{ clientX: 200, clientY: 100 }] })
+      fireEvent.touchMove(overlay, { touches: [{ clientX: 100, clientY: 105 }] })
+      fireEvent.touchEnd(overlay, { changedTouches: [{ clientX: 100, clientY: 105 }] })
+
+      // Allow the post-swipe commit timer (150ms) to fire.
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(getImage().src).toBe('https://example.com/2.png')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a tiny horizontal drag below the threshold does nothing', () => {
+    vi.useFakeTimers()
+    try {
+      render(<CardLightbox cards={fixture} startIndex={1} onClose={vi.fn()} />)
+      const overlay = screen.getByTestId('card-lightbox')
+
+      fireEvent.touchStart(overlay, { touches: [{ clientX: 200, clientY: 100 }] })
+      fireEvent.touchMove(overlay, { touches: [{ clientX: 180, clientY: 100 }] })
+      fireEvent.touchEnd(overlay, { changedTouches: [{ clientX: 180, clientY: 100 }] })
+
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(getImage().src).toBe('https://example.com/1.png')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('CardLightbox – metadata', () => {
+  it('omits the price line when showPrice is false', () => {
+    render(<CardLightbox cards={fixture} startIndex={0} onClose={vi.fn()} />)
+    expect(screen.queryByTestId('lightbox-price')).not.toBeInTheDocument()
+  })
+
+  it('shows NOK and EUR when showPrice is true', () => {
+    render(<CardLightbox cards={fixture} startIndex={0} onClose={vi.fn()} showPrice />)
+    const price = screen.getByTestId('lightbox-price')
+    // Number formatting depends on locale but both currency codes should appear.
+    expect(price.textContent ?? '').toMatch(/NOK/i)
+    expect(price.textContent ?? '').toMatch(/EUR|€/i)
+  })
+})
+
+describe('CardLightbox – action bar slot', () => {
+  it('renders the renderActionBar output and exposes the current card', () => {
+    render(
+      <CardLightbox
+        cards={fixture}
+        startIndex={1}
+        onClose={vi.fn()}
+        renderActionBar={(card) => <button type="button">action for {card.name}</button>}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'action for Card 1' })).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'ArrowRight' })
+    expect(screen.getByRole('button', { name: 'action for Card 2' })).toBeInTheDocument()
+  })
+})
+
+describe('CardLightbox – body scroll lock', () => {
+  it('locks body overflow on mount and restores on unmount', () => {
+    document.body.style.overflow = ''
+    const { unmount } = render(<CardLightbox cards={fixture} startIndex={0} onClose={vi.fn()} />)
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('')
+  })
+})

--- a/web/src/components/pokemon/CardLightbox.test.tsx
+++ b/web/src/components/pokemon/CardLightbox.test.tsx
@@ -211,4 +211,25 @@ describe('CardLightbox – body scroll lock', () => {
     unmount()
     expect(document.body.style.overflow).toBe('')
   })
+
+  it('does not unlock body overflow when an outer lock is still active', () => {
+    // Simulate an outer modal that locked the body before the lightbox
+    // mounted; the lightbox must not stomp on that value when it closes.
+    document.body.style.overflow = 'hidden'
+    const { unmount } = render(<CardLightbox cards={fixture} startIndex={0} onClose={vi.fn()} />)
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('hidden')
+    document.body.style.overflow = ''
+  })
+})
+
+describe('CardLightbox – cards shrink', () => {
+  it('clamps currentIndex when the cards list shrinks past it', () => {
+    const { rerender } = render(<CardLightbox cards={fixture} startIndex={2} onClose={vi.fn()} />)
+    expect(getImage().src).toBe('https://example.com/2.png')
+
+    rerender(<CardLightbox cards={fixture.slice(0, 1)} startIndex={2} onClose={vi.fn()} />)
+    expect(getImage().src).toBe('https://example.com/0.png')
+  })
 })

--- a/web/src/components/pokemon/CardLightbox.tsx
+++ b/web/src/components/pokemon/CardLightbox.tsx
@@ -1,0 +1,410 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import { Check, ChevronLeft, ChevronRight } from 'lucide-react'
+import { formatNumber } from '../../utils/formatDate'
+
+export interface LightboxVariant {
+  price_eur?: number | null
+  price_nok?: number | null
+  owned?: boolean
+}
+
+export interface LightboxCard {
+  id: string
+  name: string
+  collector_no: string
+  set_id?: string
+  set_name?: string
+  image_large_url: string
+  image_small_url?: string
+  variants: LightboxVariant[]
+}
+
+export interface CardLightboxProps {
+  cards: LightboxCard[]
+  startIndex: number
+  onClose: () => void
+  showPrice?: boolean
+  renderActionBar?: (card: LightboxCard, index: number) => ReactNode
+}
+
+const SWIPE_THRESHOLD_PX = 40
+const SWIPE_MAX_VERTICAL_RATIO = Math.tan((30 * Math.PI) / 180)
+const SWIPE_ANIMATE_MS = 150
+const WRAP_FLASH_MS = 250
+const CHEVRON_IDLE_MS = 1500
+
+function formatNok(amount: number | null | undefined): string {
+  if (amount == null) return '—'
+  return formatNumber(amount, {
+    style: 'currency',
+    currency: 'NOK',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+function formatEur(amount: number | null | undefined): string | null {
+  if (amount == null) return null
+  return formatNumber(amount, {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+function cardIsOwned(card: LightboxCard): boolean {
+  return card.variants.some(v => v.owned)
+}
+
+function topVariant(card: LightboxCard): LightboxVariant | undefined {
+  return card.variants[0]
+}
+
+export default function CardLightbox({
+  cards,
+  startIndex,
+  onClose,
+  showPrice = false,
+  renderActionBar,
+}: CardLightboxProps) {
+  const { t } = useTranslation('pokemon')
+
+  const safeStart = useMemo(() => {
+    if (cards.length === 0) return 0
+    if (startIndex < 0) return 0
+    if (startIndex >= cards.length) return cards.length - 1
+    return startIndex
+  }, [cards.length, startIndex])
+
+  const [currentIndex, setCurrentIndex] = useState(safeStart)
+  const [wrapFlash, setWrapFlash] = useState<'start' | 'end' | null>(null)
+  const [swipeOffset, setSwipeOffset] = useState(0)
+  const [swipeAnimating, setSwipeAnimating] = useState(false)
+  const [chevronsIdle, setChevronsIdle] = useState(false)
+  const [announce, setAnnounce] = useState('')
+
+  const overlayRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const previousFocusRef = useRef<Element | null>(null)
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+
+  const currentCard = cards[currentIndex]
+
+  const goPrev = useCallback(() => {
+    if (cards.length === 0) return
+    setCurrentIndex(prev => {
+      if (prev <= 0) {
+        setWrapFlash('end')
+        setAnnounce(t('lightbox.wrappedToEnd'))
+        return cards.length - 1
+      }
+      return prev - 1
+    })
+  }, [cards.length, t])
+
+  const goNext = useCallback(() => {
+    if (cards.length === 0) return
+    setCurrentIndex(prev => {
+      if (prev >= cards.length - 1) {
+        setWrapFlash('start')
+        setAnnounce(t('lightbox.wrappedToStart'))
+        return 0
+      }
+      return prev + 1
+    })
+  }, [cards.length, t])
+
+  // Body scroll lock — restore the previous overflow value on unmount so we
+  // don't trample over a parent that already locked scrolling.
+  useEffect(() => {
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [])
+
+  // Keyboard navigation. Capture-phase so we run before any underlying Dialog
+  // listener (e.g. AddCardPanel's surrounding modal) and can stop Escape from
+  // also closing that parent.
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        onClose()
+        return
+      }
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        goPrev()
+        return
+      }
+      if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        goNext()
+        return
+      }
+      if (e.key === 'Tab' && dialogRef.current) {
+        const focusable = Array.from(
+          dialogRef.current.querySelectorAll<HTMLElement>(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+          ),
+        )
+        if (focusable.length === 0) return
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault()
+            last.focus()
+          }
+        } else if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => document.removeEventListener('keydown', handleKeyDown, true)
+  }, [goNext, goPrev, onClose])
+
+  // Focus the dialog on open, restore the previously focused element on close.
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement
+    dialogRef.current?.focus()
+    return () => {
+      if (previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus()
+      }
+    }
+  }, [])
+
+  // Clear the wrap flash after a short tick so it acts as a one-shot pulse.
+  useEffect(() => {
+    if (!wrapFlash) return
+    const timer = setTimeout(() => setWrapFlash(null), WRAP_FLASH_MS)
+    return () => clearTimeout(timer)
+  }, [wrapFlash])
+
+  // Fade the chevron hint after the user has had a moment to see it. Reset on
+  // every navigation so the cue reappears with the new card.
+  useEffect(() => {
+    setChevronsIdle(false)
+    const timer = setTimeout(() => setChevronsIdle(true), CHEVRON_IDLE_MS)
+    return () => clearTimeout(timer)
+  }, [currentIndex])
+
+  // Reset the announce live region after the screen reader has had a chance to
+  // pick it up so the next wrap fires a fresh announcement.
+  useEffect(() => {
+    if (!announce) return
+    const timer = setTimeout(() => setAnnounce(''), 1000)
+    return () => clearTimeout(timer)
+  }, [announce])
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (e.touches.length !== 1) return
+    const touch = e.touches[0]
+    touchStartRef.current = { x: touch.clientX, y: touch.clientY }
+    setSwipeOffset(0)
+    setSwipeAnimating(false)
+  }, [])
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    const start = touchStartRef.current
+    if (!start || e.touches.length !== 1) return
+    const touch = e.touches[0]
+    const dx = touch.clientX - start.x
+    const dy = touch.clientY - start.y
+    // Only follow finger if the gesture stays roughly horizontal — otherwise
+    // it is probably a vertical scroll attempt.
+    if (Math.abs(dy) > Math.abs(dx)) return
+    setSwipeOffset(dx)
+  }, [])
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    const start = touchStartRef.current
+    touchStartRef.current = null
+    if (!start) return
+    const last = e.changedTouches[0]
+    if (!last) {
+      setSwipeOffset(0)
+      return
+    }
+    const dx = last.clientX - start.x
+    const dy = last.clientY - start.y
+    const horizontalEnough = Math.abs(dx) >= SWIPE_THRESHOLD_PX
+    const dxSafe = Math.abs(dx) || 1
+    const angleOk = Math.abs(dy) / dxSafe < SWIPE_MAX_VERTICAL_RATIO
+    if (!horizontalEnough || !angleOk) {
+      setSwipeOffset(0)
+      return
+    }
+    const direction: 'next' | 'prev' = dx < 0 ? 'next' : 'prev'
+    const viewportW = typeof window !== 'undefined' ? window.innerWidth : 800
+    setSwipeAnimating(true)
+    setSwipeOffset(direction === 'next' ? -viewportW : viewportW)
+    window.setTimeout(() => {
+      if (direction === 'next') goNext()
+      else goPrev()
+      setSwipeAnimating(false)
+      setSwipeOffset(0)
+    }, SWIPE_ANIMATE_MS)
+  }, [goNext, goPrev])
+
+  if (cards.length === 0 || !currentCard) return null
+
+  const owned = cardIsOwned(currentCard)
+  const variant = topVariant(currentCard)
+  const priceNok = variant?.price_nok ?? null
+  const priceEur = variant?.price_eur ?? null
+  const eurFormatted = formatEur(priceEur)
+
+  const imageStyle = {
+    transform: `translateX(${swipeOffset}px)`,
+    transition: swipeAnimating ? `transform ${SWIPE_ANIMATE_MS}ms ease-out` : 'none',
+  }
+
+  const wrapFlashClass = wrapFlash
+    ? wrapFlash === 'start'
+      ? 'ring-4 ring-emerald-400/70'
+      : 'ring-4 ring-amber-400/70'
+    : ''
+
+  const chevronOpacityClass = chevronsIdle
+    ? 'opacity-0 sm:opacity-40'
+    : 'opacity-40'
+
+  const dialog = (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-[60] flex bg-black/95"
+      style={{
+        paddingTop: 'env(safe-area-inset-top)',
+        paddingBottom: 'env(safe-area-inset-bottom)',
+        paddingLeft: 'env(safe-area-inset-left)',
+        paddingRight: 'env(safe-area-inset-right)',
+      }}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      data-testid="card-lightbox"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={currentCard.name}
+        tabIndex={-1}
+        className="relative flex flex-1 items-stretch outline-none"
+      >
+        <button
+          type="button"
+          onClick={goPrev}
+          aria-label={t('lightbox.previousCard')}
+          data-testid="lightbox-prev-zone"
+          className={`group flex w-[22%] min-w-[44px] items-center justify-start pl-2 cursor-pointer transition-opacity ${chevronOpacityClass} hover:!opacity-80`}
+        >
+          <ChevronLeft size={48} className="text-white drop-shadow" aria-hidden="true" />
+        </button>
+
+        <div className="relative flex flex-1 flex-col items-center justify-center px-1 sm:px-2">
+          <div className="flex flex-1 w-full items-center justify-center min-h-0">
+            {currentCard.image_large_url ? (
+              <img
+                key={currentCard.id}
+                src={currentCard.image_large_url}
+                alt={currentCard.name}
+                loading="eager"
+                decoding="sync"
+                onClick={onClose}
+                style={imageStyle}
+                data-testid="lightbox-image"
+                className={`max-h-full max-w-full object-contain rounded shadow-2xl cursor-pointer ${wrapFlashClass}`}
+              />
+            ) : (
+              <div className="text-gray-400" data-testid="lightbox-image-placeholder">
+                {currentCard.collector_no}
+              </div>
+            )}
+          </div>
+
+          <div
+            className="mt-2 sm:mt-3 w-full max-w-2xl px-3 py-2 text-center"
+            data-testid="lightbox-meta"
+          >
+            <p className="text-base sm:text-lg font-semibold text-white truncate" title={currentCard.name}>
+              {currentCard.name}
+              {owned && (
+                <span
+                  aria-label={t('detail.ownership')}
+                  className="ml-2 inline-flex items-center justify-center align-middle h-5 w-5 rounded-full bg-emerald-500 text-white"
+                >
+                  <Check size={12} aria-hidden="true" />
+                </span>
+              )}
+            </p>
+            <p className="text-xs sm:text-sm text-gray-300 mt-0.5">
+              {currentCard.set_name ? `${currentCard.set_name} · ` : ''}
+              {t('tile.collectorNo', { number: currentCard.collector_no })}
+            </p>
+            {showPrice && (
+              <p className="text-xs sm:text-sm text-gray-200 mt-0.5" data-testid="lightbox-price">
+                {formatNok(priceNok)}
+                {eurFormatted ? ` (${eurFormatted})` : ''}
+              </p>
+            )}
+          </div>
+
+          {renderActionBar && (
+            <div
+              className="w-full max-w-2xl px-3 pb-2 pt-1"
+              data-testid="lightbox-action-bar"
+              onClick={e => e.stopPropagation()}
+            >
+              {renderActionBar(currentCard, currentIndex)}
+            </div>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={goNext}
+          aria-label={t('lightbox.nextCard')}
+          data-testid="lightbox-next-zone"
+          className={`group flex w-[22%] min-w-[44px] items-center justify-end pr-2 cursor-pointer transition-opacity ${chevronOpacityClass} hover:!opacity-80`}
+        >
+          <ChevronRight size={48} className="text-white drop-shadow" aria-hidden="true" />
+        </button>
+
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t('lightbox.close')}
+          data-testid="lightbox-close"
+          className="absolute top-2 right-2 sm:top-4 sm:right-4 p-2 rounded-full bg-black/40 text-white hover:bg-black/70 cursor-pointer z-10"
+        >
+          <span aria-hidden="true" className="text-lg leading-none">×</span>
+        </button>
+
+        <div
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+          data-testid="lightbox-announce"
+        >
+          {announce}
+        </div>
+      </div>
+    </div>
+  )
+
+  if (typeof document === 'undefined') return dialog
+  return createPortal(dialog, document.body)
+}

--- a/web/src/components/pokemon/CardLightbox.tsx
+++ b/web/src/components/pokemon/CardLightbox.tsx
@@ -113,6 +113,9 @@ function CardLightbox<TCard extends LightboxCard>({
   const previousFocusRef = useRef<Element | null>(null)
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
   const swipeTimerRef = useRef<number | null>(null)
+  // Set to true when a swipe gesture is committed so the synthetic click that
+  // fires after touchend doesn't also trigger onClose via the image's onClick.
+  const swipedRef = useRef(false)
 
   const clampedIndex = cards.length === 0 ? 0 : Math.min(Math.max(0, currentIndex), cards.length - 1)
   const currentCard = cards[clampedIndex]
@@ -272,6 +275,7 @@ function CardLightbox<TCard extends LightboxCard>({
     }
     const direction: 'next' | 'prev' = dx < 0 ? 'next' : 'prev'
     const viewportW = typeof window !== 'undefined' ? window.innerWidth : 800
+    swipedRef.current = true
     setSwipeAnimating(true)
     setSwipeOffset(direction === 'next' ? -viewportW : viewportW)
     if (swipeTimerRef.current !== null) {
@@ -283,6 +287,7 @@ function CardLightbox<TCard extends LightboxCard>({
       else goPrev()
       setSwipeAnimating(false)
       setSwipeOffset(0)
+      swipedRef.current = false
     }, SWIPE_ANIMATE_MS)
   }, [goNext, goPrev])
 
@@ -361,7 +366,7 @@ function CardLightbox<TCard extends LightboxCard>({
                 alt={currentCard.name}
                 loading="eager"
                 decoding="sync"
-                onClick={onClose}
+                onClick={() => { if (swipedRef.current) return; onClose() }}
                 style={imageStyle}
                 data-testid="lightbox-image"
                 className={`max-h-full max-w-full object-contain rounded shadow-2xl cursor-pointer ${wrapFlashClass}`}

--- a/web/src/components/pokemon/CardLightbox.tsx
+++ b/web/src/components/pokemon/CardLightbox.tsx
@@ -21,12 +21,12 @@ export interface LightboxCard {
   variants: LightboxVariant[]
 }
 
-export interface CardLightboxProps {
-  cards: LightboxCard[]
+export interface CardLightboxProps<TCard extends LightboxCard = LightboxCard> {
+  cards: TCard[]
   startIndex: number
   onClose: () => void
   showPrice?: boolean
-  renderActionBar?: (card: LightboxCard, index: number) => ReactNode
+  renderActionBar?: (card: TCard, index: number) => ReactNode
 }
 
 const SWIPE_THRESHOLD_PX = 40
@@ -34,6 +34,29 @@ const SWIPE_MAX_VERTICAL_RATIO = Math.tan((30 * Math.PI) / 180)
 const SWIPE_ANIMATE_MS = 150
 const WRAP_FLASH_MS = 250
 const CHEVRON_IDLE_MS = 1500
+
+// Module-scoped lock so stacked lightboxes (or rapid mount/unmount during
+// concurrent rendering) coordinate on body.style.overflow rather than each
+// instance racing to capture/restore the value.
+let bodyScrollLockCount = 0
+let bodyScrollLockPrevious = ''
+
+function lockBodyScroll() {
+  if (bodyScrollLockCount === 0) {
+    bodyScrollLockPrevious = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+  }
+  bodyScrollLockCount += 1
+}
+
+function unlockBodyScroll() {
+  if (bodyScrollLockCount === 0) return
+  bodyScrollLockCount -= 1
+  if (bodyScrollLockCount === 0) {
+    document.body.style.overflow = bodyScrollLockPrevious
+    bodyScrollLockPrevious = ''
+  }
+}
 
 function formatNok(amount: number | null | undefined): string {
   if (amount == null) return '—'
@@ -63,13 +86,13 @@ function topVariant(card: LightboxCard): LightboxVariant | undefined {
   return card.variants[0]
 }
 
-export default function CardLightbox({
+function CardLightbox<TCard extends LightboxCard>({
   cards,
   startIndex,
   onClose,
   showPrice = false,
   renderActionBar,
-}: CardLightboxProps) {
+}: CardLightboxProps<TCard>) {
   const { t } = useTranslation('pokemon')
 
   const safeStart = useMemo(() => {
@@ -86,10 +109,10 @@ export default function CardLightbox({
   const [chevronsIdle, setChevronsIdle] = useState(false)
   const [announce, setAnnounce] = useState('')
 
-  const overlayRef = useRef<HTMLDivElement>(null)
   const dialogRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<Element | null>(null)
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const swipeTimerRef = useRef<number | null>(null)
 
   const currentCard = cards[currentIndex]
 
@@ -117,15 +140,25 @@ export default function CardLightbox({
     })
   }, [cards.length, t])
 
-  // Body scroll lock — restore the previous overflow value on unmount so we
-  // don't trample over a parent that already locked scrolling.
+  // Body scroll lock — routed through a module-scoped counter so a parent
+  // modal's lock isn't clobbered if this instance unmounts first.
   useEffect(() => {
-    const previous = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = previous
-    }
+    lockBodyScroll()
+    return () => unlockBodyScroll()
   }, [])
+
+  // Keep currentIndex in range when the cards list shrinks underneath us
+  // (e.g. the parent re-filters its visible grid while the lightbox is open).
+  // Without this, currentIndex could exceed cards.length and the lightbox
+  // would render nothing or silently unmount.
+  useEffect(() => {
+    setCurrentIndex(prev => {
+      if (cards.length === 0) return 0
+      if (prev >= cards.length) return cards.length - 1
+      if (prev < 0) return 0
+      return prev
+    })
+  }, [cards.length])
 
   // Keyboard navigation. Capture-phase so we run before any underlying Dialog
   // listener (e.g. AddCardPanel's surrounding modal) and can stop Escape from
@@ -250,13 +283,28 @@ export default function CardLightbox({
     const viewportW = typeof window !== 'undefined' ? window.innerWidth : 800
     setSwipeAnimating(true)
     setSwipeOffset(direction === 'next' ? -viewportW : viewportW)
-    window.setTimeout(() => {
+    if (swipeTimerRef.current !== null) {
+      clearTimeout(swipeTimerRef.current)
+    }
+    swipeTimerRef.current = window.setTimeout(() => {
+      swipeTimerRef.current = null
       if (direction === 'next') goNext()
       else goPrev()
       setSwipeAnimating(false)
       setSwipeOffset(0)
     }, SWIPE_ANIMATE_MS)
   }, [goNext, goPrev])
+
+  // Cancel any pending swipe-commit on unmount so we don't run setState after
+  // the component is gone.
+  useEffect(() => {
+    return () => {
+      if (swipeTimerRef.current !== null) {
+        clearTimeout(swipeTimerRef.current)
+        swipeTimerRef.current = null
+      }
+    }
+  }, [])
 
   if (cards.length === 0 || !currentCard) return null
 
@@ -283,7 +331,6 @@ export default function CardLightbox({
 
   const dialog = (
     <div
-      ref={overlayRef}
       className="fixed inset-0 z-[60] flex bg-black/95"
       style={{
         paddingTop: 'env(safe-area-inset-top)',
@@ -309,7 +356,7 @@ export default function CardLightbox({
           onClick={goPrev}
           aria-label={t('lightbox.previousCard')}
           data-testid="lightbox-prev-zone"
-          className={`group flex w-[22%] min-w-[44px] items-center justify-start pl-2 cursor-pointer transition-opacity ${chevronOpacityClass} hover:!opacity-80`}
+          className={`group flex w-[22%] min-w-[44px] items-center justify-start pl-2 cursor-pointer transition-opacity ${chevronOpacityClass} hover:!opacity-80 focus-visible:!opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400`}
         >
           <ChevronLeft size={48} className="text-white drop-shadow" aria-hidden="true" />
         </button>
@@ -378,7 +425,7 @@ export default function CardLightbox({
           onClick={goNext}
           aria-label={t('lightbox.nextCard')}
           data-testid="lightbox-next-zone"
-          className={`group flex w-[22%] min-w-[44px] items-center justify-end pr-2 cursor-pointer transition-opacity ${chevronOpacityClass} hover:!opacity-80`}
+          className={`group flex w-[22%] min-w-[44px] items-center justify-end pr-2 cursor-pointer transition-opacity ${chevronOpacityClass} hover:!opacity-80 focus-visible:!opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400`}
         >
           <ChevronRight size={48} className="text-white drop-shadow" aria-hidden="true" />
         </button>
@@ -408,3 +455,5 @@ export default function CardLightbox({
   if (typeof document === 'undefined') return dialog
   return createPortal(dialog, document.body)
 }
+
+export default CardLightbox

--- a/web/src/components/pokemon/CardLightbox.tsx
+++ b/web/src/components/pokemon/CardLightbox.tsx
@@ -114,29 +114,34 @@ function CardLightbox<TCard extends LightboxCard>({
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
   const swipeTimerRef = useRef<number | null>(null)
 
-  const currentCard = cards[currentIndex]
+  const clampedIndex = cards.length === 0 ? 0 : Math.min(Math.max(0, currentIndex), cards.length - 1)
+  const currentCard = cards[clampedIndex]
 
   const goPrev = useCallback(() => {
     if (cards.length === 0) return
+    setChevronsIdle(false)
     setCurrentIndex(prev => {
-      if (prev <= 0) {
+      const safe = Math.min(Math.max(0, prev), cards.length - 1)
+      if (safe <= 0) {
         setWrapFlash('end')
         setAnnounce(t('lightbox.wrappedToEnd'))
         return cards.length - 1
       }
-      return prev - 1
+      return safe - 1
     })
   }, [cards.length, t])
 
   const goNext = useCallback(() => {
     if (cards.length === 0) return
+    setChevronsIdle(false)
     setCurrentIndex(prev => {
-      if (prev >= cards.length - 1) {
+      const safe = Math.min(Math.max(0, prev), cards.length - 1)
+      if (safe >= cards.length - 1) {
         setWrapFlash('start')
         setAnnounce(t('lightbox.wrappedToStart'))
         return 0
       }
-      return prev + 1
+      return safe + 1
     })
   }, [cards.length, t])
 
@@ -146,19 +151,6 @@ function CardLightbox<TCard extends LightboxCard>({
     lockBodyScroll()
     return () => unlockBodyScroll()
   }, [])
-
-  // Keep currentIndex in range when the cards list shrinks underneath us
-  // (e.g. the parent re-filters its visible grid while the lightbox is open).
-  // Without this, currentIndex could exceed cards.length and the lightbox
-  // would render nothing or silently unmount.
-  useEffect(() => {
-    setCurrentIndex(prev => {
-      if (cards.length === 0) return 0
-      if (prev >= cards.length) return cards.length - 1
-      if (prev < 0) return 0
-      return prev
-    })
-  }, [cards.length])
 
   // Keyboard navigation. Capture-phase so we run before any underlying Dialog
   // listener (e.g. AddCardPanel's surrounding modal) and can stop Escape from
@@ -228,7 +220,6 @@ function CardLightbox<TCard extends LightboxCard>({
   // Fade the chevron hint after the user has had a moment to see it. Reset on
   // every navigation so the cue reappears with the new card.
   useEffect(() => {
-    setChevronsIdle(false)
     const timer = setTimeout(() => setChevronsIdle(true), CHEVRON_IDLE_MS)
     return () => clearTimeout(timer)
   }, [currentIndex])
@@ -415,7 +406,7 @@ function CardLightbox<TCard extends LightboxCard>({
               data-testid="lightbox-action-bar"
               onClick={e => e.stopPropagation()}
             >
-              {renderActionBar(currentCard, currentIndex)}
+              {renderActionBar(currentCard, clampedIndex)}
             </div>
           )}
         </div>

--- a/web/src/pages/PokemonSet.test.tsx
+++ b/web/src/pages/PokemonSet.test.tsx
@@ -405,3 +405,25 @@ describe('PokemonSet – detail panel variant selection', () => {
     expect(within(fieldset).getByText('Reverse holo')).toBeInTheDocument()
   })
 })
+
+describe('PokemonSet – lightbox', () => {
+  it('clicking a tile opens the CardLightbox dialog with the card name', async () => {
+    const set = makeSet({ total_cards: 2 })
+    const cards = [
+      makeCard({ id: 'sv1-1', name: 'Pikachu' }),
+      makeCard({ id: 'sv1-2', name: 'Eevee' }),
+    ]
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards }))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('card-tile-sv1-2'))
+
+    const dialog = await screen.findByRole('dialog', { name: 'Eevee' })
+    expect(dialog).toBeInTheDocument()
+    // Sanity: the prev/next zones from the lightbox should be present.
+    expect(screen.getByTestId('lightbox-prev-zone')).toBeInTheDocument()
+    expect(screen.getByTestId('lightbox-next-zone')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -390,17 +390,12 @@ export default function PokemonSetPage() {
     return cards
   }, [cards, filter])
 
-  // If the visible list shrinks (e.g. the filter changed) below the open
-  // index, clamp it back into range so the lightbox doesn't crash on a stale
-  // pointer; close it entirely when the list becomes empty.
-  useEffect(() => {
-    if (lightboxStartIndex == null) return
-    if (visibleCards.length === 0) {
-      setLightboxStartIndex(null)
-    } else if (lightboxStartIndex >= visibleCards.length) {
-      setLightboxStartIndex(visibleCards.length - 1)
-    }
-  }, [visibleCards, lightboxStartIndex])
+  // Clamp the lightbox start index to the visible list length during render so
+  // we never pass a stale out-of-range pointer to CardLightbox.
+  const lightboxSafeIndex =
+    lightboxStartIndex != null && visibleCards.length > 0
+      ? Math.min(lightboxStartIndex, visibleCards.length - 1)
+      : null
 
   const updateCardVariants = useCallback(
     (cardId: string, mutate: (variants: Variant[]) => Variant[]) => {
@@ -615,10 +610,10 @@ export default function PokemonSetPage() {
           </>
         )}
       </div>
-      {lightboxStartIndex != null && visibleCards.length > 0 && (
+      {lightboxSafeIndex != null && (
         <CardLightbox<Card>
           cards={visibleCards}
-          startIndex={lightboxStartIndex}
+          startIndex={lightboxSafeIndex}
           onClose={() => setLightboxStartIndex(null)}
           showPrice
           renderActionBar={(card) => (

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -305,7 +305,7 @@ function LightboxActionBar({ card, onSave, onUnmark, saving, t }: LightboxAction
             >
               {CONDITIONS.map(c => (
                 <option key={c} value={c}>
-                  {t(`condition.${c || 'unset'}`)}
+                  {t(`condition.${c || 'unset'}` as never)}
                 </option>
               ))}
             </select>

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -2,10 +2,11 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { Link, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
-import { ArrowLeft, Check, X } from 'lucide-react'
+import { ArrowLeft, Check } from 'lucide-react'
 import { Skeleton } from '../components/ui/skeleton'
 import ToastList from '../components/ToastList'
 import AddCardPanel from '../components/pokemon/AddCardPanel'
+import CardLightbox from '../components/pokemon/CardLightbox'
 import { useToast } from '../hooks/useToast'
 import { formatDate, formatNumber } from '../utils/formatDate'
 
@@ -47,16 +48,6 @@ interface PokemonSet {
 
 type Filter = 'all' | 'owned' | 'missing'
 const FILTERS: Filter[] = ['all', 'owned', 'missing']
-
-const CONDITIONS = [
-  '',
-  'mint',
-  'near_mint',
-  'lightly_played',
-  'moderately_played',
-  'heavily_played',
-  'damaged',
-] as const
 
 // parseReleaseDate accepts the "YYYY/MM/DD" or "YYYY-MM-DD" formats returned
 // by pokemontcg.io and renders a localized date. Falls back to the raw string
@@ -173,22 +164,24 @@ function CardTile({ card, onClick, t }: TileProps) {
   )
 }
 
-interface DetailPanelProps {
-  card: Card
-  onClose: () => void
-  onSave: (variantId: number, payload: SavePayload) => Promise<void>
-  onUnmark: (collectionId: number) => Promise<void>
-  saving: boolean
-  t: TFunction<'pokemon'>
-}
-
 interface SavePayload {
   quantity: number
   condition: string
   notes: string
 }
 
-function DetailPanel({ card, onClose, onSave, onUnmark, saving, t }: DetailPanelProps) {
+interface LightboxActionBarProps {
+  card: Card
+  onSave: (variantId: number, payload: SavePayload) => Promise<void>
+  onUnmark: (collectionId: number) => Promise<void>
+  saving: boolean
+  t: TFunction<'pokemon'>
+}
+
+// LightboxActionBar renders the compact add/remove-owned controls inside the
+// CardLightbox. It defaults quantity/condition/notes to sensible values — the
+// full edit form lives elsewhere (kept off the lightbox by design).
+function LightboxActionBar({ card, onSave, onUnmark, saving, t }: LightboxActionBarProps) {
   const initialVariantId = useMemo(() => {
     const ownedV = card.variants.find(v => v.owned)
     return (ownedV ?? card.variants[0])?.id ?? 0
@@ -198,26 +191,24 @@ function DetailPanel({ card, onClose, onSave, onUnmark, saving, t }: DetailPanel
     () => card.variants.find(v => v.id === selectedVariantId) ?? card.variants[0],
     [card, selectedVariantId],
   )
-  const [quantity, setQuantity] = useState<number>(Math.max(selected?.quantity ?? 1, 1))
-  const [condition, setCondition] = useState<string>(selected?.condition ?? '')
-  const [notes, setNotes] = useState<string>(selected?.notes ?? '')
 
-  // Re-sync form when the selected variant changes. Using the "adjust during
-  // render" pattern (store prev id, update state inline) avoids an extra
-  // render cycle compared to a useEffect approach.
-  const [prevVariantId, setPrevVariantId] = useState(selectedVariantId)
-  if (selectedVariantId !== prevVariantId && selected) {
-    setPrevVariantId(selectedVariantId)
-    setQuantity(Math.max(selected.quantity || 1, 1))
-    setCondition(selected.condition || '')
-    setNotes(selected.notes || '')
+  // Re-sync the selection when the user navigates to a different card in the
+  // lightbox so the variant picker reflects the new card's owned state.
+  const [prevCardId, setPrevCardId] = useState(card.id)
+  if (card.id !== prevCardId) {
+    setPrevCardId(card.id)
+    setSelectedVariantId(initialVariantId)
   }
 
   if (!selected) return null
 
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault()
-    void onSave(selected.id, { quantity, condition, notes })
+    void onSave(selected.id, {
+      quantity: Math.max(selected.quantity || 1, 1),
+      condition: selected.condition || '',
+      notes: selected.notes || '',
+    })
   }
 
   const handleUnmark = () => {
@@ -227,153 +218,64 @@ function DetailPanel({ card, onClose, onSave, onUnmark, saving, t }: DetailPanel
   }
 
   return (
-    <div className="bg-gray-800/60 border border-gray-700 rounded-lg p-4 space-y-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <h2 className="text-lg font-semibold text-white truncate">{card.name}</h2>
-          <p className="text-xs text-gray-400">
-            {t('tile.collectorNo', { number: card.collector_no })}
-            {card.rarity ? ` · ${card.rarity}` : ''}
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label={t('detail.close')}
-          className="p-1 text-gray-400 hover:text-white cursor-pointer"
-        >
-          <X size={18} />
-        </button>
-      </div>
-
-      <div className="flex flex-col sm:flex-row gap-4">
-        <div className="sm:w-48 shrink-0">
-          {card.image_large_url ? (
-            <img
-              src={card.image_large_url}
-              alt=""
-              loading="lazy"
-              className="w-full rounded shadow"
-            />
-          ) : (
-            <div className="aspect-[5/7] bg-gray-900/60 rounded" />
-          )}
-        </div>
-
-        <form onSubmit={handleSave} className="flex-1 min-w-0 space-y-3">
-          <fieldset className="space-y-1.5">
-            <legend className="text-sm font-medium text-gray-200">{t('detail.variant')}</legend>
-            <div className="flex flex-wrap gap-2">
-              {card.variants.map(v => {
-                const checked = v.id === selectedVariantId
-                return (
-                  <label
-                    key={v.id}
-                    className={`flex items-center gap-2 px-2.5 py-1.5 rounded border cursor-pointer text-sm
-                      ${checked ? 'border-emerald-500 bg-emerald-500/10 text-white' : 'border-gray-700 bg-gray-900/40 text-gray-300 hover:border-gray-600'}`}
-                  >
-                    <input
-                      type="radio"
-                      name={`variant-${card.id}`}
-                      value={v.id}
-                      checked={checked}
-                      onChange={() => setSelectedVariantId(v.id)}
-                      className="sr-only"
-                    />
-                    <span>{t(`variantKind.${v.kind}`, { defaultValue: v.kind })}</span>
-                    <span className="text-xs text-gray-400">{formatNok(v.price_nok)}</span>
-                    {v.owned && (
-                      <span aria-hidden="true" className="text-emerald-400"><Check size={14} /></span>
-                    )}
-                  </label>
-                )
-              })}
-            </div>
-          </fieldset>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <label className="block text-sm">
-              <span className="block text-gray-200 mb-1">{t('detail.quantity')}</span>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => setQuantity(q => Math.max(1, q - 1))}
-                  aria-label={t('detail.decreaseQuantity')}
-                  className="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-white rounded cursor-pointer"
+    <form
+      onSubmit={handleSave}
+      className="flex flex-col gap-2 bg-gray-900/80 border border-gray-700 rounded-lg p-3 backdrop-blur-sm"
+    >
+      {card.variants.length > 1 && (
+        <fieldset className="space-y-1.5">
+          <legend className="text-xs font-medium text-gray-300">{t('detail.variant')}</legend>
+          <div className="flex flex-wrap gap-2">
+            {card.variants.map(v => {
+              const checked = v.id === selectedVariantId
+              return (
+                <label
+                  key={v.id}
+                  className={`flex items-center gap-2 px-2.5 py-1.5 rounded border cursor-pointer text-sm
+                    ${checked ? 'border-emerald-500 bg-emerald-500/10 text-white' : 'border-gray-700 bg-gray-900/40 text-gray-300 hover:border-gray-600'}`}
                 >
-                  −
-                </button>
-                <input
-                  type="number"
-                  min={1}
-                  value={quantity}
-                  onChange={e => {
-                    const n = Number.parseInt(e.target.value, 10)
-                    setQuantity(Number.isFinite(n) && n > 0 ? n : 1)
-                  }}
-                  className="w-16 px-2 py-1 bg-gray-900 border border-gray-700 rounded text-white text-center"
-                  aria-label={t('detail.quantity')}
-                />
-                <button
-                  type="button"
-                  onClick={() => setQuantity(q => q + 1)}
-                  aria-label={t('detail.increaseQuantity')}
-                  className="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-white rounded cursor-pointer"
-                >
-                  +
-                </button>
-              </div>
-            </label>
-
-            <label className="block text-sm">
-              <span className="block text-gray-200 mb-1">{t('detail.condition')}</span>
-              <select
-                value={condition}
-                onChange={e => setCondition(e.target.value)}
-                className="w-full px-2 py-1.5 bg-gray-900 border border-gray-700 rounded text-white"
-              >
-                {CONDITIONS.map(c => (
-                  <option key={c || 'unset'} value={c}>
-                    {c ? t(`condition.${c}`) : t('condition.unset')}
-                  </option>
-                ))}
-              </select>
-            </label>
+                  <input
+                    type="radio"
+                    name={`variant-${card.id}`}
+                    value={v.id}
+                    checked={checked}
+                    onChange={() => setSelectedVariantId(v.id)}
+                    className="sr-only"
+                  />
+                  <span>{t(`variantKind.${v.kind}`, { defaultValue: v.kind })}</span>
+                  <span className="text-xs text-gray-400">{formatNok(v.price_nok)}</span>
+                  {v.owned && (
+                    <span aria-hidden="true" className="text-emerald-400"><Check size={14} /></span>
+                  )}
+                </label>
+              )
+            })}
           </div>
+        </fieldset>
+      )}
 
-          <label className="block text-sm">
-            <span className="block text-gray-200 mb-1">{t('detail.notes')}</span>
-            <textarea
-              value={notes}
-              onChange={e => setNotes(e.target.value)}
-              rows={2}
-              className="w-full px-2 py-1.5 bg-gray-900 border border-gray-700 rounded text-white"
-              placeholder={t('detail.notesPlaceholder')}
-            />
-          </label>
-
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="submit"
-              disabled={saving}
-              className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-white rounded text-sm cursor-pointer"
-            >
-              {selected.owned ? t('detail.update') : t('detail.markOwned')}
-            </button>
-            {selected.owned && selected.owned_id != null && (
-              <button
-                type="button"
-                onClick={handleUnmark}
-                disabled={saving}
-                className="px-3 py-1.5 bg-red-700/80 hover:bg-red-600 disabled:bg-red-900/60 disabled:cursor-not-allowed text-white rounded text-sm cursor-pointer"
-              >
-                {t('detail.unmark')}
-              </button>
-            )}
-          </div>
-        </form>
+      <div className="flex flex-wrap items-center gap-2">
+        {!selected.owned && (
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-white rounded text-sm cursor-pointer"
+          >
+            {t('detail.markOwned')}
+          </button>
+        )}
+        {selected.owned && selected.owned_id != null && (
+          <button
+            type="button"
+            onClick={handleUnmark}
+            disabled={saving}
+            className="px-3 py-1.5 bg-red-700/80 hover:bg-red-600 disabled:bg-red-900/60 disabled:cursor-not-allowed text-white rounded text-sm cursor-pointer"
+          >
+            {t('detail.unmark')}
+          </button>
+        )}
       </div>
-    </div>
+    </form>
   )
 }
 
@@ -405,7 +307,7 @@ export default function PokemonSetPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [filter, setFilter] = useState<Filter>('all')
-  const [expandedCardId, setExpandedCardId] = useState<string | null>(null)
+  const [lightboxStartIndex, setLightboxStartIndex] = useState<number | null>(null)
   const [savingCardId, setSavingCardId] = useState<string | null>(null)
   const [attempt, setAttempt] = useState(0)
   const cardsRef = useRef<Card[]>([])
@@ -488,10 +390,17 @@ export default function PokemonSetPage() {
     return cards
   }, [cards, filter])
 
-  const expandedCard = useMemo(
-    () => (expandedCardId ? cards.find(c => c.id === expandedCardId) ?? null : null),
-    [cards, expandedCardId],
-  )
+  // If the visible list shrinks (e.g. the filter changed) below the open
+  // index, clamp it back into range so the lightbox doesn't crash on a stale
+  // pointer; close it entirely when the list becomes empty.
+  useEffect(() => {
+    if (lightboxStartIndex == null) return
+    if (visibleCards.length === 0) {
+      setLightboxStartIndex(null)
+    } else if (lightboxStartIndex >= visibleCards.length) {
+      setLightboxStartIndex(visibleCards.length - 1)
+    }
+  }, [visibleCards, lightboxStartIndex])
 
   const updateCardVariants = useCallback(
     (cardId: string, mutate: (variants: Variant[]) => Variant[]) => {
@@ -693,31 +602,36 @@ export default function PokemonSetPage() {
               <p className="text-sm text-gray-400">{t('detail.empty')}</p>
             ) : (
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
-                {visibleCards.map(card => (
+                {visibleCards.map((card, i) => (
                   <CardTile
                     key={card.id}
                     card={card}
-                    onClick={() => setExpandedCardId(prev => (prev === card.id ? null : card.id))}
+                    onClick={() => setLightboxStartIndex(i)}
                     t={t}
                   />
                 ))}
               </div>
             )}
-
-            {expandedCard && (
-              <DetailPanel
-                key={expandedCard.id}
-                card={expandedCard}
-                onClose={() => setExpandedCardId(null)}
-                onSave={(variantId, payload) => handleSave(expandedCard.id, variantId, payload)}
-                onUnmark={(collectionId) => handleUnmark(expandedCard.id, collectionId)}
-                saving={savingCardId === expandedCard.id}
-                t={t}
-              />
-            )}
           </>
         )}
       </div>
+      {lightboxStartIndex != null && visibleCards.length > 0 && (
+        <CardLightbox
+          cards={visibleCards}
+          startIndex={lightboxStartIndex}
+          onClose={() => setLightboxStartIndex(null)}
+          showPrice
+          renderActionBar={(card) => (
+            <LightboxActionBar
+              card={card as Card}
+              onSave={(variantId, payload) => handleSave(card.id, variantId, payload)}
+              onUnmark={(collectionId) => handleUnmark(card.id, collectionId)}
+              saving={savingCardId === card.id}
+              t={t}
+            />
+          )}
+        />
+      )}
       <ToastList toasts={toasts} />
       <AddCardPanel onAdded={load} />
     </div>

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -616,14 +616,14 @@ export default function PokemonSetPage() {
         )}
       </div>
       {lightboxStartIndex != null && visibleCards.length > 0 && (
-        <CardLightbox
+        <CardLightbox<Card>
           cards={visibleCards}
           startIndex={lightboxStartIndex}
           onClose={() => setLightboxStartIndex(null)}
           showPrice
           renderActionBar={(card) => (
             <LightboxActionBar
-              card={card as Card}
+              card={card}
               onSave={(variantId, payload) => handleSave(card.id, variantId, payload)}
               onUnmark={(collectionId) => handleUnmark(card.id, collectionId)}
               saving={savingCardId === card.id}

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -48,6 +48,7 @@ interface PokemonSet {
 
 type Filter = 'all' | 'owned' | 'missing'
 const FILTERS: Filter[] = ['all', 'owned', 'missing']
+const CONDITIONS = ['', 'mint', 'near_mint', 'lightly_played', 'moderately_played', 'heavily_played', 'damaged']
 
 // parseReleaseDate accepts the "YYYY/MM/DD" or "YYYY-MM-DD" formats returned
 // by pokemontcg.io and renders a localized date. Falls back to the raw string
@@ -178,9 +179,7 @@ interface LightboxActionBarProps {
   t: TFunction<'pokemon'>
 }
 
-// LightboxActionBar renders the compact add/remove-owned controls inside the
-// CardLightbox. It defaults quantity/condition/notes to sensible values — the
-// full edit form lives elsewhere (kept off the lightbox by design).
+// LightboxActionBar renders the add/edit/remove controls inside the CardLightbox.
 function LightboxActionBar({ card, onSave, onUnmark, saving, t }: LightboxActionBarProps) {
   const initialVariantId = useMemo(() => {
     const ownedV = card.variants.find(v => v.owned)
@@ -192,12 +191,24 @@ function LightboxActionBar({ card, onSave, onUnmark, saving, t }: LightboxAction
     [card, selectedVariantId],
   )
 
-  // Re-sync the selection when the user navigates to a different card in the
-  // lightbox so the variant picker reflects the new card's owned state.
+  // Re-sync the selection when the user navigates to a different card.
   const [prevCardId, setPrevCardId] = useState(card.id)
   if (card.id !== prevCardId) {
     setPrevCardId(card.id)
     setSelectedVariantId(initialVariantId)
+  }
+
+  // Editable fields — kept in local state so the user can change them before saving.
+  const [editQuantity, setEditQuantity] = useState(Math.max(selected?.quantity || 1, 1))
+  const [editCondition, setEditCondition] = useState(selected?.condition || '')
+  const [editNotes, setEditNotes] = useState(selected?.notes || '')
+  // Sync edit fields whenever the selected variant changes (card navigation or variant pick).
+  const [prevSelectedId, setPrevSelectedId] = useState(selectedVariantId)
+  if (selectedVariantId !== prevSelectedId) {
+    setPrevSelectedId(selectedVariantId)
+    setEditQuantity(Math.max(selected?.quantity || 1, 1))
+    setEditCondition(selected?.condition || '')
+    setEditNotes(selected?.notes || '')
   }
 
   if (!selected) return null
@@ -205,9 +216,9 @@ function LightboxActionBar({ card, onSave, onUnmark, saving, t }: LightboxAction
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault()
     void onSave(selected.id, {
-      quantity: Math.max(selected.quantity || 1, 1),
-      condition: selected.condition || '',
-      notes: selected.notes || '',
+      quantity: editQuantity,
+      condition: editCondition,
+      notes: editNotes,
     })
   }
 
@@ -254,6 +265,65 @@ function LightboxActionBar({ card, onSave, onUnmark, saving, t }: LightboxAction
         </fieldset>
       )}
 
+      {selected.owned && (
+        <>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-300 w-20 shrink-0">{t('detail.quantity')}</span>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => setEditQuantity(q => Math.max(1, q - 1))}
+                disabled={saving || editQuantity <= 1}
+                aria-label={t('detail.decreaseQuantity')}
+                className="w-7 h-7 flex items-center justify-center rounded border border-gray-700 text-gray-300 hover:border-gray-500 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+              >−</button>
+              <input
+                type="number"
+                min={1}
+                max={99}
+                value={editQuantity}
+                onChange={e => setEditQuantity(Math.max(1, Math.min(99, Number(e.target.value) || 1)))}
+                disabled={saving}
+                className="w-12 text-center bg-gray-800 border border-gray-700 rounded text-sm text-white py-0.5"
+              />
+              <button
+                type="button"
+                onClick={() => setEditQuantity(q => Math.min(99, q + 1))}
+                disabled={saving || editQuantity >= 99}
+                aria-label={t('detail.increaseQuantity')}
+                className="w-7 h-7 flex items-center justify-center rounded border border-gray-700 text-gray-300 hover:border-gray-500 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+              >+</button>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-300 w-20 shrink-0">{t('detail.condition')}</span>
+            <select
+              value={editCondition}
+              onChange={e => setEditCondition(e.target.value)}
+              disabled={saving}
+              className="flex-1 bg-gray-800 border border-gray-700 rounded text-sm text-white py-0.5 px-1"
+            >
+              {CONDITIONS.map(c => (
+                <option key={c} value={c}>
+                  {t(`condition.${c || 'unset'}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-xs text-gray-300">{t('detail.notes')}</span>
+            <textarea
+              value={editNotes}
+              onChange={e => setEditNotes(e.target.value)}
+              disabled={saving}
+              rows={2}
+              placeholder={t('detail.notesPlaceholder')}
+              className="w-full bg-gray-800 border border-gray-700 rounded text-sm text-white px-2 py-1 resize-none"
+            />
+          </div>
+        </>
+      )}
+
       <div className="flex flex-wrap items-center gap-2">
         {!selected.owned && (
           <button
@@ -262,6 +332,15 @@ function LightboxActionBar({ card, onSave, onUnmark, saving, t }: LightboxAction
             className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-white rounded text-sm cursor-pointer"
           >
             {t('detail.markOwned')}
+          </button>
+        )}
+        {selected.owned && (
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-white rounded text-sm cursor-pointer"
+          >
+            {t('detail.update')}
           </button>
         )}
         {selected.owned && selected.owned_id != null && (


### PR DESCRIPTION
## Changes

- **Pokémon card lightbox** - Tap a card thumbnail on the Pokémon set detail page or in the add-card search to open a full-screen lightbox of the high-resolution image. Navigate adjacent cards with arrow keys, left/right tap zones, or horizontal swipe; the list wraps at the edges with a brief flash. Mark/remove owned and add-to-collection actions stay reachable in a bottom action bar inside the lightbox. (Hytte-sevm)

## Original Issue (feature): Pokémon: full-size lightbox with prev/next nav (tap-zones, keyboard, swipe)

The card thumbnails on the Pokémon set-detail page and in the add-card search results are small. Tapping a card should open a full-screen lightbox showing the high-resolution image with the option to flip through the surrounding cards.

## Component

New shared component: `web/src/components/pokemon/CardLightbox.tsx`.

### Props

    interface CardLightboxProps {
      cards: PokemonCard[]       // the list to navigate through
      startIndex: number         // which one to show first
      onClose: () => void
      // Optional — show price + owned indicator on the metadata line
      showPrice?: boolean
    }

### Behaviour

- **Open**: rendered as a `<dialog>` or a fixed-position portal at the top of the React tree (use `createPortal` to escape parent z-index quirks). Dark backdrop (95% black). Card image takes the centre, sized to fit viewport with respect for safe-area on iOS.
- **Image rendering**: use `image_large_url` from the card data (the API already exposes this). `loading="eager"` + `decoding="sync"` so the next image is ready when the user navigates.
- **Metadata line below the image**: card name, set name + collector number, top-variant price (NOK + EUR in parens) when `showPrice` is on, small "owned" checkmark if the current user owns it.

### Navigation

- **Click anywhere on the IMAGE itself** → close.
- **Click left half of the dark backdrop area** (the empty space to the left of the image, plus a thin overlay strip near the left edge of the image) → previous card.
- **Click right half** → next card.
- Use a CSS layout with three flex columns (left tap zone, image, right tap zone) so the hit testing is unambiguous. Each tap zone is ~20–25% of viewport width.
- **Visual indicators**: small chevron icons (Lucide `ChevronLeft` / `ChevronRight`) in the left/right tap zones at 40% opacity, scaling to 80% on hover. On mobile they fade in for ~1.5s after open then idle.
- **Keyboard**: ArrowLeft / ArrowRight navigate, Esc closes. Add a `useEffect` that registers / unregisters the listener on mount/unmount.
- **Swipe (mobile)**: touchstart / touchmove / touchend; threshold 40px horizontal AND less than 30° from horizontal axis (don't trigger on vertical scrolls). Below threshold = no-op. On commit, animate the image off in the swipe direction over ~150ms before swapping.
- **Loop at edges**: navigating past the last card wraps to the first, past the first wraps to the last. Show a brief flash / colour pulse on the wrap to signal the loop.

### Body scroll lock

While open, add `overflow: hidden` to `<body>` (and restore on close). Prevents background scrolling.

### Accessibility

- The dialog has `aria-modal="true"` and `aria-label` set to the current card name.
- Focus moves to the dialog on open; trap focus while open; restore focus to the trigger on close.
- Chevron buttons have `aria-label="Previous card"` / `"Next card"`.

## Wire it up at three surfaces

1. **`web/src/pages/PokemonSet.tsx`** — clicking a card tile (currently expands or opens a small modal per Hytte-te43) now opens the CardLightbox instead, with the set's cards as the navigation context. Keep the existing add/remove-owned actions accessible from inside the lightbox (e.g. a small action bar at the bottom). The lightbox's `cards` prop = the filtered visible grid.

2. **`web/src/components/pokemon/AddCardPanel.tsx`** (the search box) — clicking a result row's thumbnail opens the lightbox with the search results as the navigation context. The metadata row in the lightbox keeps the "Add to collection / Pick variant" actions.

3. **(Future-bound)** Hytte-0tu0 (Top valued cards page) is in the queue but not yet built — the bead body should reference using this lightbox there too, so the implementer of 0tu0 doesn't build a sibling.

## i18n

Add to `web/public/locales/{en,nb,th}/pokemon.json`:
- lightbox.previousCard — accessible label
- lightbox.nextCard — accessible label
- lightbox.close — accessible label
- lightbox.wrappedToStart / lightbox.wrappedToEnd — for screen reader announcements on loop

## Tests

- `CardLightbox.test.tsx`: render with a 3-card fixture starting at index 1; assert that ArrowLeft goes to index 0, ArrowRight goes to index 2, Esc closes, clicking image closes, click left zone goes back, click right zone goes forward, wrap-around works at both ends.
- Existing `PokemonSet.test.tsx` and `AddCardPanel.test.tsx`: extend to assert clicking a thumbnail opens the lightbox.
- Smoke swipe test: simulate touchstart→touchmove→touchend with the threshold delta and assert the index changes.

## Acceptance

- `npm run lint`, `npm run build`, `npm test -- --run src/components/pokemon/CardLightbox` all pass.
- Open the set detail page: tap a card → big image fills the screen. Tap the image → it closes. Tap left/right edges or arrow keys → adjacent cards. Swipe on mobile → same.
- Open the add-card search → tap a result → same lightbox behaviour over the search results.
- Mobile at 375px works without horizontal overflow.
- Changelog fragment in changelog.d/ (category: Added).

## Non-goals

- Pinch-zoom inside the lightbox. The large image is already detailed; pinch can come later.
- Pre-loading more than the next/previous neighbour.
- Animated transitions between cards beyond the swipe-commit slide-out. A cross-fade would be nice but adds complexity.
- A standalone gallery / slideshow mode unrelated to a card list.

## Reference

- web/src/pages/PokemonSet.tsx — current tile rendering, where the click handler changes.
- web/src/components/pokemon/AddCardPanel.tsx — search results thumbnails.
- web/src/types/pokemon.ts (or wherever PokemonCard type lives) — `image_small_url` and `image_large_url`.
- React 19's `createPortal` for the dialog root.
- Lucide React `ChevronLeft` / `ChevronRight` for the nav indicators.
- Hytte-0tu0 — Top valued cards page (open, in queue) should use this component too when its implementer picks it up.


---
Bead: Hytte-sevm | Branch: forge/Hytte-sevm
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->