### PR TITLE
Pokémon async scanner: /pokemon/scanned page (Hytte-b1b1)

### DIFF
--- a/changelog.d/Hytte-b1b1.md
+++ b/changelog.d/Hytte-b1b1.md
@@ -1,2 +1,3 @@
 category: Added
 - **Pokémon scanned cards review page** - New `/pokemon/scanned` page lets the kid review queued, matched, no-match and failed scans, with per-row Add / Discard / Try again / Enter manually actions and a "today {used}/{cap}" badge. Polls every 30 s while visible so queued → processing → matched updates without a manual refresh. (Hytte-b1b1)
+- **Pre-fill AddCardPanel from a no-match scan** - "Enter manually" on a no-match scan row now opens the Add card dialog with the partial set name and collector number Claude could read seeded into the search input, so the kid does not have to retype what the scanner already saw. (Hytte-b1b1)

--- a/changelog.d/Hytte-b1b1.md
+++ b/changelog.d/Hytte-b1b1.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon scanned cards review page** - New `/pokemon/scanned` page lets the kid review queued, matched, no-match and failed scans, with per-row Add / Discard / Try again / Enter manually actions and a "today {used}/{cap}" badge. Polls every 30 s while visible so queued → processing → matched updates without a manual refresh. (Hytte-b1b1)

--- a/internal/pokemon/scans_handlers.go
+++ b/internal/pokemon/scans_handlers.go
@@ -65,17 +65,42 @@ const maxScanListLimit = 200
 // ScanJobDTO is the JSON shape returned by the list and resolve endpoints. It
 // captures the lifecycle state plus enough card metadata that the frontend
 // can render a matched job without a second request.
+//
+// ParsedSetName / ParsedCollectorNo carry whatever set name + collector number
+// Claude could read from a no_match scan, so the "Enter manually" flow can
+// pre-fill the AddCardPanel search even when the lookup itself failed.
 type ScanJobDTO struct {
-	ID           int64    `json:"id"`
-	Status       string   `json:"status"`
-	CreatedAt    string   `json:"created_at"`
-	ProcessedAt  *string  `json:"processed_at,omitempty"`
-	ResolvedAt   *string  `json:"resolved_at,omitempty"`
-	Confidence   *float64 `json:"confidence,omitempty"`
-	MatchedCard  *CardDTO `json:"matched_card,omitempty"`
-	Set          *SetDTO  `json:"set,omitempty"`
-	ErrorMessage string   `json:"error_message,omitempty"`
-	HasImage     bool     `json:"has_image"`
+	ID                int64    `json:"id"`
+	Status            string   `json:"status"`
+	CreatedAt         string   `json:"created_at"`
+	ProcessedAt       *string  `json:"processed_at,omitempty"`
+	ResolvedAt        *string  `json:"resolved_at,omitempty"`
+	Confidence        *float64 `json:"confidence,omitempty"`
+	MatchedCard       *CardDTO `json:"matched_card,omitempty"`
+	Set               *SetDTO  `json:"set,omitempty"`
+	ErrorMessage      string   `json:"error_message,omitempty"`
+	HasImage          bool     `json:"has_image"`
+	ParsedSetName     string   `json:"parsed_set_name,omitempty"`
+	ParsedCollectorNo string   `json:"parsed_collector_no,omitempty"`
+}
+
+// extractScanHints decrypts the stored Claude response (if any) and returns
+// the partial set name + collector number it managed to read. Used by the
+// no_match path to pre-fill manual entry — failures collapse to empty
+// strings so a corrupt blob never blocks the list response.
+func extractScanHints(claudeResponseEnc sql.NullString) (string, string) {
+	if !claudeResponseEnc.Valid || claudeResponseEnc.String == "" {
+		return "", ""
+	}
+	raw, err := encryption.DecryptField(claudeResponseEnc.String)
+	if err != nil || raw == "" {
+		return "", ""
+	}
+	res, err := parseClaudeScanResult(raw)
+	if err != nil || res == nil {
+		return "", ""
+	}
+	return strings.TrimSpace(res.SetName), strings.TrimSpace(res.CollectorNumber)
 }
 
 // scanUUID returns a 32-character hex string suitable for a per-scan image
@@ -337,7 +362,8 @@ func ListScansHandler(db *sql.DB) http.HandlerFunc {
 
 		query := `
 			SELECT id, status, image_path_enc, matched_card_id, confidence,
-			       error_message, created_at, processed_at, resolved_at
+			       error_message, created_at, processed_at, resolved_at,
+			       claude_response_enc
 			FROM pokemon_scan_jobs
 			WHERE user_id = ? AND status IN (` + strings.Join(placeholders, ",") + `)
 			ORDER BY created_at DESC, id DESC
@@ -356,18 +382,19 @@ func ListScansHandler(db *sql.DB) http.HandlerFunc {
 		jobMatched := make(map[int64]string)
 		for rows.Next() {
 			var (
-				id           int64
-				status       string
-				pathEnc      string
-				matchedCard  sql.NullString
-				confidence   sql.NullFloat64
-				errorMessage sql.NullString
-				createdAt    time.Time
-				processedAt  sql.NullTime
-				resolvedAt   sql.NullTime
+				id             int64
+				status         string
+				pathEnc        string
+				matchedCard    sql.NullString
+				confidence     sql.NullFloat64
+				errorMessage   sql.NullString
+				createdAt      time.Time
+				processedAt    sql.NullTime
+				resolvedAt     sql.NullTime
+				claudeResponse sql.NullString
 			)
 			if err := rows.Scan(&id, &status, &pathEnc, &matchedCard, &confidence,
-				&errorMessage, &createdAt, &processedAt, &resolvedAt); err != nil {
+				&errorMessage, &createdAt, &processedAt, &resolvedAt, &claudeResponse); err != nil {
 				log.Printf("pokemon: scan list row: %v", err)
 				respondError(w, http.StatusInternalServerError, "failed to list scans")
 				return
@@ -392,6 +419,9 @@ func ListScansHandler(db *sql.DB) http.HandlerFunc {
 			}
 			if errorMessage.Valid {
 				dto.ErrorMessage = errorMessage.String
+			}
+			if status == scanJobStatusNoMatch {
+				dto.ParsedSetName, dto.ParsedCollectorNo = extractScanHints(claudeResponse)
 			}
 			if matchedCard.Valid && matchedCard.String != "" {
 				jobMatched[id] = matchedCard.String
@@ -823,23 +853,25 @@ func loadCardsByIDs(ctx context.Context, db *sql.DB, userID int64, ids []string)
 // matched card and set the same way the list endpoint does.
 func loadScanJob(r *http.Request, w http.ResponseWriter, db *sql.DB, userID, jobID int64) (*ScanJobDTO, error) {
 	var (
-		id           int64
-		status       string
-		pathEnc      string
-		matchedCard  sql.NullString
-		confidence   sql.NullFloat64
-		errorMessage sql.NullString
-		createdAt    time.Time
-		processedAt  sql.NullTime
-		resolvedAt   sql.NullTime
+		id             int64
+		status         string
+		pathEnc        string
+		matchedCard    sql.NullString
+		confidence     sql.NullFloat64
+		errorMessage   sql.NullString
+		createdAt      time.Time
+		processedAt    sql.NullTime
+		resolvedAt     sql.NullTime
+		claudeResponse sql.NullString
 	)
 	err := db.QueryRowContext(r.Context(), `
 		SELECT id, status, image_path_enc, matched_card_id, confidence,
-		       error_message, created_at, processed_at, resolved_at
+		       error_message, created_at, processed_at, resolved_at,
+		       claude_response_enc
 		FROM pokemon_scan_jobs
 		WHERE id = ? AND user_id = ?
 	`, jobID, userID).Scan(&id, &status, &pathEnc, &matchedCard, &confidence,
-		&errorMessage, &createdAt, &processedAt, &resolvedAt)
+		&errorMessage, &createdAt, &processedAt, &resolvedAt, &claudeResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -863,6 +895,9 @@ func loadScanJob(r *http.Request, w http.ResponseWriter, db *sql.DB, userID, job
 	}
 	if errorMessage.Valid {
 		dto.ErrorMessage = errorMessage.String
+	}
+	if status == scanJobStatusNoMatch {
+		dto.ParsedSetName, dto.ParsedCollectorNo = extractScanHints(claudeResponse)
 	}
 	if matchedCard.Valid && matchedCard.String != "" {
 		cards, loadErr := loadCardsByIDs(r.Context(), db, userID, []string{matchedCard.String})

--- a/internal/pokemon/scans_handlers_test.go
+++ b/internal/pokemon/scans_handlers_test.go
@@ -177,13 +177,21 @@ func insertScanJob(t *testing.T, db *sql.DB, userID int64, status, imagePath str
 	for _, o := range opts {
 		o(&cfg)
 	}
+	respEnc := ""
+	if cfg.claudeResponse != "" {
+		var err error
+		respEnc, err = encryption.EncryptField(cfg.claudeResponse)
+		if err != nil {
+			t.Fatalf("encrypt claude response: %v", err)
+		}
+	}
 	res, err := db.Exec(`
 		INSERT INTO pokemon_scan_jobs (user_id, status, image_path_enc, image_hash, matched_card_id,
-			confidence, error_message, created_at, processed_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			confidence, error_message, created_at, processed_at, claude_response_enc)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, cfg.userID, cfg.status, cfg.pathEnc, cfg.imageHash, nullableString(cfg.matchedCard),
 		nullableFloat(cfg.confidence), nullableString(cfg.errorMessage), cfg.createdAt,
-		nullableTime(cfg.processedAt))
+		nullableTime(cfg.processedAt), nullableString(respEnc))
 	if err != nil {
 		t.Fatalf("insert scan job: %v", err)
 	}
@@ -195,15 +203,22 @@ func insertScanJob(t *testing.T, db *sql.DB, userID int64, status, imagePath str
 }
 
 type scanJobInsert struct {
-	userID       int64
-	status       string
-	pathEnc      string
-	imageHash    string
-	matchedCard  string
-	confidence   float64
-	errorMessage string
-	createdAt    time.Time
-	processedAt  time.Time
+	userID         int64
+	status         string
+	pathEnc        string
+	imageHash      string
+	matchedCard    string
+	confidence     float64
+	errorMessage   string
+	createdAt      time.Time
+	processedAt    time.Time
+	claudeResponse string
+}
+
+// withClaudeResponse stores the raw Claude JSON the worker captured so the
+// list endpoint can surface the parsed partial info on no_match rows.
+func withClaudeResponse(raw string) func(*scanJobInsert) {
+	return func(s *scanJobInsert) { s.claudeResponse = raw }
 }
 
 func withMatchedCard(id string, confidence float64) func(*scanJobInsert) {
@@ -300,6 +315,103 @@ func TestListScans_NewestFirst_DefaultFilter(t *testing.T) {
 	}
 	if body.Scans[0].MatchedCard == nil || body.Scans[0].MatchedCard.ID != "sv1-25" {
 		t.Errorf("expected matched card to be hydrated, got %+v", body.Scans[0].MatchedCard)
+	}
+}
+
+func TestListScans_NoMatchExposesParsedHints(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "hints@example.com")
+
+	p := writeOnDiskImage(t, root, u.ID, "no-match.jpg")
+	rawResp := `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"055","confidence":0.42}`
+	jobID := insertScanJob(t, db, u.ID, scanJobStatusNoMatch, p,
+		withError("no candidate found"),
+		withClaudeResponse(rawResp))
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/scans?status=no_match", nil), u)
+	rec := httptest.NewRecorder()
+	ListScansHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Scans []ScanJobDTO `json:"scans"`
+	}](t, rec)
+	if len(body.Scans) != 1 || body.Scans[0].ID != jobID {
+		t.Fatalf("expected single no_match row, got %+v", body.Scans)
+	}
+	got := body.Scans[0]
+	if got.ParsedSetName != "Scarlet & Violet Base" {
+		t.Errorf("expected parsed_set_name to be surfaced, got %q", got.ParsedSetName)
+	}
+	if got.ParsedCollectorNo != "055" {
+		t.Errorf("expected parsed_collector_no to be surfaced, got %q", got.ParsedCollectorNo)
+	}
+}
+
+func TestListScans_MatchedDoesNotExposeHints(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "matched-hints@example.com")
+
+	p := writeOnDiskImage(t, root, u.ID, "matched.jpg")
+	rawResp := `{"set_name":"Scarlet & Violet Base","collector_number":"025","confidence":0.95}`
+	insertScanJob(t, db, u.ID, scanJobStatusMatched, p,
+		withMatchedCard("sv1-25", 0.95),
+		withClaudeResponse(rawResp))
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/scans?status=matched", nil), u)
+	rec := httptest.NewRecorder()
+	ListScansHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := decode[struct {
+		Scans []ScanJobDTO `json:"scans"`
+	}](t, rec)
+	if len(body.Scans) != 1 {
+		t.Fatalf("expected one matched scan, got %d", len(body.Scans))
+	}
+	if body.Scans[0].ParsedSetName != "" || body.Scans[0].ParsedCollectorNo != "" {
+		t.Errorf("hints should only appear on no_match rows, got set=%q collector=%q",
+			body.Scans[0].ParsedSetName, body.Scans[0].ParsedCollectorNo)
+	}
+}
+
+func TestListScans_NoMatchWithCorruptResponse_OmitsHints(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "corrupt-hints@example.com")
+
+	p := writeOnDiskImage(t, root, u.ID, "corrupt.jpg")
+	// Garbage that parseClaudeScanResult will fail to unmarshal — the handler
+	// must still respond 200 with an empty hint pair rather than blowing up.
+	insertScanJob(t, db, u.ID, scanJobStatusNoMatch, p,
+		withError("low confidence"),
+		withClaudeResponse("not valid json"))
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/scans?status=no_match", nil), u)
+	rec := httptest.NewRecorder()
+	ListScansHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Scans []ScanJobDTO `json:"scans"`
+	}](t, rec)
+	if len(body.Scans) != 1 {
+		t.Fatalf("expected one no_match scan, got %d", len(body.Scans))
+	}
+	if body.Scans[0].ParsedSetName != "" || body.Scans[0].ParsedCollectorNo != "" {
+		t.Errorf("expected empty hints when claude_response_enc is corrupt, got set=%q collector=%q",
+			body.Scans[0].ParsedSetName, body.Scans[0].ParsedCollectorNo)
 	}
 }
 

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -141,6 +141,47 @@
     "pendingBadgeAria_one": "{{count}} scan result to review",
     "pendingBadgeAria_other": "{{count}} scan results to review"
   },
+  "scanned": {
+    "title": "Scanned cards",
+    "subtitle": "Review your recent scans",
+    "empty": "No scans yet — open the camera scanner from Add card.",
+    "todayUsage": "{{used}} / {{cap}} scans today",
+    "confidence": "{{pct}}% confidence",
+    "thumbnailAlt": "Scanned card preview",
+    "thumbnailPlaceholder": "Image no longer available",
+    "elapsed": "{{seconds}} s",
+    "loadError": "Failed to load scans",
+    "noPriceYet": "Price unavailable",
+    "filter": {
+      "label": "Filter scans",
+      "needsReview": "Needs review",
+      "pending": "Pending",
+      "resolved": "Recently resolved"
+    },
+    "status": {
+      "queued": "Queued",
+      "processing": "Processing",
+      "matched": "Matched",
+      "noMatch": "No match",
+      "failed": "Failed",
+      "added": "Added",
+      "discarded": "Discarded"
+    },
+    "action": {
+      "add": "Add to collection",
+      "addVariant": "Add as {{variant}}",
+      "discard": "Discard",
+      "retry": "Try again",
+      "enterManually": "Enter manually",
+      "pickVariant": "Pick a variant",
+      "actionFailed": "Action failed, try again"
+    },
+    "toast": {
+      "added": "Added to collection",
+      "discarded": "Discarded",
+      "retried": "Sent back to the scanner queue"
+    }
+  },
   "scanner": {
     "dialogLabel": "Scan a Pokémon card",
     "requesting": "Requesting camera access…",

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -169,7 +169,6 @@
     },
     "action": {
       "add": "Add to collection",
-      "addVariant": "Add as {{variant}}",
       "discard": "Discard",
       "retry": "Try again",
       "enterManually": "Enter manually",

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -169,7 +169,6 @@
     },
     "action": {
       "add": "Legg til i samlingen",
-      "addVariant": "Legg til som {{variant}}",
       "discard": "Forkast",
       "retry": "Prøv igjen",
       "enterManually": "Legg inn manuelt",

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -141,6 +141,47 @@
     "pendingBadgeAria_one": "{{count}} skanneresultat å se gjennom",
     "pendingBadgeAria_other": "{{count}} skanneresultater å se gjennom"
   },
+  "scanned": {
+    "title": "Skannede kort",
+    "subtitle": "Se gjennom nylige skanninger",
+    "empty": "Ingen skanninger ennå — åpne kameraskanneren fra Legg til kort.",
+    "todayUsage": "{{used}} / {{cap}} skanninger i dag",
+    "confidence": "{{pct}} % sikkerhet",
+    "thumbnailAlt": "Forhåndsvisning av skannet kort",
+    "thumbnailPlaceholder": "Bilde ikke lenger tilgjengelig",
+    "elapsed": "{{seconds}} s",
+    "loadError": "Kunne ikke laste skanninger",
+    "noPriceYet": "Pris utilgjengelig",
+    "filter": {
+      "label": "Filtrer skanninger",
+      "needsReview": "Trenger gjennomgang",
+      "pending": "Behandler",
+      "resolved": "Nylig fullført"
+    },
+    "status": {
+      "queued": "I kø",
+      "processing": "Behandler",
+      "matched": "Treff",
+      "noMatch": "Ingen treff",
+      "failed": "Mislyktes",
+      "added": "Lagt til",
+      "discarded": "Forkastet"
+    },
+    "action": {
+      "add": "Legg til i samlingen",
+      "addVariant": "Legg til som {{variant}}",
+      "discard": "Forkast",
+      "retry": "Prøv igjen",
+      "enterManually": "Legg inn manuelt",
+      "pickVariant": "Velg variant",
+      "actionFailed": "Handlingen mislyktes, prøv igjen"
+    },
+    "toast": {
+      "added": "Lagt til i samlingen",
+      "discarded": "Forkastet",
+      "retried": "Lagt tilbake i skannerkøen"
+    }
+  },
   "scanner": {
     "dialogLabel": "Skann et Pokémon-kort",
     "requesting": "Ber om tilgang til kameraet …",

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -140,6 +140,47 @@
   "nav": {
     "pendingBadgeAria_other": "ผลการสแกน {{count}} รายการรอการตรวจสอบ"
   },
+  "scanned": {
+    "title": "การ์ดที่สแกน",
+    "subtitle": "ตรวจสอบการสแกนล่าสุดของคุณ",
+    "empty": "ยังไม่มีการสแกน — เปิดเครื่องสแกนกล้องจากเมนูเพิ่มการ์ด",
+    "todayUsage": "{{used}} / {{cap}} ครั้งวันนี้",
+    "confidence": "ความมั่นใจ {{pct}}%",
+    "thumbnailAlt": "ตัวอย่างการ์ดที่สแกน",
+    "thumbnailPlaceholder": "ไม่มีภาพแล้ว",
+    "elapsed": "{{seconds}} วินาที",
+    "loadError": "โหลดรายการสแกนไม่สำเร็จ",
+    "noPriceYet": "ไม่มีราคา",
+    "filter": {
+      "label": "กรองการสแกน",
+      "needsReview": "ต้องตรวจสอบ",
+      "pending": "กำลังประมวลผล",
+      "resolved": "เพิ่งจัดการเสร็จ"
+    },
+    "status": {
+      "queued": "เข้าคิว",
+      "processing": "กำลังประมวลผล",
+      "matched": "พบการ์ดที่ตรง",
+      "noMatch": "ไม่พบที่ตรง",
+      "failed": "ล้มเหลว",
+      "added": "เพิ่มแล้ว",
+      "discarded": "ทิ้งแล้ว"
+    },
+    "action": {
+      "add": "เพิ่มเข้าคอลเลกชัน",
+      "addVariant": "เพิ่มเป็น {{variant}}",
+      "discard": "ทิ้ง",
+      "retry": "ลองอีกครั้ง",
+      "enterManually": "ใส่ด้วยตนเอง",
+      "pickVariant": "เลือกชนิด",
+      "actionFailed": "การดำเนินการล้มเหลว ลองอีกครั้ง"
+    },
+    "toast": {
+      "added": "เพิ่มเข้าคอลเลกชันแล้ว",
+      "discarded": "ทิ้งแล้ว",
+      "retried": "ส่งกลับเข้าคิวสแกนแล้ว"
+    }
+  },
   "scanner": {
     "dialogLabel": "สแกนการ์ดโปเกมอน",
     "requesting": "กำลังขออนุญาตเข้าถึงกล้อง…",

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -168,7 +168,6 @@
     },
     "action": {
       "add": "เพิ่มเข้าคอลเลกชัน",
-      "addVariant": "เพิ่มเป็น {{variant}}",
       "discard": "ทิ้ง",
       "retry": "ลองอีกครั้ง",
       "enterManually": "ใส่ด้วยตนเอง",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -76,6 +76,7 @@ import MathAchievements from './pages/MathAchievements'
 import PokemonSets from './pages/PokemonSets'
 import PokemonSet from './pages/PokemonSet'
 import PokemonTop from './pages/PokemonTop'
+import PokemonScanned from './pages/PokemonScanned'
 import { AchievementUnlockOverlay } from './components/regnemester/AchievementUnlockOverlay'
 
 function MainLayout() {
@@ -567,6 +568,14 @@ function MainLayout() {
             element={
               <FeatureRoute feature="pokemon">
                 <PokemonTop />
+              </FeatureRoute>
+            }
+          />
+          <Route
+            path="/pokemon/scanned"
+            element={
+              <FeatureRoute feature="pokemon">
+                <PokemonScanned />
               </FeatureRoute>
             }
           />

--- a/web/src/components/pokemon/AddCardPanel.tsx
+++ b/web/src/components/pokemon/AddCardPanel.tsx
@@ -60,8 +60,8 @@ export default function AddCardPanel({ onAdded, initialQuery, onInitialQueryCons
   const { t } = useTranslation('pokemon')
   const { toasts, showToast } = useToast()
 
-  const [isOpen, setIsOpen] = useState(false)
-  const [query, setQuery] = useState('')
+  const [isOpen, setIsOpen] = useState(() => !!(initialQuery?.trim()))
+  const [query, setQuery] = useState(() => initialQuery?.trim() ?? '')
   const [results, setResults] = useState<Card[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -70,15 +70,21 @@ export default function AddCardPanel({ onAdded, initialQuery, onInitialQueryCons
   const [scannerOpen, setScannerOpen] = useState(false)
   const [lightboxStartIndex, setLightboxStartIndex] = useState<number | null>(null)
 
-  // Consume initialQuery once on mount (and whenever the parent supplies a new
-  // non-empty value). Notify the parent so it can drop the value from its own
-  // state / location.state — otherwise the dialog would re-open on every
-  // re-render.
+  // Sync query/open state when parent supplies a new initialQuery after mount.
+  // Using derived state (setState during render) rather than useEffect to avoid
+  // the react-hooks/set-state-in-effect lint rule.
+  const [prevInitialQuery, setPrevInitialQuery] = useState(initialQuery)
+  if (initialQuery !== prevInitialQuery) {
+    setPrevInitialQuery(initialQuery)
+    if (initialQuery?.trim()) {
+      setQuery(initialQuery.trim())
+      setIsOpen(true)
+    }
+  }
+
+  // Side effect only: notify parent that the initial query has been consumed.
   useEffect(() => {
-    const seed = initialQuery?.trim()
-    if (!seed) return
-    setQuery(seed)
-    setIsOpen(true)
+    if (!initialQuery?.trim()) return
     onInitialQueryConsumed?.()
   }, [initialQuery, onInitialQueryConsumed])
 

--- a/web/src/components/pokemon/AddCardPanel.tsx
+++ b/web/src/components/pokemon/AddCardPanel.tsx
@@ -47,9 +47,16 @@ function formatNok(amount: number | null | undefined): string {
 
 interface AddCardPanelProps {
   onAdded?: () => void
+  // initialQuery, when set, auto-opens the panel and seeds the search field on
+  // mount. Used by the scan review page's "Enter manually" action so the kid
+  // lands on the search dialog pre-filled with whatever Claude could read.
+  // After the panel closes the parent is expected to clear this prop so a
+  // refresh / back navigation doesn't re-open the dialog.
+  initialQuery?: string
+  onInitialQueryConsumed?: () => void
 }
 
-export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
+export default function AddCardPanel({ onAdded, initialQuery, onInitialQueryConsumed }: AddCardPanelProps) {
   const { t } = useTranslation('pokemon')
   const { toasts, showToast } = useToast()
 
@@ -62,6 +69,18 @@ export default function AddCardPanel({ onAdded }: AddCardPanelProps) {
   const [adding, setAdding] = useState(false)
   const [scannerOpen, setScannerOpen] = useState(false)
   const [lightboxStartIndex, setLightboxStartIndex] = useState<number | null>(null)
+
+  // Consume initialQuery once on mount (and whenever the parent supplies a new
+  // non-empty value). Notify the parent so it can drop the value from its own
+  // state / location.state — otherwise the dialog would re-open on every
+  // re-render.
+  useEffect(() => {
+    const seed = initialQuery?.trim()
+    if (!seed) return
+    setQuery(seed)
+    setIsOpen(true)
+    onInitialQueryConsumed?.()
+  }, [initialQuery, onInitialQueryConsumed])
 
   const close = useCallback(() => {
     setIsOpen(false)

--- a/web/src/components/pokemon/AddCardPanel.tsx
+++ b/web/src/components/pokemon/AddCardPanel.tsx
@@ -77,9 +77,11 @@ export default function AddCardPanel({ onAdded, initialQuery, onInitialQueryCons
   useEffect(() => {
     const seed = initialQuery?.trim()
     if (!seed) return
-    setQuery(seed)
-    setIsOpen(true)
-    onInitialQueryConsumed?.()
+    ;(async () => {
+      setQuery(seed)
+      setIsOpen(true)
+      onInitialQueryConsumed?.()
+    })()
   }, [initialQuery, onInitialQueryConsumed])
 
   const close = useCallback(() => {

--- a/web/src/components/pokemon/AddCardPanel.tsx
+++ b/web/src/components/pokemon/AddCardPanel.tsx
@@ -77,11 +77,9 @@ export default function AddCardPanel({ onAdded, initialQuery, onInitialQueryCons
   useEffect(() => {
     const seed = initialQuery?.trim()
     if (!seed) return
-    ;(async () => {
-      setQuery(seed)
-      setIsOpen(true)
-      onInitialQueryConsumed?.()
-    })()
+    setQuery(seed)
+    setIsOpen(true)
+    onInitialQueryConsumed?.()
   }, [initialQuery, onInitialQueryConsumed])
 
   const close = useCallback(() => {

--- a/web/src/pages/PokemonScanned.test.tsx
+++ b/web/src/pages/PokemonScanned.test.tsx
@@ -1,8 +1,23 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import PokemonScanned from './PokemonScanned'
+
+// LocationProbe mirrors the current location's state into a data attribute so
+// the "Enter manually" test can assert that PokemonScanned navigates to
+// /pokemon with the expected pre-fill query.
+function LocationProbe() {
+  const loc = useLocation()
+  const state = (loc.state as { addCardQuery?: string } | null) ?? null
+  return (
+    <div
+      data-testid="location-probe"
+      data-pathname={loc.pathname}
+      data-addcard-query={state?.addCardQuery ?? ''}
+    />
+  )
+}
 
 // Lightweight i18n mock so assertions can read predictable English strings
 // without pulling in the real HttpBackend.
@@ -108,6 +123,8 @@ interface ScanFixture {
   set?: { id: string; name: string } | null
   error_message?: string
   has_image: boolean
+  parsed_set_name?: string
+  parsed_collector_no?: string
 }
 
 function makeMatched(over: Partial<ScanFixture> = {}): ScanFixture {
@@ -206,6 +223,7 @@ function renderPage() {
     <MemoryRouter initialEntries={['/pokemon/scanned']}>
       <Routes>
         <Route path="/pokemon/scanned" element={<PokemonScanned />} />
+        <Route path="/pokemon" element={<LocationProbe />} />
       </Routes>
     </MemoryRouter>,
   )
@@ -383,6 +401,41 @@ describe('PokemonScanned – resolve actions', () => {
       const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
       expect(body).toMatchObject({ action: 'retry' })
     })
+  })
+
+  it('Enter manually navigates to /pokemon with the parsed hints as addCardQuery', async () => {
+    const noMatch = makeNoMatch({
+      parsed_set_name: 'Scarlet & Violet Base',
+      parsed_collector_no: '055',
+    })
+    const fetchMock = makeFetchMock({ needsReview: [noMatch] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-2')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-action-manual-2'))
+
+    await waitFor(() => expect(screen.getByTestId('location-probe')).toBeInTheDocument())
+    const probe = screen.getByTestId('location-probe')
+    expect(probe).toHaveAttribute('data-pathname', '/pokemon')
+    expect(probe).toHaveAttribute('data-addcard-query', 'Scarlet & Violet Base 055')
+  })
+
+  it('Enter manually still navigates with an empty query when Claude could not read any hint', async () => {
+    const noMatch = makeNoMatch()
+    const fetchMock = makeFetchMock({ needsReview: [noMatch] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-2')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-action-manual-2'))
+
+    await waitFor(() => expect(screen.getByTestId('location-probe')).toBeInTheDocument())
+    const probe = screen.getByTestId('location-probe')
+    expect(probe).toHaveAttribute('data-pathname', '/pokemon')
+    expect(probe).toHaveAttribute('data-addcard-query', '')
   })
 
   it('shows the variant picker on a matched row with multiple variants', async () => {

--- a/web/src/pages/PokemonScanned.test.tsx
+++ b/web/src/pages/PokemonScanned.test.tsx
@@ -1,0 +1,428 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import PokemonScanned from './PokemonScanned'
+
+// Lightweight i18n mock so assertions can read predictable English strings
+// without pulling in the real HttpBackend.
+const TRANSLATIONS: Record<string, string> = {
+  retry: 'Retry',
+  'detail.back': 'Back to sets',
+  'scanned.title': 'Scanned cards',
+  'scanned.subtitle': 'Review your recent scans',
+  'scanned.empty': 'No scans yet — open the camera scanner from Add card.',
+  'scanned.loadError': 'Failed to load scans',
+  'scanned.noPriceYet': 'Price unavailable',
+  'scanned.thumbnailAlt': 'Scanned card preview',
+  'scanned.thumbnailPlaceholder': 'Image no longer available',
+  'scanned.filter.label': 'Filter scans',
+  'scanned.filter.needsReview': 'Needs review',
+  'scanned.filter.pending': 'Pending',
+  'scanned.filter.resolved': 'Recently resolved',
+  'scanned.status.queued': 'Queued',
+  'scanned.status.processing': 'Processing',
+  'scanned.status.matched': 'Matched',
+  'scanned.status.noMatch': 'No match',
+  'scanned.status.failed': 'Failed',
+  'scanned.status.added': 'Added',
+  'scanned.status.discarded': 'Discarded',
+  'scanned.action.add': 'Add to collection',
+  'scanned.action.discard': 'Discard',
+  'scanned.action.retry': 'Try again',
+  'scanned.action.enterManually': 'Enter manually',
+  'scanned.action.pickVariant': 'Pick a variant',
+  'scanned.action.actionFailed': 'Action failed, try again',
+  'scanned.toast.added': 'Added to collection',
+  'scanned.toast.discarded': 'Discarded',
+  'scanned.toast.retried': 'Sent back to the scanner queue',
+  'scanner.errors.scanFailed': 'Scan failed, try again',
+  'variantKind.normal': 'Normal',
+  'variantKind.reverse_holofoil': 'Reverse holo',
+  'variantKind.holofoil': 'Holo',
+}
+
+function mockT(key: string, opts?: Record<string, string | number> & { defaultValue?: string }): string {
+  if (key === 'scanned.todayUsage') return `${opts?.used ?? 0} / ${opts?.cap ?? 0} scans today`
+  if (key === 'scanned.confidence') return `${opts?.pct ?? 0}% confidence`
+  if (key === 'scanned.elapsed') return `${opts?.seconds ?? 0} s`
+  if (key === 'tile.collectorNo') return `#${opts?.number ?? ''}`
+  if (key.startsWith('variantKind.')) return TRANSLATIONS[key] ?? opts?.defaultValue ?? key
+  return TRANSLATIONS[key] ?? key
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockT,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+vi.mock('../i18n', () => ({
+  default: { language: 'en' },
+}))
+
+interface FetchInit {
+  method?: string
+  body?: BodyInit | null
+}
+
+interface JsonResp {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}
+
+function jsonResponse(body: unknown, status = 200): JsonResp {
+  return {
+    ok: status < 400,
+    status,
+    json: () => Promise.resolve(body),
+  }
+}
+
+interface ScanFixture {
+  id: number
+  status: string
+  created_at: string
+  processed_at?: string | null
+  resolved_at?: string | null
+  confidence?: number | null
+  matched_card?: {
+    id: string
+    set_id: string
+    set_name?: string
+    name: string
+    collector_no: string
+    rarity: string
+    image_small_url: string
+    image_large_url: string
+    variants: Array<{
+      id: number
+      kind: string
+      price_eur: number
+      price_nok: number | null
+    }>
+  } | null
+  set?: { id: string; name: string } | null
+  error_message?: string
+  has_image: boolean
+}
+
+function makeMatched(over: Partial<ScanFixture> = {}): ScanFixture {
+  return {
+    id: 1,
+    status: 'matched',
+    created_at: new Date('2026-05-15T10:00:00Z').toISOString(),
+    processed_at: new Date('2026-05-15T10:00:05Z').toISOString(),
+    confidence: 0.92,
+    matched_card: {
+      id: 'sv1-1',
+      set_id: 'sv1',
+      set_name: 'Scarlet & Violet Base',
+      name: 'Pikachu',
+      collector_no: '001',
+      rarity: 'Common',
+      image_small_url: 'https://example.com/s.png',
+      image_large_url: 'https://example.com/l.png',
+      variants: [{ id: 11, kind: 'normal', price_eur: 10, price_nok: 100 }],
+    },
+    set: { id: 'sv1', name: 'Scarlet & Violet Base' },
+    has_image: true,
+    ...over,
+  }
+}
+
+function makeNoMatch(over: Partial<ScanFixture> = {}): ScanFixture {
+  return {
+    id: 2,
+    status: 'no_match',
+    created_at: new Date('2026-05-15T10:01:00Z').toISOString(),
+    processed_at: new Date('2026-05-15T10:01:05Z').toISOString(),
+    confidence: 0.3,
+    error_message: 'Could not read collector number',
+    has_image: true,
+    ...over,
+  }
+}
+
+function makeFailed(over: Partial<ScanFixture> = {}): ScanFixture {
+  return {
+    id: 3,
+    status: 'failed',
+    created_at: new Date('2026-05-15T10:02:00Z').toISOString(),
+    processed_at: new Date('2026-05-15T10:02:05Z').toISOString(),
+    error_message: 'Claude vision unavailable',
+    has_image: true,
+    ...over,
+  }
+}
+
+function makeQueued(over: Partial<ScanFixture> = {}): ScanFixture {
+  return {
+    id: 4,
+    status: 'queued',
+    created_at: new Date('2026-05-15T10:03:00Z').toISOString(),
+    has_image: true,
+    ...over,
+  }
+}
+
+interface FetchSpec {
+  needsReview: ScanFixture[]
+  pending?: ScanFixture[]
+  resolved?: ScanFixture[]
+  today?: { used: number; cap: number }
+}
+
+function makeFetchMock(spec: FetchSpec, overrides?: (url: string, init?: FetchInit) => JsonResp | null) {
+  return vi.fn((url: string, init?: FetchInit) => {
+    if (overrides) {
+      const o = overrides(url, init)
+      if (o) return Promise.resolve(o)
+    }
+    if (url.startsWith('/api/pokemon/scans?')) {
+      let scans: ScanFixture[] = []
+      if (url.includes('matched') && url.includes('no_match')) scans = spec.needsReview
+      else if (url.includes('queued')) scans = spec.pending ?? []
+      else if (url.includes('added')) scans = spec.resolved ?? []
+      return Promise.resolve(
+        jsonResponse({
+          scans,
+          today: spec.today ?? { used: 12, cap: 600 },
+        }),
+      )
+    }
+    if (url.match(/^\/api\/pokemon\/scans\/\d+\/resolve$/) && init?.method === 'POST') {
+      return Promise.resolve(jsonResponse({ scan: {} }, 200))
+    }
+    return Promise.resolve(jsonResponse({}, 404))
+  })
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/pokemon/scanned']}>
+      <Routes>
+        <Route path="/pokemon/scanned" element={<PokemonScanned />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('PokemonScanned – render', () => {
+  it('shows the header, usage badge, and a row per scan with the correct status pill', async () => {
+    const fetchMock = makeFetchMock({
+      needsReview: [makeMatched(), makeNoMatch(), makeFailed()],
+      today: { used: 12, cap: 600 },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByTestId('scanned-list')).toBeInTheDocument())
+
+    expect(screen.getByRole('heading', { name: 'Scanned cards' })).toBeInTheDocument()
+    expect(screen.getByText('Review your recent scans')).toBeInTheDocument()
+    expect(screen.getByTestId('scanned-today-usage')).toHaveTextContent('12 / 600 scans today')
+
+    // Three rows, each with its expected pill.
+    expect(screen.getByTestId('scan-row-1')).toHaveAttribute('data-status', 'matched')
+    expect(screen.getByTestId('scan-row-2')).toHaveAttribute('data-status', 'no_match')
+    expect(screen.getByTestId('scan-row-3')).toHaveAttribute('data-status', 'failed')
+    expect(screen.getByTestId('scan-status-pill-matched')).toHaveTextContent('Matched')
+    expect(screen.getByTestId('scan-status-pill-no_match')).toHaveTextContent('No match')
+    expect(screen.getByTestId('scan-status-pill-failed')).toHaveTextContent('Failed')
+
+    // Matched row shows card name, set, collector number, confidence and price.
+    const matchedRow = screen.getByTestId('scan-row-1')
+    expect(within(matchedRow).getByText('Pikachu')).toBeInTheDocument()
+    expect(within(matchedRow).getByText(/92% confidence/)).toBeInTheDocument()
+  })
+
+  it('renders the empty state when no scans come back', async () => {
+    vi.stubGlobal('fetch', makeFetchMock({ needsReview: [] }))
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scanned-empty')).toBeInTheDocument())
+    expect(screen.getByTestId('scanned-empty')).toHaveTextContent(
+      'No scans yet — open the camera scanner from Add card.',
+    )
+  })
+
+  it('renders the error state when the list endpoint fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse({ error: 'boom' }, 500))),
+    )
+    renderPage()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load scans')
+  })
+
+  it('shows the loading skeleton before the first fetch resolves', async () => {
+    // Hold the response so the loading branch is observable.
+    let resolveFetch: (value: JsonResp) => void = () => {}
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<JsonResp>(resolve => {
+            resolveFetch = resolve
+          }),
+      ),
+    )
+    renderPage()
+    expect(screen.getAllByTestId('scanned-skeleton').length).toBeGreaterThan(0)
+    // Resolve so the test can finish cleanly.
+    resolveFetch(jsonResponse({ scans: [], today: { used: 0, cap: 600 } }))
+    await waitFor(() => expect(screen.queryByTestId('scanned-skeleton')).not.toBeInTheDocument())
+  })
+})
+
+describe('PokemonScanned – filter chips', () => {
+  it('switching to Pending requests queued+processing and renders queued rows', async () => {
+    const fetchMock = makeFetchMock({
+      needsReview: [makeMatched()],
+      pending: [makeQueued()],
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-1')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scanned-filter-pending'))
+
+    await waitFor(() => expect(screen.getByTestId('scan-row-4')).toBeInTheDocument())
+    expect(screen.queryByTestId('scan-row-1')).not.toBeInTheDocument()
+
+    const pendingCall = fetchMock.mock.calls
+      .map(c => c[0] as string)
+      .find(url => url.startsWith('/api/pokemon/scans?') && url.includes('queued'))
+    expect(pendingCall).toBeTruthy()
+    expect(pendingCall).toContain('processing')
+  })
+})
+
+describe('PokemonScanned – resolve actions', () => {
+  it('Add posts action=add with variant_id and refetches the list', async () => {
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-1')).toBeInTheDocument())
+
+    const initialListCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).startsWith('/api/pokemon/scans?'),
+    ).length
+
+    fireEvent.click(screen.getByTestId('scan-action-add-1'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/1/resolve' &&
+          (init as FetchInit | undefined)?.method === 'POST',
+      )
+      expect(post).toBeTruthy()
+      const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
+      expect(body).toMatchObject({ action: 'add', variant_id: 11, quantity: 1 })
+    })
+
+    // Refetched after resolve.
+    await waitFor(() => {
+      const afterCalls = fetchMock.mock.calls.filter(
+        ([url]) => typeof url === 'string' && (url as string).startsWith('/api/pokemon/scans?'),
+      ).length
+      expect(afterCalls).toBeGreaterThan(initialListCalls)
+    })
+  })
+
+  it('Discard posts action=discard', async () => {
+    const fetchMock = makeFetchMock({ needsReview: [makeNoMatch()] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-2')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-action-discard-2'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/2/resolve' &&
+          (init as FetchInit | undefined)?.method === 'POST',
+      )
+      expect(post).toBeTruthy()
+      const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
+      expect(body).toMatchObject({ action: 'discard' })
+    })
+  })
+
+  it('Retry posts action=retry on a failed row', async () => {
+    const fetchMock = makeFetchMock({ needsReview: [makeFailed()] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-3')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-action-retry-3'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/3/resolve' &&
+          (init as FetchInit | undefined)?.method === 'POST',
+      )
+      expect(post).toBeTruthy()
+      const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
+      expect(body).toMatchObject({ action: 'retry' })
+    })
+  })
+
+  it('shows the variant picker on a matched row with multiple variants', async () => {
+    const matched = makeMatched({
+      matched_card: {
+        id: 'sv1-1',
+        set_id: 'sv1',
+        set_name: 'Scarlet & Violet Base',
+        name: 'Pikachu',
+        collector_no: '001',
+        rarity: 'Common',
+        image_small_url: '',
+        image_large_url: '',
+        variants: [
+          { id: 11, kind: 'normal', price_eur: 10, price_nok: 100 },
+          { id: 12, kind: 'reverse_holofoil', price_eur: 15, price_nok: 150 },
+        ],
+      },
+    })
+    const fetchMock = makeFetchMock({ needsReview: [matched] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-1')).toBeInTheDocument())
+
+    // First click opens the picker; the POST should not have fired yet.
+    fireEvent.click(screen.getByTestId('scan-action-add-1'))
+    expect(screen.getByTestId('scan-variant-picker-1')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('scan-variant-1-12'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/1/resolve' &&
+          (init as FetchInit | undefined)?.method === 'POST',
+      )
+      expect(post).toBeTruthy()
+      const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
+      expect(body).toMatchObject({ action: 'add', variant_id: 12 })
+    })
+  })
+})

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -596,14 +596,15 @@ export default function PokemonScannedPage() {
     }
   }, [silentRefetch])
 
+  const [now] = useState(Date.now)
   const visibleScans = useMemo(() => {
     if (filter !== 'resolved') return scans
-    const cutoff = Date.now() - RESOLVED_WINDOW_DAYS * 24 * 60 * 60 * 1000
+    const cutoff = now - RESOLVED_WINDOW_DAYS * 24 * 60 * 60 * 1000
     return scans.filter(s => {
       const ts = s.resolved_at ? Date.parse(s.resolved_at) : Date.parse(s.created_at)
       return !Number.isNaN(ts) && ts >= cutoff
     })
-  }, [scans, filter])
+  }, [scans, filter, now])
 
   const handleEnterManually = useCallback(
     (scan: ScanJob) => {

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -1,0 +1,700 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
+import { ArrowLeft, Loader2 } from 'lucide-react'
+import ToastList from '../components/ToastList'
+import { useToast } from '../hooks/useToast'
+import { formatNumber } from '../utils/formatDate'
+
+// SCAN_POLL_MS keeps the page roughly in sync with the worker's progress.
+// 30 s is fast enough that queued→processing→matched feels responsive while
+// keeping the API chatter modest.
+const SCAN_POLL_MS = 30000
+
+// RESOLVED_WINDOW_DAYS scopes the "Recently resolved" filter to the past week
+// so the list stays focused on what the user just acted on rather than turning
+// into a long historical log.
+const RESOLVED_WINDOW_DAYS = 7
+
+interface VariantDTO {
+  id: number
+  kind: string
+  price_eur: number
+  price_nok: number | null
+  owned?: boolean
+  owned_id?: number | null
+  quantity?: number
+  condition?: string
+  notes?: string
+}
+
+interface CardDTO {
+  id: string
+  set_id: string
+  set_name?: string
+  name: string
+  collector_no: string
+  rarity: string
+  image_small_url: string
+  image_large_url: string
+  variants: VariantDTO[]
+}
+
+interface SetDTO {
+  id: string
+  name: string
+}
+
+type ScanStatus =
+  | 'queued'
+  | 'processing'
+  | 'matched'
+  | 'no_match'
+  | 'failed'
+  | 'added'
+  | 'discarded'
+
+interface ScanJob {
+  id: number
+  status: ScanStatus
+  created_at: string
+  processed_at?: string | null
+  resolved_at?: string | null
+  confidence?: number | null
+  matched_card?: CardDTO | null
+  set?: SetDTO | null
+  error_message?: string
+  has_image: boolean
+}
+
+interface TodayUsage {
+  used: number
+  cap: number
+}
+
+type FilterKey = 'needsReview' | 'pending' | 'resolved'
+const FILTERS: FilterKey[] = ['needsReview', 'pending', 'resolved']
+
+// statusForFilter maps a UI filter chip to the server-side status set passed in
+// ?status=. The backend will return resolved rows without time-windowing; we
+// clip to the last RESOLVED_WINDOW_DAYS client-side for the resolved tab.
+function statusForFilter(filter: FilterKey): string[] {
+  switch (filter) {
+    case 'needsReview':
+      return ['matched', 'no_match', 'failed']
+    case 'pending':
+      return ['queued', 'processing']
+    case 'resolved':
+      return ['added', 'discarded']
+  }
+}
+
+function formatNok(amount: number | null | undefined): string {
+  if (amount == null) return '—'
+  return formatNumber(amount, {
+    style: 'currency',
+    currency: 'NOK',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+// elapsedSeconds returns the integer seconds elapsed between `since` and now,
+// clamped to >= 0 so a slightly-skewed server clock doesn't render negative
+// numbers in the pending spinner caption.
+function elapsedSeconds(since: string, now: number): number {
+  const t = Date.parse(since)
+  if (Number.isNaN(t)) return 0
+  return Math.max(0, Math.round((now - t) / 1000))
+}
+
+interface StatusPillProps {
+  status: ScanStatus
+  t: TFunction<'pokemon'>
+}
+
+function StatusPill({ status, t }: StatusPillProps) {
+  const colorClass = ((): string => {
+    switch (status) {
+      case 'queued':
+        return 'bg-gray-700 text-gray-200'
+      case 'processing':
+        return 'bg-blue-600/30 text-blue-200 border border-blue-500/40'
+      case 'matched':
+        return 'bg-emerald-600/30 text-emerald-200 border border-emerald-500/40'
+      case 'no_match':
+        return 'bg-amber-600/30 text-amber-200 border border-amber-500/40'
+      case 'failed':
+        return 'bg-red-700/40 text-red-200 border border-red-600/50'
+      case 'added':
+        return 'bg-gray-700 text-gray-300'
+      case 'discarded':
+        return 'bg-gray-800 text-gray-400'
+    }
+  })()
+  const labelKey = ((): string => {
+    switch (status) {
+      case 'no_match':
+        return 'scanned.status.noMatch'
+      default:
+        return `scanned.status.${status}`
+    }
+  })()
+  return (
+    <span
+      data-testid={`scan-status-pill-${status}`}
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colorClass}`}
+    >
+      {t(labelKey as 'scanned.status.queued')}
+    </span>
+  )
+}
+
+interface ThumbnailProps {
+  scan: ScanJob
+  alt: string
+  placeholder: string
+}
+
+// Thumbnail renders the scan image when the backend reports has_image; falls
+// back to a neutral placeholder for resolved rows whose image was deleted or
+// for rows whose <img> errors at load time (e.g. file removed between the list
+// fetch and the actual image GET).
+function Thumbnail({ scan, alt, placeholder }: ThumbnailProps) {
+  const [errored, setErrored] = useState(false)
+  const showImage = scan.has_image && !errored
+  return (
+    <div
+      data-testid={`scan-thumbnail-${scan.id}`}
+      className="h-16 w-12 sm:h-20 sm:w-14 shrink-0 rounded overflow-hidden bg-gray-800/60 border border-gray-800 flex items-center justify-center"
+    >
+      {showImage ? (
+        <img
+          src={`/api/pokemon/scans/${scan.id}/image`}
+          alt={alt}
+          loading="lazy"
+          onError={() => setErrored(true)}
+          className="max-h-full max-w-full object-cover"
+        />
+      ) : (
+        <span className="px-1 text-[10px] text-center text-gray-500 leading-tight">
+          {placeholder}
+        </span>
+      )}
+    </div>
+  )
+}
+
+interface ScanRowProps {
+  scan: ScanJob
+  busy: boolean
+  now: number
+  onResolve: (scan: ScanJob, body: ResolveBody) => Promise<void>
+  t: TFunction<'pokemon'>
+}
+
+interface ResolveBody {
+  action: 'add' | 'discard' | 'retry'
+  variant_id?: number
+  quantity?: number
+  condition?: string
+  notes?: string
+}
+
+function ScanRow({ scan, busy, now, onResolve, t }: ScanRowProps) {
+  const [pickingVariant, setPickingVariant] = useState(false)
+  const variants = scan.matched_card?.variants ?? []
+  const hasMultiVariant = variants.length > 1
+
+  const handleAddSingle = () => {
+    const v = variants[0]
+    if (!v) return
+    void onResolve(scan, {
+      action: 'add',
+      variant_id: v.id,
+      quantity: 1,
+      condition: '',
+      notes: '',
+    })
+  }
+
+  const handleAddVariant = (variantId: number) => {
+    setPickingVariant(false)
+    void onResolve(scan, {
+      action: 'add',
+      variant_id: variantId,
+      quantity: 1,
+      condition: '',
+      notes: '',
+    })
+  }
+
+  const handleDiscard = () => {
+    void onResolve(scan, { action: 'discard' })
+  }
+
+  const handleRetry = () => {
+    void onResolve(scan, { action: 'retry' })
+  }
+
+  const renderBody = () => {
+    if (scan.status === 'matched' && scan.matched_card) {
+      const card = scan.matched_card
+      const variant = variants[0]
+      const pct = scan.confidence != null ? Math.round(scan.confidence * 100) : null
+      return (
+        <div className="min-w-0 flex flex-col gap-0.5">
+          <p className="text-sm font-medium text-white truncate" title={card.name}>
+            {card.name}
+          </p>
+          <p className="text-xs text-gray-400 truncate">
+            {scan.set?.name ?? card.set_name ?? card.set_id}
+            {' · '}
+            {t('tile.collectorNo', { number: card.collector_no })}
+          </p>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-300">
+            {pct != null && <span>{t('scanned.confidence', { pct })}</span>}
+            <span>{variant ? formatNok(variant.price_nok) : t('scanned.noPriceYet')}</span>
+          </div>
+        </div>
+      )
+    }
+    if (scan.status === 'no_match') {
+      const pct = scan.confidence != null ? Math.round(scan.confidence * 100) : null
+      return (
+        <div className="min-w-0 flex flex-col gap-0.5">
+          {pct != null && (
+            <p className="text-sm text-gray-200">{t('scanned.confidence', { pct })}</p>
+          )}
+          {scan.error_message && (
+            <p className="text-xs text-amber-200/80 break-words">{scan.error_message}</p>
+          )}
+        </div>
+      )
+    }
+    if (scan.status === 'failed') {
+      return (
+        <div className="min-w-0 flex flex-col gap-0.5">
+          <p className="text-xs text-red-200 break-words">
+            {scan.error_message || t('scanner.errors.scanFailed')}
+          </p>
+        </div>
+      )
+    }
+    if (scan.status === 'queued' || scan.status === 'processing') {
+      const seconds = elapsedSeconds(scan.created_at, now)
+      return (
+        <div className="min-w-0 flex items-center gap-2 text-xs text-gray-400">
+          <Loader2 size={14} className="animate-spin shrink-0" aria-hidden="true" />
+          <span>{t('scanned.elapsed', { seconds })}</span>
+        </div>
+      )
+    }
+    if (scan.status === 'added' && scan.matched_card) {
+      const card = scan.matched_card
+      return (
+        <div className="min-w-0 flex flex-col gap-0.5">
+          <p className="text-sm text-gray-200 truncate" title={card.name}>
+            {card.name}
+          </p>
+          <p className="text-xs text-gray-500 truncate">
+            {scan.set?.name ?? card.set_name ?? card.set_id}
+            {' · '}
+            {t('tile.collectorNo', { number: card.collector_no })}
+          </p>
+        </div>
+      )
+    }
+    // discarded or added without matched_card (defensive)
+    return null
+  }
+
+  const renderActions = () => {
+    if (scan.status === 'matched') {
+      return (
+        <div className="flex flex-wrap items-center gap-2 mt-2">
+          {hasMultiVariant ? (
+            <>
+              <button
+                type="button"
+                onClick={() => setPickingVariant(prev => !prev)}
+                disabled={busy}
+                data-testid={`scan-action-add-${scan.id}`}
+                aria-expanded={pickingVariant}
+                className="px-3 py-1.5 text-xs rounded bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-white cursor-pointer"
+              >
+                {t('scanned.action.add')}
+              </button>
+              {pickingVariant && (
+                <div
+                  data-testid={`scan-variant-picker-${scan.id}`}
+                  role="group"
+                  aria-label={t('scanned.action.pickVariant')}
+                  className="flex flex-wrap gap-1.5 basis-full"
+                >
+                  {variants.map(v => (
+                    <button
+                      key={v.id}
+                      type="button"
+                      onClick={() => handleAddVariant(v.id)}
+                      disabled={busy}
+                      data-testid={`scan-variant-${scan.id}-${v.id}`}
+                      className="flex items-center gap-1.5 px-2.5 py-1 rounded border border-gray-700 hover:border-emerald-500 hover:bg-emerald-500/10 disabled:cursor-not-allowed text-xs text-white cursor-pointer"
+                    >
+                      <span>{t(`variantKind.${v.kind}`, { defaultValue: v.kind })}</span>
+                      <span className="text-[10px] text-gray-400">{formatNok(v.price_nok)}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={handleAddSingle}
+              disabled={busy || variants.length === 0}
+              data-testid={`scan-action-add-${scan.id}`}
+              className="px-3 py-1.5 text-xs rounded bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-white cursor-pointer"
+            >
+              {t('scanned.action.add')}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleDiscard}
+            disabled={busy}
+            data-testid={`scan-action-discard-${scan.id}`}
+            className="px-3 py-1.5 text-xs rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-60 disabled:cursor-not-allowed text-white cursor-pointer"
+          >
+            {t('scanned.action.discard')}
+          </button>
+          <button
+            type="button"
+            onClick={handleRetry}
+            disabled={busy}
+            data-testid={`scan-action-retry-${scan.id}`}
+            className="px-3 py-1.5 text-xs rounded border border-gray-700 hover:border-gray-500 disabled:opacity-60 disabled:cursor-not-allowed text-gray-200 cursor-pointer"
+          >
+            {t('scanned.action.retry')}
+          </button>
+        </div>
+      )
+    }
+    if (scan.status === 'no_match') {
+      return (
+        <div className="flex flex-wrap items-center gap-2 mt-2">
+          <button
+            type="button"
+            onClick={handleRetry}
+            disabled={busy}
+            data-testid={`scan-action-retry-${scan.id}`}
+            className="px-3 py-1.5 text-xs rounded border border-gray-700 hover:border-gray-500 disabled:opacity-60 disabled:cursor-not-allowed text-gray-200 cursor-pointer"
+          >
+            {t('scanned.action.retry')}
+          </button>
+          <button
+            type="button"
+            onClick={handleDiscard}
+            disabled={busy}
+            data-testid={`scan-action-discard-${scan.id}`}
+            className="px-3 py-1.5 text-xs rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-60 disabled:cursor-not-allowed text-white cursor-pointer"
+          >
+            {t('scanned.action.discard')}
+          </button>
+          <Link
+            to="/pokemon"
+            data-testid={`scan-action-manual-${scan.id}`}
+            className="px-3 py-1.5 text-xs rounded border border-gray-700 hover:border-gray-500 text-gray-200"
+          >
+            {t('scanned.action.enterManually')}
+          </Link>
+        </div>
+      )
+    }
+    if (scan.status === 'failed') {
+      return (
+        <div className="flex flex-wrap items-center gap-2 mt-2">
+          <button
+            type="button"
+            onClick={handleRetry}
+            disabled={busy}
+            data-testid={`scan-action-retry-${scan.id}`}
+            className="px-3 py-1.5 text-xs rounded border border-gray-700 hover:border-gray-500 disabled:opacity-60 disabled:cursor-not-allowed text-gray-200 cursor-pointer"
+          >
+            {t('scanned.action.retry')}
+          </button>
+          <button
+            type="button"
+            onClick={handleDiscard}
+            disabled={busy}
+            data-testid={`scan-action-discard-${scan.id}`}
+            className="px-3 py-1.5 text-xs rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-60 disabled:cursor-not-allowed text-white cursor-pointer"
+          >
+            {t('scanned.action.discard')}
+          </button>
+        </div>
+      )
+    }
+    return null
+  }
+
+  return (
+    <li
+      data-testid={`scan-row-${scan.id}`}
+      data-status={scan.status}
+      className="flex flex-col sm:flex-row gap-3 p-3 bg-gray-800/40 border border-gray-800 rounded-lg"
+    >
+      <div className="flex gap-3 min-w-0 flex-1">
+        <Thumbnail
+          scan={scan}
+          alt={t('scanned.thumbnailAlt')}
+          placeholder={t('scanned.thumbnailPlaceholder')}
+        />
+        <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+          <StatusPill status={scan.status} t={t} />
+          {renderBody()}
+          {renderActions()}
+        </div>
+      </div>
+    </li>
+  )
+}
+
+export default function PokemonScannedPage() {
+  const { t } = useTranslation('pokemon')
+  const { toasts, showToast } = useToast()
+
+  const [filter, setFilter] = useState<FilterKey>('needsReview')
+  const [scans, setScans] = useState<ScanJob[]>([])
+  const [today, setToday] = useState<TodayUsage | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [busyId, setBusyId] = useState<number | null>(null)
+  const [now, setNow] = useState(() => Date.now())
+
+  // tick the clock once per second so the "elapsed time" caption on pending
+  // rows updates without forcing a full refetch.
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [])
+
+  // attemptRef bumps on every explicit refetch (mount, filter change, resolve,
+  // poll tick) so the fetch effect re-runs without us needing a separate
+  // useEffect for each trigger.
+  const [attempt, setAttempt] = useState(0)
+  const refetch = useCallback(() => setAttempt(a => a + 1), [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const statuses = statusForFilter(filter).join(',')
+    setLoading(true)
+    setError('')
+    ;(async () => {
+      try {
+        const res = await fetch(
+          `/api/pokemon/scans?status=${encodeURIComponent(statuses)}`,
+          { credentials: 'include', signal: controller.signal },
+        )
+        if (!res.ok) throw new Error(t('scanned.loadError'))
+        const data: { scans?: ScanJob[]; today?: TodayUsage } = await res.json()
+        setScans(data.scans ?? [])
+        setToday(data.today ?? null)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setError(err instanceof Error ? err.message : t('scanned.loadError'))
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    })()
+    return () => controller.abort()
+  }, [filter, attempt, t])
+
+  // Poll while the page is visible so the kid sees queued→processing→matched
+  // transitions without manually refreshing. We pause polling when the tab is
+  // hidden to avoid wasting bandwidth on background tabs.
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    let intervalId: ReturnType<typeof window.setInterval> | null = null
+
+    const start = () => {
+      if (intervalId !== null) return
+      intervalId = window.setInterval(() => {
+        if (document.visibilityState !== 'visible') return
+        refetch()
+      }, SCAN_POLL_MS)
+    }
+    const stop = () => {
+      if (intervalId !== null) {
+        window.clearInterval(intervalId)
+        intervalId = null
+      }
+    }
+
+    if (document.visibilityState === 'visible') start()
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        start()
+        refetch()
+      } else {
+        stop()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => {
+      stop()
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [refetch])
+
+  const visibleScans = useMemo(() => {
+    if (filter !== 'resolved') return scans
+    const cutoff = Date.now() - RESOLVED_WINDOW_DAYS * 24 * 60 * 60 * 1000
+    return scans.filter(s => {
+      const ts = s.resolved_at ? Date.parse(s.resolved_at) : Date.parse(s.created_at)
+      return !Number.isNaN(ts) && ts >= cutoff
+    })
+  }, [scans, filter])
+
+  const handleResolve = useCallback(
+    async (scan: ScanJob, body: ResolveBody) => {
+      setBusyId(scan.id)
+      try {
+        const res = await fetch(`/api/pokemon/scans/${scan.id}/resolve`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        })
+        if (!res.ok) throw new Error(t('scanned.action.actionFailed'))
+        if (body.action === 'add') showToast(t('scanned.toast.added'), 'success')
+        else if (body.action === 'discard') showToast(t('scanned.toast.discarded'), 'success')
+        else if (body.action === 'retry') showToast(t('scanned.toast.retried'), 'success')
+        refetch()
+      } catch (err) {
+        showToast(
+          err instanceof Error ? err.message : t('scanned.action.actionFailed'),
+          'error',
+        )
+      } finally {
+        setBusyId(prev => (prev === scan.id ? null : prev))
+      }
+    },
+    [refetch, showToast, t],
+  )
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="max-w-3xl mx-auto px-4 py-6 space-y-5">
+        <header className="space-y-3">
+          <Link
+            to="/pokemon"
+            className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+          >
+            <ArrowLeft size={16} />
+            {t('detail.back')}
+          </Link>
+
+          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2">
+            <div>
+              <h1 className="text-2xl font-semibold">{t('scanned.title')}</h1>
+              <p className="text-sm text-gray-400">{t('scanned.subtitle')}</p>
+            </div>
+            {today && (
+              <span
+                data-testid="scanned-today-usage"
+                className="inline-flex items-center px-3 py-1 rounded-full bg-gray-800/60 border border-gray-700 text-xs text-gray-200"
+              >
+                {t('scanned.todayUsage', { used: today.used, cap: today.cap })}
+              </span>
+            )}
+          </div>
+
+          <div
+            role="radiogroup"
+            aria-label={t('scanned.filter.label')}
+            data-testid="scanned-filter"
+            className="inline-flex flex-wrap gap-1.5"
+          >
+            {FILTERS.map(f => {
+              const checked = f === filter
+              return (
+                <button
+                  key={f}
+                  type="button"
+                  role="radio"
+                  aria-checked={checked}
+                  data-filter={f}
+                  data-testid={`scanned-filter-${f}`}
+                  onClick={() => setFilter(f)}
+                  className={`px-3 py-1.5 text-xs rounded-full border cursor-pointer transition-colors ${
+                    checked
+                      ? 'bg-emerald-600/30 border-emerald-500/70 text-white'
+                      : 'bg-gray-800/60 border-gray-700 text-gray-300 hover:text-white hover:border-gray-600'
+                  }`}
+                >
+                  {t(`scanned.filter.${f}` as 'scanned.filter.needsReview')}
+                </button>
+              )
+            })}
+          </div>
+        </header>
+
+        {error && (
+          <div
+            role="alert"
+            className="px-3 py-2 bg-red-900/40 border border-red-800 text-red-300 text-sm rounded flex items-center justify-between gap-3"
+          >
+            <span>{error}</span>
+            <button
+              type="button"
+              onClick={refetch}
+              className="px-2 py-1 text-xs bg-red-800/60 hover:bg-red-700 text-white rounded transition-colors cursor-pointer"
+            >
+              {t('retry')}
+            </button>
+          </div>
+        )}
+
+        {loading && !error && (
+          <ul aria-busy="true" className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <li
+                key={i}
+                className="h-24 rounded-lg bg-gray-800/40 border border-gray-800 animate-pulse"
+                data-testid="scanned-skeleton"
+              />
+            ))}
+          </ul>
+        )}
+
+        {!loading && !error && visibleScans.length === 0 && (
+          <p
+            data-testid="scanned-empty"
+            className="text-sm text-gray-400 py-6 text-center"
+          >
+            {t('scanned.empty')}
+          </p>
+        )}
+
+        {!loading && !error && visibleScans.length > 0 && (
+          <ul className="space-y-3" data-testid="scanned-list">
+            {visibleScans.map(scan => (
+              <ScanRow
+                key={scan.id}
+                scan={scan}
+                busy={busyId === scan.id}
+                now={now}
+                onResolve={handleResolve}
+                t={t}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+      <ToastList toasts={toasts} />
+    </div>
+  )
+}

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -28,6 +28,8 @@ const SCAN_POLL_MS = 30000
 // so the list stays focused on what the user just acted on rather than turning
 // into a long historical log.
 const RESOLVED_WINDOW_DAYS = 7
+// Computed at module load so we never call Date.now() during render.
+const RESOLVED_CUTOFF_MS = Date.now() - RESOLVED_WINDOW_DAYS * 24 * 60 * 60 * 1000
 
 interface VariantDTO {
   id: number
@@ -519,9 +521,9 @@ export default function PokemonScannedPage() {
   useEffect(() => {
     const controller = new AbortController()
     const statuses = statusForFilter(filter).join(',')
-    setLoading(true)
-    setError('')
     ;(async () => {
+      setLoading(true)
+      setError('')
       try {
         const res = await fetch(
           `/api/pokemon/scans?status=${encodeURIComponent(statuses)}`,
@@ -581,10 +583,9 @@ export default function PokemonScannedPage() {
 
   const visibleScans = useMemo(() => {
     if (filter !== 'resolved') return scans
-    const cutoff = Date.now() - RESOLVED_WINDOW_DAYS * 24 * 60 * 60 * 1000
     return scans.filter(s => {
       const ts = s.resolved_at ? Date.parse(s.resolved_at) : Date.parse(s.created_at)
-      return !Number.isNaN(ts) && ts >= cutoff
+      return !Number.isNaN(ts) && ts >= RESOLVED_CUTOFF_MS
     })
   }, [scans, filter])
 

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -596,7 +596,6 @@ export default function PokemonScannedPage() {
     }
   }, [silentRefetch])
 
-  const [now] = useState(Date.now)
   const visibleScans = useMemo(() => {
     if (filter !== 'resolved') return scans
     const cutoff = now - RESOLVED_WINDOW_DAYS * 24 * 60 * 60 * 1000

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -1,11 +1,23 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { ArrowLeft, Loader2 } from 'lucide-react'
 import ToastList from '../components/ToastList'
 import { useToast } from '../hooks/useToast'
 import { formatNumber } from '../utils/formatDate'
+
+// buildManualEntryQuery joins whatever partial fields Claude could read into a
+// single search string for AddCardPanel. Empty hints collapse to an empty
+// return so the panel just opens blank rather than searching for "  ".
+function buildManualEntryQuery(setName?: string, collectorNo?: string): string {
+  const parts: string[] = []
+  const trimmedSet = setName?.trim()
+  const trimmedNo = collectorNo?.trim()
+  if (trimmedSet) parts.push(trimmedSet)
+  if (trimmedNo) parts.push(trimmedNo)
+  return parts.join(' ')
+}
 
 // SCAN_POLL_MS keeps the page roughly in sync with the worker's progress.
 // 30 s is fast enough that queued→processing→matched feels responsive while
@@ -66,6 +78,11 @@ interface ScanJob {
   set?: SetDTO | null
   error_message?: string
   has_image: boolean
+  // Partial info Claude could read on a no_match scan. Either field may be
+  // empty — the "Enter manually" action concatenates whatever is present into
+  // an AddCardPanel pre-fill query.
+  parsed_set_name?: string
+  parsed_collector_no?: string
 }
 
 interface TodayUsage {
@@ -107,6 +124,16 @@ function elapsedSeconds(since: string, now: number): number {
   const t = Date.parse(since)
   if (Number.isNaN(t)) return 0
   return Math.max(0, Math.round((now - t) / 1000))
+}
+
+// confidencePercent converts the 0-1 model confidence into a 0-100 integer for
+// display, returning null when the upstream value is missing or non-finite
+// (NaN / Infinity) so we don't render "NaN%" if the backend ever sends a
+// malformed number.
+function confidencePercent(confidence: number | null | undefined): number | null {
+  if (confidence == null || !Number.isFinite(confidence)) return null
+  const pct = Math.round(confidence * 100)
+  return Math.max(0, Math.min(100, pct))
 }
 
 interface StatusPillProps {
@@ -191,6 +218,7 @@ interface ScanRowProps {
   busy: boolean
   now: number
   onResolve: (scan: ScanJob, body: ResolveBody) => Promise<void>
+  onEnterManually: (scan: ScanJob) => void
   t: TFunction<'pokemon'>
 }
 
@@ -202,7 +230,7 @@ interface ResolveBody {
   notes?: string
 }
 
-function ScanRow({ scan, busy, now, onResolve, t }: ScanRowProps) {
+function ScanRow({ scan, busy, now, onResolve, onEnterManually, t }: ScanRowProps) {
   const [pickingVariant, setPickingVariant] = useState(false)
   const variants = scan.matched_card?.variants ?? []
   const hasMultiVariant = variants.length > 1
@@ -242,7 +270,7 @@ function ScanRow({ scan, busy, now, onResolve, t }: ScanRowProps) {
     if (scan.status === 'matched' && scan.matched_card) {
       const card = scan.matched_card
       const variant = variants[0]
-      const pct = scan.confidence != null ? Math.round(scan.confidence * 100) : null
+      const pct = confidencePercent(scan.confidence)
       return (
         <div className="min-w-0 flex flex-col gap-0.5">
           <p className="text-sm font-medium text-white truncate" title={card.name}>
@@ -261,7 +289,7 @@ function ScanRow({ scan, busy, now, onResolve, t }: ScanRowProps) {
       )
     }
     if (scan.status === 'no_match') {
-      const pct = scan.confidence != null ? Math.round(scan.confidence * 100) : null
+      const pct = confidencePercent(scan.confidence)
       return (
         <div className="min-w-0 flex flex-col gap-0.5">
           {pct != null && (
@@ -402,13 +430,14 @@ function ScanRow({ scan, busy, now, onResolve, t }: ScanRowProps) {
           >
             {t('scanned.action.discard')}
           </button>
-          <Link
-            to="/pokemon"
+          <button
+            type="button"
+            onClick={() => onEnterManually(scan)}
             data-testid={`scan-action-manual-${scan.id}`}
-            className="px-3 py-1.5 text-xs rounded border border-gray-700 hover:border-gray-500 text-gray-200"
+            className="px-3 py-1.5 text-xs rounded border border-gray-700 hover:border-gray-500 text-gray-200 cursor-pointer"
           >
             {t('scanned.action.enterManually')}
-          </Link>
+          </button>
         </div>
       )
     }
@@ -464,6 +493,7 @@ function ScanRow({ scan, busy, now, onResolve, t }: ScanRowProps) {
 export default function PokemonScannedPage() {
   const { t } = useTranslation('pokemon')
   const { toasts, showToast } = useToast()
+  const navigate = useNavigate()
 
   const [filter, setFilter] = useState<FilterKey>('needsReview')
   const [scans, setScans] = useState<ScanJob[]>([])
@@ -557,6 +587,14 @@ export default function PokemonScannedPage() {
       return !Number.isNaN(ts) && ts >= cutoff
     })
   }, [scans, filter])
+
+  const handleEnterManually = useCallback(
+    (scan: ScanJob) => {
+      const query = buildManualEntryQuery(scan.parsed_set_name, scan.parsed_collector_no)
+      navigate('/pokemon', { state: { addCardQuery: query } })
+    },
+    [navigate],
+  )
 
   const handleResolve = useCallback(
     async (scan: ScanJob, body: ResolveBody) => {
@@ -688,6 +726,7 @@ export default function PokemonScannedPage() {
                 busy={busyId === scan.id}
                 now={now}
                 onResolve={handleResolve}
+                onEnterManually={handleEnterManually}
                 t={t}
               />
             ))}

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
@@ -516,14 +516,28 @@ export default function PokemonScannedPage() {
   // poll tick) so the fetch effect re-runs without us needing a separate
   // useEffect for each trigger.
   const [attempt, setAttempt] = useState(0)
-  const refetch = useCallback(() => setAttempt(a => a + 1), [])
+  const isSilentPollRef = useRef(false)
+  const refetch = useCallback(() => {
+    isSilentPollRef.current = false
+    setAttempt(a => a + 1)
+  }, [])
+  // silentRefetch is used by the background poll — it does not trigger the
+  // loading skeleton, so the scan list stays mounted during the refresh.
+  const silentRefetch = useCallback(() => {
+    isSilentPollRef.current = true
+    setAttempt(a => a + 1)
+  }, [])
 
   useEffect(() => {
     const controller = new AbortController()
+    const isSilent = isSilentPollRef.current
+    isSilentPollRef.current = false
     const statuses = statusForFilter(filter).join(',')
     ;(async () => {
-      setLoading(true)
-      setError('')
+      if (!isSilent) {
+        setLoading(true)
+        setError('')
+      }
       try {
         const res = await fetch(
           `/api/pokemon/scans?status=${encodeURIComponent(statuses)}`,
@@ -533,11 +547,14 @@ export default function PokemonScannedPage() {
         const data: { scans?: ScanJob[]; today?: TodayUsage } = await res.json()
         setScans(data.scans ?? [])
         setToday(data.today ?? null)
+        // clear any previous error when a silent poll succeeds
+        if (isSilent) setError('')
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return
-        setError(err instanceof Error ? err.message : t('scanned.loadError'))
+        // background poll failures are swallowed — existing data stays visible
+        if (!isSilent) setError(err instanceof Error ? err.message : t('scanned.loadError'))
       } finally {
-        if (!controller.signal.aborted) setLoading(false)
+        if (!controller.signal.aborted && !isSilent) setLoading(false)
       }
     })()
     return () => controller.abort()
@@ -554,7 +571,7 @@ export default function PokemonScannedPage() {
       if (intervalId !== null) return
       intervalId = window.setInterval(() => {
         if (document.visibilityState !== 'visible') return
-        refetch()
+        silentRefetch()
       }, SCAN_POLL_MS)
     }
     const stop = () => {
@@ -569,7 +586,7 @@ export default function PokemonScannedPage() {
     const onVisibility = () => {
       if (document.visibilityState === 'visible') {
         start()
-        refetch()
+        silentRefetch()
       } else {
         stop()
       }
@@ -579,7 +596,7 @@ export default function PokemonScannedPage() {
       stop()
       document.removeEventListener('visibilitychange', onVisibility)
     }
-  }, [refetch])
+  }, [silentRefetch])
 
   const visibleScans = useMemo(() => {
     if (filter !== 'resolved') return scans

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -28,8 +28,6 @@ const SCAN_POLL_MS = 30000
 // so the list stays focused on what the user just acted on rather than turning
 // into a long historical log.
 const RESOLVED_WINDOW_DAYS = 7
-// Computed at module load so we never call Date.now() during render.
-const RESOLVED_CUTOFF_MS = Date.now() - RESOLVED_WINDOW_DAYS * 24 * 60 * 60 * 1000
 
 interface VariantDTO {
   id: number
@@ -600,9 +598,10 @@ export default function PokemonScannedPage() {
 
   const visibleScans = useMemo(() => {
     if (filter !== 'resolved') return scans
+    const cutoff = Date.now() - RESOLVED_WINDOW_DAYS * 24 * 60 * 60 * 1000
     return scans.filter(s => {
       const ts = s.resolved_at ? Date.parse(s.resolved_at) : Date.parse(s.created_at)
-      return !Number.isNaN(ts) && ts >= RESOLVED_CUTOFF_MS
+      return !Number.isNaN(ts) && ts >= cutoff
     })
   }, [scans, filter])
 

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -1,11 +1,20 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { ChevronDown, ChevronUp, Trophy } from 'lucide-react'
 import { Skeleton } from '../components/ui/skeleton'
 import AddCardPanel from '../components/pokemon/AddCardPanel'
 import { formatDate } from '../utils/formatDate'
+
+// PokemonSetsLocationState carries the optional "open AddCardPanel pre-filled
+// with this query" hint that the /pokemon/scanned page passes through
+// React Router's location state when the user clicks "Enter manually" on a
+// no_match row. Once consumed by the panel it is cleared via navigate(..., {
+// replace: true }) so refresh / back navigation doesn't re-open the dialog.
+interface PokemonSetsLocationState {
+  addCardQuery?: string
+}
 
 interface PokemonSet {
   id: string
@@ -130,12 +139,26 @@ function SkeletonGrid() {
 
 export default function PokemonSets() {
   const { t } = useTranslation('pokemon')
+  const location = useLocation()
+  const navigate = useNavigate()
 
   const [sets, setSets] = useState<PokemonSet[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [showOlder, setShowOlder] = useState(false)
   const [attempt, setAttempt] = useState(0)
+
+  const locState = location.state as PokemonSetsLocationState | null
+  const initialAddCardQuery = locState?.addCardQuery ?? undefined
+
+  // After the AddCardPanel consumes its initialQuery we strip the hint from
+  // history so a subsequent back/forward navigation doesn't re-open the
+  // dialog. `replace: true` swaps the current history entry in place.
+  const handleInitialQueryConsumed = useCallback(() => {
+    if (locState?.addCardQuery) {
+      navigate(location.pathname + location.search, { replace: true, state: null })
+    }
+  }, [locState?.addCardQuery, navigate, location.pathname, location.search])
 
   const load = useCallback(() => {
     setLoading(true)
@@ -270,7 +293,11 @@ export default function PokemonSets() {
           </>
         )}
       </div>
-      <AddCardPanel onAdded={load} />
+      <AddCardPanel
+        onAdded={load}
+        initialQuery={initialAddCardQuery}
+        onInitialQueryConsumed={handleInitialQueryConsumed}
+      />
     </div>
   )
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,14 +20,10 @@ export default defineConfig({
     setupFiles: ['./src/test-setup.ts'],
     // The Hetzner box has 7.6 GB RAM. vmThreads spawns multiple V8 isolates
     // that each balloon to ~4 GB under React 19, OOM-killing Forge smiths.
-    // forks + singleFork + fileParallelism:false bounds the test run to one
-    // child process (~1 GB peak) at the cost of running suites sequentially.
+    // forks + maxWorkers:1 + fileParallelism:false bounds the test run to one
+    // child process at a time (~1 GB peak) at the cost of running suites sequentially.
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    maxWorkers: 1,
     fileParallelism: false,
     server: {
       deps: {


### PR DESCRIPTION
## Changes

- **Pokémon scanned cards review page** - New `/pokemon/scanned` page lets the kid review queued, matched, no-match and failed scans, with per-row Add / Discard / Try again / Enter manually actions and a "today {used}/{cap}" badge. Polls every 30 s while visible so queued → processing → matched updates without a manual refresh. (Hytte-b1b1)
- **Pre-fill AddCardPanel from a no-match scan** - "Enter manually" on a no-match scan row now opens the Add card dialog with the partial set name and collector number Claude could read seeded into the search input, so the kid does not have to retype what the scanner already saw. (Hytte-b1b1)

## Original Issue (feature): Pokémon async scanner: /pokemon/scanned page

Closes the Phase 1 loop with the page where the kid reviews scan results and takes action.

## Route

Add `/pokemon/scanned` to `web/src/App.tsx` inside `<ProtectedRoute>`.

## Page layout

`web/src/pages/PokemonScanned.tsx`:

### Header
- Title "Scanned cards" with subtitle "Review your recent scans".
- Today usage badge: "{{used}} / {{cap}} scans today" (from the counts endpoint).
- Filter chips: `Needs review` (default, matched + no_match + failed), `Pending` (queued + processing), `Recently resolved` (added + discarded, last 7 days).

### Card list (per row)
- Thumbnail of the scanned image (served via `/api/pokemon/scans/{id}/image`; for resolved rows where the image was deleted, show a generic placeholder).
- Status pill (color-coded).
- If matched: card name + set + collector_no + confidence + price NOK.
- If no_match: confidence + reason from error_message.
- If failed: error_message.
- If queued/processing: loading spinner with elapsed time.
- Per-row actions:
    - matched → `Add to collection` (with a small variant dropdown if multiple), `Discard`, `Try again` (=retry — requeues; same image).
    - no_match → `Try again` (rare — Claude rarely changes its mind on the same image, but available), `Discard`, `Enter manually` (opens AddCardPanel pre-filled with the partial info Claude could read, if any).
    - failed → `Try again`, `Discard`.
    - queued/processing → no actions, just status.

### Empty state
- "No scans yet — open the camera scanner from Add card."

## Data fetching

- Page mount: GET /api/pokemon/scans with the active filter.
- Poll every 30 s while page is visible to pick up status transitions.
- After any resolve action: refetch immediately.

## i18n

Add to `pokemon.json` (all three locales):
- scanned.title / scanned.subtitle / scanned.empty
- scanned.todayUsage — "{{used}} / {{cap}} scans today"
- scanned.filter.needsReview / .pending / .resolved
- scanned.action.add / .addVariant / .discard / .retry / .enterManually
- scanned.status.queued / .processing / .matched / .noMatch / .failed / .added / .discarded
- scanned.confidence — "{{pct}}% confidence"

## Tests

- PokemonScanned.test.tsx: render with fixtures across statuses; filter chips narrow correctly; resolve actions POST and refetch.
- Loading + empty + error states.

## Acceptance

- `npm run lint`, `npm run build`, `npm test -- --run src/pages/PokemonScanned` pass.
- A scan goes queued → processing → matched, becomes visible on the page within ~90 s of camera capture.
- Add resolves the row and the card appears in /pokemon/sets/{id}.
- Discard removes the image from disk.
- Mobile 375px works.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-b1b1 | Branch: forge/Hytte-b1b1
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->