### PR TITLE
Pokémon async scanner: webpush per resolved scan (Hytte-1dyw)

### DIFF
--- a/changelog.d/Hytte-1dyw.md
+++ b/changelog.d/Hytte-1dyw.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon scan push notifications** - Resolving a card scan now fires a Web Push so the kid knows the result is ready; tapping it opens /pokemon/scanned focused on that row. Includes an opt-out toggle in Settings → Pokémon and is on by default. (Hytte-1dyw)

--- a/internal/auth/settings_handlers.go
+++ b/internal/auth/settings_handlers.go
@@ -214,6 +214,7 @@ func PreferencesPutHandler(db *sql.DB) http.HandlerFunc {
 			"calendar_visible_ids":               true,
 			"regnemester_muted":                  true,
 			"pokemon_scan_daily_cap":             true,
+			"pokemon_scan_push_enabled":          true,
 		}
 
 		// Integer range keys: HR/pace, work hours, budget preferences, and other numeric settings.

--- a/internal/pokemon/scan_worker.go
+++ b/internal/pokemon/scan_worker.go
@@ -3,15 +3,19 @@ package pokemon
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/Robin831/Hytte/internal/push"
 	"github.com/Robin831/Hytte/internal/training"
 )
 
@@ -201,6 +205,7 @@ func processScanJob(ctx context.Context, db *sql.DB, job scanJob) {
 		if r := recover(); r != nil {
 			log.Printf("pokemon: scan worker panic on job %d: %v", job.ID, r)
 			finalizeScanJobFailed(db, job.ID, fmt.Sprintf("worker panic: %v", r))
+			notifyScanResult(db, job.UserID, job.ID, scanJobStatusFailed, "", "")
 		}
 	}()
 
@@ -217,30 +222,36 @@ func processScanJob(ctx context.Context, db *sql.DB, job scanJob) {
 	imagePath, err := encryption.DecryptField(job.ImagePathEnc)
 	if err != nil {
 		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("decrypt image path: %v", err))
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusFailed, "", "")
 		return
 	}
 	if imagePath == "" {
 		finalizeScanJobFailed(db, job.ID, "empty image path")
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusFailed, "", "")
 		return
 	}
 	if _, err := os.Stat(imagePath); err != nil {
 		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("stat image: %v", err))
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusFailed, "", "")
 		return
 	}
 
 	cfg, err := training.LoadClaudeConfig(db, job.UserID)
 	if err != nil {
 		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("load claude config: %v", err))
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusFailed, "", "")
 		return
 	}
 	if !cfg.Enabled {
 		finalizeScanJobFailed(db, job.ID, "claude is not enabled for this user")
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusFailed, "", "")
 		return
 	}
 
 	raw, err := scanRunPromptFn(ctx, cfg, scanPrompt, imagePath)
 	if err != nil {
 		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("claude scan: %v", err))
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusFailed, "", "")
 		return
 	}
 
@@ -256,16 +267,19 @@ func processScanJob(ctx context.Context, db *sql.DB, job scanJob) {
 	result, parseErr := parseClaudeScanResult(raw)
 	if parseErr != nil {
 		finalizeScanJobNoMatch(db, job.ID, 0, fmt.Sprintf("could not parse vision response: %v", parseErr), respEnc)
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusNoMatch, "", "")
 		return
 	}
 	if result.Confidence < scanConfidenceThreshold {
 		finalizeScanJobNoMatch(db, job.ID, result.Confidence, "low confidence", respEnc)
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusNoMatch, "", "")
 		return
 	}
 
 	candidates, reason, err := findScanCandidates(ctx, db, job.UserID, result)
 	if err != nil {
 		finalizeScanJobFailed(db, job.ID, fmt.Sprintf("find candidates: %v", err))
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusFailed, "", "")
 		return
 	}
 	if len(candidates) == 0 {
@@ -273,6 +287,7 @@ func processScanJob(ctx context.Context, db *sql.DB, job scanJob) {
 			reason = "no candidate found"
 		}
 		finalizeScanJobNoMatch(db, job.ID, result.Confidence, reason, respEnc)
+		notifyScanResult(db, job.UserID, job.ID, scanJobStatusNoMatch, "", "")
 		return
 	}
 
@@ -282,6 +297,11 @@ func processScanJob(ctx context.Context, db *sql.DB, job scanJob) {
 	// user picks the specific kind (normal vs reverse vs holo) during resolve.
 	matched := candidates[0]
 	finalizeScanJobMatched(db, job.ID, matched.Card.ID, result.Confidence, respEnc)
+	setName := ""
+	if matched.Set != nil {
+		setName = matched.Set.Name
+	}
+	notifyScanResult(db, job.UserID, job.ID, scanJobStatusMatched, matched.Card.Name, setName)
 }
 
 // finalizeScanJobMatched sets the terminal 'matched' state. Uses a short
@@ -339,4 +359,90 @@ func nullIfEmpty(s string) any {
 		return nil
 	}
 	return s
+}
+
+// scanPushPreferenceKey is the user preference that opts a kid out of per-scan
+// push notifications. Default is enabled — only an explicit "false" disables.
+const scanPushPreferenceKey = "pokemon_scan_push_enabled"
+
+// scanPushHTTPClient is the HTTP client used for sending scan-result push
+// notifications. A short timeout keeps the worker goroutine from stalling
+// indefinitely on a slow push endpoint.
+var scanPushHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// scanPushSendFn is the package-level seam tests override to capture push
+// payloads without exercising the real HTTP transport. Production wires it to
+// push.SendToUser.
+var scanPushSendFn = func(db *sql.DB, userID int64, payload []byte) ([]push.SendResult, error) {
+	return push.SendToUser(db, scanPushHTTPClient, userID, payload)
+}
+
+// scanPushEnabled returns whether the user accepts per-scan push notifications.
+// Missing preference defaults to true; only the literal string "false" opts a
+// user out. DB errors fail-open so a transient lookup failure does not
+// permanently silence notifications.
+func scanPushEnabled(db *sql.DB, userID int64) bool {
+	prefs, err := auth.GetPreferences(db, userID)
+	if err != nil {
+		log.Printf("pokemon: scan push load preferences for user %d: %v", userID, err)
+		return true
+	}
+	v, ok := prefs[scanPushPreferenceKey]
+	if !ok {
+		return true
+	}
+	return v != "false"
+}
+
+// notifyScanResult dispatches a push notification for a scan job that just
+// transitioned to a terminal state. All errors are logged and swallowed —
+// push delivery must never block the worker. cardName and setName are used
+// only for the matched status; ignored otherwise.
+func notifyScanResult(db *sql.DB, userID, jobID int64, status, cardName, setName string) {
+	if !scanPushEnabled(db, userID) {
+		return
+	}
+	notif, ok := buildScanResultNotification(status, jobID, cardName, setName)
+	if !ok {
+		return
+	}
+	payload, err := json.Marshal(notif)
+	if err != nil {
+		log.Printf("pokemon: marshal scan push for job %d: %v", jobID, err)
+		return
+	}
+	if _, err := scanPushSendFn(db, userID, payload); err != nil {
+		log.Printf("pokemon: send scan push for job %d: %v", jobID, err)
+	}
+}
+
+// buildScanResultNotification returns the Notification body for a terminal
+// status. The tag collapses repeats for the same job; the URL deep-links the
+// scanned page focused on the row so a notification click takes the kid
+// straight to the result. Unknown statuses return ok=false so callers can
+// skip the send.
+func buildScanResultNotification(status string, jobID int64, cardName, setName string) (push.Notification, bool) {
+	var body string
+	switch status {
+	case scanJobStatusMatched:
+		if setName != "" {
+			body = fmt.Sprintf("Found: %s (%s)", cardName, setName)
+		} else if cardName != "" {
+			body = fmt.Sprintf("Found: %s", cardName)
+		} else {
+			body = "Card matched"
+		}
+	case scanJobStatusNoMatch:
+		body = "Couldn't read the card — try another angle"
+	case scanJobStatusFailed:
+		body = "Scan failed — try again"
+	default:
+		return push.Notification{}, false
+	}
+	return push.Notification{
+		Title: "Scan result",
+		Body:  body,
+		Tag:   fmt.Sprintf("pokemon-scan-%d", jobID),
+		URL:   fmt.Sprintf("/pokemon/scanned?focus=%d", jobID),
+	}, true
 }

--- a/internal/pokemon/scan_worker.go
+++ b/internal/pokemon/scan_worker.go
@@ -411,8 +411,17 @@ func notifyScanResult(db *sql.DB, userID, jobID int64, status, cardName, setName
 		log.Printf("pokemon: marshal scan push for job %d: %v", jobID, err)
 		return
 	}
-	if _, err := scanPushSendFn(db, userID, payload); err != nil {
+	results, err := scanPushSendFn(db, userID, payload)
+	if err != nil {
 		log.Printf("pokemon: send scan push for job %d: %v", jobID, err)
+		return
+	}
+	for _, r := range results {
+		if r.Err != nil {
+			log.Printf("pokemon: scan push delivery failed for job %d subscription %d: %v", jobID, r.SubscriptionID, r.Err)
+		} else if r.StatusCode != 0 && r.StatusCode != 201 && r.StatusCode != 200 {
+			log.Printf("pokemon: scan push non-2xx for job %d subscription %d: status %d", jobID, r.SubscriptionID, r.StatusCode)
+		}
 	}
 }
 
@@ -421,6 +430,13 @@ func notifyScanResult(db *sql.DB, userID, jobID int64, status, cardName, setName
 // scanned page focused on the row so a notification click takes the kid
 // straight to the result. Unknown statuses return ok=false so callers can
 // skip the send.
+//
+// Strings are intentionally in English: backend push payloads are opaque bytes
+// delivered before the browser renders them, and there is no server-side
+// translation mechanism. This matches the existing pattern in
+// internal/webhooks/push_dispatch.go. Localisation of notification text would
+// require a server-side translation helper keyed on the user's language
+// preference — a separate concern outside the scope of this feature.
 func buildScanResultNotification(status string, jobID int64, cardName, setName string) (push.Notification, bool) {
 	var body string
 	switch status {

--- a/internal/pokemon/scan_worker_test.go
+++ b/internal/pokemon/scan_worker_test.go
@@ -2,9 +2,16 @@ package pokemon
 
 import (
 	"context"
+	"crypto/ecdh"
+	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,7 +20,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/Robin831/Hytte/internal/push"
 	"github.com/Robin831/Hytte/internal/training"
 )
 
@@ -542,4 +551,234 @@ func stubScanPromptFn(t *testing.T, fn func() (string, error)) {
 		defer stubScanPromptMu.Unlock()
 		scanRunPromptFn = orig
 	})
+}
+
+// capturedPush is a single (userID, payload) pair sent to scanPushSendFn while
+// a test has the seam stubbed.
+type capturedPush struct {
+	userID  int64
+	payload []byte
+}
+
+// pushCapture serialises writes to its underlying slice so concurrent tests
+// (e.g. TestStartScanWorker_ProcessesQueuedJobs) can collect pushes without
+// racing.
+type pushCapture struct {
+	mu    sync.Mutex
+	calls []capturedPush
+}
+
+func (c *pushCapture) record(userID int64, payload []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Copy the payload because callers reuse the buffer.
+	cp := make([]byte, len(payload))
+	copy(cp, payload)
+	c.calls = append(c.calls, capturedPush{userID: userID, payload: cp})
+}
+
+func (c *pushCapture) snapshot() []capturedPush {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]capturedPush, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
+// stubScanPushCapture replaces scanPushSendFn with a no-op recorder that
+// returns a single successful SendResult so callers in production code see a
+// healthy response. The original function is restored on cleanup.
+func stubScanPushCapture(t *testing.T) *pushCapture {
+	t.Helper()
+	rec := &pushCapture{}
+	orig := scanPushSendFn
+	scanPushSendFn = func(_ *sql.DB, userID int64, payload []byte) ([]push.SendResult, error) {
+		rec.record(userID, payload)
+		return []push.SendResult{{SubscriptionID: 1, StatusCode: http.StatusCreated}}, nil
+	}
+	t.Cleanup(func() { scanPushSendFn = orig })
+	return rec
+}
+
+// decodeNotification unmarshals a captured payload, failing the test if the
+// JSON is invalid.
+func decodeNotification(t *testing.T, payload []byte) push.Notification {
+	t.Helper()
+	var n push.Notification
+	if err := json.Unmarshal(payload, &n); err != nil {
+		t.Fatalf("decode notification payload: %v (raw=%q)", err, payload)
+	}
+	return n
+}
+
+// TestProcessScanJob_PushEnabled_Matched verifies the matched terminal status
+// fires a push with the expected title, body, tag, and click URL.
+func TestProcessScanJob_PushEnabled_Matched(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+	pushed := stubScanPushCapture(t)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	stubScanPrompt(t, `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"025","confidence":0.92}`, nil)
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	calls := pushed.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 push call, got %d", len(calls))
+	}
+	if calls[0].userID != u.ID {
+		t.Errorf("push userID = %d, want %d", calls[0].userID, u.ID)
+	}
+	notif := decodeNotification(t, calls[0].payload)
+	if notif.Title != "Scan result" {
+		t.Errorf("title = %q, want %q", notif.Title, "Scan result")
+	}
+	wantBody := "Found: Pikachu (Scarlet & Violet Base)"
+	if notif.Body != wantBody {
+		t.Errorf("body = %q, want %q", notif.Body, wantBody)
+	}
+	wantTag := fmt.Sprintf("pokemon-scan-%d", jobID)
+	if notif.Tag != wantTag {
+		t.Errorf("tag = %q, want %q", notif.Tag, wantTag)
+	}
+	wantURL := fmt.Sprintf("/pokemon/scanned?focus=%d", jobID)
+	if notif.URL != wantURL {
+		t.Errorf("url = %q, want %q", notif.URL, wantURL)
+	}
+}
+
+// TestProcessScanJob_PushEnabled_NoMatch verifies the no_match terminal status
+// fires a push with the friendly retry copy.
+func TestProcessScanJob_PushEnabled_NoMatch(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+	pushed := stubScanPushCapture(t)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	stubScanPrompt(t, "i give up", nil)
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	calls := pushed.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 push call, got %d", len(calls))
+	}
+	notif := decodeNotification(t, calls[0].payload)
+	if notif.Body != "Couldn't read the card — try another angle" {
+		t.Errorf("body = %q", notif.Body)
+	}
+	if notif.Tag != fmt.Sprintf("pokemon-scan-%d", jobID) {
+		t.Errorf("tag = %q", notif.Tag)
+	}
+}
+
+// TestProcessScanJob_PushEnabled_Failed verifies the failed terminal status
+// (Claude CLI error here) fires a push with the failure copy.
+func TestProcessScanJob_PushEnabled_Failed(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+	pushed := stubScanPushCapture(t)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	stubScanPrompt(t, "", &stubError{msg: "claude CLI exploded"})
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	calls := pushed.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 push call, got %d", len(calls))
+	}
+	notif := decodeNotification(t, calls[0].payload)
+	if notif.Body != "Scan failed — try again" {
+		t.Errorf("body = %q", notif.Body)
+	}
+}
+
+// TestProcessScanJob_PushDisabled_NoSend verifies the opt-out preference
+// suppresses the push entirely.
+func TestProcessScanJob_PushDisabled_NoSend(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+	if err := auth.SetPreference(db, u.ID, scanPushPreferenceKey, "false"); err != nil {
+		t.Fatalf("set pref: %v", err)
+	}
+	pushed := stubScanPushCapture(t)
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	stubScanPrompt(t, `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"025","confidence":0.92}`, nil)
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	if calls := pushed.snapshot(); len(calls) != 0 {
+		t.Errorf("expected no push calls when disabled, got %d", len(calls))
+	}
+}
+
+// TestProcessScanJob_PushStaleSubscriptionDeleted exercises the real
+// push.SendToUser path against a test endpoint that returns 410 Gone. After
+// the worker finishes, the stale subscription must be gone from the DB and
+// the worker must not have errored out.
+func TestProcessScanJob_PushStaleSubscriptionDeleted(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "scan@example.com")
+	enableClaudeForUser(t, db, u.ID)
+
+	// Test push endpoint that always responds 410 Gone — RFC 8030 marker for
+	// a subscription the user agent has unregistered.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGone)
+	}))
+	t.Cleanup(ts.Close)
+
+	curve := ecdh.P256()
+	priv, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	p256dh := base64.RawURLEncoding.EncodeToString(priv.PublicKey().Bytes())
+	authSecret := base64.RawURLEncoding.EncodeToString(make([]byte, 16))
+
+	if _, err := push.SaveSubscription(db, u.ID, ts.URL, p256dh, authSecret); err != nil {
+		t.Fatalf("save subscription: %v", err)
+	}
+
+	// Point the worker's push HTTP client at the test server so TLS verifies.
+	origClient := scanPushHTTPClient
+	scanPushHTTPClient = ts.Client()
+	t.Cleanup(func() { scanPushHTTPClient = origClient })
+
+	imagePath, imageHash := writeTempScanImage(t)
+	jobID := enqueueScanJob(t, db, u.ID, imagePath, imageHash)
+
+	stubScanPrompt(t, `{"set_name":"Scarlet & Violet Base","set_id_hint":"sv1","collector_number":"025","confidence":0.92}`, nil)
+	processScanJob(context.Background(), db, scanJob{ID: jobID, UserID: u.ID, ImagePathEnc: encryptPath(t, imagePath)})
+
+	// Worker must still finalize the row normally.
+	row := readScanJob(t, db, jobID)
+	if row.Status != scanJobStatusMatched {
+		t.Errorf("expected matched status despite stale push subscription, got %q", row.Status)
+	}
+
+	// Subscription must be deleted by SendToUser's 410 handling.
+	subs, err := push.GetSubscriptionsByUser(db, u.ID)
+	if err != nil {
+		t.Fatalf("get subscriptions: %v", err)
+	}
+	if len(subs) != 0 {
+		t.Errorf("expected stale subscription to be deleted, got %d remaining", len(subs))
+	}
 }

--- a/web/public/locales/en/settings.json
+++ b/web/public/locales/en/settings.json
@@ -241,6 +241,13 @@
     "disableFeature": "Disable {{feature}} for {{name}}",
     "toggleError": "Failed to update {{feature}} for user — {{error}}"
   },
+  "pokemon": {
+    "heading": "Pokémon",
+    "scanPushTitle": "Scan result notifications",
+    "scanPushDescription": "Get a push when a card scan finishes (matched, no match, or failed).",
+    "enableScanPush": "Enable scan result notifications",
+    "disableScanPush": "Disable scan result notifications"
+  },
   "kioskTokens": {
     "heading": "Kiosk Tokens",
     "description": "Manage access tokens for the public kiosk display",

--- a/web/public/locales/nb/settings.json
+++ b/web/public/locales/nb/settings.json
@@ -241,6 +241,13 @@
     "disableFeature": "Deaktiver {{feature}} for {{name}}",
     "toggleError": "Kunne ikke oppdatere {{feature}} for bruker — {{error}}"
   },
+  "pokemon": {
+    "heading": "Pokémon",
+    "scanPushTitle": "Varsler om skanneresultater",
+    "scanPushDescription": "Få et push når en kortskanning er ferdig (treff, ingen treff eller feil).",
+    "enableScanPush": "Slå på varsler om skanneresultater",
+    "disableScanPush": "Slå av varsler om skanneresultater"
+  },
   "kioskTokens": {
     "heading": "Kiosktokens",
     "description": "Administrer tilgangstokens for offentlig kioskvisning",

--- a/web/public/locales/th/settings.json
+++ b/web/public/locales/th/settings.json
@@ -241,6 +241,13 @@
     "disableFeature": "ปิดใช้งาน {{feature}} สำหรับ {{name}}",
     "toggleError": "อัปเดต {{feature}} สำหรับผู้ใช้ไม่สำเร็จ — {{error}}"
   },
+  "pokemon": {
+    "heading": "โปเกมอน",
+    "scanPushTitle": "การแจ้งเตือนผลการสแกน",
+    "scanPushDescription": "รับการแจ้งเตือนเมื่อการสแกนการ์ดเสร็จสิ้น (พบ ไม่พบ หรือสแกนไม่สำเร็จ)",
+    "enableScanPush": "เปิดการแจ้งเตือนผลการสแกน",
+    "disableScanPush": "ปิดการแจ้งเตือนผลการสแกน"
+  },
   "kioskTokens": {
     "heading": "Kiosk Tokens",
     "description": "จัดการ access token สำหรับหน้าจอ kiosk สาธารณะ",

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { ArrowLeft, Loader2 } from 'lucide-react'
@@ -217,6 +217,8 @@ interface ScanRowProps {
   scan: ScanJob
   busy: boolean
   now: number
+  highlighted: boolean
+  rowRef?: (el: HTMLLIElement | null) => void
   onResolve: (scan: ScanJob, body: ResolveBody) => Promise<void>
   onEnterManually: (scan: ScanJob) => void
   t: TFunction<'pokemon'>
@@ -230,7 +232,7 @@ interface ResolveBody {
   notes?: string
 }
 
-function ScanRow({ scan, busy, now, onResolve, onEnterManually, t }: ScanRowProps) {
+function ScanRow({ scan, busy, now, highlighted, rowRef, onResolve, onEnterManually, t }: ScanRowProps) {
   const [pickingVariant, setPickingVariant] = useState(false)
   const variants = scan.matched_card?.variants ?? []
   const hasMultiVariant = variants.length > 1
@@ -470,9 +472,15 @@ function ScanRow({ scan, busy, now, onResolve, onEnterManually, t }: ScanRowProp
 
   return (
     <li
+      ref={rowRef}
       data-testid={`scan-row-${scan.id}`}
       data-status={scan.status}
-      className="flex flex-col sm:flex-row gap-3 p-3 bg-gray-800/40 border border-gray-800 rounded-lg"
+      data-highlighted={highlighted ? 'true' : undefined}
+      className={`flex flex-col sm:flex-row gap-3 p-3 bg-gray-800/40 border rounded-lg transition-shadow duration-700 ${
+        highlighted
+          ? 'border-emerald-400 ring-2 ring-emerald-400/70 shadow-lg shadow-emerald-500/20'
+          : 'border-gray-800'
+      }`}
     >
       <div className="flex gap-3 min-w-0 flex-1">
         <Thumbnail
@@ -494,6 +502,14 @@ export default function PokemonScannedPage() {
   const { t } = useTranslation('pokemon')
   const { toasts, showToast } = useToast()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const focusParam = searchParams.get('focus')
+  const focusedId = useMemo(() => {
+    if (!focusParam) return null
+    const parsed = parseInt(focusParam, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+  }, [focusParam])
 
   const [filter, setFilter] = useState<FilterKey>('needsReview')
   const [scans, setScans] = useState<ScanJob[]>([])
@@ -502,6 +518,9 @@ export default function PokemonScannedPage() {
   const [error, setError] = useState('')
   const [busyId, setBusyId] = useState<number | null>(null)
   const [now, setNow] = useState(() => Date.now())
+  const [highlightedId, setHighlightedId] = useState<number | null>(null)
+  const rowRefs = useRef<Map<number, HTMLLIElement>>(new Map())
+  const focusHandledRef = useRef<number | null>(null)
 
   // tick the clock once per second so the "elapsed time" caption on pending
   // rows updates without forcing a full refetch.
@@ -604,6 +623,38 @@ export default function PokemonScannedPage() {
       return !Number.isNaN(ts) && ts >= cutoff
     })
   }, [scans, filter, now])
+
+  // When ?focus=N is present (e.g. opened from a scan-result push), scroll the
+  // matching row into view and apply a brief highlight so the kid can tell
+  // which result is theirs. focusHandledRef ensures we only scroll once per
+  // focus id even though visibleScans churns on every background poll.
+  useEffect(() => {
+    if (focusedId == null) return
+    if (loading) return
+    if (focusHandledRef.current === focusedId) return
+    const target = visibleScans.find(s => s.id === focusedId)
+    if (!target) return
+    const el = rowRefs.current.get(focusedId)
+    if (!el) return
+    focusHandledRef.current = focusedId
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    setHighlightedId(focusedId)
+    // Strip ?focus= once the focus is consumed so a refresh does not re-trigger
+    // the highlight after the user has moved on.
+    const next = new URLSearchParams(searchParams)
+    next.delete('focus')
+    setSearchParams(next, { replace: true })
+  }, [focusedId, loading, visibleScans, searchParams, setSearchParams])
+
+  // Auto-clear the row highlight after a short window so the visual nudge
+  // fades back to normal styling without lingering forever. Split from the
+  // scroll effect so the timer is not cancelled by unrelated re-renders
+  // (e.g. when the background poll refreshes visibleScans).
+  useEffect(() => {
+    if (highlightedId == null) return
+    const timer = window.setTimeout(() => setHighlightedId(null), 2500)
+    return () => window.clearTimeout(timer)
+  }, [highlightedId])
 
   const handleEnterManually = useCallback(
     (scan: ScanJob) => {
@@ -742,6 +793,14 @@ export default function PokemonScannedPage() {
                 scan={scan}
                 busy={busyId === scan.id}
                 now={now}
+                highlighted={highlightedId === scan.id}
+                rowRef={el => {
+                  if (el) {
+                    rowRefs.current.set(scan.id, el)
+                  } else {
+                    rowRefs.current.delete(scan.id)
+                  }
+                }}
                 onResolve={handleResolve}
                 onEnterManually={handleEnterManually}
                 t={t}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -2093,6 +2093,45 @@ function Settings() {
       </CollapsibleSection>
       )}
 
+      {/* Pokémon — gated by the per-user feature flag */}
+      {hasFeature('pokemon') && (
+        <CollapsibleSection id="pokemon" title={t('pokemon.heading')}>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium">{t('pokemon.scanPushTitle')}</p>
+              <p className="text-sm text-gray-400">{t('pokemon.scanPushDescription')}</p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={preferences.pokemon_scan_push_enabled !== 'false'}
+              aria-label={
+                preferences.pokemon_scan_push_enabled !== 'false'
+                  ? t('pokemon.disableScanPush')
+                  : t('pokemon.enableScanPush')
+              }
+              onClick={async () => {
+                const next =
+                  preferences.pokemon_scan_push_enabled === 'false' ? 'true' : 'false'
+                await savePreference('pokemon_scan_push_enabled', next)
+              }}
+              disabled={saving}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
+                preferences.pokemon_scan_push_enabled !== 'false' ? 'bg-blue-600' : 'bg-gray-600'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                  preferences.pokemon_scan_push_enabled !== 'false'
+                    ? 'translate-x-6'
+                    : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
+        </CollapsibleSection>
+      )}
+
       {/* AI & Automation — admin only */}
       {user?.is_admin && (
       <CollapsibleSection id="ai-automation" title={t('aiAutomation.heading')}>


### PR DESCRIPTION
## Changes

- **Pokémon scan push notifications** - Resolving a card scan now fires a Web Push so the kid knows the result is ready; tapping it opens /pokemon/scanned focused on that row. Includes an opt-out toggle in Settings → Pokémon and is on by default. (Hytte-1dyw)

## Original Issue (feature): Pokémon async scanner: webpush per resolved scan

Phase 2 polish: when a scan job transitions out of queued/processing into matched/no_match/failed, fire a webpush notification so the kid knows there's something to look at.

## Backend

In the worker (scan_worker.go from the first bead in this chain):
- After updating a job's row to matched/no_match/failed, look up the user's active push subscriptions and send a notification.
- Title: "Scan result" (i18n).
- Body:
    - matched: "Found: {{card_name}} ({{set_name}})"
    - no_match: "Couldn't read the card — try another angle"
    - failed: "Scan failed — try again"
- Tag: `pokemon-scan-{{job_id}}` so duplicate notifications collapse.
- Click URL: `/pokemon/scanned?focus={{job_id}}` — opens the scanned page and scrolls to that row.
- Reuse the existing `internal/push` package; no new VAPID keys.
- Per-subscription errors are logged but never block the worker.

## Frontend

- Service worker (`web/public/sw.js` or wherever push handling lives today) already handles notification click → focus the app at the URL. Verify `/pokemon/scanned?focus=N` works (small extension to the existing routing if needed).
- On the scanned page, if `?focus=N` is present, scroll that row into view + briefly highlight it.

## Opt-out

Per-user preference key `pokemon_scan_push_enabled`, default true. Add a toggle on the Pokémon settings panel (which doesn't exist yet — add a minimal one to the scanned page header, or to Settings.tsx in a "Pokémon" subsection — pick whichever fits the existing structure).

## Tests

- scan_worker_test.go: when push is enabled, the worker invokes the push helper with the right payload. When disabled, it does not.
- 410-stale-subscription failure removes the subscription row (existing webpush behaviour — verify it still works through this code path).

## Acceptance

- `make build`, `make test`, `npm run build` pass.
- Resolving a scan job results in a notification on the user's phone within seconds (assuming a push subscription is active).
- Clicking the notification opens /pokemon/scanned scrolled to the right row.
- Opt-out preference works.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-1dyw | Branch: forge/Hytte-1dyw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->