### PR TITLE
Pokémon sets browser: derive recent eras dynamically, not hardcoded (Hytte-zoma)

### DIFF
--- a/changelog.d/Hytte-zoma.md
+++ b/changelog.d/Hytte-zoma.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Pokémon sets browser shows the newest eras expanded by default** - The list of expanded series is now derived from the actual set release dates instead of a hardcoded constant, so brand-new series like Mega Evolution appear in the top 3 expanded sections automatically. (Hytte-zoma)

--- a/web/src/pages/PokemonSets.test.tsx
+++ b/web/src/pages/PokemonSets.test.tsx
@@ -96,9 +96,11 @@ describe('PokemonSets – expand-older toggle', () => {
   afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
 
   it('hides legacy era sections behind a toggle by default', async () => {
-    const sv = makeSet({ id: 'sv1', name: 'SV Base', series: 'Scarlet & Violet' })
+    const sv = makeSet({ id: 'sv1', name: 'SV Base', series: 'Scarlet & Violet', release_date: '2023/03/31' })
+    const swsh = makeSet({ id: 'swsh1', name: 'SWSH Base', series: 'Sword & Shield', release_date: '2020/02/07' })
+    const sm = makeSet({ id: 'sm1', name: 'SM Base', series: 'Sun & Moon', release_date: '2017/02/03' })
     const xy = makeSet({ id: 'xy1', name: 'XY Base', series: 'XY', release_date: '2014/02/05' })
-    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(setsResponse([sv, xy]))))
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(setsResponse([sv, swsh, sm, xy]))))
 
     renderPage()
     await waitFor(() => expect(screen.getByText('SV Base')).toBeInTheDocument())
@@ -123,6 +125,64 @@ describe('PokemonSets – expand-older toggle', () => {
     renderPage()
     await waitFor(() => expect(screen.getByText('SV Base')).toBeInTheDocument())
     expect(screen.queryByRole('button', { name: 'Show older sets' })).not.toBeInTheDocument()
+  })
+})
+
+describe('PokemonSets – dynamic recent eras', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('derives the top 3 expanded eras from the newest release_date per series', async () => {
+    const me = makeSet({ id: 'me1', name: 'Mega Evolution Base', series: 'Mega Evolution', release_date: '2025/09/26' })
+    const sv = makeSet({ id: 'sv1', name: 'SV Base', series: 'Scarlet & Violet', release_date: '2023/03/31' })
+    const swsh = makeSet({ id: 'swsh1', name: 'SWSH Base', series: 'Sword & Shield', release_date: '2020/02/07' })
+    const sm = makeSet({ id: 'sm1', name: 'SM Base', series: 'Sun & Moon', release_date: '2017/02/03' })
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(setsResponse([sm, swsh, sv, me]))))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Mega Evolution Base')).toBeInTheDocument())
+
+    // Top 3 newest series are expanded by default.
+    expect(screen.getByRole('heading', { name: 'Mega Evolution' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Scarlet & Violet' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Sword & Shield' })).toBeInTheDocument()
+
+    // Sun & Moon is the 4th newest, so it falls under the toggle.
+    expect(screen.queryByRole('heading', { name: 'Sun & Moon' })).not.toBeInTheDocument()
+    expect(screen.queryByText('SM Base')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show older sets' }))
+    expect(screen.getByRole('heading', { name: 'Sun & Moon' })).toBeInTheDocument()
+    expect(screen.getByText('SM Base')).toBeInTheDocument()
+  })
+
+  it('shows the single available series expanded when fewer than 3 series exist', async () => {
+    const me = makeSet({ id: 'me1', name: 'Mega Evolution Base', series: 'Mega Evolution', release_date: '2026/03/01' })
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(setsResponse([me]))))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Mega Evolution Base')).toBeInTheDocument())
+
+    expect(screen.getByRole('heading', { name: 'Mega Evolution' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Show older sets' })).not.toBeInTheDocument()
+  })
+
+  it('breaks ties on max release_date alphabetically for determinism', async () => {
+    // All three eras share the same latest release_date. With alphabetical
+    // tie-break Alpha < Beta < Gamma should appear in that order; the fourth
+    // era (Delta, older) should fall under the older toggle.
+    const a = makeSet({ id: 'a1', name: 'Alpha Card', series: 'Alpha', release_date: '2025/01/01' })
+    const b = makeSet({ id: 'b1', name: 'Beta Card', series: 'Beta', release_date: '2025/01/01' })
+    const g = makeSet({ id: 'g1', name: 'Gamma Card', series: 'Gamma', release_date: '2025/01/01' })
+    const d = makeSet({ id: 'd1', name: 'Delta Card', series: 'Delta', release_date: '2020/01/01' })
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(setsResponse([g, a, d, b]))))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alpha Card')).toBeInTheDocument())
+
+    expect(screen.getByRole('heading', { name: 'Alpha' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Beta' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Gamma' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Delta' })).not.toBeInTheDocument()
   })
 })
 

--- a/web/src/pages/PokemonSets.test.tsx
+++ b/web/src/pages/PokemonSets.test.tsx
@@ -179,9 +179,9 @@ describe('PokemonSets – dynamic recent eras', () => {
     renderPage()
     await waitFor(() => expect(screen.getByText('Alpha Card')).toBeInTheDocument())
 
-    expect(screen.getByRole('heading', { name: 'Alpha' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Beta' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Gamma' })).toBeInTheDocument()
+    // Assert DOM order: Alpha → Beta → Gamma (alphabetical tie-break), Delta hidden.
+    const eraHeadings = screen.getAllByRole('heading', { level: 2 }).map(h => h.textContent)
+    expect(eraHeadings).toEqual(['Alpha', 'Beta', 'Gamma'])
     expect(screen.queryByRole('heading', { name: 'Delta' })).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -18,10 +18,6 @@ interface PokemonSet {
   owned_count: number
 }
 
-// RECENT_ERAS lists the series that stay expanded by default. Any set whose
-// `series` does not appear here is hidden behind the "Show older sets" toggle.
-const RECENT_ERAS = ['Scarlet & Violet', 'Sword & Shield', 'Sun & Moon'] as const
-
 // eraSlug converts a series name into a safe HTML id fragment so values like
 // "Scarlet & Violet" don't break aria-labelledby (ids may not contain spaces
 // and ampersands are awkward to reference).
@@ -178,9 +174,10 @@ export default function PokemonSets() {
     return () => { controller.abort() }
   }, [t, attempt])
 
-  // groupedRecent and groupedOlder preserve the canonical order of RECENT_ERAS
-  // and sort older series newest-first by the most-recent release_date in each
-  // series. This keeps the page deterministic regardless of API ordering.
+  // The top 3 series ranked by the most-recent release_date in each series are
+  // shown expanded; everything else is hidden behind the "Show older sets"
+  // toggle. Older series are sorted newest-first by their max release_date,
+  // with ties broken alphabetically for determinism.
   const { recent, older } = useMemo(() => {
     const byEra = new Map<string, PokemonSet[]>()
     for (const s of sets) {
@@ -191,23 +188,16 @@ export default function PokemonSets() {
     for (const list of byEra.values()) {
       list.sort((a, b) => (a.release_date < b.release_date ? 1 : a.release_date > b.release_date ? -1 : 0))
     }
-    const recentGroups: Array<[string, PokemonSet[]]> = []
-    for (const era of RECENT_ERAS) {
-      const list = byEra.get(era)
-      if (list && list.length > 0) recentGroups.push([era, list])
-    }
-    const olderGroups: Array<[string, PokemonSet[]]> = []
-    for (const [era, list] of byEra.entries()) {
-      if ((RECENT_ERAS as readonly string[]).includes(era)) continue
-      olderGroups.push([era, list])
-    }
-    olderGroups.sort((a, b) => {
+    const erasByLatest: Array<[string, PokemonSet[]]> = [...byEra.entries()]
+    erasByLatest.sort((a, b) => {
       const aLatest = a[1][0]?.release_date ?? ''
       const bLatest = b[1][0]?.release_date ?? ''
       if (aLatest < bLatest) return 1
       if (aLatest > bLatest) return -1
       return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0
     })
+    const recentGroups = erasByLatest.slice(0, 3)
+    const olderGroups = erasByLatest.slice(3)
     return { recent: recentGroups, older: olderGroups }
   }, [sets])
 


### PR DESCRIPTION
## Changes

- **Pokémon sets browser shows the newest eras expanded by default** - The list of expanded series is now derived from the actual set release dates instead of a hardcoded constant, so brand-new series like Mega Evolution appear in the top 3 expanded sections automatically. (Hytte-zoma)

## Original Issue (bug): Pokémon sets browser: derive recent eras dynamically, not hardcoded

The sets browser hides newer eras behind "Show older sets" because the list of "current" eras is hardcoded.

`web/src/pages/PokemonSets.tsx:23`:

    const RECENT_ERAS = ['Scarlet & Violet', 'Sword & Shield', 'Sun & Moon'] as const

A brand-new series — "Mega Evolution", introduced late 2025 with 4 sets so far (me1 Mega Evolution Sep 2025, me2 Phantasmal Flames Nov 2025, me2pt5 Ascended Heroes Jan 2026, me3 Perfect Order Mar 2026, total 737 cards) — does not appear in `RECENT_ERAS`, so it falls into the "older sets" expander even though it's the newest era we have.

## Fix

Derive `recentEras` from the actual set data: pick the top 3 series ranked by the most recent `release_date` of any set in that series.

Pseudo:

    const recentEras = useMemo(() => {
      const newestByEra = new Map<string, string>() // series -> newest release_date
      for (const s of sets) {
        const cur = newestByEra.get(s.series)
        if (!cur || s.release_date > cur) newestByEra.set(s.series, s.release_date)
      }
      return [...newestByEra.entries()]
        .sort(([, a], [, b]) => (a < b ? 1 : a > b ? -1 : 0))
        .slice(0, 3)
        .map(([era]) => era)
    }, [sets])

Use that in the grouping logic instead of the constant. Delete the `RECENT_ERAS` constant.

Order within `recentEras`: still newest first by their max release_date (so right now the result would be `['Mega Evolution', 'Scarlet & Violet', 'Sword & Shield']`).

## Edge cases

- If fewer than 3 series exist in the data, just show what's there.
- If two series tie on max release_date, break the tie by series name alphabetical for determinism.

## Tests

`PokemonSets.test.tsx`:
- Fixture with sets from "Mega Evolution" (2026), "Scarlet & Violet" (2024), "Sword & Shield" (2021), "Sun & Moon" (2018) → assert "Mega Evolution" + "Scarlet & Violet" + "Sword & Shield" are the expanded sections, and "Sun & Moon" is under the older toggle.
- Fixture with only one series in 2026 → assert that single series is expanded, no error.

## Acceptance

- `npm run lint`, `npm run build`, `npm test -- --run src/pages/PokemonSets` all pass.
- Loading the page shows Mega Evolution sets in an expanded section by default.
- Changelog fragment in changelog.d/ (category: Fixed).

## Non-goals

- A UI to let the user pin specific eras as expanded. Dynamic-from-data is the v1.
- Showing more than 3 recent eras by default. Stays at 3; user clicks "Show older" for the rest.

## Reference

- web/src/pages/PokemonSets.tsx:23 — the hardcoded constant to remove.
- The grouping logic around lines 181–210 uses `RECENT_ERAS`; that's the second touch point.


---
Bead: Hytte-zoma | Branch: forge/Hytte-zoma
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->