### PR TITLE
Pokémon async scanner: schema + worker goroutine (Hytte-cgsl)

### DIFF
--- a/changelog.d/Hytte-cgsl.md
+++ b/changelog.d/Hytte-cgsl.md
@@ -1,0 +1,2 @@
+category: Added
+- **Async Pokémon scan job queue + worker** - Introduced the `pokemon_scan_jobs` table and a background worker goroutine in Hytte. The worker polls for queued vision-scan jobs, runs Claude over each card image, and writes the match outcome (`matched` / `no_match` / `failed`) back to the row. This is the foundation for the async scanner refactor — subsequent beads will swap the synchronous `/api/pokemon/scan` endpoint over to enqueue jobs and add the resolution UI. (Hytte-cgsl)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -390,6 +390,11 @@ func main() {
 		}
 	}()
 
+	// Pokémon async scan worker (Hytte-cgsl): polls pokemon_scan_jobs for
+	// queued rows and runs Claude vision in the background. Honours notifCtx
+	// so it stops cleanly on shutdown.
+	go pokemon.StartScanWorker(notifCtx, database)
+
 	// Schedule weekly Pokémon TCG full sync (Sunday 04:00 Europe/Oslo) and
 	// a daily price refresh (07:00 Europe/Oslo). Both run in the same
 	// goroutine to keep startup tidy; whichever timer fires first advances

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1684,6 +1684,33 @@ func createSchema(db *sql.DB) error {
 		PRIMARY KEY(pair, observed)
 	);
 
+	-- pokemon_scan_jobs (Hytte-cgsl): async scanner queue. The HTTP endpoint
+	-- enqueues a row with status='queued' and returns 202 immediately; a
+	-- background worker picks it up, runs Claude vision, and writes the
+	-- match outcome. Terminal statuses: matched | no_match | failed (set by
+	-- the worker), or added | discarded (set later by the resolution flow).
+	-- image_path_enc holds the encrypted absolute path to the scan image on
+	-- disk; the worker decrypts it to feed Claude's Read tool. image_hash is
+	-- the SHA-256 of the raw bytes, used for dedupe in a later bead.
+	CREATE TABLE IF NOT EXISTS pokemon_scan_jobs (
+		id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_id             INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		status              TEXT NOT NULL,
+		image_path_enc      TEXT NOT NULL,
+		image_hash          TEXT NOT NULL,
+		matched_card_id     TEXT,
+		matched_variant_id  INTEGER,
+		confidence          REAL,
+		claude_response_enc TEXT,
+		error_message       TEXT,
+		created_at          TIMESTAMP NOT NULL,
+		processed_at        TIMESTAMP,
+		resolved_at         TIMESTAMP,
+		FOREIGN KEY (matched_card_id) REFERENCES pokemon_cards(id) ON DELETE SET NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_pokemon_scan_jobs_user_status ON pokemon_scan_jobs(user_id, status);
+	CREATE INDEX IF NOT EXISTS idx_pokemon_scan_jobs_queued ON pokemon_scan_jobs(status, created_at) WHERE status = 'queued';
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1695,7 +1695,7 @@ func createSchema(db *sql.DB) error {
 	CREATE TABLE IF NOT EXISTS pokemon_scan_jobs (
 		id                  INTEGER PRIMARY KEY AUTOINCREMENT,
 		user_id             INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-		status              TEXT NOT NULL,
+		status              TEXT NOT NULL CHECK (status IN ('queued','processing','matched','no_match','failed','added','discarded')),
 		image_path_enc      TEXT NOT NULL,
 		image_hash          TEXT NOT NULL,
 		matched_card_id     TEXT,

--- a/internal/pokemon/scan_worker.go
+++ b/internal/pokemon/scan_worker.go
@@ -1,0 +1,336 @@
+package pokemon
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+// scanWorkerMaxConcurrent caps the number of Claude vision calls the worker
+// has in flight at once. Two is a deliberate trade-off: the kids may scan a
+// stack of cards in quick succession, but each Claude call uses meaningful
+// quota and the CLI sub-process is heavy. Two keeps interactive scanning
+// responsive without melting the rate limit.
+const scanWorkerMaxConcurrent = 2
+
+// scanWorkerPollInterval is how often the worker checks for new queued jobs.
+// Five seconds keeps the user-perceived latency low (queue endpoint returns
+// 202; the worker picks it up within a few seconds) without hammering the DB.
+const scanWorkerPollInterval = 5 * time.Second
+
+// scanWorkerBatchSize bounds the queued rows fetched per tick. The poll runs
+// often enough that a small batch is sufficient; a larger batch only matters
+// during catch-up after a restart.
+const scanWorkerBatchSize = 10
+
+// scanJobStatus enumerates the lifecycle values stored in
+// pokemon_scan_jobs.status. The worker only writes queued → processing →
+// {matched, no_match, failed}; later beads add the {added, discarded}
+// resolution transitions.
+const (
+	scanJobStatusQueued     = "queued"
+	scanJobStatusProcessing = "processing"
+	scanJobStatusMatched    = "matched"
+	scanJobStatusNoMatch    = "no_match"
+	scanJobStatusFailed     = "failed"
+)
+
+// scanJob is the worker's internal view of a pokemon_scan_jobs row. The
+// HTTP endpoint (next bead) writes these; the worker only reads + updates.
+type scanJob struct {
+	ID           int64
+	UserID       int64
+	ImagePathEnc string
+}
+
+// scanImageRoot returns the base directory under which scan images are
+// stored. Honours UPLOAD_ROOT for deploys that mount a dedicated volume; the
+// production server's default is /var/lib/hytte. The directory is not
+// created here — ScanImagePath does that lazily per-user.
+func scanImageRoot() string {
+	if root := os.Getenv("UPLOAD_ROOT"); root != "" {
+		return filepath.Join(root, "pokemon-scans")
+	}
+	return "/var/lib/hytte/pokemon-scans"
+}
+
+// ScanImagePath returns the absolute path where the scan image for the given
+// (user, job) should live: <root>/<user_id>/<job_id>.jpg. The per-user
+// directory is created lazily with 0700 permissions so one user's scans are
+// not readable by another. Callers must already hold the bytes — this helper
+// does not touch the file itself.
+func ScanImagePath(userID, jobID int64) (string, error) {
+	dir := filepath.Join(scanImageRoot(), strconv.FormatInt(userID, 10))
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("create scan image dir %s: %w", dir, err)
+	}
+	return filepath.Join(dir, fmt.Sprintf("%d.jpg", jobID)), nil
+}
+
+// StartScanWorker runs the async scanner worker until ctx is cancelled. It
+// polls pokemon_scan_jobs for queued rows, claims them atomically, and
+// processes up to scanWorkerMaxConcurrent at a time. On shutdown it waits for
+// in-flight jobs to reach a terminal state so no row is left in 'processing'.
+//
+// Call site: a single `go pokemon.StartScanWorker(notifCtx, db)` from
+// cmd/server/main.go, alongside the suggestion-scheduler and other
+// long-running background routines.
+func StartScanWorker(ctx context.Context, db *sql.DB) {
+	sem := make(chan struct{}, scanWorkerMaxConcurrent)
+	var wg sync.WaitGroup
+
+	ticker := time.NewTicker(scanWorkerPollInterval)
+	defer ticker.Stop()
+
+	// Run one immediate tick so a row enqueued just before startup is picked
+	// up without waiting a full interval. This mirrors the currency sync
+	// pattern (best-effort startup pass before entering the ticker loop).
+	dispatchScanJobs(ctx, db, sem, &wg)
+
+	for {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		case <-ticker.C:
+			dispatchScanJobs(ctx, db, sem, &wg)
+		}
+	}
+}
+
+// dispatchScanJobs polls a single batch and spawns processor goroutines up to
+// the semaphore limit. If the context is cancelled mid-dispatch we stop
+// enqueueing new work — in-flight goroutines complete on their own.
+func dispatchScanJobs(ctx context.Context, db *sql.DB, sem chan struct{}, wg *sync.WaitGroup) {
+	if ctx.Err() != nil {
+		return
+	}
+	jobs, err := pollQueuedScanJobs(ctx, db, scanWorkerBatchSize)
+	if err != nil {
+		log.Printf("pokemon: scan worker poll: %v", err)
+		return
+	}
+	for _, job := range jobs {
+		select {
+		case <-ctx.Done():
+			return
+		case sem <- struct{}{}:
+		}
+		wg.Add(1)
+		go func(j scanJob) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			processScanJob(ctx, db, j)
+		}(job)
+	}
+}
+
+// pollQueuedScanJobs returns up to limit queued rows ordered by created_at so
+// the oldest queued scan runs first. Only the columns the worker needs are
+// read; the row is fully claimed (status='processing') inside processScanJob.
+func pollQueuedScanJobs(ctx context.Context, db *sql.DB, limit int) ([]scanJob, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, user_id, image_path_enc
+		FROM pokemon_scan_jobs
+		WHERE status = ?
+		ORDER BY created_at, id
+		LIMIT ?
+	`, scanJobStatusQueued, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query queued scan jobs: %w", err)
+	}
+	defer rows.Close()
+
+	var jobs []scanJob
+	for rows.Next() {
+		var j scanJob
+		if err := rows.Scan(&j.ID, &j.UserID, &j.ImagePathEnc); err != nil {
+			return nil, fmt.Errorf("scan queued row: %w", err)
+		}
+		jobs = append(jobs, j)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate queued rows: %w", err)
+	}
+	return jobs, nil
+}
+
+// claimScanJob atomically transitions a row from queued → processing. It
+// returns true when this caller won the claim, false when another worker
+// already picked the row (or it has moved on to a terminal state). Using
+// status as part of the WHERE clause means concurrent workers — including
+// future horizontally-scaled instances — never both process the same job.
+func claimScanJob(ctx context.Context, db *sql.DB, jobID int64) (bool, error) {
+	res, err := db.ExecContext(ctx, `
+		UPDATE pokemon_scan_jobs
+		SET status = ?, processed_at = ?
+		WHERE id = ? AND status = ?
+	`, scanJobStatusProcessing, time.Now().UTC(), jobID, scanJobStatusQueued)
+	if err != nil {
+		return false, fmt.Errorf("claim scan job %d: %w", jobID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("claim scan job %d rows affected: %w", jobID, err)
+	}
+	return n == 1, nil
+}
+
+// processScanJob runs a single queued job end-to-end. It is structured so
+// that every exit path lands in a terminal status — a panic or unexpected
+// error must never leave the row stuck in 'processing'. The function never
+// returns an error: failures are recorded on the row itself via
+// finalizeScanJob.
+func processScanJob(ctx context.Context, db *sql.DB, job scanJob) {
+	// finalizeCtx is used for the final UPDATE so a parent-context cancellation
+	// mid-job still records the terminal state. We give it a short deadline to
+	// avoid blocking shutdown indefinitely if the DB itself is unhealthy.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("pokemon: scan worker panic on job %d: %v", job.ID, r)
+			finalizeScanJobFailed(db, job.ID, fmt.Sprintf("worker panic: %v", r))
+		}
+	}()
+
+	claimed, err := claimScanJob(ctx, db, job.ID)
+	if err != nil {
+		log.Printf("pokemon: scan worker claim job %d: %v", job.ID, err)
+		return
+	}
+	if !claimed {
+		// Another instance picked it up, or the row was already terminal.
+		return
+	}
+
+	imagePath, err := encryption.DecryptField(job.ImagePathEnc)
+	if err != nil {
+		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("decrypt image path: %v", err))
+		return
+	}
+	if imagePath == "" {
+		finalizeScanJobFailed(db, job.ID, "empty image path")
+		return
+	}
+	if _, err := os.Stat(imagePath); err != nil {
+		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("stat image: %v", err))
+		return
+	}
+
+	cfg, err := training.LoadClaudeConfig(db, job.UserID)
+	if err != nil {
+		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("load claude config: %v", err))
+		return
+	}
+	if !cfg.Enabled {
+		finalizeScanJobFailed(db, job.ID, "claude is not enabled for this user")
+		return
+	}
+
+	raw, err := scanRunPromptFn(ctx, cfg, scanPrompt, imagePath)
+	if err != nil {
+		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("claude scan: %v", err))
+		return
+	}
+
+	respEnc, encErr := encryption.EncryptField(raw)
+	if encErr != nil {
+		// A failed encrypt of the raw response is not fatal — we'd still
+		// like to record the match outcome. Log and continue with a NULL
+		// claude_response_enc.
+		log.Printf("pokemon: scan worker encrypt response for job %d: %v", job.ID, encErr)
+		respEnc = ""
+	}
+
+	result, parseErr := parseClaudeScanResult(raw)
+	if parseErr != nil {
+		finalizeScanJobNoMatch(db, job.ID, 0, fmt.Sprintf("could not parse vision response: %v", parseErr), respEnc)
+		return
+	}
+	if result.Confidence < scanConfidenceThreshold {
+		finalizeScanJobNoMatch(db, job.ID, result.Confidence, "low confidence", respEnc)
+		return
+	}
+
+	candidates, reason, err := findScanCandidates(ctx, db, job.UserID, result)
+	if err != nil {
+		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("find candidates: %v", err))
+		return
+	}
+	if len(candidates) == 0 {
+		if reason == "" {
+			reason = "no candidate found"
+		}
+		finalizeScanJobNoMatch(db, job.ID, result.Confidence, reason, respEnc)
+		return
+	}
+
+	// Multiple candidates are still a 'matched' outcome — the resolution UI
+	// (next bead) lets the user pick. We record the first candidate's card id
+	// so the row has a non-null reference; variant id stays NULL because the
+	// user picks the specific kind (normal vs reverse vs holo) during resolve.
+	matched := candidates[0]
+	finalizeScanJobMatched(db, job.ID, matched.Card.ID, result.Confidence, respEnc)
+}
+
+// finalizeScanJobMatched sets the terminal 'matched' state. Uses a short
+// background deadline so a cancelled parent context does not lose the result.
+func finalizeScanJobMatched(db *sql.DB, jobID int64, cardID string, confidence float64, respEnc string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := db.ExecContext(ctx, `
+		UPDATE pokemon_scan_jobs
+		SET status = ?, matched_card_id = ?, confidence = ?, claude_response_enc = ?, error_message = NULL
+		WHERE id = ?
+	`, scanJobStatusMatched, cardID, confidence, nullIfEmpty(respEnc), jobID); err != nil {
+		log.Printf("pokemon: finalize matched scan job %d: %v", jobID, err)
+	}
+}
+
+// finalizeScanJobNoMatch sets the terminal 'no_match' state with the supplied
+// reason in error_message. The Claude response (if encryptable) is preserved
+// for debugging.
+func finalizeScanJobNoMatch(db *sql.DB, jobID int64, confidence float64, reason, respEnc string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := db.ExecContext(ctx, `
+		UPDATE pokemon_scan_jobs
+		SET status = ?, confidence = ?, error_message = ?, claude_response_enc = ?
+		WHERE id = ?
+	`, scanJobStatusNoMatch, confidence, reason, nullIfEmpty(respEnc), jobID); err != nil {
+		log.Printf("pokemon: finalize no_match scan job %d: %v", jobID, err)
+	}
+}
+
+// finalizeScanJobFailed sets the terminal 'failed' state with the error
+// message. Used for infrastructure failures (disk, Claude CLI, DB) — distinct
+// from no_match which means "Claude returned no usable answer".
+func finalizeScanJobFailed(db *sql.DB, jobID int64, message string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := db.ExecContext(ctx, `
+		UPDATE pokemon_scan_jobs
+		SET status = ?, error_message = ?
+		WHERE id = ?
+	`, scanJobStatusFailed, message, jobID); err != nil {
+		log.Printf("pokemon: finalize failed scan job %d: %v", jobID, err)
+	}
+}
+
+// nullIfEmpty returns nil for an empty string so the column stores SQL NULL
+// rather than the empty TEXT — keeps the schema clean and lets "has response"
+// queries use IS NOT NULL.
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/pokemon/scan_worker.go
+++ b/internal/pokemon/scan_worker.go
@@ -169,12 +169,15 @@ func pollQueuedScanJobs(ctx context.Context, db *sql.DB, limit int) ([]scanJob, 
 // already picked the row (or it has moved on to a terminal state). Using
 // status as part of the WHERE clause means concurrent workers — including
 // future horizontally-scaled instances — never both process the same job.
+// processed_at is intentionally NOT set here — it is written by the finalize
+// helpers when the job reaches a terminal state so the column reflects
+// completion time, not claim time.
 func claimScanJob(ctx context.Context, db *sql.DB, jobID int64) (bool, error) {
 	res, err := db.ExecContext(ctx, `
 		UPDATE pokemon_scan_jobs
-		SET status = ?, processed_at = ?
+		SET status = ?
 		WHERE id = ? AND status = ?
-	`, scanJobStatusProcessing, time.Now().UTC(), jobID, scanJobStatusQueued)
+	`, scanJobStatusProcessing, jobID, scanJobStatusQueued)
 	if err != nil {
 		return false, fmt.Errorf("claim scan job %d: %w", jobID, err)
 	}
@@ -283,44 +286,47 @@ func processScanJob(ctx context.Context, db *sql.DB, job scanJob) {
 
 // finalizeScanJobMatched sets the terminal 'matched' state. Uses a short
 // background deadline so a cancelled parent context does not lose the result.
+// processed_at is stamped here (not at claim time) so it reflects when the
+// worker actually finished the job.
 func finalizeScanJobMatched(db *sql.DB, jobID int64, cardID string, confidence float64, respEnc string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if _, err := db.ExecContext(ctx, `
 		UPDATE pokemon_scan_jobs
-		SET status = ?, matched_card_id = ?, confidence = ?, claude_response_enc = ?, error_message = NULL
+		SET status = ?, matched_card_id = ?, confidence = ?, claude_response_enc = ?, error_message = NULL, processed_at = ?
 		WHERE id = ?
-	`, scanJobStatusMatched, cardID, confidence, nullIfEmpty(respEnc), jobID); err != nil {
+	`, scanJobStatusMatched, cardID, confidence, nullIfEmpty(respEnc), time.Now().UTC(), jobID); err != nil {
 		log.Printf("pokemon: finalize matched scan job %d: %v", jobID, err)
 	}
 }
 
 // finalizeScanJobNoMatch sets the terminal 'no_match' state with the supplied
 // reason in error_message. The Claude response (if encryptable) is preserved
-// for debugging.
+// for debugging. processed_at is stamped here on completion.
 func finalizeScanJobNoMatch(db *sql.DB, jobID int64, confidence float64, reason, respEnc string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if _, err := db.ExecContext(ctx, `
 		UPDATE pokemon_scan_jobs
-		SET status = ?, confidence = ?, error_message = ?, claude_response_enc = ?
+		SET status = ?, confidence = ?, error_message = ?, claude_response_enc = ?, processed_at = ?
 		WHERE id = ?
-	`, scanJobStatusNoMatch, confidence, reason, nullIfEmpty(respEnc), jobID); err != nil {
+	`, scanJobStatusNoMatch, confidence, reason, nullIfEmpty(respEnc), time.Now().UTC(), jobID); err != nil {
 		log.Printf("pokemon: finalize no_match scan job %d: %v", jobID, err)
 	}
 }
 
 // finalizeScanJobFailed sets the terminal 'failed' state with the error
 // message. Used for infrastructure failures (disk, Claude CLI, DB) — distinct
-// from no_match which means "Claude returned no usable answer".
+// from no_match which means "Claude returned no usable answer". processed_at
+// is stamped here on completion.
 func finalizeScanJobFailed(db *sql.DB, jobID int64, message string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if _, err := db.ExecContext(ctx, `
 		UPDATE pokemon_scan_jobs
-		SET status = ?, error_message = ?
+		SET status = ?, error_message = ?, processed_at = ?
 		WHERE id = ?
-	`, scanJobStatusFailed, message, jobID); err != nil {
+	`, scanJobStatusFailed, message, time.Now().UTC(), jobID); err != nil {
 		log.Printf("pokemon: finalize failed scan job %d: %v", jobID, err)
 	}
 }

--- a/internal/pokemon/scan_worker_test.go
+++ b/internal/pokemon/scan_worker_test.go
@@ -1,0 +1,484 @@
+package pokemon
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/Robin831/Hytte/internal/training"
+)
+
+// writeTempScanImage writes a tiny PNG-ish payload to a temp file and returns
+// (path, sha256_hex). The bytes are not a real image — the worker does not
+// inspect them; that is the HTTP endpoint's job (next bead). All the worker
+// needs is a readable path on disk.
+func writeTempScanImage(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "card.png")
+	payload := append([]byte{0x89, 0x50, 0x4E, 0x47}, []byte("scan-worker-test")...)
+	if err := os.WriteFile(path, payload, 0600); err != nil {
+		t.Fatalf("write temp image: %v", err)
+	}
+	sum := sha256.Sum256(payload)
+	return path, hex.EncodeToString(sum[:])
+}
+
+// enqueueScanJob inserts a queued pokemon_scan_jobs row with the supplied
+// on-disk image path (encrypted via encryption.EncryptField, just like the
+// production enqueue path will).
+func enqueueScanJob(t *testing.T, db *sql.DB, userID int64, imagePath, imageHash string) int64 {
+	t.Helper()
+	enc, err := encryption.EncryptField(imagePath)
+	if err != nil {
+		t.Fatalf("encrypt image path: %v", err)
+	}
+	res, err := db.Exec(`
+		INSERT INTO pokemon_scan_jobs (user_id, status, image_path_enc, image_hash, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, userID, scanJobStatusQueued, enc, imageHash, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("enqueue scan job: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	return id
+}
+
+// scanJobRow is the test-side view of the row, exposing the columns assertions
+// care about. claude_response_enc + image_hash are read as nullable because
+// the helper inserts and the worker writes them in different code paths.
+type scanJobRow struct {
+	Status         string
+	MatchedCardID  sql.NullString
+	MatchedVariant sql.NullInt64
+	Confidence     sql.NullFloat64
+	ErrorMessage   sql.NullString
+	ResponseEnc    sql.NullString
+	ProcessedAt    sql.NullTime
+}
+
+func readScanJob(t *testing.T, db *sql.DB, jobID int64) scanJobRow {
+	t.Helper()
+	var row scanJobRow
+	err := db.QueryRow(`
+		SELECT status, matched_card_id, matched_variant_id, confidence,
+		       error_message, claude_response_enc, processed_at
+		FROM pokemon_scan_jobs WHERE id = ?
+	`, jobID).Scan(&row.Status, &row.MatchedCardID, &row.MatchedVariant,
+		&row.Confidence, &row.ErrorMessage, &row.ResponseEnc, &row.ProcessedAt)
+	if err != nil {
+		t.Fatalf("read scan job %d: %v", jobID, err)
+	}
+	return row
+}
+
+func TestProcessScanJob_HappyPath(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	stubScanPrompt(t, `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"025","confidence":0.92}`, nil)
+
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	row := readScanJob(t, db, jobID)
+	if row.Status != scanJobStatusMatched {
+		t.Fatalf("expected status=matched, got %q (err=%q)", row.Status, row.ErrorMessage.String)
+	}
+	if !row.MatchedCardID.Valid || row.MatchedCardID.String != "sv1-25" {
+		t.Errorf("expected matched_card_id=sv1-25, got %+v", row.MatchedCardID)
+	}
+	if !row.Confidence.Valid || row.Confidence.Float64 != 0.92 {
+		t.Errorf("expected confidence=0.92, got %+v", row.Confidence)
+	}
+	if !row.ResponseEnc.Valid || row.ResponseEnc.String == "" {
+		t.Errorf("expected claude_response_enc to be populated, got %+v", row.ResponseEnc)
+	}
+	if !row.ProcessedAt.Valid {
+		t.Errorf("expected processed_at to be set")
+	}
+}
+
+func TestProcessScanJob_MalformedJSON_NoMatch(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	stubScanPrompt(t, "i give up", nil)
+
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	row := readScanJob(t, db, jobID)
+	if row.Status != scanJobStatusNoMatch {
+		t.Fatalf("expected status=no_match on malformed JSON, got %q", row.Status)
+	}
+	if !row.ErrorMessage.Valid || row.ErrorMessage.String == "" {
+		t.Errorf("expected error_message to describe parse failure, got %+v", row.ErrorMessage)
+	}
+}
+
+func TestProcessScanJob_ClaudeError_Failed(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	stubScanPrompt(t, "", &stubError{msg: "claude CLI exploded"})
+
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	row := readScanJob(t, db, jobID)
+	if row.Status != scanJobStatusFailed {
+		t.Fatalf("expected status=failed on Claude error, got %q", row.Status)
+	}
+	if !row.ErrorMessage.Valid || row.ErrorMessage.String == "" {
+		t.Errorf("expected error_message to be populated, got %+v", row.ErrorMessage)
+	}
+}
+
+func TestProcessScanJob_LowConfidence_NoMatch(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	stubScanPrompt(t, `{"set_name":"x","set_id_hint":"","collector_number":"025","confidence":0.1}`, nil)
+
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	row := readScanJob(t, db, jobID)
+	if row.Status != scanJobStatusNoMatch {
+		t.Fatalf("expected status=no_match on low confidence, got %q", row.Status)
+	}
+	if !row.Confidence.Valid || row.Confidence.Float64 != 0.1 {
+		t.Errorf("expected confidence=0.1, got %+v", row.Confidence)
+	}
+	if row.ErrorMessage.String == "" {
+		t.Errorf("expected reason in error_message")
+	}
+}
+
+func TestProcessScanJob_NoCardMatch_NoMatch(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	// High confidence but a collector number that doesn't exist in the seed.
+	stubScanPrompt(t, `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"999","confidence":0.9}`, nil)
+
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	row := readScanJob(t, db, jobID)
+	if row.Status != scanJobStatusNoMatch {
+		t.Fatalf("expected status=no_match when no card found, got %q", row.Status)
+	}
+	if !row.Confidence.Valid || row.Confidence.Float64 != 0.9 {
+		t.Errorf("expected confidence to pass through, got %+v", row.Confidence)
+	}
+}
+
+func TestProcessScanJob_MissingImageFile_Failed(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	// Reference a file that does not exist on disk.
+	missingPath := filepath.Join(t.TempDir(), "does-not-exist.png")
+	jobID := enqueueScanJob(t, db, u.ID, missingPath, "deadbeef")
+
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, missingPath)})
+
+	row := readScanJob(t, db, jobID)
+	if row.Status != scanJobStatusFailed {
+		t.Fatalf("expected status=failed on missing image, got %q (err=%q)", row.Status, row.ErrorMessage.String)
+	}
+}
+
+func TestProcessScanJob_ClaudeDisabled_Failed(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	// Intentionally do NOT enable Claude for this user.
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	row := readScanJob(t, db, jobID)
+	if row.Status != scanJobStatusFailed {
+		t.Fatalf("expected status=failed when claude disabled, got %q", row.Status)
+	}
+}
+
+// TestStartScanWorker_ProcessesQueuedJobs spins up the actual polling loop
+// and verifies it picks up rows and writes terminal states. The poll interval
+// is left at the production default; we cancel the worker as soon as both
+// jobs reach a terminal status.
+func TestStartScanWorker_ProcessesQueuedJobs(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	// Track the maximum number of concurrent stub invocations so we can
+	// assert the semaphore actually let two jobs run in parallel rather than
+	// serializing them. The stub also sleeps briefly so the overlap window
+	// is wide enough to observe even on a busy CI box.
+	var inFlight atomic.Int32
+	var maxObserved atomic.Int32
+	stubScanPromptFn(t, func() (string, error) {
+		cur := inFlight.Add(1)
+		defer inFlight.Add(-1)
+		for {
+			prev := maxObserved.Load()
+			if cur <= prev || maxObserved.CompareAndSwap(prev, cur) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+		return `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"025","confidence":0.9}`, nil
+	})
+
+	imagePath1, hash1 := writeTempScanImage(t)
+	imagePath2, hash2 := writeTempScanImage(t)
+	job1 := enqueueScanJob(t, db, u.ID, imagePath1, hash1)
+	job2 := enqueueScanJob(t, db, u.ID, imagePath2, hash2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartScanWorker(ctx, db)
+		close(done)
+	}()
+
+	// Wait for both jobs to land in a terminal state. The worker runs an
+	// immediate dispatch tick at startup, so we shouldn't have to wait long.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		r1 := readScanJob(t, db, job1)
+		r2 := readScanJob(t, db, job2)
+		if r1.Status != scanJobStatusQueued && r1.Status != scanJobStatusProcessing &&
+			r2.Status != scanJobStatusQueued && r2.Status != scanJobStatusProcessing {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	r1 := readScanJob(t, db, job1)
+	r2 := readScanJob(t, db, job2)
+	if r1.Status != scanJobStatusMatched {
+		t.Errorf("job1 expected matched, got %q (err=%q)", r1.Status, r1.ErrorMessage.String)
+	}
+	if r2.Status != scanJobStatusMatched {
+		t.Errorf("job2 expected matched, got %q (err=%q)", r2.Status, r2.ErrorMessage.String)
+	}
+	if maxObserved.Load() < 1 {
+		t.Errorf("expected stub to have been called at least once, got max in-flight %d", maxObserved.Load())
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("worker did not shut down after context cancel")
+	}
+}
+
+// TestStartScanWorker_ShutsDownOnCancel verifies the worker returns promptly
+// when its context is cancelled, even with no work in flight.
+func TestStartScanWorker_ShutsDownOnCancel(t *testing.T) {
+	db := setupTestDB(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		StartScanWorker(ctx, db)
+		close(done)
+	}()
+
+	// Cancel right away — there is no queued work, so the worker should be
+	// idle on the ticker channel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("worker did not shut down after context cancel")
+	}
+}
+
+// TestPollQueuedScanJobs_OrdersByCreatedAt asserts FIFO behaviour so the
+// kid scanning a card first does not get jumped by a later submitter.
+func TestPollQueuedScanJobs_OrdersByCreatedAt(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "scan@example.com")
+
+	// Insert two rows with explicit timestamps so ordering is deterministic.
+	older := time.Now().UTC().Add(-time.Hour)
+	newer := time.Now().UTC()
+	mustInsertScanJob(t, db, u.ID, "first.png", "h1", older)
+	mustInsertScanJob(t, db, u.ID, "second.png", "h2", newer)
+
+	jobs, err := pollQueuedScanJobs(context.Background(), db, 10)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(jobs))
+	}
+	if got, _ := encryption.DecryptField(jobs[0].ImagePathEnc); got != "first.png" {
+		t.Errorf("expected first.png first, got %q", got)
+	}
+}
+
+// TestClaimScanJob_OnceOnly proves the atomic claim works: a second call for
+// the same id returns false, so two workers cannot process the same row.
+func TestClaimScanJob_OnceOnly(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "scan@example.com")
+	jobID := mustInsertScanJob(t, db, u.ID, "img.png", "h", time.Now().UTC())
+
+	ok, err := claimScanJob(context.Background(), db, jobID)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if !ok {
+		t.Fatalf("first claim should succeed")
+	}
+
+	ok, err = claimScanJob(context.Background(), db, jobID)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if ok {
+		t.Fatalf("second claim should fail (row no longer queued)")
+	}
+}
+
+// TestScanImagePath_CreatesPerUserDir confirms the per-user directory is
+// created with the correct permissions and that the returned path follows
+// the documented layout.
+func TestScanImagePath_CreatesPerUserDir(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+
+	path, err := ScanImagePath(42, 7)
+	if err != nil {
+		t.Fatalf("ScanImagePath: %v", err)
+	}
+	expected := filepath.Join(root, "pokemon-scans", "42", "7.jpg")
+	if path != expected {
+		t.Errorf("expected %q, got %q", expected, path)
+	}
+	dir := filepath.Dir(path)
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected directory, got %s", info.Mode())
+	}
+	// Permission check skipped on Windows.
+	if info.Mode().Perm()&0077 != 0 {
+		t.Errorf("expected 0700 perms (no group/other), got %o", info.Mode().Perm())
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+// stubError is the error type returned from the stub Claude function in
+// failure tests. Using a dedicated type keeps the assertion explicit.
+type stubError struct{ msg string }
+
+func (e *stubError) Error() string { return e.msg }
+
+// encryptPath is a test helper that encrypts a plaintext on-disk path using
+// the same encryption layer the production enqueue path will use.
+func encryptPath(t *testing.T, path string) string {
+	t.Helper()
+	enc, err := encryption.EncryptField(path)
+	if err != nil {
+		t.Fatalf("encrypt path: %v", err)
+	}
+	return enc
+}
+
+// mustInsertScanJob inserts a queued scan job with a caller-supplied
+// created_at so tests can deterministically assert ordering.
+func mustInsertScanJob(t *testing.T, db *sql.DB, userID int64, imagePath, imageHash string, createdAt time.Time) int64 {
+	t.Helper()
+	enc, err := encryption.EncryptField(imagePath)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	res, err := db.Exec(`
+		INSERT INTO pokemon_scan_jobs (user_id, status, image_path_enc, image_hash, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, userID, scanJobStatusQueued, enc, imageHash, createdAt)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last id: %v", err)
+	}
+	return id
+}
+
+// stubScanPromptFn replaces scanRunPromptFn with a closure that delegates to
+// fn (a parameterless function returning the canned response + error). The
+// original is restored on t.Cleanup. Used by the concurrency test which
+// needs to track in-flight callers, not just the call count.
+//
+// Wrapped here (rather than reusing stubScanPrompt) because the existing
+// helper takes a fixed response and we need the closure to observe state.
+var stubScanPromptMu sync.Mutex
+
+func stubScanPromptFn(t *testing.T, fn func() (string, error)) {
+	t.Helper()
+	stubScanPromptMu.Lock()
+	defer stubScanPromptMu.Unlock()
+	orig := scanRunPromptFn
+	scanRunPromptFn = func(_ context.Context, _ *training.ClaudeConfig, _, _ string) (string, error) {
+		return fn()
+	}
+	t.Cleanup(func() {
+		stubScanPromptMu.Lock()
+		defer stubScanPromptMu.Unlock()
+		scanRunPromptFn = orig
+	})
+}

--- a/internal/pokemon/scan_worker_test.go
+++ b/internal/pokemon/scan_worker_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -305,8 +306,8 @@ func TestStartScanWorker_ProcessesQueuedJobs(t *testing.T) {
 	if r2.Status != scanJobStatusMatched {
 		t.Errorf("job2 expected matched, got %q (err=%q)", r2.Status, r2.ErrorMessage.String)
 	}
-	if maxObserved.Load() < 1 {
-		t.Errorf("expected stub to have been called at least once, got max in-flight %d", maxObserved.Load())
+	if maxObserved.Load() < int32(scanWorkerMaxConcurrent) {
+		t.Errorf("expected max in-flight to reach %d (scanWorkerMaxConcurrent), got %d", scanWorkerMaxConcurrent, maxObserved.Load())
 	}
 
 	cancel()
@@ -338,6 +339,65 @@ func TestStartScanWorker_ShutsDownOnCancel(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatalf("worker did not shut down after context cancel")
+	}
+}
+
+// TestStartScanWorker_CancelMidJob verifies the worker shuts down cleanly and
+// leaves no row stuck in 'processing' when the context is cancelled while a
+// Claude call is in-flight.
+func TestStartScanWorker_CancelMidJob(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	// entered is closed the moment the stub is entered so the test knows the
+	// job is in-flight before it cancels the worker context.
+	entered := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stubScanPromptFn(t, func() (string, error) {
+		close(entered)
+		// Block until the worker context is cancelled, simulating a long-running
+		// Claude call that is interrupted mid-flight.
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+
+	done := make(chan struct{})
+	go func() {
+		StartScanWorker(ctx, db)
+		close(done)
+	}()
+
+	// Wait until the job is actually in-flight before pulling the plug.
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("stub never entered — job was not picked up by the worker")
+	}
+
+	// Cancel the worker context while the Claude call is still blocking.
+	cancel()
+
+	// The worker must drain in-flight goroutines and then exit.
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("worker did not shut down after context cancel")
+	}
+
+	// The row must be in a terminal state — never stuck in 'processing'.
+	row := readScanJob(t, db, jobID)
+	if row.Status == scanJobStatusProcessing {
+		t.Errorf("job left in 'processing' state after worker shutdown — expected a terminal state")
+	}
+	if row.Status == scanJobStatusQueued {
+		t.Errorf("job left in 'queued' state — worker should have claimed and finalized it")
 	}
 }
 
@@ -412,9 +472,10 @@ func TestScanImagePath_CreatesPerUserDir(t *testing.T) {
 	if !info.IsDir() {
 		t.Errorf("expected directory, got %s", info.Mode())
 	}
-	// Permission check skipped on Windows.
-	if info.Mode().Perm()&0077 != 0 {
-		t.Errorf("expected 0700 perms (no group/other), got %o", info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		if info.Mode().Perm()&0077 != 0 {
+			t.Errorf("expected 0700 perms (no group/other), got %o", info.Mode().Perm())
+		}
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Async Pokémon scan job queue + worker** - Introduced the `pokemon_scan_jobs` table and a background worker goroutine in Hytte. The worker polls for queued vision-scan jobs, runs Claude over each card image, and writes the match outcome (`matched` / `no_match` / `failed`) back to the row. This is the foundation for the async scanner refactor — subsequent beads will swap the synchronous `/api/pokemon/scan` endpoint over to enqueue jobs and add the resolution UI. (Hytte-cgsl)

## Original Issue (feature): Pokémon async scanner: schema + worker goroutine

Foundational bead for the async-scanner refactor. Today the scanner is synchronous (POST /api/pokemon/scan blocks for 60–90 s while Claude vision runs, and the frontend stares at a spinner). New flow: scanner submits a job to a queue, returns 202 immediately, and a background worker on Hytte processes jobs and writes results back to a new table. Subsequent beads in this chain build the API surface, the cost guards, the UI, and the Scanned page.

## Scope (this bead)

### Schema (`internal/db/db.go createSchema`)

    CREATE TABLE IF NOT EXISTS pokemon_scan_jobs (
      id                  INTEGER PRIMARY KEY AUTOINCREMENT,
      user_id             INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
      status              TEXT NOT NULL,  -- 'queued' | 'processing' | 'matched' | 'no_match' | 'failed' | 'added' | 'discarded'
      image_path_enc      TEXT NOT NULL,  -- encrypted absolute path on disk
      image_hash          TEXT NOT NULL,  -- for dedupe; SHA-256 of the bytes
      matched_card_id     TEXT,
      matched_variant_id  INTEGER,
      confidence          REAL,
      claude_response_enc TEXT,           -- encrypted raw response for debugging
      error_message       TEXT,
      created_at          TIMESTAMP NOT NULL,
      processed_at        TIMESTAMP,
      resolved_at         TIMESTAMP,
      FOREIGN KEY (matched_card_id) REFERENCES pokemon_cards(id) ON DELETE SET NULL
    );
    CREATE INDEX IF NOT EXISTS idx_pokemon_scan_jobs_user_status ON pokemon_scan_jobs(user_id, status);
    CREATE INDEX IF NOT EXISTS idx_pokemon_scan_jobs_queued ON pokemon_scan_jobs(status, created_at) WHERE status = 'queued';

### Package internal/pokemon/scan_worker.go

A single worker goroutine that polls for `status='queued'` rows and processes them:

- Started from `cmd/server/main.go` mirroring the existing suggestion-scheduler pattern. Honour the existing `notifCtx` for graceful shutdown.
- Concurrency: up to 2 jobs in flight at once. Use a semaphore channel.
- For each job: load image from `image_path_enc`, call `training.RunPromptWithImage` with the existing scan prompt + Claude config for the job's user, parse the response, update the row to `matched` (with card/variant/confidence) or `no_match` (with confidence + reason in error_message) or `failed` (with error_message).
- The same JSON parsing + candidate lookup that exists in `internal/pokemon/scan.go` should be refactored into a shared helper so the worker reuses it. Keep the scan.go handler around for one bead — the next bead in the chain replaces it with a queue endpoint.
- Image cleanup: on transition to `matched`/`no_match`/`failed` keep the image on disk so the UI can display it for resolution; on transition to `added`/`discarded` (next bead) delete it.

### Encryption

`image_path_enc` and `claude_response_enc` use `encryption.EncryptField` / `DecryptField`. `error_message` is short and not sensitive — plaintext is fine for filtering.

### Storage layout for images

Pick a path under the user's data dir: `/var/lib/hytte/pokemon-scans/<user_id>/<job_id>.jpg` (or wherever `UPLOAD_ROOT` env var points). Create the dir lazily. Permissions 0700.

### Tests

- `scan_worker_test.go` exercises the worker with mocked `runPromptFn` (use the existing seam in `internal/training/claude.go`). Happy path: queued → processing → matched, row updated correctly. Sad path: queued → failed. Concurrency: two jobs in queue, both finish, no row-loss.
- Worker shuts down cleanly when ctx is cancelled mid-job.

### Non-goals (NOT in this bead)

- HTTP endpoints — next bead.
- Cost cap / dedupe — third bead.
- Frontend changes — fourth bead.
- Deleting the existing sync `ScanHandler` — next bead will swap it for the queue endpoint.

### Acceptance

- `make build`, `make test ./internal/pokemon/...`, `go vet ./...` pass.
- Schema applied on startup. Worker goroutine starts with the rest of Hytte.
- Manually inserting a row with status=queued (via sqlite3 + a real image on disk) causes the worker to process it within ~30 s and update status to matched/no_match.
- Changelog fragment in changelog.d/ (category: Added).

### Reference

- internal/pokemon/scan.go — current sync handler; the Claude prompt + parsing logic to lift into a shared helper.
- internal/training/claude.go RunPromptWithImage — what the worker calls.
- cmd/server/main.go — pattern for starting a background scheduler under notifCtx (search for "stride: nightly evaluation" or "suggestions: scheduler").


---
Bead: Hytte-cgsl | Branch: forge/Hytte-cgsl
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->