### PR TITLE
Pokémon: 'Top valuable cards' view (Hytte-0tu0)

### DIFF
--- a/changelog.d/Hytte-0tu0.md
+++ b/changelog.d/Hytte-0tu0.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon: Top valued cards view** - New `/pokemon/top` page and `GET /api/pokemon/top` endpoint that lists the most valuable cards in the registry across all sets, with prominent NOK pricing, the top variant kind label, and an Owned/Missing filter so kids can quickly see what they could still find in a pack. (Hytte-0tu0)

--- a/internal/pokemon/handlers.go
+++ b/internal/pokemon/handlers.go
@@ -29,6 +29,14 @@ const defaultListLimit = 50
 // list endpoints stay snappy when the upper bound is tight.
 const maxListLimit = 50
 
+// defaultTopLimit is the default page size for the "top valued cards" view.
+const defaultTopLimit = 50
+
+// maxTopLimit caps ?limit= on the top endpoint. The view is meant for a
+// curated highlights list, not a full leaderboard, so the upper bound stays
+// modest to keep the query fast and the response tile-friendly.
+const maxTopLimit = 100
+
 // allowedConditions enumerates the grades we accept for a collection row.
 // An empty string is also permitted (callers may not yet have graded the card).
 var allowedConditions = map[string]bool{
@@ -78,17 +86,22 @@ type VariantDTO struct {
 	AcquiredAt *string  `json:"acquired_at,omitempty"`
 }
 
-// CardDTO is the JSON shape returned for any card listing.
+// CardDTO is the JSON shape returned for any card listing. TopVariantKind is
+// populated only by the Top endpoint; it names the variant with the highest
+// price_eur so the UI can label the tile ("Reverse Holo €123" etc.) without
+// re-deriving it client-side.
 type CardDTO struct {
-	ID            string       `json:"id"`
-	SetID         string       `json:"set_id"`
-	SetName       string       `json:"set_name,omitempty"`
-	Name          string       `json:"name"`
-	CollectorNo   string       `json:"collector_no"`
-	Rarity        string       `json:"rarity"`
-	ImageSmallURL string       `json:"image_small_url"`
-	ImageLargeURL string       `json:"image_large_url"`
-	Variants      []VariantDTO `json:"variants"`
+	ID             string       `json:"id"`
+	SetID          string       `json:"set_id"`
+	SetName        string       `json:"set_name,omitempty"`
+	Name           string       `json:"name"`
+	CollectorNo    string       `json:"collector_no"`
+	Rarity         string       `json:"rarity"`
+	ImageSmallURL  string       `json:"image_small_url"`
+	ImageLargeURL  string       `json:"image_large_url"`
+	Variants       []VariantDTO `json:"variants"`
+	TopVariantKind string       `json:"top_variant_kind,omitempty"`
+	OwnedByMe      *bool        `json:"owned_by_me,omitempty"`
 }
 
 // CollectionRow is the JSON shape for collection CRUD responses. Timestamps
@@ -115,6 +128,7 @@ func RegisterRoutes(r chi.Router, db *sql.DB) {
 		r.Get("/pokemon/sets", ListSetsHandler(db))
 		r.Get("/pokemon/sets/{id}/cards", ListSetCardsHandler(db))
 		r.Get("/pokemon/cards/search", SearchCardsHandler(db))
+		r.Get("/pokemon/top", TopHandler(db))
 		r.Post("/pokemon/collection", UpsertCollectionHandler(db))
 		r.Patch("/pokemon/collection/{id}", UpdateCollectionHandler(db))
 		r.Delete("/pokemon/collection/{id}", DeleteCollectionHandler(db))
@@ -638,6 +652,113 @@ func MissingFromSetHandler(db *sql.DB) http.HandlerFunc {
 		applyNOK(w, missing, rate, ok)
 		respondJSON(w, http.StatusOK, map[string]any{"cards": missing})
 	}
+}
+
+// TopHandler returns the highest-valued cards across the entire catalogue,
+// ranked by the max price_eur among each card's variants. It powers the
+// "Top valued cards" highlights view — a fun "look what could be in here"
+// surface for the kids. The optional ?owned=owned|missing|any filter lets the
+// UI narrow the list to "what I'm still missing" without a second request.
+// ?limit= defaults to 50 and is clamped to [1, 100].
+func TopHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		limit := parseLimit(r, defaultTopLimit, maxTopLimit)
+		owned := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("owned")))
+		switch owned {
+		case "", "any", "owned", "missing":
+		default:
+			respondError(w, http.StatusBadRequest, "invalid owned filter")
+			return
+		}
+
+		cards, err := loadTopCards(r, db, user.ID, owned, limit)
+		if err != nil {
+			log.Printf("pokemon: top cards: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to list top cards")
+			return
+		}
+
+		rate, ok := loadRate(r, db)
+		applyNOK(w, cards, rate, ok)
+		respondJSON(w, http.StatusOK, map[string]any{"cards": cards})
+	}
+}
+
+// loadTopCards executes the ranked-variant join and returns CardDTOs with
+// their variants hydrated and the highest-priced variant flagged via
+// TopVariantKind. The owned filter is applied at SQL time so the limit
+// matches the visible card count, not the raw catalogue position.
+func loadTopCards(r *http.Request, db *sql.DB, userID int64, owned string, limit int) ([]CardDTO, error) {
+	// Window function pulls the highest-priced variant per card; the outer
+	// join then filters to top-priced rows and joins the catalogue.
+	query := `
+		WITH ranked AS (
+			SELECT card_id, kind, price_eur,
+			       ROW_NUMBER() OVER (PARTITION BY card_id ORDER BY price_eur DESC, id) AS rn
+			FROM pokemon_card_variants
+		)
+		SELECT c.id, c.set_id, s.name, c.name, c.collector_no, c.rarity,
+		       c.image_small_url, c.image_large_url,
+		       r.kind, r.price_eur,
+		       CASE WHEN EXISTS (
+		         SELECT 1 FROM pokemon_collections col
+		         WHERE col.user_id = ? AND col.card_id = c.id AND col.quantity > 0
+		       ) THEN 1 ELSE 0 END AS owned
+		FROM ranked r
+		JOIN pokemon_cards c ON c.id = r.card_id
+		JOIN pokemon_sets s ON s.id = c.set_id
+		WHERE r.rn = 1 AND r.price_eur > 0
+	`
+	args := []any{userID}
+	switch owned {
+	case "owned":
+		query += ` AND EXISTS (SELECT 1 FROM pokemon_collections col WHERE col.user_id = ? AND col.card_id = c.id AND col.quantity > 0)`
+		args = append(args, userID)
+	case "missing":
+		query += ` AND NOT EXISTS (SELECT 1 FROM pokemon_collections col WHERE col.user_id = ? AND col.card_id = c.id AND col.quantity > 0)`
+		args = append(args, userID)
+	}
+	query += ` ORDER BY r.price_eur DESC, c.id LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := db.QueryContext(r.Context(), query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cards := make([]CardDTO, 0)
+	cardIndex := make(map[string]int)
+	for rows.Next() {
+		var (
+			c        CardDTO
+			topKind  string
+			topPrice float64
+			ownedInt int
+		)
+		if err := rows.Scan(&c.ID, &c.SetID, &c.SetName, &c.Name, &c.CollectorNo, &c.Rarity,
+			&c.ImageSmallURL, &c.ImageLargeURL, &topKind, &topPrice, &ownedInt); err != nil {
+			return nil, err
+		}
+		c.TopVariantKind = topKind
+		ownedBool := ownedInt == 1
+		c.OwnedByMe = &ownedBool
+		c.Variants = []VariantDTO{}
+		cardIndex[c.ID] = len(cards)
+		cards = append(cards, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(cards) == 0 {
+		return cards, nil
+	}
+	return hydrateVariants(r, db, userID, cards, cardIndex)
 }
 
 // loadCardsForSet hydrates every card in a set with its variants and owner

--- a/internal/pokemon/handlers.go
+++ b/internal/pokemon/handlers.go
@@ -128,6 +128,8 @@ func RegisterRoutes(r chi.Router, db *sql.DB) {
 		r.Get("/pokemon/sets", ListSetsHandler(db))
 		r.Get("/pokemon/sets/{id}/cards", ListSetCardsHandler(db))
 		r.Get("/pokemon/cards/search", SearchCardsHandler(db))
+		// /pokemon/top is intentionally accessible to all pokemon-feature users,
+		// not admin-only — it's a fun highlights surface for every collector.
 		r.Get("/pokemon/top", TopHandler(db))
 		r.Post("/pokemon/collection", UpsertCollectionHandler(db))
 		r.Patch("/pokemon/collection/{id}", UpdateCollectionHandler(db))
@@ -659,7 +661,7 @@ func MissingFromSetHandler(db *sql.DB) http.HandlerFunc {
 // "Top valued cards" highlights view — a fun "look what could be in here"
 // surface for the kids. The optional ?owned=owned|missing|any filter lets the
 // UI narrow the list to "what I'm still missing" without a second request.
-// ?limit= defaults to 50 and is clamped to [1, 100].
+// ?limit= defaults to 50 and is upper-bounded at 100; missing or invalid values use the default.
 func TopHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())

--- a/internal/pokemon/handlers_test.go
+++ b/internal/pokemon/handlers_test.go
@@ -473,6 +473,229 @@ func TestSearchCardsHandler_EmptyQuery(t *testing.T) {
 	}
 }
 
+// --- TopHandler ---------------------------------------------------------------
+
+// TestTopHandler_SortsByMaxVariantPrice asserts the top endpoint orders cards
+// by the highest-priced variant per card, descending. With the seeded
+// catalogue: swsh1-1 (25.0) > sv1-25 (14.5 reverse holo) > swsh1-25 (8.0) >
+// sv1-100 (2.5), and the response should preserve that order.
+func TestTopHandler_SortsByMaxVariantPrice(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/top", nil), u)
+	rec := httptest.NewRecorder()
+	TopHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	if len(body.Cards) != 4 {
+		t.Fatalf("expected 4 cards, got %d", len(body.Cards))
+	}
+	wantOrder := []string{"swsh1-1", "sv1-25", "swsh1-25", "sv1-100"}
+	for i, id := range wantOrder {
+		if body.Cards[i].ID != id {
+			t.Errorf("position %d: expected %q, got %q", i, id, body.Cards[i].ID)
+		}
+	}
+	// The top-priced sv1-25 variant is reverse_holofoil at 14.5 EUR.
+	if body.Cards[1].TopVariantKind != "reverse_holofoil" {
+		t.Errorf("expected top variant for sv1-25 to be reverse_holofoil, got %q", body.Cards[1].TopVariantKind)
+	}
+	if body.Cards[1].SetName != "Scarlet & Violet Base" {
+		t.Errorf("expected set name to be embedded, got %q", body.Cards[1].SetName)
+	}
+}
+
+func TestTopHandler_LimitClamping(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	cases := []struct {
+		query string
+		want  int
+	}{
+		{"limit=2", 2},
+		{"limit=0", 4},
+		{"limit=-5", 4},
+		{"limit=200", 4},
+		{"", 4},
+	}
+	for _, c := range cases {
+		path := "/api/pokemon/top"
+		if c.query != "" {
+			path += "?" + c.query
+		}
+		req := asUser(httptest.NewRequest(http.MethodGet, path, nil), u)
+		rec := httptest.NewRecorder()
+		TopHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d: %s", c.query, rec.Code, rec.Body.String())
+		}
+		body := decode[struct {
+			Cards []CardDTO `json:"cards"`
+		}](t, rec)
+		if len(body.Cards) != c.want {
+			t.Errorf("%s: expected %d cards, got %d", c.query, c.want, len(body.Cards))
+		}
+	}
+}
+
+func TestTopHandler_OwnedFilter(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	// User owns the swsh1-1 normal variant (25 EUR, top-priced card).
+	celebiNormal := variantID(t, db, "swsh1-1", "normal")
+	if _, err := db.Exec(`
+		INSERT INTO pokemon_collections (user_id, card_id, variant_id, quantity, condition, acquired_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, u.ID, "swsh1-1", celebiNormal, 1, "near_mint", time.Now().UTC()); err != nil {
+		t.Fatalf("seed collection: %v", err)
+	}
+
+	t.Run("owned only", func(t *testing.T) {
+		req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/top?owned=owned", nil), u)
+		rec := httptest.NewRecorder()
+		TopHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		body := decode[struct {
+			Cards []CardDTO `json:"cards"`
+		}](t, rec)
+		if len(body.Cards) != 1 || body.Cards[0].ID != "swsh1-1" {
+			t.Fatalf("expected only swsh1-1 in owned filter, got %+v", body.Cards)
+		}
+		if body.Cards[0].OwnedByMe == nil || !*body.Cards[0].OwnedByMe {
+			t.Errorf("expected owned_by_me=true for owned card, got %+v", body.Cards[0].OwnedByMe)
+		}
+	})
+
+	t.Run("missing only", func(t *testing.T) {
+		req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/top?owned=missing", nil), u)
+		rec := httptest.NewRecorder()
+		TopHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		body := decode[struct {
+			Cards []CardDTO `json:"cards"`
+		}](t, rec)
+		ids := make([]string, 0, len(body.Cards))
+		for _, c := range body.Cards {
+			ids = append(ids, c.ID)
+			if c.OwnedByMe == nil || *c.OwnedByMe {
+				t.Errorf("expected owned_by_me=false on missing card %s, got %+v", c.ID, c.OwnedByMe)
+			}
+		}
+		// swsh1-1 owned → filtered out. Remaining 3 cards in price order.
+		want := []string{"sv1-25", "swsh1-25", "sv1-100"}
+		if len(ids) != len(want) {
+			t.Fatalf("expected %d missing cards, got %d (%v)", len(want), len(ids), ids)
+		}
+		for i, id := range want {
+			if ids[i] != id {
+				t.Errorf("missing position %d: expected %q, got %q", i, id, ids[i])
+			}
+		}
+	})
+
+	t.Run("any explicit", func(t *testing.T) {
+		req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/top?owned=any", nil), u)
+		rec := httptest.NewRecorder()
+		TopHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		body := decode[struct {
+			Cards []CardDTO `json:"cards"`
+		}](t, rec)
+		if len(body.Cards) != 4 {
+			t.Errorf("expected 4 cards under owned=any, got %d", len(body.Cards))
+		}
+	})
+
+	t.Run("invalid filter", func(t *testing.T) {
+		req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/top?owned=garbage", nil), u)
+		rec := httptest.NewRecorder()
+		TopHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rec.Code)
+		}
+	})
+}
+
+func TestTopHandler_NOKConversion(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	seedRate(t, db, 11.5)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/top?limit=1", nil), u)
+	rec := httptest.NewRecorder()
+	TopHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Header().Get("X-Pokemon-Rate-Missing") != "" {
+		t.Errorf("expected no rate-missing header, got %q", rec.Header().Get("X-Pokemon-Rate-Missing"))
+	}
+	body := decode[struct {
+		Cards []CardDTO `json:"cards"`
+	}](t, rec)
+	if len(body.Cards) != 1 || body.Cards[0].ID != "swsh1-1" {
+		t.Fatalf("expected swsh1-1 first, got %+v", body.Cards)
+	}
+	// swsh1-1 normal variant: 25 EUR × 11.5 → 287.5 NOK.
+	for _, v := range body.Cards[0].Variants {
+		if v.Kind != "normal" {
+			continue
+		}
+		if v.PriceNOK == nil {
+			t.Fatalf("expected non-nil price_nok for top card")
+		}
+		if got := *v.PriceNOK; got != 287.5 {
+			t.Errorf("expected price_nok=287.5, got %v", got)
+		}
+	}
+}
+
+func TestTopHandler_MissingRate(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/top?limit=1", nil), u)
+	rec := httptest.NewRecorder()
+	TopHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Header().Get("X-Pokemon-Rate-Missing") != "1" {
+		t.Errorf("expected X-Pokemon-Rate-Missing=1 header, got %q", rec.Header().Get("X-Pokemon-Rate-Missing"))
+	}
+}
+
+func TestTopHandler_Unauthorized(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/pokemon/top", nil)
+	rec := httptest.NewRecorder()
+	TopHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
 // --- Collection CRUD ----------------------------------------------------------
 
 func TestUpsertCollectionHandler_CreatesAndUpdates(t *testing.T) {
@@ -730,6 +953,7 @@ func TestFeatureFlagEnforcement_All(t *testing.T) {
 			r.Get("/api/pokemon/sets", ListSetsHandler(db))
 			r.Get("/api/pokemon/sets/{id}/cards", ListSetCardsHandler(db))
 			r.Get("/api/pokemon/cards/search", SearchCardsHandler(db))
+			r.Get("/api/pokemon/top", TopHandler(db))
 			r.Post("/api/pokemon/collection", UpsertCollectionHandler(db))
 			r.Patch("/api/pokemon/collection/{id}", UpdateCollectionHandler(db))
 			r.Delete("/api/pokemon/collection/{id}", DeleteCollectionHandler(db))
@@ -743,6 +967,7 @@ func TestFeatureFlagEnforcement_All(t *testing.T) {
 		{http.MethodGet, "/api/pokemon/sets"},
 		{http.MethodGet, "/api/pokemon/sets/sv1/cards"},
 		{http.MethodGet, "/api/pokemon/cards/search?q=pika"},
+		{http.MethodGet, "/api/pokemon/top"},
 		{http.MethodPost, "/api/pokemon/collection"},
 		{http.MethodPatch, "/api/pokemon/collection/1"},
 		{http.MethodDelete, "/api/pokemon/collection/1"},

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -94,6 +94,18 @@
       "addFailed": "Failed to add card"
     }
   },
+  "top": {
+    "title": "Top valued cards",
+    "subtitle": "What the kid could find in a pack…",
+    "entryButton": "Top valued",
+    "filter": {
+      "all": "All",
+      "owned": "Owned",
+      "missing": "Missing"
+    },
+    "priceLabel": "{{nok}} kr",
+    "priceLabelDetailed": "{{nok}} kr (€{{eur}})"
+  },
   "scanner": {
     "dialogLabel": "Scan a Pokémon card",
     "requesting": "Requesting camera access…",

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -98,13 +98,22 @@
     "title": "Top valued cards",
     "subtitle": "What the kid could find in a pack…",
     "entryButton": "Top valued",
+    "entryLabel": "View the top valued cards",
+    "back": "Back to Pokémon sets",
+    "empty": "No top valued cards match this filter.",
+    "filterLabel": "Filter top valued cards",
     "filter": {
       "all": "All",
       "owned": "Owned",
       "missing": "Missing"
     },
+    "ownership": {
+      "owned": "owned",
+      "missing": "not owned"
+    },
     "priceLabel": "{{nok}} kr",
-    "priceLabelDetailed": "{{nok}} kr (€{{eur}})"
+    "priceLabelDetailed": "{{nok}} kr (€{{eur}})",
+    "tileLabel": "Open {{name}} from {{set}} (#{{number}}), rank {{rank}}, {{variant}}, {{price}}, {{ownership}}"
   },
   "scanner": {
     "dialogLabel": "Scan a Pokémon card",

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -98,13 +98,22 @@
     "title": "Mest verdifulle kort",
     "subtitle": "Hva kan ungen finne i en pakke …",
     "entryButton": "Mest verdifulle",
+    "entryLabel": "Vis de mest verdifulle kortene",
+    "back": "Tilbake til Pokémon-sett",
+    "empty": "Ingen verdifulle kort matcher dette filteret.",
+    "filterLabel": "Filtrer mest verdifulle kort",
     "filter": {
       "all": "Alle",
       "owned": "Eide",
       "missing": "Mangler"
     },
+    "ownership": {
+      "owned": "eid",
+      "missing": "ikke eid"
+    },
     "priceLabel": "{{nok}} kr",
-    "priceLabelDetailed": "{{nok}} kr (€{{eur}})"
+    "priceLabelDetailed": "{{nok}} kr (€{{eur}})",
+    "tileLabel": "Åpne {{name}} fra {{set}} (#{{number}}), plass {{rank}}, {{variant}}, {{price}}, {{ownership}}"
   },
   "scanner": {
     "dialogLabel": "Skann et Pokémon-kort",

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -94,6 +94,18 @@
       "addFailed": "Kunne ikke legge til kort"
     }
   },
+  "top": {
+    "title": "Mest verdifulle kort",
+    "subtitle": "Hva kan ungen finne i en pakke …",
+    "entryButton": "Mest verdifulle",
+    "filter": {
+      "all": "Alle",
+      "owned": "Eide",
+      "missing": "Mangler"
+    },
+    "priceLabel": "{{nok}} kr",
+    "priceLabelDetailed": "{{nok}} kr (€{{eur}})"
+  },
   "scanner": {
     "dialogLabel": "Skann et Pokémon-kort",
     "requesting": "Ber om tilgang til kameraet …",

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -98,13 +98,22 @@
     "title": "การ์ดมูลค่าสูงสุด",
     "subtitle": "เด็ก ๆ อาจเจออะไรในซอง…",
     "entryButton": "มูลค่าสูงสุด",
+    "entryLabel": "ดูการ์ดมูลค่าสูงสุด",
+    "back": "กลับไปยังชุดโปเกมอน",
+    "empty": "ไม่พบการ์ดมูลค่าสูงที่ตรงกับตัวกรองนี้",
+    "filterLabel": "กรองการ์ดมูลค่าสูงสุด",
     "filter": {
       "all": "ทั้งหมด",
       "owned": "ที่มี",
       "missing": "ที่ขาด"
     },
+    "ownership": {
+      "owned": "มีในคอลเลกชัน",
+      "missing": "ยังไม่มี"
+    },
     "priceLabel": "{{nok}} kr",
-    "priceLabelDetailed": "{{nok}} kr (€{{eur}})"
+    "priceLabelDetailed": "{{nok}} kr (€{{eur}})",
+    "tileLabel": "เปิด {{name}} จาก {{set}} (#{{number}}), อันดับ {{rank}}, {{variant}}, {{price}}, {{ownership}}"
   },
   "scanner": {
     "dialogLabel": "สแกนการ์ดโปเกมอน",

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -94,6 +94,18 @@
       "addFailed": "เพิ่มการ์ดไม่สำเร็จ"
     }
   },
+  "top": {
+    "title": "การ์ดมูลค่าสูงสุด",
+    "subtitle": "เด็ก ๆ อาจเจออะไรในซอง…",
+    "entryButton": "มูลค่าสูงสุด",
+    "filter": {
+      "all": "ทั้งหมด",
+      "owned": "ที่มี",
+      "missing": "ที่ขาด"
+    },
+    "priceLabel": "{{nok}} kr",
+    "priceLabelDetailed": "{{nok}} kr (€{{eur}})"
+  },
   "scanner": {
     "dialogLabel": "สแกนการ์ดโปเกมอน",
     "requesting": "กำลังขออนุญาตเข้าถึงกล้อง…",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -75,6 +75,7 @@ import MathHeatmap from './pages/MathHeatmap'
 import MathAchievements from './pages/MathAchievements'
 import PokemonSets from './pages/PokemonSets'
 import PokemonSet from './pages/PokemonSet'
+import PokemonTop from './pages/PokemonTop'
 import { AchievementUnlockOverlay } from './components/regnemester/AchievementUnlockOverlay'
 
 function MainLayout() {
@@ -558,6 +559,14 @@ function MainLayout() {
             element={
               <FeatureRoute feature="pokemon">
                 <PokemonSets />
+              </FeatureRoute>
+            }
+          />
+          <Route
+            path="/pokemon/top"
+            element={
+              <FeatureRoute feature="pokemon">
+                <PokemonTop />
               </FeatureRoute>
             }
           />

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -218,6 +218,7 @@ export default function PokemonSets() {
           <h1 className="text-2xl font-semibold">{t('pageTitle')}</h1>
           <Link
             to="/pokemon/top"
+            aria-label={t('top.entryLabel')}
             className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm bg-amber-600/20 hover:bg-amber-600/30 border border-amber-500/40 text-amber-200 rounded transition-colors"
             data-testid="pokemon-top-link"
           >

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown, ChevronUp, Trophy } from 'lucide-react'
 import { Skeleton } from '../components/ui/skeleton'
 import AddCardPanel from '../components/pokemon/AddCardPanel'
 import { formatDate } from '../utils/formatDate'
@@ -214,8 +214,16 @@ export default function PokemonSets() {
   return (
     <div className="min-h-screen bg-gray-900 text-white">
       <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
-        <header>
+        <header className="flex items-center justify-between gap-3">
           <h1 className="text-2xl font-semibold">{t('pageTitle')}</h1>
+          <Link
+            to="/pokemon/top"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm bg-amber-600/20 hover:bg-amber-600/30 border border-amber-500/40 text-amber-200 rounded transition-colors"
+            data-testid="pokemon-top-link"
+          >
+            <Trophy size={16} aria-hidden="true" />
+            <span>{t('top.entryButton')}</span>
+          </Link>
         </header>
 
         {error && (

--- a/web/src/pages/PokemonTop.test.tsx
+++ b/web/src/pages/PokemonTop.test.tsx
@@ -7,23 +7,30 @@ import PokemonTop from './PokemonTop'
 const TRANSLATIONS: Record<string, string> = {
   'retry': 'Retry',
   'errors.failedToLoad': 'Failed to load Pokémon cards',
-  'detail.back': 'Back to sets',
-  'detail.empty': 'No cards match this filter.',
-  'detail.filter': 'Filter cards',
   'top.title': 'Top valued cards',
   'top.subtitle': 'What the kid could find in a pack…',
   'top.entryButton': 'Top valued',
+  'top.entryLabel': 'View the top valued cards',
+  'top.back': 'Back to Pokémon sets',
+  'top.empty': 'No top valued cards match this filter.',
+  'top.filterLabel': 'Filter top valued cards',
   'top.filter.all': 'All',
   'top.filter.owned': 'Owned',
   'top.filter.missing': 'Missing',
+  'top.ownership.owned': 'owned',
+  'top.ownership.missing': 'not owned',
   'variantKind.normal': 'Normal',
   'variantKind.holofoil': 'Holo',
   'variantKind.reverse_holofoil': 'Reverse holo',
 }
 
 function mockT(key: string, opts?: Record<string, string | number> & { defaultValue?: string }): string {
-  if (key === 'tile.openCard') return `Open ${opts?.name ?? ''} (#${opts?.number ?? ''})`
   if (key === 'tile.collectorNo') return `#${opts?.number ?? ''}`
+  if (key === 'top.priceLabel') return `${opts?.nok ?? ''} kr`
+  if (key === 'top.priceLabelDetailed') return `${opts?.nok ?? ''} kr (€${opts?.eur ?? ''})`
+  if (key === 'top.tileLabel') {
+    return `Open ${opts?.name ?? ''} from ${opts?.set ?? ''} (#${opts?.number ?? ''}), rank ${opts?.rank ?? ''}, ${opts?.variant ?? ''}, ${opts?.price ?? ''}, ${opts?.ownership ?? ''}`
+  }
   if (key.startsWith('variantKind.')) return TRANSLATIONS[key] ?? opts?.defaultValue ?? key
   return TRANSLATIONS[key] ?? key
 }
@@ -209,7 +216,63 @@ describe('PokemonTop – empty state', () => {
     renderPage()
 
     await waitFor(() => {
-      expect(screen.getByText('No cards match this filter.')).toBeInTheDocument()
+      expect(screen.getByText('No top valued cards match this filter.')).toBeInTheDocument()
     })
+  })
+})
+
+describe('PokemonTop – accessible tile label', () => {
+  it('includes rank, set, variant, price, and ownership in the aria-label', async () => {
+    const cards: TopCard[] = [
+      makeCard({
+        id: 'sv1-25',
+        set_id: 'sv1',
+        set_name: 'Scarlet & Violet Base',
+        name: 'Pikachu',
+        collector_no: '025',
+        top_variant_kind: 'reverse_holofoil',
+        owned_by_me: false,
+        variants: [
+          { id: 2, kind: 'normal', price_eur: 10, price_nok: 115 },
+          { id: 3, kind: 'reverse_holofoil', price_eur: 14.5, price_nok: 166 },
+        ],
+      }),
+      makeCard({
+        id: 'swsh1-1',
+        set_id: 'swsh1',
+        set_name: 'Sword & Shield Base',
+        name: 'Celebi V',
+        collector_no: '001',
+        top_variant_kind: 'normal',
+        owned_by_me: true,
+        variants: [{ id: 1, kind: 'normal', price_eur: 25, price_nok: 287 }],
+      }),
+    ]
+    vi.stubGlobal('fetch', makeFetchMock(cards))
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Pikachu')).toBeInTheDocument()
+    })
+
+    const pikachuTile = screen.getByTestId('top-card-tile-sv1-25')
+    const pikachuLabel = pikachuTile.getAttribute('aria-label') ?? ''
+    expect(pikachuLabel).toMatch(/Pikachu/)
+    expect(pikachuLabel).toMatch(/Scarlet & Violet Base/)
+    expect(pikachuLabel).toMatch(/#025/)
+    expect(pikachuLabel).toMatch(/rank 1/)
+    expect(pikachuLabel).toMatch(/Reverse holo/)
+    expect(pikachuLabel).toMatch(/166 kr/)
+    expect(pikachuLabel).toMatch(/not owned/)
+    // Should not advertise toggle semantics — this is a navigation button.
+    expect(pikachuTile.hasAttribute('aria-pressed')).toBe(false)
+
+    const celebiTile = screen.getByTestId('top-card-tile-swsh1-1')
+    const celebiLabel = celebiTile.getAttribute('aria-label') ?? ''
+    expect(celebiLabel).toMatch(/rank 2/)
+    // Owned cards must report "owned" (not "not owned") as the ownership suffix.
+    expect(celebiLabel).toMatch(/, owned$/)
+    expect(celebiTile.hasAttribute('aria-pressed')).toBe(false)
   })
 })

--- a/web/src/pages/PokemonTop.test.tsx
+++ b/web/src/pages/PokemonTop.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import PokemonTop from './PokemonTop'
+
+const TRANSLATIONS: Record<string, string> = {
+  'retry': 'Retry',
+  'errors.failedToLoad': 'Failed to load Pokémon cards',
+  'detail.back': 'Back to sets',
+  'detail.empty': 'No cards match this filter.',
+  'detail.filter': 'Filter cards',
+  'top.title': 'Top valued cards',
+  'top.subtitle': 'What the kid could find in a pack…',
+  'top.entryButton': 'Top valued',
+  'top.filter.all': 'All',
+  'top.filter.owned': 'Owned',
+  'top.filter.missing': 'Missing',
+  'variantKind.normal': 'Normal',
+  'variantKind.holofoil': 'Holo',
+  'variantKind.reverse_holofoil': 'Reverse holo',
+}
+
+function mockT(key: string, opts?: Record<string, string | number> & { defaultValue?: string }): string {
+  if (key === 'tile.openCard') return `Open ${opts?.name ?? ''} (#${opts?.number ?? ''})`
+  if (key === 'tile.collectorNo') return `#${opts?.number ?? ''}`
+  if (key.startsWith('variantKind.')) return TRANSLATIONS[key] ?? opts?.defaultValue ?? key
+  return TRANSLATIONS[key] ?? key
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockT,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+vi.mock('../i18n', () => ({
+  default: { language: 'en' },
+}))
+
+interface Variant {
+  id: number
+  kind: string
+  price_eur: number
+  price_nok: number | null
+}
+
+interface TopCard {
+  id: string
+  set_id: string
+  set_name: string
+  name: string
+  collector_no: string
+  rarity: string
+  image_small_url: string
+  image_large_url: string
+  variants: Variant[]
+  top_variant_kind: string
+  owned_by_me: boolean
+}
+
+function makeCard(over: Partial<TopCard> = {}): TopCard {
+  return {
+    id: 'sv1-1',
+    set_id: 'sv1',
+    set_name: 'Scarlet & Violet Base',
+    name: 'Pikachu',
+    collector_no: '001',
+    rarity: 'Common',
+    image_small_url: 'https://example.com/small.png',
+    image_large_url: 'https://example.com/large.png',
+    variants: [
+      { id: 1, kind: 'normal', price_eur: 25, price_nok: 287 },
+    ],
+    top_variant_kind: 'normal',
+    owned_by_me: false,
+    ...over,
+  }
+}
+
+function jsonResponse<T>(body: T, init: { status?: number } = {}) {
+  return {
+    ok: (init.status ?? 200) < 400,
+    status: init.status ?? 200,
+    json: () => Promise.resolve(body),
+  }
+}
+
+function makeFetchMock(cards: TopCard[]) {
+  return vi.fn((_url: string, _init?: RequestInit) => {
+    return Promise.resolve(jsonResponse({ cards }))
+  })
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/pokemon/top']}>
+      <Routes>
+        <Route path="/pokemon/top" element={<PokemonTop />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('PokemonTop – renders top cards', () => {
+  it('shows three tiles with prices and the owned indicator on the right card', async () => {
+    const cards: TopCard[] = [
+      makeCard({
+        id: 'swsh1-1',
+        set_id: 'swsh1',
+        set_name: 'Sword & Shield Base',
+        name: 'Celebi V',
+        collector_no: '001',
+        top_variant_kind: 'normal',
+        owned_by_me: true,
+        variants: [{ id: 1, kind: 'normal', price_eur: 25, price_nok: 287 }],
+      }),
+      makeCard({
+        id: 'sv1-25',
+        set_id: 'sv1',
+        set_name: 'Scarlet & Violet Base',
+        name: 'Pikachu',
+        collector_no: '025',
+        top_variant_kind: 'reverse_holofoil',
+        owned_by_me: false,
+        variants: [
+          { id: 2, kind: 'normal', price_eur: 10, price_nok: 115 },
+          { id: 3, kind: 'reverse_holofoil', price_eur: 14.5, price_nok: 166 },
+        ],
+      }),
+      makeCard({
+        id: 'sv1-100',
+        set_id: 'sv1',
+        set_name: 'Scarlet & Violet Base',
+        name: 'Eevee',
+        collector_no: '100',
+        top_variant_kind: 'normal',
+        owned_by_me: false,
+        variants: [{ id: 4, kind: 'normal', price_eur: 2.5, price_nok: 29 }],
+      }),
+    ]
+    vi.stubGlobal('fetch', makeFetchMock(cards))
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Celebi V')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Pikachu')).toBeInTheDocument()
+    expect(screen.getByText('Eevee')).toBeInTheDocument()
+
+    // Prices rendered (currency formatting is locale-dependent so we look for the digits).
+    const celebiTile = screen.getByTestId('top-card-tile-swsh1-1')
+    expect(celebiTile.textContent ?? '').toMatch(/287/)
+    const pikachuTile = screen.getByTestId('top-card-tile-sv1-25')
+    expect(pikachuTile.textContent ?? '').toMatch(/166/)
+    // EUR fallback price also visible.
+    expect(pikachuTile.textContent ?? '').toMatch(/14|15/)
+    // Variant kind label for the top variant.
+    expect(pikachuTile.textContent ?? '').toMatch(/Reverse holo/)
+
+    // Owned indicator appears only on Celebi V.
+    expect(screen.getByTestId('top-card-owned-swsh1-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('top-card-owned-sv1-25')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('top-card-owned-sv1-100')).not.toBeInTheDocument()
+  })
+})
+
+describe('PokemonTop – filter chips change the fetch URL', () => {
+  it('refetches with owned=owned when the Owned chip is clicked', async () => {
+    const fetchMock = makeFetchMock([])
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    // Initial mount fires the "any" request.
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled()
+    })
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/pokemon/top?owned=any')
+
+    fireEvent.click(screen.getByTestId('top-filter-owned'))
+
+    await waitFor(() => {
+      const ownedCall = fetchMock.mock.calls.find(([url]) => url === '/api/pokemon/top?owned=owned')
+      expect(ownedCall).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByTestId('top-filter-missing'))
+
+    await waitFor(() => {
+      const missingCall = fetchMock.mock.calls.find(([url]) => url === '/api/pokemon/top?owned=missing')
+      expect(missingCall).toBeTruthy()
+    })
+  })
+})
+
+describe('PokemonTop – empty state', () => {
+  it('shows the empty message when no cards are returned', async () => {
+    vi.stubGlobal('fetch', makeFetchMock([]))
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('No cards match this filter.')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/pages/PokemonTop.tsx
+++ b/web/src/pages/PokemonTop.tsx
@@ -1,0 +1,320 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
+import { ArrowLeft, Check, Trophy } from 'lucide-react'
+import { Skeleton } from '../components/ui/skeleton'
+import { formatNumber } from '../utils/formatDate'
+
+interface Variant {
+  id: number
+  kind: string
+  price_eur: number
+  price_nok: number | null
+}
+
+interface TopCard {
+  id: string
+  set_id: string
+  set_name: string
+  name: string
+  collector_no: string
+  rarity: string
+  image_small_url: string
+  image_large_url: string
+  variants: Variant[]
+  top_variant_kind: string
+  owned_by_me: boolean
+}
+
+type Filter = 'all' | 'owned' | 'missing'
+const FILTERS: Filter[] = ['all', 'owned', 'missing']
+
+// filterToQuery maps a UI filter to the ?owned= query value expected by the
+// backend. The "All" filter sends no parameter so the server defaults to "any".
+function filterToQuery(filter: Filter): string {
+  if (filter === 'owned') return 'owned'
+  if (filter === 'missing') return 'missing'
+  return 'any'
+}
+
+function formatNok(amount: number | null | undefined): string {
+  if (amount == null) return '—'
+  return formatNumber(amount, {
+    style: 'currency',
+    currency: 'NOK',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+function formatEur(amount: number | null | undefined): string {
+  if (amount == null) return '—'
+  return formatNumber(amount, {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+// topVariant returns the variant with the highest price_eur, falling back to
+// the first variant when prices are missing.
+function topVariant(card: TopCard): Variant | undefined {
+  if (card.variants.length === 0) return undefined
+  return card.variants.reduce((best, current) =>
+    current.price_eur > best.price_eur ? current : best,
+  )
+}
+
+interface TileProps {
+  card: TopCard
+  rank: number
+  onClick: () => void
+  t: TFunction<'pokemon'>
+}
+
+function TopCardTile({ card, rank, onClick, t }: TileProps) {
+  const top = topVariant(card)
+  const priceNok = top?.price_nok ?? null
+  const priceEur = top?.price_eur ?? null
+  const variantLabel = card.top_variant_kind
+    ? t(`variantKind.${card.top_variant_kind}`, { defaultValue: card.top_variant_kind })
+    : ''
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={`top-card-tile-${card.id}`}
+      aria-label={t('tile.openCard', { name: card.name, number: card.collector_no })}
+      aria-pressed={card.owned_by_me}
+      className={`flex flex-col gap-2 p-2 rounded-lg border bg-gray-800/40 transition-colors text-left cursor-pointer
+        ${card.owned_by_me
+          ? 'border-emerald-500/70 ring-1 ring-emerald-500/40 hover:bg-gray-800/70'
+          : 'border-gray-800 hover:border-gray-700 hover:bg-gray-800/70'
+        }`}
+    >
+      <div className="relative aspect-[5/7] flex items-center justify-center bg-gray-900/40 rounded overflow-hidden">
+        {card.image_small_url ? (
+          <img
+            src={card.image_small_url}
+            alt=""
+            loading="lazy"
+            className="max-h-full max-w-full object-contain"
+          />
+        ) : (
+          <span className="text-xs text-gray-500">{card.collector_no}</span>
+        )}
+        <span
+          aria-hidden="true"
+          className="absolute top-1 left-1 px-1.5 py-0.5 rounded bg-black/60 text-xs font-semibold text-amber-300"
+        >
+          #{rank}
+        </span>
+        {card.owned_by_me && (
+          <span
+            aria-hidden="true"
+            data-testid={`top-card-owned-${card.id}`}
+            className="absolute top-1 right-1 flex items-center justify-center h-5 w-5 rounded-full bg-emerald-500 text-white shadow"
+          >
+            <Check size={12} />
+          </span>
+        )}
+      </div>
+      <div className="min-w-0 space-y-0.5">
+        <p className="text-sm font-medium text-white truncate" title={card.name}>{card.name}</p>
+        <p className="text-xs text-gray-500 truncate" title={card.set_name}>{card.set_name}</p>
+        <p className="text-xs text-gray-500">{t('tile.collectorNo', { number: card.collector_no })}</p>
+        {variantLabel && (
+          <p className="text-xs text-amber-300/90">{variantLabel}</p>
+        )}
+        <p className="text-base font-semibold text-white pt-0.5">{formatNok(priceNok)}</p>
+        {priceEur != null && (
+          <p className="text-xs text-gray-400">({formatEur(priceEur)})</p>
+        )}
+      </div>
+    </button>
+  )
+}
+
+function GridSkeleton() {
+  return (
+    <div
+      className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3"
+      aria-busy="true"
+    >
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="p-2 bg-gray-800/40 border border-gray-800 rounded-lg space-y-2">
+          <Skeleton className="aspect-[5/7] w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-3 w-1/2" />
+          <Skeleton className="h-5 w-2/3" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function PokemonTopPage() {
+  const { t } = useTranslation('pokemon')
+  const navigate = useNavigate()
+
+  const [cards, setCards] = useState<TopCard[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [filter, setFilter] = useState<Filter>('all')
+  const [attempt, setAttempt] = useState(0)
+  const filterButtonRefs = useRef<Array<HTMLButtonElement | null>>([])
+
+  const reload = useCallback(() => {
+    setLoading(true)
+    setError('')
+    setAttempt(a => a + 1)
+  }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    ;(async () => {
+      try {
+        const url = `/api/pokemon/top?owned=${filterToQuery(filter)}`
+        const res = await fetch(url, {
+          credentials: 'include',
+          signal: controller.signal,
+        })
+        if (!res.ok) throw new Error(t('errors.failedToLoad'))
+        const data: { cards?: TopCard[] } = await res.json()
+        setCards(data.cards ?? [])
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setError(err instanceof Error ? err.message : t('errors.failedToLoad'))
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    })()
+    return () => { controller.abort() }
+  }, [filter, attempt, t])
+
+  const selectFilter = useCallback((index: number) => {
+    const next = FILTERS[index]
+    if (!next) return
+    setFilter(next)
+    filterButtonRefs.current[index]?.focus()
+  }, [])
+
+  const handleFilterKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          e.preventDefault()
+          selectFilter((index + 1) % FILTERS.length)
+          break
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          e.preventDefault()
+          selectFilter((index - 1 + FILTERS.length) % FILTERS.length)
+          break
+        case 'Home':
+          e.preventDefault()
+          selectFilter(0)
+          break
+        case 'End':
+          e.preventDefault()
+          selectFilter(FILTERS.length - 1)
+          break
+      }
+    },
+    [selectFilter],
+  )
+
+  const openCard = useCallback((card: TopCard) => {
+    navigate(`/pokemon/sets/${encodeURIComponent(card.set_id)}#card-${encodeURIComponent(card.collector_no)}`)
+  }, [navigate])
+
+  const visibleCards = useMemo(() => cards, [cards])
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
+        <header className="space-y-3">
+          <Link
+            to="/pokemon"
+            className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+          >
+            <ArrowLeft size={16} />
+            {t('detail.back')}
+          </Link>
+          <div className="flex items-center gap-3">
+            <Trophy size={28} className="text-amber-400 shrink-0" aria-hidden="true" />
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold truncate">{t('top.title')}</h1>
+              <p className="text-sm text-gray-400">{t('top.subtitle')}</p>
+            </div>
+          </div>
+
+          <div
+            role="radiogroup"
+            aria-label={t('detail.filter')}
+            className="inline-flex p-0.5 rounded-md bg-gray-800/60 border border-gray-800"
+          >
+            {FILTERS.map((f, i) => {
+              const checked = f === filter
+              return (
+                <button
+                  key={f}
+                  ref={el => { filterButtonRefs.current[i] = el }}
+                  type="button"
+                  role="radio"
+                  aria-checked={checked}
+                  tabIndex={checked ? 0 : -1}
+                  onClick={() => selectFilter(i)}
+                  onKeyDown={e => handleFilterKeyDown(e, i)}
+                  data-testid={`top-filter-${f}`}
+                  className={`px-3 py-1 text-xs rounded cursor-pointer transition-colors
+                    ${checked ? 'bg-gray-700 text-white' : 'text-gray-400 hover:text-white'}`}
+                >
+                  {t(`top.filter.${f}`)}
+                </button>
+              )
+            })}
+          </div>
+        </header>
+
+        {error && (
+          <div role="alert" className="px-3 py-2 bg-red-900/40 border border-red-800 text-red-300 text-sm rounded flex items-center justify-between gap-3">
+            <span>{error}</span>
+            <button
+              type="button"
+              onClick={reload}
+              className="px-2 py-1 text-xs bg-red-800/60 hover:bg-red-700 text-white rounded transition-colors cursor-pointer"
+            >
+              {t('retry')}
+            </button>
+          </div>
+        )}
+
+        {loading && !error && <GridSkeleton />}
+
+        {!loading && !error && (
+          <>
+            {visibleCards.length === 0 ? (
+              <p className="text-sm text-gray-400">{t('detail.empty')}</p>
+            ) : (
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+                {visibleCards.map((card, i) => (
+                  <TopCardTile
+                    key={card.id}
+                    card={card}
+                    rank={i + 1}
+                    onClick={() => openCard(card)}
+                    t={t}
+                  />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/PokemonTop.tsx
+++ b/web/src/pages/PokemonTop.tsx
@@ -31,7 +31,7 @@ type Filter = 'all' | 'owned' | 'missing'
 const FILTERS: Filter[] = ['all', 'owned', 'missing']
 
 // filterToQuery maps a UI filter to the ?owned= query value expected by the
-// backend. The "All" filter sends no parameter so the server defaults to "any".
+// backend. The "All" filter sends owned=any so the server returns all cards.
 function filterToQuery(filter: Filter): string {
   if (filter === 'owned') return 'owned'
   if (filter === 'missing') return 'missing'
@@ -58,10 +58,15 @@ function formatEur(amount: number | null | undefined): string {
   })
 }
 
-// topVariant returns the variant with the highest price_eur, falling back to
-// the first variant when prices are missing.
+// topVariant returns the variant identified by top_variant_kind, so the label
+// and price always refer to the same variant. Falls back to max-price selection
+// only when top_variant_kind is absent (e.g. legacy data with no kind set).
 function topVariant(card: TopCard): Variant | undefined {
   if (card.variants.length === 0) return undefined
+  if (card.top_variant_kind) {
+    const match = card.variants.find(v => v.kind === card.top_variant_kind)
+    if (match) return match
+  }
   return card.variants.reduce((best, current) =>
     current.price_eur > best.price_eur ? current : best,
   )

--- a/web/src/pages/PokemonTop.tsx
+++ b/web/src/pages/PokemonTop.tsx
@@ -74,6 +74,40 @@ interface TileProps {
   t: TFunction<'pokemon'>
 }
 
+// buildTileLabel composes a rich accessible name from the rank, card metadata,
+// top variant, price, and ownership state so screen-reader users get the same
+// information as sighted users (rank badge, checkmark, prominent price).
+function buildTileLabel(card: TopCard, rank: number, t: TFunction<'pokemon'>): string {
+  const top = topVariant(card)
+  const variantKey = card.top_variant_kind || top?.kind || ''
+  const variantLabel = variantKey
+    ? t(`variantKind.${variantKey}`, { defaultValue: variantKey })
+    : ''
+  const priceNok = top?.price_nok ?? null
+  const priceEur = top?.price_eur ?? null
+  let priceText = ''
+  if (priceNok != null && priceEur != null) {
+    priceText = t('top.priceLabelDetailed', {
+      nok: Math.round(priceNok),
+      eur: Math.round(priceEur),
+    })
+  } else if (priceNok != null) {
+    priceText = t('top.priceLabel', { nok: Math.round(priceNok) })
+  } else if (priceEur != null) {
+    priceText = `€${Math.round(priceEur)}`
+  }
+  const ownership = t(card.owned_by_me ? 'top.ownership.owned' : 'top.ownership.missing')
+  return t('top.tileLabel', {
+    rank,
+    name: card.name,
+    set: card.set_name,
+    number: card.collector_no,
+    variant: variantLabel,
+    price: priceText,
+    ownership,
+  })
+}
+
 function TopCardTile({ card, rank, onClick, t }: TileProps) {
   const top = topVariant(card)
   const priceNok = top?.price_nok ?? null
@@ -86,8 +120,7 @@ function TopCardTile({ card, rank, onClick, t }: TileProps) {
       type="button"
       onClick={onClick}
       data-testid={`top-card-tile-${card.id}`}
-      aria-label={t('tile.openCard', { name: card.name, number: card.collector_no })}
-      aria-pressed={card.owned_by_me}
+      aria-label={buildTileLabel(card, rank, t)}
       className={`flex flex-col gap-2 p-2 rounded-lg border bg-gray-800/40 transition-colors text-left cursor-pointer
         ${card.owned_by_me
           ? 'border-emerald-500/70 ring-1 ring-emerald-500/40 hover:bg-gray-800/70'
@@ -241,8 +274,8 @@ export default function PokemonTopPage() {
             to="/pokemon"
             className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-white transition-colors"
           >
-            <ArrowLeft size={16} />
-            {t('detail.back')}
+            <ArrowLeft size={16} aria-hidden="true" />
+            {t('top.back')}
           </Link>
           <div className="flex items-center gap-3">
             <Trophy size={28} className="text-amber-400 shrink-0" aria-hidden="true" />
@@ -254,7 +287,7 @@ export default function PokemonTopPage() {
 
           <div
             role="radiogroup"
-            aria-label={t('detail.filter')}
+            aria-label={t('top.filterLabel')}
             className="inline-flex p-0.5 rounded-md bg-gray-800/60 border border-gray-800"
           >
             {FILTERS.map((f, i) => {
@@ -298,7 +331,7 @@ export default function PokemonTopPage() {
         {!loading && !error && (
           <>
             {visibleCards.length === 0 ? (
-              <p className="text-sm text-gray-400">{t('detail.empty')}</p>
+              <p className="text-sm text-gray-400">{t('top.empty')}</p>
             ) : (
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
                 {visibleCards.map((card, i) => (


### PR DESCRIPTION
## Changes

- **Pokémon: Top valued cards view** - New `/pokemon/top` page and `GET /api/pokemon/top` endpoint that lists the most valuable cards in the registry across all sets, with prominent NOK pricing, the top variant kind label, and an Owned/Missing filter so kids can quickly see what they could still find in a pack. (Hytte-0tu0)

## Original Issue (feature): Pokémon: 'Top valuable cards' view

Add a "Top 50 most valuable cards" view so kids can browse the highest-priced cards in the registry — a fun "look what could be in here" gamification surface alongside their own collection.

## Backend

New endpoint: `GET /api/pokemon/top?limit=<n>` (admin + `RequireFeature(db, "pokemon")` like the other Pokémon routes).

- Default `limit=50`, hard cap 100.
- Query: group `pokemon_card_variants` by `card_id`, take `MAX(price_eur)` per card, join to `pokemon_cards` and `pokemon_sets`, order by that max desc.
- Response shape mirrors the existing search results — array of `{card, set, variants, owned_by_me}` objects with `price_eur` and `price_nok` (computed via the cached EUR/NOK rate at the handler boundary, same as other endpoints).
- For each row, include the kind of the highest-priced variant so the UI can label it ("Reverse Holo €123" etc.).
- Optional filter `?owned=missing|owned|any` so the user can quickly see "top-valued cards I'm missing".

Query sketch:

    SELECT c.id, c.set_id, s.name AS set_name, c.name, c.collector_no, c.rarity,
           c.image_small_url, c.image_large_url,
           v.kind AS top_variant_kind, v.price_eur AS top_price_eur,
           CASE WHEN col.id IS NOT NULL THEN 1 ELSE 0 END AS owned
    FROM pokemon_card_variants v
    JOIN pokemon_cards c ON c.id = v.card_id
    JOIN pokemon_sets s ON s.id = c.set_id
    LEFT JOIN pokemon_collections col ON col.user_id = ? AND col.card_id = c.id AND col.variant_id = v.id
    WHERE v.price_eur = (SELECT MAX(price_eur) FROM pokemon_card_variants WHERE card_id = v.card_id)
    ORDER BY v.price_eur DESC
    LIMIT ?

(Or a subquery / window function if cleaner — implementer's call. SQLite supports window functions in modern versions.)

## Frontend

`web/src/pages/PokemonTop.tsx` (or `PokemonHighlights.tsx` — pick whichever reads cleaner):

- Header: "Top valued cards", subtitle "What the kid could find in a pack…", small filter chip row: All / Owned / Missing.
- List/grid of card tiles, similar to `PokemonSet.tsx` but with **price prominently displayed** in NOK and a small EUR underneath in parens.
- Each tile shows: image, name, set name, collector no, top variant kind ("Holo", "Reverse Holo", etc.), `XX XXX kr` price, owned indicator (checkmark if owned).
- Mobile-first; 2 columns on phone, 3-4 on desktop.
- Tap a tile → opens the set detail page focused on that card (same modal as in PokemonSet.tsx, or just navigate to `/pokemon/sets/{set_id}#card-{collector_no}`).

### Entry point

Add a small **"🏆 Top valued cards"** button (or a Lucide `Trophy` icon button) to:
- The `PokemonSets.tsx` header bar, top-right next to "Add card" / scan buttons.
- Optionally the global "+ Add card" panel — defer if it adds friction.

Route: `/pokemon/top`. Add to `App.tsx` inside `<ProtectedRoute>`.

## i18n

Add to `web/public/locales/{en,nb,th}/pokemon.json`:
- top.title — "Top valued cards" / "Mest verdifulle kort" / Thai
- top.subtitle
- top.filter.all / top.filter.owned / top.filter.missing
- top.entryButton — "Top valued"
- top.priceLabel — "{{nok}} kr"
- top.priceLabelDetailed — "{{nok}} kr (€{{eur}})"

## Tests

- `internal/pokemon/handlers_test.go` extends with TopHandler tests: limit clamping, sort order, owned/missing filter, NOK conversion math.
- `PokemonTop.test.tsx` smoke: mocked fetch returning 3 entries, assert tiles render with prices, filter chip changes the request, owned indicator appears correctly.

## Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build`, `npm test -- --run src/pages/PokemonTop` all pass.
- Visiting `/pokemon/top` lists the 50 most-valuable cards across all sets, sorted descending by EUR price.
- Filter chips Owned / Missing narrow the list accordingly.
- Mobile 375px works.
- Changelog fragment in changelog.d/ (category: Added).

## Non-goals

- Per-set top lists. The global top is the v1 ask.
- Historical price trend ("price went up 30% this month"). Defer until we have multiple price snapshots over time.
- Sharing the list externally. Family-only.
- Multi-currency. NOK only, matching the rest of the feature.

## Reference

- internal/pokemon/handlers.go — existing handler patterns (`SearchCardsHandler`, `ListSetCardsHandler`) for NOK conversion + response shape.
- internal/pokemon/models.go — card / variant struct shapes.
- web/src/pages/PokemonSet.tsx — tile rendering pattern to reuse for the grid.
- web/src/pages/PokemonSets.tsx — header bar for the entry button.


---
Bead: Hytte-0tu0 | Branch: forge/Hytte-0tu0
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->