### PR TITLE
Pokémon set view: variant-aware ownership + filter chip (Hytte-9yhn)

### DIFF
--- a/changelog.d/Hytte-9yhn.md
+++ b/changelog.d/Hytte-9yhn.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon set view: variant-aware ownership filter** - Set-detail pages now expose a chip row (Any / Normal / Reverse Holo / All variants / other kinds present in the set) that controls how each tile's ownership indicator and the header completion stat are computed. Per-kind chips render dynamically based on the variants the set actually has; cards without the active variant kind are excluded from the denominator and shown as not-applicable. The active filter round-trips through the URL as `?variant=...`. (Hytte-9yhn)

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -59,6 +59,22 @@
     "holofoil": "Holo",
     "reverse_holofoil": "Reverse holo"
   },
+  "set": {
+    "variantFilter": {
+      "label": "Variant:",
+      "any": "Any",
+      "normal": "Normal",
+      "reverseHolo": "Reverse Holo",
+      "allVariants": "All variants"
+    },
+    "completion": {
+      "any": "{{owned}} / {{total}} cards (any variant)",
+      "normal": "{{owned}} / {{total}} cards with normal print owned",
+      "reverseHolo": "{{owned}} / {{total}} cards with reverse holo owned",
+      "allVariants": "{{owned}} / {{total}} cards with every variant owned",
+      "kind": "{{owned}} / {{total}} cards (this variant)"
+    }
+  },
   "toast": {
     "marked": "Added to collection",
     "unmarked": "Removed from collection"

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -9,7 +9,13 @@
     "ownership": "{{owned}} / {{total}} — {{percent}}%",
     "openSet": "Open {{name}}",
     "openCard": "Open {{name}} (#{{number}})",
-    "collectorNo": "#{{number}}"
+    "collectorNo": "#{{number}}",
+    "status": {
+      "owned": "owned",
+      "partial": "partially owned",
+      "missing": "not owned",
+      "na": "not applicable"
+    }
   },
   "errors": {
     "failedToLoad": "Failed to load Pokémon sets",

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -59,6 +59,22 @@
     "holofoil": "Holo",
     "reverse_holofoil": "Reverse holo"
   },
+  "set": {
+    "variantFilter": {
+      "label": "Variant:",
+      "any": "Alle",
+      "normal": "Normal",
+      "reverseHolo": "Reverse holo",
+      "allVariants": "Alle varianter"
+    },
+    "completion": {
+      "any": "{{owned}} / {{total}} kort (en hvilken som helst variant)",
+      "normal": "{{owned}} / {{total}} kort med normal utgave eid",
+      "reverseHolo": "{{owned}} / {{total}} kort med reverse holo eid",
+      "allVariants": "{{owned}} / {{total}} kort med alle varianter eid",
+      "kind": "{{owned}} / {{total}} kort (denne varianten)"
+    }
+  },
   "toast": {
     "marked": "Lagt til i samlingen",
     "unmarked": "Fjernet fra samlingen"

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -9,7 +9,13 @@
     "ownership": "{{owned}} / {{total}} — {{percent}} %",
     "openSet": "Åpne {{name}}",
     "openCard": "Åpne {{name}} (#{{number}})",
-    "collectorNo": "#{{number}}"
+    "collectorNo": "#{{number}}",
+    "status": {
+      "owned": "eid",
+      "partial": "delvis eid",
+      "missing": "ikke eid",
+      "na": "ikke aktuelt"
+    }
   },
   "errors": {
     "failedToLoad": "Kunne ikke laste Pokémon-sett",

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -59,6 +59,22 @@
     "holofoil": "Holo",
     "reverse_holofoil": "Reverse holo"
   },
+  "set": {
+    "variantFilter": {
+      "label": "ชนิด:",
+      "any": "ใดก็ได้",
+      "normal": "ปกติ",
+      "reverseHolo": "Reverse holo",
+      "allVariants": "ทุกชนิด"
+    },
+    "completion": {
+      "any": "{{owned}} / {{total}} ใบ (ชนิดใดก็ได้)",
+      "normal": "{{owned}} / {{total}} ใบที่มีฉบับปกติ",
+      "reverseHolo": "{{owned}} / {{total}} ใบที่มี reverse holo",
+      "allVariants": "{{owned}} / {{total}} ใบที่มีครบทุกชนิด",
+      "kind": "{{owned}} / {{total}} ใบ (ชนิดนี้)"
+    }
+  },
   "toast": {
     "marked": "เพิ่มเข้าคอลเลกชันแล้ว",
     "unmarked": "ลบออกจากคอลเลกชันแล้ว"

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -9,7 +9,13 @@
     "ownership": "{{owned}} / {{total}} — {{percent}}%",
     "openSet": "เปิด {{name}}",
     "openCard": "เปิด {{name}} (#{{number}})",
-    "collectorNo": "#{{number}}"
+    "collectorNo": "#{{number}}",
+    "status": {
+      "owned": "มีแล้ว",
+      "partial": "มีบางส่วน",
+      "missing": "ยังไม่มี",
+      "na": "ไม่เกี่ยวข้อง"
+    }
   },
   "errors": {
     "failedToLoad": "โหลดชุดโปเกมอนไม่สำเร็จ",

--- a/web/src/pages/PokemonSet.test.tsx
+++ b/web/src/pages/PokemonSet.test.tsx
@@ -298,7 +298,7 @@ describe('PokemonSet – mark owned (POST)', () => {
 
     await waitFor(() => expect(screen.getByTestId('owned-count')).toHaveTextContent('1 / 1'))
     const tile = screen.getByTestId('card-tile-sv1-1')
-    expect(tile).toHaveAttribute('aria-pressed', 'true')
+    expect(tile).toHaveAttribute('data-ownership', 'owned')
   })
 })
 
@@ -330,7 +330,7 @@ describe('PokemonSet – unmark owned (DELETE)', () => {
     })
 
     await waitFor(() => expect(screen.getByTestId('owned-count')).toHaveTextContent('0 / 1'))
-    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('data-ownership', 'missing')
   })
 })
 
@@ -389,7 +389,7 @@ describe('PokemonSet – mark error reverts optimistic UI', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Mark as owned' }))
 
     await waitFor(() => expect(screen.getByTestId('owned-count')).toHaveTextContent('0 / 1'))
-    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('data-ownership', 'missing')
   })
 })
 
@@ -535,9 +535,9 @@ describe('PokemonSet – variant filter chip', () => {
 
     // Pikachu owns normal, Eevee owns reverse → 2/3 owned, Mew missing.
     expect(screen.getByTestId('owned-count')).toHaveTextContent('2 / 3')
-    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByTestId('card-tile-sv1-2')).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByTestId('card-tile-sv1-3')).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('data-ownership', 'owned')
+    expect(screen.getByTestId('card-tile-sv1-2')).toHaveAttribute('data-ownership', 'owned')
+    expect(screen.getByTestId('card-tile-sv1-3')).toHaveAttribute('data-ownership', 'missing')
   })
 
   it('Normal filter shows owned only for cards whose normal is owned', async () => {
@@ -551,9 +551,9 @@ describe('PokemonSet – variant filter chip', () => {
 
     // Only Pikachu owns normal → 1/3.
     expect(screen.getByTestId('owned-count')).toHaveTextContent('1 / 3')
-    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByTestId('card-tile-sv1-2')).toHaveAttribute('aria-pressed', 'false')
-    expect(screen.getByTestId('card-tile-sv1-3')).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('data-ownership', 'owned')
+    expect(screen.getByTestId('card-tile-sv1-2')).toHaveAttribute('data-ownership', 'missing')
+    expect(screen.getByTestId('card-tile-sv1-3')).toHaveAttribute('data-ownership', 'missing')
   })
 
   it('Reverse Holo filter excludes cards without a reverse variant from the denominator', async () => {

--- a/web/src/pages/PokemonSet.test.tsx
+++ b/web/src/pages/PokemonSet.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import PokemonSet from './PokemonSet'
 
 // Lightweight i18n mock — return predictable English strings keyed off the
@@ -41,14 +41,25 @@ const TRANSLATIONS: Record<string, string> = {
   'condition.damaged': 'Damaged',
   'variantKind.normal': 'Normal',
   'variantKind.reverse_holofoil': 'Reverse holo',
+  'variantKind.holofoil': 'Holo',
   'toast.marked': 'Added to collection',
   'toast.unmarked': 'Removed from collection',
+  'set.variantFilter.label': 'Variant:',
+  'set.variantFilter.any': 'Any',
+  'set.variantFilter.normal': 'Normal',
+  'set.variantFilter.reverseHolo': 'Reverse Holo',
+  'set.variantFilter.allVariants': 'All variants',
 }
 
 function mockT(key: string, opts?: Record<string, string | number> & { defaultValue?: string }): string {
   if (key === 'detail.ownedOf') return `${opts?.owned ?? 0} / ${opts?.total ?? 0}`
   if (key === 'tile.openCard') return `Open ${opts?.name ?? ''} (#${opts?.number ?? ''})`
   if (key === 'tile.collectorNo') return `#${opts?.number ?? ''}`
+  if (key === 'set.completion.any') return `${opts?.owned ?? 0} / ${opts?.total ?? 0} cards (any variant)`
+  if (key === 'set.completion.normal') return `${opts?.owned ?? 0} / ${opts?.total ?? 0} cards with normal print owned`
+  if (key === 'set.completion.reverseHolo') return `${opts?.owned ?? 0} / ${opts?.total ?? 0} cards with reverse holo owned`
+  if (key === 'set.completion.allVariants') return `${opts?.owned ?? 0} / ${opts?.total ?? 0} cards with every variant owned`
+  if (key === 'set.completion.kind') return `${opts?.owned ?? 0} / ${opts?.total ?? 0} cards (this variant)`
   if (key.startsWith('variantKind.')) return TRANSLATIONS[key] ?? opts?.defaultValue ?? key
   return TRANSLATIONS[key] ?? key
 }
@@ -190,11 +201,37 @@ function makeFetchMock(spec: FetchSpec, overrides?: (url: string, init?: Request
   })
 }
 
-function renderPage() {
+function renderPage(initialPath = '/pokemon/sets/sv1') {
   return render(
-    <MemoryRouter initialEntries={['/pokemon/sets/sv1']}>
+    <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/pokemon/sets/:id" element={<PokemonSet />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// LocationProbe exposes the current router location to assertions by writing
+// `?...` into a hidden DOM node. We use it to verify the variant filter
+// round-trips through the URL.
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="location-probe" data-pathname={loc.pathname} data-search={loc.search} />
+}
+
+function renderPageWithProbe(initialPath = '/pokemon/sets/sv1') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="/pokemon/sets/:id"
+          element={
+            <>
+              <PokemonSet />
+              <LocationProbe />
+            </>
+          }
+        />
       </Routes>
     </MemoryRouter>,
   )
@@ -425,5 +462,208 @@ describe('PokemonSet – lightbox', () => {
     // Sanity: the prev/next zones from the lightbox should be present.
     expect(screen.getByTestId('lightbox-prev-zone')).toBeInTheDocument()
     expect(screen.getByTestId('lightbox-next-zone')).toBeInTheDocument()
+  })
+})
+
+describe('PokemonSet – variant filter chip', () => {
+  // Fixture: three cards.
+  //  sv1-1 Pikachu: normal owned, reverse_holofoil missing
+  //  sv1-2 Eevee:   normal missing, reverse_holofoil owned
+  //  sv1-3 Mew:     ultra rare with only normal (no reverse)
+  function mixedCards() {
+    return [
+      makeCard({
+        id: 'sv1-1',
+        name: 'Pikachu',
+        variants: [
+          makeVariant({ id: 1, kind: 'normal', owned: true, owned_id: 11, quantity: 1, price_nok: 50 }),
+          makeVariant({ id: 2, kind: 'reverse_holofoil', owned: false, price_nok: 80 }),
+        ],
+      }),
+      makeCard({
+        id: 'sv1-2',
+        name: 'Eevee',
+        variants: [
+          makeVariant({ id: 3, kind: 'normal', owned: false, price_nok: 60 }),
+          makeVariant({ id: 4, kind: 'reverse_holofoil', owned: true, owned_id: 12, quantity: 1, price_nok: 100 }),
+        ],
+      }),
+      makeCard({
+        id: 'sv1-3',
+        name: 'Mew',
+        variants: [
+          makeVariant({ id: 5, kind: 'normal', owned: false, price_nok: 500 }),
+        ],
+      }),
+    ]
+  }
+
+  it('renders chips dynamically for the kinds in the set', async () => {
+    const set = makeSet({ total_cards: 3 })
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards: mixedCards() }))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    const group = screen.getByTestId('variant-filter')
+    expect(within(group).getByRole('radio', { name: 'Any' })).toBeInTheDocument()
+    expect(within(group).getByRole('radio', { name: 'Normal' })).toBeInTheDocument()
+    expect(within(group).getByRole('radio', { name: 'Reverse Holo' })).toBeInTheDocument()
+    expect(within(group).getByRole('radio', { name: 'All variants' })).toBeInTheDocument()
+  })
+
+  it('hides chips for kinds not present in the set', async () => {
+    // Only normal variants in this set — no Reverse Holo chip, and no "All
+    // variants" chip because no card has more than one variant.
+    const set = makeSet({ total_cards: 1 })
+    const cards = [makeCard({ id: 'sv1-1', variants: [makeVariant({ id: 1, kind: 'normal' })] })]
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards }))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    // With a single-kind, single-variant set the chip row collapses entirely.
+    expect(screen.queryByTestId('variant-filter')).not.toBeInTheDocument()
+  })
+
+  it('Any (default) counts a card as owned when any variant is owned', async () => {
+    const set = makeSet({ total_cards: 3 })
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards: mixedCards() }))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    // Pikachu owns normal, Eevee owns reverse → 2/3 owned, Mew missing.
+    expect(screen.getByTestId('owned-count')).toHaveTextContent('2 / 3')
+    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('card-tile-sv1-2')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('card-tile-sv1-3')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('Normal filter shows owned only for cards whose normal is owned', async () => {
+    const set = makeSet({ total_cards: 3 })
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards: mixedCards() }))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    fireEvent.click(within(screen.getByTestId('variant-filter')).getByRole('radio', { name: 'Normal' }))
+
+    // Only Pikachu owns normal → 1/3.
+    expect(screen.getByTestId('owned-count')).toHaveTextContent('1 / 3')
+    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('card-tile-sv1-2')).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('card-tile-sv1-3')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('Reverse Holo filter excludes cards without a reverse variant from the denominator', async () => {
+    const set = makeSet({ total_cards: 3 })
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards: mixedCards() }))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    fireEvent.click(
+      within(screen.getByTestId('variant-filter')).getByRole('radio', { name: 'Reverse Holo' }),
+    )
+
+    // Two cards have a reverse_holofoil variant (Pikachu, Eevee). Eevee owns it.
+    expect(screen.getByTestId('owned-count')).toHaveTextContent('1 / 2')
+    // Mew has no reverse variant — tile is marked not-applicable.
+    expect(screen.getByTestId('card-tile-sv1-3')).toHaveAttribute('data-ownership', 'na')
+  })
+
+  it('All variants filter only counts cards where every variant is owned', async () => {
+    const set = makeSet({ total_cards: 3 })
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards: mixedCards() }))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    fireEvent.click(
+      within(screen.getByTestId('variant-filter')).getByRole('radio', { name: 'All variants' }),
+    )
+
+    // No card has every variant owned → 0/3.
+    expect(screen.getByTestId('owned-count')).toHaveTextContent('0 / 3')
+    // Partial ownership indicator on cards with some variants owned.
+    expect(screen.getByTestId('card-tile-sv1-1')).toHaveAttribute('data-ownership', 'partial')
+    expect(screen.getByTestId('card-tile-sv1-2')).toHaveAttribute('data-ownership', 'partial')
+    // Mew has only one variant and isn't owned → fully missing.
+    expect(screen.getByTestId('card-tile-sv1-3')).toHaveAttribute('data-ownership', 'missing')
+  })
+
+  it('initializes from URL ?variant=reverse_holofoil', async () => {
+    const set = makeSet({ total_cards: 3 })
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards: mixedCards() }))
+
+    renderPageWithProbe('/pokemon/sets/sv1?variant=reverse_holofoil')
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    expect(
+      within(screen.getByTestId('variant-filter')).getByRole('radio', { name: 'Reverse Holo' }),
+    ).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('owned-count')).toHaveTextContent('1 / 2')
+  })
+
+  it('writes the active filter back to the URL', async () => {
+    const set = makeSet({ total_cards: 3 })
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards: mixedCards() }))
+
+    renderPageWithProbe()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    // Default 'any' should not appear in the URL.
+    expect(screen.getByTestId('location-probe')).toHaveAttribute('data-search', '')
+
+    fireEvent.click(
+      within(screen.getByTestId('variant-filter')).getByRole('radio', { name: 'Reverse Holo' }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-probe')).toHaveAttribute(
+        'data-search',
+        '?variant=reverse_holofoil',
+      )
+    })
+
+    // Switching back to Any clears the param.
+    fireEvent.click(within(screen.getByTestId('variant-filter')).getByRole('radio', { name: 'Any' }))
+    await waitFor(() => {
+      expect(screen.getByTestId('location-probe')).toHaveAttribute('data-search', '')
+    })
+  })
+
+  it('falls back to Any when the URL contains an unknown variant', async () => {
+    const set = makeSet({ total_cards: 3 })
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards: mixedCards() }))
+
+    renderPage('/pokemon/sets/sv1?variant=holofoil')
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    // holofoil isn't in this set's kinds → no chip rendered, Any stays checked.
+    expect(
+      within(screen.getByTestId('variant-filter')).getByRole('radio', { name: 'Any' }),
+    ).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('Set value updates to the active variants only', async () => {
+    const set = makeSet({ total_cards: 3 })
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards: mixedCards() }))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    // Default 'any': owned variants are Pikachu-normal (50) and Eevee-reverse
+    // (100) → 150.
+    expect(screen.getByTestId('set-value').textContent ?? '').toMatch(/150/)
+
+    fireEvent.click(within(screen.getByTestId('variant-filter')).getByRole('radio', { name: 'Normal' }))
+    // Only Pikachu-normal counted under the Normal filter → 50.
+    await waitFor(() => {
+      const text = screen.getByTestId('set-value').textContent ?? ''
+      expect(text).toMatch(/50/)
+      expect(text).not.toMatch(/150/)
+    })
   })
 })

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -131,17 +131,29 @@ function computeCompletion(cards: Card[], filter: VariantFilter): Completion {
 }
 
 // computeSetValue sums the NOK price of the owned variants in scope for the
-// active filter. 'any' sums every owned variant on every card (the
-// pre-existing behaviour). Kind filters sum only that variant. 'all' sums
-// every owned variant, same as 'any' — under the strictest filter we still
-// reflect total monetary value.
+// active filter. 'any' picks the single best-priced owned variant per card
+// so multi-variant cards are not double-counted. Kind filters sum only that
+// variant. 'all' sums every owned variant across all cards.
 function computeSetValue(cards: Card[], filter: VariantFilter): number {
   let total = 0
   for (const card of cards) {
-    for (const variant of card.variants) {
-      if (!variant.owned || variant.price_nok == null) continue
-      if (filter !== 'any' && filter !== 'all' && variant.kind !== filter) continue
-      total += variant.price_nok * Math.max(variant.quantity, 1)
+    if (filter === 'any') {
+      let best: number | null = null
+      for (const v of card.variants) {
+        if (!v.owned || v.price_nok == null) continue
+        const value = v.price_nok * Math.max(v.quantity, 1)
+        if (best == null || value > best) best = value
+      }
+      if (best != null) total += best
+    } else if (filter === 'all') {
+      for (const v of card.variants) {
+        if (!v.owned || v.price_nok == null) continue
+        total += v.price_nok * Math.max(v.quantity, 1)
+      }
+    } else {
+      const v = card.variants.find(x => x.kind === filter)
+      if (!v || !v.owned || v.price_nok == null) continue
+      total += v.price_nok * Math.max(v.quantity, 1)
     }
   }
   return total
@@ -176,14 +188,21 @@ function hasMultiVariantCard(cards: Card[]): boolean {
 }
 
 // availableVariantFilters builds the chip list dynamically. 'any' is always
-// present; per-kind chips appear when at least one card carries that kind;
-// 'all' only appears when there is at least one card with multiple variants.
+// present. Per-kind chips are only added when the set has more than one kind
+// or at least one card with multiple variants — if every card has a single
+// variant of a single kind, 'any' and the kind chip are equivalent and the
+// row would be redundant. 'all' only appears when there is at least one card
+// with multiple variants.
 function availableVariantFilters(cards: Card[]): VariantFilter[] {
   const filters: VariantFilter[] = ['any']
-  for (const kind of availableVariantKinds(cards)) {
-    filters.push(kind)
+  const kinds = availableVariantKinds(cards)
+  const multi = hasMultiVariantCard(cards)
+  if (kinds.length > 1 || multi) {
+    for (const kind of kinds) {
+      filters.push(kind)
+    }
   }
-  if (hasMultiVariantCard(cards)) filters.push('all')
+  if (multi) filters.push('all')
   return filters
 }
 
@@ -284,7 +303,7 @@ function CardTile({ card, filter, onClick, t }: TileProps) {
       onClick={onClick}
       data-testid={`card-tile-${card.id}`}
       aria-label={t('tile.openCard', { name: card.name, number: card.collector_no })}
-      aria-pressed={applicable ? owned : false}
+      aria-pressed={applicable ? (owned ? true : partial ? 'mixed' : false) : false}
       data-ownership={!applicable ? 'na' : owned ? 'owned' : partial ? 'partial' : 'missing'}
       className={`flex flex-col gap-2 p-2 rounded-lg border bg-gray-800/40 transition-colors text-left cursor-pointer ${tileClass}`}
     >

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
-import { ArrowLeft, Check } from 'lucide-react'
+import { ArrowLeft, Check, Minus } from 'lucide-react'
 import { Skeleton } from '../components/ui/skeleton'
 import ToastList from '../components/ToastList'
 import AddCardPanel from '../components/pokemon/AddCardPanel'
@@ -50,6 +50,164 @@ type Filter = 'all' | 'owned' | 'missing'
 const FILTERS: Filter[] = ['all', 'owned', 'missing']
 const CONDITIONS = ['', 'mint', 'near_mint', 'lightly_played', 'moderately_played', 'heavily_played', 'damaged']
 
+// VariantFilter narrows what "owned" means for the at-a-glance grid and the
+// header completion stat. 'any' counts a card as owned if any variant is owned
+// (today's default). 'all' is stricter: every variant must be owned. Any other
+// value is a specific variant kind from the set (e.g. 'normal',
+// 'reverse_holofoil').
+type VariantFilter = 'any' | 'all' | string
+
+// KNOWN_VARIANT_KIND_ORDER controls the chip ordering for the kinds we
+// recognise; unknown kinds fall through to the end in alphabetical order.
+const KNOWN_VARIANT_KIND_ORDER = ['normal', 'holofoil', 'reverse_holofoil', '1st_edition']
+
+// computeCardOwnership returns the ownership view of a card under the active
+// variant filter. `applicable` is false when the filter targets a specific
+// kind and the card has no variant of that kind — the card is excluded from
+// the completion denominator and rendered with a muted "not applicable"
+// indicator.
+interface CardOwnership {
+  owned: boolean
+  partial: boolean
+  applicable: boolean
+}
+
+function computeCardOwnership(card: Card, filter: VariantFilter): CardOwnership {
+  if (filter === 'any') {
+    return {
+      owned: card.variants.some(v => v.owned),
+      partial: false,
+      applicable: true,
+    }
+  }
+  if (filter === 'all') {
+    if (card.variants.length === 0) return { owned: false, partial: false, applicable: true }
+    const ownedCount = card.variants.reduce((n, v) => (v.owned ? n + 1 : n), 0)
+    return {
+      owned: ownedCount === card.variants.length,
+      partial: ownedCount > 0 && ownedCount < card.variants.length,
+      applicable: true,
+    }
+  }
+  const variant = card.variants.find(v => v.kind === filter)
+  if (!variant) return { owned: false, partial: false, applicable: false }
+  return { owned: variant.owned, partial: false, applicable: true }
+}
+
+// computeCompletion returns the owned / total counts under the active filter.
+// 'any' counts every card; specific-kind filters only count cards that have
+// that kind in their variants list (so unique variants like Reverse Holo
+// don't drag the denominator down for ultra rares).
+interface Completion {
+  owned: number
+  total: number
+}
+
+function computeCompletion(cards: Card[], filter: VariantFilter): Completion {
+  if (filter === 'any') {
+    let owned = 0
+    for (const card of cards) {
+      if (card.variants.some(v => v.owned)) owned++
+    }
+    return { owned, total: cards.length }
+  }
+  if (filter === 'all') {
+    let owned = 0
+    for (const card of cards) {
+      if (card.variants.length === 0) continue
+      if (card.variants.every(v => v.owned)) owned++
+    }
+    return { owned, total: cards.length }
+  }
+  let owned = 0
+  let total = 0
+  for (const card of cards) {
+    const variant = card.variants.find(v => v.kind === filter)
+    if (!variant) continue
+    total++
+    if (variant.owned) owned++
+  }
+  return { owned, total }
+}
+
+// computeSetValue sums the NOK price of the owned variants in scope for the
+// active filter. 'any' sums every owned variant on every card (the
+// pre-existing behaviour). Kind filters sum only that variant. 'all' sums
+// every owned variant, same as 'any' — under the strictest filter we still
+// reflect total monetary value.
+function computeSetValue(cards: Card[], filter: VariantFilter): number {
+  let total = 0
+  for (const card of cards) {
+    for (const variant of card.variants) {
+      if (!variant.owned || variant.price_nok == null) continue
+      if (filter !== 'any' && filter !== 'all' && variant.kind !== filter) continue
+      total += variant.price_nok * Math.max(variant.quantity, 1)
+    }
+  }
+  return total
+}
+
+// availableVariantKinds returns the variant kinds present in the set, ordered
+// by KNOWN_VARIANT_KIND_ORDER then alphabetically. Empty when no card has any
+// variant (a degenerate set).
+function availableVariantKinds(cards: Card[]): string[] {
+  const seen = new Set<string>()
+  for (const card of cards) {
+    for (const variant of card.variants) {
+      if (variant.kind) seen.add(variant.kind)
+    }
+  }
+  return Array.from(seen).sort((a, b) => {
+    const ia = KNOWN_VARIANT_KIND_ORDER.indexOf(a)
+    const ib = KNOWN_VARIANT_KIND_ORDER.indexOf(b)
+    const ra = ia === -1 ? KNOWN_VARIANT_KIND_ORDER.length : ia
+    const rb = ib === -1 ? KNOWN_VARIANT_KIND_ORDER.length : ib
+    if (ra !== rb) return ra - rb
+    return a.localeCompare(b)
+  })
+}
+
+// hasMultiVariantCard returns true when at least one card in the set carries
+// more than one variant — used to decide whether the "All variants" chip
+// would be meaningfully different from "Any" (it would not, if every card has
+// a single variant).
+function hasMultiVariantCard(cards: Card[]): boolean {
+  return cards.some(c => c.variants.length > 1)
+}
+
+// availableVariantFilters builds the chip list dynamically. 'any' is always
+// present; per-kind chips appear when at least one card carries that kind;
+// 'all' only appears when there is at least one card with multiple variants.
+function availableVariantFilters(cards: Card[]): VariantFilter[] {
+  const filters: VariantFilter[] = ['any']
+  for (const kind of availableVariantKinds(cards)) {
+    filters.push(kind)
+  }
+  if (hasMultiVariantCard(cards)) filters.push('all')
+  return filters
+}
+
+// variantFilterLabelKey maps a filter slug to its i18n key. Aggregate filters
+// have explicit keys; per-kind filters reuse variantKind.* with a fallback
+// for kinds we don't have a localized label for.
+function variantFilterLabelKey(filter: VariantFilter): string {
+  if (filter === 'any') return 'set.variantFilter.any'
+  if (filter === 'all') return 'set.variantFilter.allVariants'
+  if (filter === 'normal') return 'set.variantFilter.normal'
+  if (filter === 'reverse_holofoil') return 'set.variantFilter.reverseHolo'
+  return `variantKind.${filter}`
+}
+
+// variantCompletionLabelKey selects which sentence to render below the owned
+// count, e.g. "12 / 195 cards (any variant)".
+function variantCompletionLabelKey(filter: VariantFilter): string {
+  if (filter === 'any') return 'set.completion.any'
+  if (filter === 'all') return 'set.completion.allVariants'
+  if (filter === 'normal') return 'set.completion.normal'
+  if (filter === 'reverse_holofoil') return 'set.completion.reverseHolo'
+  return 'set.completion.kind'
+}
+
 // parseReleaseDate accepts the "YYYY/MM/DD" or "YYYY-MM-DD" formats returned
 // by pokemontcg.io and renders a localized date. Falls back to the raw string
 // when parsing fails so we never render "Invalid Date".
@@ -81,60 +239,54 @@ function formatNok(amount: number | null | undefined): string {
 
 // defaultVariant returns the variant we display on a card tile. The backend
 // orders variants by kind, so "normal" precedes "reverse_holofoil"; we treat
-// the first variant as the canonical one.
-function defaultVariant(card: Card): Variant | undefined {
+// the first variant as the canonical one. When a per-kind filter is active
+// we prefer that variant so the tile's price reflects what the user is
+// looking at.
+function defaultVariant(card: Card, filter: VariantFilter): Variant | undefined {
+  if (filter !== 'any' && filter !== 'all') {
+    const v = card.variants.find(x => x.kind === filter)
+    if (v) return v
+  }
   return card.variants[0]
-}
-
-function cardIsOwned(card: Card): boolean {
-  return card.variants.some(v => v.owned)
-}
-
-// ownedSetValue sums the NOK price of every owned variant. Missing rates are
-// silently skipped — the caller already surfaces "rate unavailable" via the
-// X-Pokemon-Rate-Missing response header, so we don't double-warn here.
-function ownedSetValue(cards: Card[]): number {
-  let total = 0
-  for (const card of cards) {
-    for (const variant of card.variants) {
-      if (variant.owned && variant.price_nok != null) {
-        total += variant.price_nok * Math.max(variant.quantity, 1)
-      }
-    }
-  }
-  return total
-}
-
-function ownedCardCount(cards: Card[]): number {
-  let count = 0
-  for (const card of cards) {
-    if (cardIsOwned(card)) count++
-  }
-  return count
 }
 
 interface TileProps {
   card: Card
+  filter: VariantFilter
   onClick: () => void
   t: TFunction<'pokemon'>
 }
 
-function CardTile({ card, onClick, t }: TileProps) {
-  const owned = cardIsOwned(card)
-  const variant = defaultVariant(card)
+function CardTile({ card, filter, onClick, t }: TileProps) {
+  const ownership = computeCardOwnership(card, filter)
+  const { owned, partial, applicable } = ownership
+  const variant = defaultVariant(card, filter)
   const price = variant?.price_nok
+  // Border state:
+  // - `owned` → emerald ring
+  // - `partial` (under 'all' filter, some but not every variant) → amber ring
+  // - `!applicable` (per-kind filter, kind not present on this card) → muted
+  //   border, no checkmark; tile is informative but not counted
+  // - otherwise → default missing styling
+  let tileClass: string
+  if (!applicable) {
+    tileClass = 'border-gray-800 opacity-40 hover:opacity-70 hover:border-gray-700 hover:bg-gray-800/70'
+  } else if (owned) {
+    tileClass = 'border-emerald-500/70 ring-1 ring-emerald-500/40 hover:bg-gray-800/70'
+  } else if (partial) {
+    tileClass = 'border-amber-500/70 ring-1 ring-amber-500/40 hover:bg-gray-800/70'
+  } else {
+    tileClass = 'border-gray-800 opacity-60 hover:opacity-100 hover:border-gray-700 hover:bg-gray-800/70'
+  }
   return (
     <button
       type="button"
       onClick={onClick}
       data-testid={`card-tile-${card.id}`}
       aria-label={t('tile.openCard', { name: card.name, number: card.collector_no })}
-      aria-pressed={owned}
-      className={`flex flex-col gap-2 p-2 rounded-lg border bg-gray-800/40 transition-colors text-left cursor-pointer
-        ${owned
-          ? 'border-emerald-500/70 ring-1 ring-emerald-500/40 hover:bg-gray-800/70'
-          : 'border-gray-800 opacity-60 hover:opacity-100 hover:border-gray-700 hover:bg-gray-800/70'
-        }`}
+      aria-pressed={applicable ? owned : false}
+      data-ownership={!applicable ? 'na' : owned ? 'owned' : partial ? 'partial' : 'missing'}
+      className={`flex flex-col gap-2 p-2 rounded-lg border bg-gray-800/40 transition-colors text-left cursor-pointer ${tileClass}`}
     >
       <div className="relative aspect-[5/7] flex items-center justify-center bg-gray-900/40 rounded overflow-hidden">
         {card.image_small_url ? (
@@ -147,12 +299,20 @@ function CardTile({ card, onClick, t }: TileProps) {
         ) : (
           <span className="text-xs text-gray-500">{card.collector_no}</span>
         )}
-        {owned && (
+        {applicable && owned && (
           <span
             aria-hidden="true"
             className="absolute top-1 right-1 flex items-center justify-center h-5 w-5 rounded-full bg-emerald-500 text-white shadow"
           >
             <Check size={12} />
+          </span>
+        )}
+        {applicable && !owned && partial && (
+          <span
+            aria-hidden="true"
+            className="absolute top-1 right-1 flex items-center justify-center h-5 w-5 rounded-full bg-amber-500 text-white shadow"
+          >
+            <Minus size={12} />
           </span>
         )}
       </div>
@@ -380,6 +540,7 @@ export default function PokemonSetPage() {
   const { id } = useParams<{ id: string }>()
   const setId = id ?? ''
   const { toasts, showToast } = useToast()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const [set, setSet] = useState<PokemonSet | null>(null)
   const [cards, setCards] = useState<Card[]>([])
@@ -392,6 +553,7 @@ export default function PokemonSetPage() {
   const cardsRef = useRef<Card[]>([])
   useLayoutEffect(() => { cardsRef.current = cards })
   const filterButtonRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const variantFilterButtonRefs = useRef<Array<HTMLButtonElement | null>>([])
 
   // selectFilter implements the WAI-ARIA radiogroup keyboard pattern: focus the
   // target radio and select it. Used by both pointer clicks and arrow/Home/End
@@ -459,15 +621,85 @@ export default function PokemonSetPage() {
     return () => { controller.abort() }
   }, [setId, attempt, t])
 
-  const ownedCount = useMemo(() => ownedCardCount(cards), [cards])
-  const setValueNok = useMemo(() => ownedSetValue(cards), [cards])
+  // Variant filter state lives in the URL (?variant=...). Default is 'any'.
+  // We read raw, then validate against the set's available filters on render
+  // so an unknown or stale value gracefully falls back to 'any' without
+  // touching the URL until the user picks a real chip.
+  const rawVariantParam = searchParams.get('variant')
+  const variantFilters = useMemo(() => availableVariantFilters(cards), [cards])
+  const variantFilter: VariantFilter =
+    rawVariantParam && variantFilters.includes(rawVariantParam) ? rawVariantParam : 'any'
+
+  const selectVariantFilter = useCallback(
+    (next: VariantFilter) => {
+      setSearchParams(
+        prev => {
+          const params = new URLSearchParams(prev)
+          if (next === 'any') {
+            params.delete('variant')
+          } else {
+            params.set('variant', next)
+          }
+          return params
+        },
+        { replace: true },
+      )
+    },
+    [setSearchParams],
+  )
+
+  const handleVariantFilterKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const move = (next: number) => {
+        const f = variantFilters[next]
+        if (!f) return
+        e.preventDefault()
+        selectVariantFilter(f)
+        variantFilterButtonRefs.current[next]?.focus()
+      }
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          move((index + 1) % variantFilters.length)
+          break
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          move((index - 1 + variantFilters.length) % variantFilters.length)
+          break
+        case 'Home':
+          move(0)
+          break
+        case 'End':
+          move(variantFilters.length - 1)
+          break
+      }
+    },
+    [variantFilters, selectVariantFilter],
+  )
+
+  const completion = useMemo(() => computeCompletion(cards, variantFilter), [cards, variantFilter])
+  const setValueNok = useMemo(() => computeSetValue(cards, variantFilter), [cards, variantFilter])
+  // We expose the variant-aware denominator on the header so the user always
+  // knows what they're looking at. For the "Total cards" tile we still show
+  // the printed set total when known, since that's a property of the set
+  // itself rather than the active filter.
   const totalCards = set?.total_cards ?? cards.length
 
   const visibleCards = useMemo(() => {
-    if (filter === 'owned') return cards.filter(cardIsOwned)
-    if (filter === 'missing') return cards.filter(c => !cardIsOwned(c))
+    if (filter === 'owned') {
+      return cards.filter(c => {
+        const o = computeCardOwnership(c, variantFilter)
+        return o.applicable && o.owned
+      })
+    }
+    if (filter === 'missing') {
+      return cards.filter(c => {
+        const o = computeCardOwnership(c, variantFilter)
+        return o.applicable && !o.owned
+      })
+    }
     return cards
-  }, [cards, filter])
+  }, [cards, filter, variantFilter])
 
   // Clamp the lightbox start index to the visible list length during render so
   // we never pass a stale out-of-range pointer to CardLightbox.
@@ -612,7 +844,16 @@ export default function PokemonSetPage() {
                 className="text-sm font-medium text-white"
                 data-testid="owned-count"
               >
-                {t('detail.ownedOf', { owned: ownedCount, total: totalCards })}
+                {t('detail.ownedOf', { owned: completion.owned, total: completion.total })}
+              </dd>
+              <dd
+                className="text-[11px] text-gray-400 mt-0.5"
+                data-testid="owned-count-label"
+              >
+                {t(variantCompletionLabelKey(variantFilter), {
+                  owned: completion.owned,
+                  total: completion.total,
+                })}
               </dd>
             </div>
             <div className="px-3 py-2 bg-gray-800/40 border border-gray-800 rounded">
@@ -624,6 +865,46 @@ export default function PokemonSetPage() {
               <dd className="text-sm font-medium text-white">{totalCards}</dd>
             </div>
           </dl>
+
+          {variantFilters.length > 1 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                id="variant-filter-label"
+                className="text-xs text-gray-400"
+              >
+                {t('set.variantFilter.label')}
+              </span>
+              <div
+                role="radiogroup"
+                aria-labelledby="variant-filter-label"
+                className="flex flex-wrap gap-1.5"
+                data-testid="variant-filter"
+              >
+                {variantFilters.map((f, i) => {
+                  const checked = f === variantFilter
+                  return (
+                    <button
+                      key={f}
+                      ref={el => { variantFilterButtonRefs.current[i] = el }}
+                      type="button"
+                      role="radio"
+                      aria-checked={checked}
+                      tabIndex={checked ? 0 : -1}
+                      onClick={() => selectVariantFilter(f)}
+                      onKeyDown={e => handleVariantFilterKeyDown(e, i)}
+                      data-variant={f}
+                      className={`px-2.5 py-1 text-xs rounded-full border cursor-pointer transition-colors
+                        ${checked
+                          ? 'bg-emerald-600/30 border-emerald-500/70 text-white'
+                          : 'bg-gray-800/60 border-gray-700 text-gray-300 hover:text-white hover:border-gray-600'}`}
+                    >
+                      {t(variantFilterLabelKey(f), { defaultValue: f })}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
 
           <div
             role="radiogroup"
@@ -680,6 +961,7 @@ export default function PokemonSetPage() {
                   <CardTile
                     key={card.id}
                     card={card}
+                    filter={variantFilter}
                     onClick={() => setLightboxStartIndex(i)}
                     t={t}
                   />

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -850,7 +850,7 @@ export default function PokemonSetPage() {
                 className="text-[11px] text-gray-400 mt-0.5"
                 data-testid="owned-count-label"
               >
-                {t(variantCompletionLabelKey(variantFilter), {
+                {t(variantCompletionLabelKey(variantFilter) as 'set.completion.any', {
                   owned: completion.owned,
                   total: completion.total,
                 })}

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -55,7 +55,8 @@ const CONDITIONS = ['', 'mint', 'near_mint', 'lightly_played', 'moderately_playe
 // (today's default). 'all' is stricter: every variant must be owned. Any other
 // value is a specific variant kind from the set (e.g. 'normal',
 // 'reverse_holofoil').
-type VariantFilter = 'any' | 'all' | string
+type VariantKind = string
+type VariantFilter = 'any' | 'all' | VariantKind
 
 // KNOWN_VARIANT_KIND_ORDER controls the chip ordering for the kinds we
 // recognise; unknown kinds fall through to the end in alphabetical order.
@@ -303,7 +304,6 @@ function CardTile({ card, filter, onClick, t }: TileProps) {
       onClick={onClick}
       data-testid={`card-tile-${card.id}`}
       aria-label={t('tile.openCard', { name: card.name, number: card.collector_no })}
-      aria-pressed={applicable ? (owned ? true : partial ? 'mixed' : false) : false}
       data-ownership={!applicable ? 'na' : owned ? 'owned' : partial ? 'partial' : 'missing'}
       className={`flex flex-col gap-2 p-2 rounded-lg border bg-gray-800/40 transition-colors text-left cursor-pointer ${tileClass}`}
     >
@@ -340,6 +340,15 @@ function CardTile({ card, filter, onClick, t }: TileProps) {
         <p className="text-xs text-gray-500">{t('tile.collectorNo', { number: card.collector_no })}</p>
         <p className="text-xs text-gray-300 mt-0.5">{formatNok(price)}</p>
       </div>
+      <span className="sr-only">
+        {!applicable
+          ? t('tile.status.na')
+          : owned
+            ? t('tile.status.owned')
+            : partial
+              ? t('tile.status.partial')
+              : t('tile.status.missing')}
+      </span>
     </button>
   )
 }


### PR DESCRIPTION
## Changes

- **Pokémon set view: variant-aware ownership filter** - Set-detail pages now expose a chip row (Any / Normal / Reverse Holo / All variants / other kinds present in the set) that controls how each tile's ownership indicator and the header completion stat are computed. Per-kind chips render dynamically based on the variants the set actually has; cards without the active variant kind are excluded from the denominator and shown as not-applicable. The active filter round-trips through the URL as `?variant=...`. (Hytte-9yhn)

## Original Issue (feature): Pokémon set view: variant-aware ownership + filter chip

The set-detail page (`web/src/pages/PokemonSet.tsx` from Hytte-te43) currently renders one tile per card and shows an "owned" indicator. With variants in play, the operator needs a clear way to ask three different questions about set completeness:

1. **"Have I collected this set at all?"** — ownership counted per CARD; if I own ANY variant of a card, it counts. (Default.)
2. **"Do I have the normal-print version of every card?"** — counted per card based on whether I own the `normal` variant.
3. **"Do I have the reverse-holo of every card?"** — same as above but for the `reverse_holofoil` variant.
4. **Same idea generalising to any other kind that has substantial coverage in the set** (e.g. `holofoil`, `1st_edition` in old sets).

Tiles must never be duplicated (one tile per card). The filter changes how each card's ownership state is computed and how the set-completion percentage at the top of the page is computed.

## UX

At the top of the set detail page, add a small filter row with chips:

    Variant: [ Any (default) | Normal | Reverse Holo | All variants ]

- **Any**: owned indicator = "I own at least one variant of this card". Set completion = cards with ANY variant owned / total cards. (Today's behaviour, just made explicit.)
- **Normal**: owned indicator = "I own the `normal` variant". Set completion = cards where normal is owned / cards that HAVE a normal variant. (Most sets: this is most cards.)
- **Reverse Holo**: same for `reverse_holofoil`. Excludes cards that don't have a reverse-holo variant from the denominator (typical for ultra rares).
- **All variants**: stricter — owned indicator = "I own EVERY variant of this card". Set completion = cards where I own all variants / total cards.

Don't render a chip for a variant kind that no card in the set has (e.g. don't show "Reverse Holo" if no card in the set has that kind). Compute the chips dynamically from the variants returned by the API for this set.

## Per-tile visual

- Each tile still shows the card art, name, collector number, and an ownership indicator.
- Under the active filter, the indicator reflects that view (checkmark / partial-checkmark / empty).
- Expand a tile (existing behaviour) shows the per-variant ownership table, unchanged — the filter only changes the at-a-glance grid.

## Backend

Most of the work can stay client-side: the existing `GET /api/pokemon/sets/{id}/cards` already returns each card with its variants and `owned` flag per variant (from Hytte-l9op). The frontend computes the filtered indicator and percentage.

Sanity-check the backend response: it should include, per variant, a boolean indicating whether the current user owns that variant. If it doesn't, extend the response — that's a tiny change.

## Set completion summary

The header "Owned: X / Y" + "Set value: Z kr" both update based on the active filter:

- "Any": X = cards with ≥1 owned variant. Set value = sum of best-priced owned variant per card.
- "Normal": X = cards where normal owned. Set value = sum of normal-variant prices for owned cards.
- "Reverse Holo": same but for reverse-holo.
- "All variants": X = cards where all variants owned. Set value = sum of all owned-variant prices.

Display the denominator clearly: "12 / 195 cards (Any variant)" so the user always knows what they're looking at.

## URL state

Reflect the active filter in the URL query string (e.g. `?variant=reverse`) so the operator can share or refresh-and-return. Default omitted = `any`.

## i18n

Add to `web/public/locales/{en,nb,th}/pokemon.json`:
- set.variantFilter.label — "Variant:"
- set.variantFilter.any / set.variantFilter.normal / set.variantFilter.reverseHolo / set.variantFilter.allVariants
- set.completion.any / set.completion.normal / set.completion.reverseHolo / set.completion.allVariants — e.g. "{{owned}} / {{total}} cards (any variant)"

## Tests

`PokemonSet.test.tsx`:
- Fixture with cards each having normal + reverse-holo variants, with mixed ownership across variants. Switching the chip changes the visible owned/missing indicators and the completion count.
- Cards with only one variant kind handle gracefully under each filter.
- URL query param round-trips through reload.

## Acceptance

- `npm run lint`, `npm run build`, `npm test -- --run src/pages/PokemonSet` all pass.
- Filter chips render dynamically based on which kinds exist in the set.
- Switching the chip immediately updates the indicator on each tile and the header completion stat.
- Default behaviour matches today (no regression for sets with only one variant kind).
- Mobile 375px works.
- Changelog fragment in changelog.d/ (category: Added).

## Non-goals

- Filtering by RARITY (Common / Holo / Ultra Rare). The bead's filter is about variant **printings**, not rarities. Rarity-based filter is a separate feature, if ever.
- Filtering in the Top Valued cards page (Hytte-0tu0) — separate context, defer.
- Filtering by acquired-at / condition. Defer.

## Reference

- web/src/pages/PokemonSet.tsx (from Hytte-te43) — the page that gets the filter chip + the changed ownership logic.
- internal/pokemon/handlers.go — `ListSetCardsHandler`, ensure the response per-variant has an `owned_by_me` boolean.
- Hytte-zoma (open, queued) for dynamic recent-eras logic — different file, no conflict.


---
Bead: Hytte-9yhn | Branch: forge/Hytte-9yhn
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->