### PR TITLE
Pokémon sync: always create a 'normal' variant row even when no price data exists (Hytte-h4tn)

### DIFF
--- a/changelog.d/Hytte-h4tn.md
+++ b/changelog.d/Hytte-h4tn.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Pokémon sync now always creates a `normal` variant row for every card** - For very new sets where Cardmarket has no price data yet (e.g. the Mega Evolution era), the sync no longer skips creating variants entirely. Each card gets a placeholder `normal` variant at price 0 so the user can mark it as owned, and a self-healing backfill pass at the end of `SyncAll` repairs historical gaps. Real Cardmarket prices arriving on a later re-sync still overwrite the placeholder. (Hytte-h4tn)

--- a/internal/pokemon/sync.go
+++ b/internal/pokemon/sync.go
@@ -120,9 +120,11 @@ func SyncAll(ctx context.Context, db *sql.DB, client *Client) error {
 			continue
 		}
 	}
-	if n, err := backfillNormalVariants(ctx, db); err != nil {
-		log.Printf("pokemon: backfill normal variants: %v", err)
-	} else if n > 0 {
+	n, err := backfillNormalVariants(ctx, db)
+	if err != nil {
+		return fmt.Errorf("backfill normal variants: %w", err)
+	}
+	if n > 0 {
 		log.Printf("pokemon: backfilled %d normal variant rows for cards with no price data", n)
 	}
 	return nil
@@ -251,17 +253,17 @@ func ensureNormalVariant(ctx context.Context, db *sql.DB, cardID string) error {
 	return err
 }
 
-// backfillNormalVariants ensures every card has at least one variant row by
-// inserting a placeholder normal-kind row (price 0) for any card without one.
-// This is the self-healing pass run at the end of SyncAll to repair historical
-// gaps where Cardmarket had no price data when the card was first synced.
+// backfillNormalVariants ensures every card has a kind='normal' variant row by
+// inserting a placeholder (price 0) for any card that lacks one. Cards that
+// already have other variants (e.g. reverse_holofoil) but no normal row are
+// also repaired. This is the self-healing pass run at the end of SyncAll.
 func backfillNormalVariants(ctx context.Context, db *sql.DB) (int64, error) {
 	res, err := db.ExecContext(ctx, `
 		INSERT INTO pokemon_card_variants (card_id, kind, price_eur, price_at)
 		SELECT c.id, 'normal', 0, NULL
 		FROM pokemon_cards c
 		WHERE NOT EXISTS (
-			SELECT 1 FROM pokemon_card_variants v WHERE v.card_id = c.id
+			SELECT 1 FROM pokemon_card_variants v WHERE v.card_id = c.id AND v.kind = 'normal'
 		)
 	`)
 	if err != nil {

--- a/internal/pokemon/sync.go
+++ b/internal/pokemon/sync.go
@@ -120,6 +120,11 @@ func SyncAll(ctx context.Context, db *sql.DB, client *Client) error {
 			continue
 		}
 	}
+	if n, err := backfillNormalVariants(ctx, db); err != nil {
+		log.Printf("pokemon: backfill normal variants: %v", err)
+	} else if n > 0 {
+		log.Printf("pokemon: backfilled %d normal variant rows for cards with no price data", n)
+	}
 	return nil
 }
 
@@ -198,7 +203,16 @@ func upsertCard(ctx context.Context, db *sql.DB, setID string, c Card, now time.
 // upsertVariants persists Cardmarket prices for a card. The cardmarket.prices
 // field is a flat object with named metric keys, so we map the two variant
 // kinds we persist (normal, reverse_holofoil) to their corresponding fields.
+//
+// A placeholder "normal" row is inserted first with price 0 so that every card
+// has at least one variant the user can mark as owned, even when Cardmarket
+// has no pricing data yet (e.g. brand-new sets). The placeholder uses
+// DO NOTHING so it cannot clobber an existing price, while real prices below
+// still upsert with DO UPDATE.
 func upsertVariants(ctx context.Context, db *sql.DB, c Card, now time.Time) error {
+	if err := ensureNormalVariant(ctx, db, c.ID); err != nil {
+		return err
+	}
 	p := c.Cardmarket.Prices
 	type variantRow struct {
 		kind string
@@ -223,6 +237,38 @@ func upsertVariants(ctx context.Context, db *sql.DB, c Card, now time.Time) erro
 		}
 	}
 	return nil
+}
+
+// ensureNormalVariant inserts a placeholder normal-kind row with price 0 if
+// none exists for the card. The UNIQUE(card_id, kind) constraint with
+// DO NOTHING guarantees an existing priced row is left untouched.
+func ensureNormalVariant(ctx context.Context, db *sql.DB, cardID string) error {
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO pokemon_card_variants (card_id, kind, price_eur, price_at)
+		VALUES (?, 'normal', 0, NULL)
+		ON CONFLICT(card_id, kind) DO NOTHING
+	`, cardID)
+	return err
+}
+
+// backfillNormalVariants ensures every card has at least one variant row by
+// inserting a placeholder normal-kind row (price 0) for any card without one.
+// This is the self-healing pass run at the end of SyncAll to repair historical
+// gaps where Cardmarket had no price data when the card was first synced.
+func backfillNormalVariants(ctx context.Context, db *sql.DB) (int64, error) {
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO pokemon_card_variants (card_id, kind, price_eur, price_at)
+		SELECT c.id, 'normal', 0, NULL
+		FROM pokemon_cards c
+		WHERE NOT EXISTS (
+			SELECT 1 FROM pokemon_card_variants v WHERE v.card_id = c.id
+		)
+	`)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
 }
 
 // pickPrice returns trend when non-zero, otherwise avg.

--- a/internal/pokemon/sync_test.go
+++ b/internal/pokemon/sync_test.go
@@ -233,6 +233,133 @@ func TestSyncCards_InsertsCardsAndVariants(t *testing.T) {
 	}
 }
 
+func TestSyncCards_FallbackNormalVariantWithoutPrices(t *testing.T) {
+	cases := []struct {
+		name   string
+		prices CardmarketPrices
+		want   map[string]float64
+	}{
+		{
+			name:   "no cardmarket prices -> single normal row at 0",
+			prices: CardmarketPrices{},
+			want:   map[string]float64{"normal": 0},
+		},
+		{
+			name:   "normal trendPrice present -> placeholder overwritten",
+			prices: CardmarketPrices{TrendPrice: 12.34},
+			want:   map[string]float64{"normal": 12.34},
+		},
+		{
+			name:   "reverse holo price only -> normal placeholder kept at 0 alongside reverse_holofoil",
+			prices: CardmarketPrices{ReverseHoloTrend: 5.0},
+			want: map[string]float64{
+				"normal":           0,
+				"reverse_holofoil": 5.0,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := setupTestDB(t)
+			if _, err := d.Exec(`INSERT INTO pokemon_sets (id, name, series, release_date, total_cards, synced_at)
+				VALUES (?, ?, ?, ?, ?, ?)`, "me1", "Mega Evolution", "Mega Evolution", "2026/01/01", 1, time.Now()); err != nil {
+				t.Fatalf("seed set: %v", err)
+			}
+
+			card := Card{
+				ID:         "me1-1",
+				Name:       "Mega Charizard ex",
+				Number:     "1",
+				Cardmarket: Cardmarket{Prices: tc.prices},
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(t, w, CardsResponse{
+					Page: 1, PageSize: PageSize, Count: 1, TotalCount: 1,
+					Data: []Card{card},
+				})
+			}))
+			defer srv.Close()
+
+			if err := SyncCards(context.Background(), d, newTestClient(srv), "me1"); err != nil {
+				t.Fatalf("SyncCards: %v", err)
+			}
+
+			rows, err := d.Query(`SELECT kind, price_eur FROM pokemon_card_variants WHERE card_id = ? ORDER BY kind`, "me1-1")
+			if err != nil {
+				t.Fatalf("query variants: %v", err)
+			}
+			defer rows.Close()
+
+			got := map[string]float64{}
+			for rows.Next() {
+				var k string
+				var p float64
+				if err := rows.Scan(&k, &p); err != nil {
+					t.Fatalf("scan: %v", err)
+				}
+				got[k] = p
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %d variant rows, got %d: %+v", len(tc.want), len(got), got)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("variant %s: expected %v, got %v", k, v, got[k])
+				}
+			}
+		})
+	}
+}
+
+func TestSyncAll_BackfillCreatesNormalVariantForOrphanCards(t *testing.T) {
+	d := setupTestDB(t)
+	now := time.Now().UTC()
+	if _, err := d.Exec(`INSERT INTO pokemon_sets (id, name, series, release_date, total_cards, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?)`, "me1", "Mega Evolution", "Mega Evolution", "2026/01/01", 1, now); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+	if _, err := d.Exec(`INSERT INTO pokemon_cards (id, set_id, name, collector_no, rarity, image_small_url, image_large_url, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"me1-1", "me1", "Mega Charizard ex", "1", "Rare", "", "", now); err != nil {
+		t.Fatalf("seed orphan card: %v", err)
+	}
+
+	var existing int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM pokemon_card_variants WHERE card_id = ?`, "me1-1").Scan(&existing); err != nil {
+		t.Fatalf("count before: %v", err)
+	}
+	if existing != 0 {
+		t.Fatalf("expected 0 variants before backfill, got %d", existing)
+	}
+
+	n, err := backfillNormalVariants(context.Background(), d)
+	if err != nil {
+		t.Fatalf("backfillNormalVariants: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 row backfilled, got %d", n)
+	}
+
+	var kind string
+	var price float64
+	if err := d.QueryRow(`SELECT kind, price_eur FROM pokemon_card_variants WHERE card_id = ?`, "me1-1").Scan(&kind, &price); err != nil {
+		t.Fatalf("read variant: %v", err)
+	}
+	if kind != "normal" || price != 0 {
+		t.Fatalf("expected (normal,0), got (%s,%v)", kind, price)
+	}
+
+	// Idempotent: a second pass does not duplicate rows.
+	n2, err := backfillNormalVariants(context.Background(), d)
+	if err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if n2 != 0 {
+		t.Fatalf("expected 0 rows on second pass, got %d", n2)
+	}
+}
+
 func TestSyncCards_VariantUpsertUpdatesPrice(t *testing.T) {
 	d := setupTestDB(t)
 	if _, err := d.Exec(`INSERT INTO pokemon_sets (id, name, series, release_date, total_cards, synced_at)

--- a/internal/pokemon/sync_test.go
+++ b/internal/pokemon/sync_test.go
@@ -360,6 +360,69 @@ func TestSyncAll_BackfillCreatesNormalVariantForOrphanCards(t *testing.T) {
 	}
 }
 
+func TestSyncAll_BackfillAddsNormalWhenOnlyNonNormalVariantExists(t *testing.T) {
+	d := setupTestDB(t)
+	now := time.Now().UTC()
+	if _, err := d.Exec(`INSERT INTO pokemon_sets (id, name, series, release_date, total_cards, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?)`, "me2", "Mega Evolution 2", "Mega Evolution", "2026/02/01", 1, now); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+	if _, err := d.Exec(`INSERT INTO pokemon_cards (id, set_id, name, collector_no, rarity, image_small_url, image_large_url, synced_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"me2-1", "me2", "Mega Blastoise ex", "1", "Rare", "", "", now); err != nil {
+		t.Fatalf("seed card: %v", err)
+	}
+	// Card already has a reverse_holofoil variant but no normal variant.
+	if _, err := d.Exec(`INSERT INTO pokemon_card_variants (card_id, kind, price_eur, price_at) VALUES (?, 'reverse_holofoil', 3.5, ?)`,
+		"me2-1", now); err != nil {
+		t.Fatalf("seed reverse_holofoil variant: %v", err)
+	}
+
+	n, err := backfillNormalVariants(context.Background(), d)
+	if err != nil {
+		t.Fatalf("backfillNormalVariants: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 row backfilled, got %d", n)
+	}
+
+	rows, err := d.Query(`SELECT kind, price_eur FROM pokemon_card_variants WHERE card_id = ? ORDER BY kind`, "me2-1")
+	if err != nil {
+		t.Fatalf("query variants: %v", err)
+	}
+	defer rows.Close()
+	got := map[string]float64{}
+	for rows.Next() {
+		var k string
+		var p float64
+		if err := rows.Scan(&k, &p); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[k] = p
+	}
+	want := map[string]float64{
+		"normal":           0,
+		"reverse_holofoil": 3.5,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d variants, got %d: %+v", len(want), len(got), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("variant %s: expected %v, got %v", k, v, got[k])
+		}
+	}
+
+	// Idempotent: reverse_holofoil price must not be touched.
+	n2, err := backfillNormalVariants(context.Background(), d)
+	if err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if n2 != 0 {
+		t.Fatalf("expected 0 rows on second pass, got %d", n2)
+	}
+}
+
 func TestSyncCards_VariantUpsertUpdatesPrice(t *testing.T) {
 	d := setupTestDB(t)
 	if _, err := d.Exec(`INSERT INTO pokemon_sets (id, name, series, release_date, total_cards, synced_at)


### PR DESCRIPTION
## Changes

- **Pokémon sync now always creates a `normal` variant row for every card** - For very new sets where Cardmarket has no price data yet (e.g. the Mega Evolution era), the sync no longer skips creating variants entirely. Each card gets a placeholder `normal` variant at price 0 so the user can mark it as owned, and a self-healing backfill pass at the end of `SyncAll` repairs historical gaps. Real Cardmarket prices arriving on a later re-sync still overwrite the placeholder. (Hytte-h4tn)

## Original Issue (bug): Pokémon sync: always create a 'normal' variant row even when no price data exists

The metadata sync (`internal/pokemon/sync.go` `SyncCards`) only creates `pokemon_card_variants` rows by walking the response's `cardmarket.prices` block. For very new sets where Cardmarket has no price data yet — currently the entire Mega Evolution era (me1, me2, me2pt5, me3 — 737 cards) — zero variants get created. The set browser shows the cards but the user **cannot mark them as owned** because the variant picker has nothing to pick.

## Fix

In `SyncCards` (or wherever per-card variant rows are created), unconditionally ensure each card has at least a `kind="normal"` variant row, with `price_eur=0` and `price_at` left null. If Cardmarket prices for the card later arrive on a re-sync, the upsert keyed by `(card_id, kind)` updates the price; if Cardmarket reports additional kinds like `reverse_holofoil`, those get added as separate rows.

Concretely:

1. After parsing the card response, BEFORE iterating the cardmarket prices block, do an upsert of `(card_id, kind='normal', price_eur=0)`. The unique `(card_id, kind)` constraint guarantees this doesn't clobber an existing price if it's already there.
2. Then iterate `cardmarket.prices` as today — each kind found gets its own upsert. The `normal` row may get a price overwrite if Cardmarket has a "trendPrice"/"averageSellPrice" — that's correct.

If the API returns specific kinds like `holofoil` or `1stEditionHolofoil`, keep the existing kind-mapping logic. The only change is the guaranteed-`normal`-row fallback.

## Backfill

After deploying the code, a one-shot backfill is needed for the currently-empty Mega Evolution era. The fix's logic on a re-sync will create the rows. Either:

- Trigger the existing `POST /api/pokemon/admin/sync` endpoint manually after deploy.
- Or include a small migration step in `SyncAll` that, for any card with zero variant rows, creates the `normal` fallback.

Option B is more robust (self-healing on every nightly run); recommended.

## Tests

- `sync_test.go` extended: a card response with no `cardmarket.prices` block → exactly one variant row inserted, `kind='normal'`, `price_eur=0`.
- A card response WITH `cardmarket.prices.normal.trendPrice = 12.34` → one variant row with that price (the unconditional row was overwritten by the price).
- A card response WITH `cardmarket.prices.reverseHolofoil.trendPrice = 5.0` and no `normal` block → TWO variant rows: `kind='normal'` price 0, `kind='reverse_holofoil'` price 5.0.

## Acceptance

- `make build`, `make test`, `npm run build` all pass.
- After deploy + a re-sync trigger, `SELECT COUNT(*) FROM pokemon_card_variants v JOIN pokemon_cards c ON c.id=v.card_id JOIN pokemon_sets s ON s.id=c.set_id WHERE s.series='Mega Evolution'` is > 0 — every Mega Evolution card has at least a `normal` variant row.
- User can mark Mega Evolution cards as owned via the existing add-card flow.
- Existing prices on older sets are unchanged.
- Changelog fragment in changelog.d/ (category: Fixed).

## Reference

- internal/pokemon/sync.go `SyncCards` — the function to extend.
- internal/db/db.go schema — `pokemon_card_variants` table with UNIQUE(card_id, kind).
- Concrete repro today: `SELECT COUNT(*) FROM pokemon_cards c JOIN pokemon_sets s ON s.id=c.set_id WHERE s.series='Mega Evolution'` returns 737 but the variants table has 0 rows for those cards.


---
Bead: Hytte-h4tn | Branch: forge/Hytte-h4tn
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->