### PR TITLE
Pokémon async scanner: auto-discard unresolved scans after 24h (Hytte-sx2t)

### DIFF
--- a/changelog.d/Hytte-sx2t.md
+++ b/changelog.d/Hytte-sx2t.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon scan auto-discard** - Unresolved Pokémon scans in matched/no_match/failed status are now auto-discarded after 24 hours: the image file is removed from disk, the row is marked discarded with resolved_at stamped, and the per-user preference `pokemon_scan_auto_discard_hours` (default 24, 0 disables, max 168) can override the window. A separate pass forces queued or processing jobs stuck for more than an hour to fail with "stale — worker did not complete in time" so a crashed worker no longer blocks the queue. (Hytte-sx2t)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -395,6 +395,11 @@ func main() {
 	// so it stops cleanly on shutdown.
 	go pokemon.StartScanWorker(notifCtx, database)
 
+	// Pokémon scan cleanup loop (Hytte-sx2t): wakes every hour to auto-discard
+	// unresolved matched/no_match/failed scans past the user's retention
+	// window and to force stuck queued/processing rows to 'failed'.
+	go pokemon.StartScanCleanupLoop(notifCtx, database)
+
 	// Schedule weekly Pokémon TCG full sync (Sunday 04:00 Europe/Oslo) and
 	// a daily price refresh (07:00 Europe/Oslo). Both run in the same
 	// goroutine to keep startup tidy; whichever timer fires first advances

--- a/internal/auth/settings_handlers.go
+++ b/internal/auth/settings_handlers.go
@@ -215,6 +215,7 @@ func PreferencesPutHandler(db *sql.DB) http.HandlerFunc {
 			"regnemester_muted":                  true,
 			"pokemon_scan_daily_cap":             true,
 			"pokemon_scan_push_enabled":          true,
+			"pokemon_scan_auto_discard_hours":    true,
 		}
 
 		// Integer range keys: HR/pace, work hours, budget preferences, and other numeric settings.
@@ -234,6 +235,7 @@ func PreferencesPutHandler(db *sql.DB) http.HandlerFunc {
 			"income_day":                      {1, 31},       // day of month; must match budget.defaultIncomeDay
 			"partner_income_day":              {1, 31},
 			"pokemon_scan_daily_cap":          {1, 100000}, // override for ScanDailyCap (600); upper bound keeps a typo from disabling the cap
+			"pokemon_scan_auto_discard_hours": {0, 168},    // 0 disables auto-discard for this user; cap at one week
 		}
 
 		allowedEvents := allowedEventKeys()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1703,9 +1703,10 @@ func createSchema(db *sql.DB) error {
 		confidence          REAL,
 		claude_response_enc TEXT,
 		error_message       TEXT,
-		created_at          TIMESTAMP NOT NULL,
-		processed_at        TIMESTAMP,
-		resolved_at         TIMESTAMP,
+		created_at               TIMESTAMP NOT NULL,
+		processing_started_at    TIMESTAMP,
+		processed_at             TIMESTAMP,
+		resolved_at              TIMESTAMP,
 		FOREIGN KEY (matched_card_id) REFERENCES pokemon_cards(id) ON DELETE SET NULL
 	);
 	CREATE INDEX IF NOT EXISTS idx_pokemon_scan_jobs_user_status ON pokemon_scan_jobs(user_id, status);
@@ -2423,6 +2424,20 @@ func createSchema(db *sql.DB) error {
 	}
 	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_task_tags_user_label_hmac ON task_tags(user_id, label_hmac) WHERE label_hmac != ''`); err != nil {
 		return fmt.Errorf("create task_tags label_hmac index: %w", err)
+	}
+
+	// Add processing_started_at to pokemon_scan_jobs (Hytte-sx2t): stamped when
+	// the worker claims a row (queued → processing) so the cleanup pass can
+	// distinguish a job that has been processing for 5 minutes from one that was
+	// merely created 5 minutes ago and is still queued.
+	var hasPokemonProcessingStartedAt int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('pokemon_scan_jobs') WHERE name = 'processing_started_at'`).Scan(&hasPokemonProcessingStartedAt); err != nil {
+		return fmt.Errorf("check pokemon_scan_jobs processing_started_at column: %w", err)
+	}
+	if hasPokemonProcessingStartedAt == 0 {
+		if _, err := db.Exec(`ALTER TABLE pokemon_scan_jobs ADD COLUMN processing_started_at TIMESTAMP`); err != nil {
+			return fmt.Errorf("add pokemon_scan_jobs processing_started_at column: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/pokemon/scan_cleanup.go
+++ b/internal/pokemon/scan_cleanup.go
@@ -94,17 +94,34 @@ func RunScanCleanup(ctx context.Context, db *sql.DB, now time.Time) (ScanCleanup
 	var result ScanCleanupResult
 
 	staleCutoff := now.Add(-scanStaleQueuedHours)
-	staleRes, err := db.ExecContext(ctx, `
+	// Queued jobs: measure staleness from created_at (they have never been
+	// claimed, so that is the only relevant timestamp).
+	staleQueuedRes, err := db.ExecContext(ctx, `
 		UPDATE pokemon_scan_jobs
 		SET status = ?, error_message = ?, processed_at = ?
-		WHERE status IN (?, ?) AND created_at < ?
+		WHERE status = ? AND created_at < ?
 	`, scanJobStatusFailed, scanStaleErrorMessage, now.UTC(),
-		scanJobStatusQueued, scanJobStatusProcessing, staleCutoff.UTC())
+		scanJobStatusQueued, staleCutoff.UTC())
 	if err != nil {
-		return result, fmt.Errorf("mark stale scan jobs failed: %w", err)
+		return result, fmt.Errorf("mark stale queued scan jobs failed: %w", err)
 	}
-	if n, err := staleRes.RowsAffected(); err == nil {
-		result.StaleFailed = int(n)
+	if n, err := staleQueuedRes.RowsAffected(); err == nil {
+		result.StaleFailed += int(n)
+	}
+	// Processing jobs: measure staleness from processing_started_at (stamped
+	// when the worker claims the row). Fall back to created_at for rows that
+	// pre-date the column so existing stuck jobs are still cleaned up.
+	staleProcessingRes, err := db.ExecContext(ctx, `
+		UPDATE pokemon_scan_jobs
+		SET status = ?, error_message = ?, processed_at = ?
+		WHERE status = ? AND COALESCE(processing_started_at, created_at) < ?
+	`, scanJobStatusFailed, scanStaleErrorMessage, now.UTC(),
+		scanJobStatusProcessing, staleCutoff.UTC())
+	if err != nil {
+		return result, fmt.Errorf("mark stale processing scan jobs failed: %w", err)
+	}
+	if n, err := staleProcessingRes.RowsAffected(); err == nil {
+		result.StaleFailed += int(n)
 	}
 
 	rows, err := db.QueryContext(ctx, `
@@ -164,13 +181,25 @@ func RunScanCleanup(ctx context.Context, db *sql.DB, now time.Time) (ScanCleanup
 		if c.errorMessage.Valid && c.errorMessage.String != "" {
 			newErr = c.errorMessage.String
 		}
-		if _, err := db.ExecContext(ctx, `
+		discardRes, err := db.ExecContext(ctx, `
 			UPDATE pokemon_scan_jobs
 			SET status = ?, resolved_at = ?, error_message = ?, image_path_enc = ''
 			WHERE id = ? AND resolved_at IS NULL AND status IN (?, ?, ?)
 		`, scanJobStatusDiscarded, now.UTC(), newErr, c.id,
-			scanJobStatusMatched, scanJobStatusNoMatch, scanJobStatusFailed); err != nil {
+			scanJobStatusMatched, scanJobStatusNoMatch, scanJobStatusFailed)
+		if err != nil {
 			log.Printf("pokemon: scan cleanup discard job=%d: %v", c.id, err)
+			continue
+		}
+		// Guard against the race where the user resolved or retried the scan
+		// between our SELECT and this UPDATE. Only delete the image and count the
+		// discard when the UPDATE actually changed the row.
+		n, err := discardRes.RowsAffected()
+		if err != nil {
+			log.Printf("pokemon: scan cleanup discard job=%d rows affected: %v", c.id, err)
+			continue
+		}
+		if n == 0 {
 			continue
 		}
 		deleteScanImageBestEffort(c.pathEnc)

--- a/internal/pokemon/scan_cleanup.go
+++ b/internal/pokemon/scan_cleanup.go
@@ -1,0 +1,240 @@
+package pokemon
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+// scanAutoDiscardPrefKey is the per-user preference that overrides the default
+// 24-hour auto-discard window. Stored as a base-10 integer in hours. 0 disables
+// auto-discard for that user; ScanAutoDiscardMaxHours caps the upper end so a
+// runaway pref can't keep stale images forever.
+const scanAutoDiscardPrefKey = "pokemon_scan_auto_discard_hours"
+
+// ScanAutoDiscardDefaultHours is the default retention window for unresolved
+// matched/no_match/failed scans before the cleanup pass discards them.
+const ScanAutoDiscardDefaultHours = 24
+
+// ScanAutoDiscardMaxHours caps the per-user override at one week.
+const ScanAutoDiscardMaxHours = 168
+
+// scanStaleQueuedHours is the threshold after which a job stuck in 'queued' or
+// 'processing' is forcibly transitioned to 'failed'. One hour is well above the
+// happy-path duration (Claude vision finishes in seconds) but well below the
+// 24-hour user-action window — a worker crash or unclean shutdown should not
+// leave a row blocking the worker for a full day.
+const scanStaleQueuedHours = 1 * time.Hour
+
+// scanStaleErrorMessage is the error_message written to rows the cleanup pass
+// transitions from queued/processing → failed. Kept as a constant so tests and
+// support tooling can match on the exact string.
+const scanStaleErrorMessage = "stale — worker did not complete in time"
+
+// scanAutoDiscardErrorMessage is the error_message stamped on rows the
+// cleanup pass auto-discards when the row does not already carry one (matched
+// rows reach the terminal state with NULL error_message; no_match/failed rows
+// already have a meaningful one we should preserve).
+const scanAutoDiscardErrorMessage = "auto-discarded after 24h"
+
+// scanCleanupInterval is how often the cleanup goroutine wakes. Mirrors the
+// existing session cleanup cadence in cmd/server/main.go — once an hour is
+// frequent enough that nothing lingers far past its window and infrequent
+// enough that the pass costs effectively nothing.
+const scanCleanupInterval = 1 * time.Hour
+
+// getUserAutoDiscardHours returns the clamped retention window for the user.
+// Missing / blank / non-integer values fall back to ScanAutoDiscardDefaultHours
+// so a malformed pref cannot silently disable cleanup. The result is clamped
+// to [0, ScanAutoDiscardMaxHours]; 0 means "never auto-discard for this user".
+func getUserAutoDiscardHours(ctx context.Context, db *sql.DB, userID int64) (int, error) {
+	var raw string
+	err := db.QueryRowContext(ctx, `
+		SELECT value FROM user_preferences WHERE user_id = ? AND key = ?
+	`, userID, scanAutoDiscardPrefKey).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ScanAutoDiscardDefaultHours, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("load scan auto-discard pref: %w", err)
+	}
+	n, convErr := strconv.Atoi(raw)
+	if convErr != nil {
+		return ScanAutoDiscardDefaultHours, nil
+	}
+	if n < 0 {
+		return 0, nil
+	}
+	if n > ScanAutoDiscardMaxHours {
+		return ScanAutoDiscardMaxHours, nil
+	}
+	return n, nil
+}
+
+// ScanCleanupResult is the per-run summary. Returned from RunScanCleanup so
+// tests can assert without scraping logs; production logs the same numbers.
+type ScanCleanupResult struct {
+	Discarded   int
+	StaleFailed int
+}
+
+// RunScanCleanup performs both housekeeping passes once: stale queued /
+// processing jobs are forced to 'failed', and unresolved terminal rows past
+// the per-user retention window are auto-discarded (image file removed,
+// status='discarded', resolved_at stamped). The now parameter makes the age
+// thresholds deterministic in tests.
+func RunScanCleanup(ctx context.Context, db *sql.DB, now time.Time) (ScanCleanupResult, error) {
+	var result ScanCleanupResult
+
+	staleCutoff := now.Add(-scanStaleQueuedHours)
+	staleRes, err := db.ExecContext(ctx, `
+		UPDATE pokemon_scan_jobs
+		SET status = ?, error_message = ?, processed_at = ?
+		WHERE status IN (?, ?) AND created_at < ?
+	`, scanJobStatusFailed, scanStaleErrorMessage, now.UTC(),
+		scanJobStatusQueued, scanJobStatusProcessing, staleCutoff.UTC())
+	if err != nil {
+		return result, fmt.Errorf("mark stale scan jobs failed: %w", err)
+	}
+	if n, err := staleRes.RowsAffected(); err == nil {
+		result.StaleFailed = int(n)
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, user_id, image_path_enc, created_at, error_message
+		FROM pokemon_scan_jobs
+		WHERE status IN (?, ?, ?) AND resolved_at IS NULL
+	`, scanJobStatusMatched, scanJobStatusNoMatch, scanJobStatusFailed)
+	if err != nil {
+		return result, fmt.Errorf("select unresolved scan jobs: %w", err)
+	}
+
+	type candidate struct {
+		id           int64
+		userID       int64
+		pathEnc      string
+		createdAt    time.Time
+		errorMessage sql.NullString
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.id, &c.userID, &c.pathEnc, &c.createdAt, &c.errorMessage); err != nil {
+			rows.Close()
+			return result, fmt.Errorf("scan unresolved row: %w", err)
+		}
+		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return result, fmt.Errorf("iterate unresolved rows: %w", err)
+	}
+	rows.Close()
+
+	hoursByUser := make(map[int64]int)
+	for _, c := range candidates {
+		hours, ok := hoursByUser[c.userID]
+		if !ok {
+			h, err := getUserAutoDiscardHours(ctx, db, c.userID)
+			if err != nil {
+				log.Printf("pokemon: scan cleanup load pref user=%d: %v", c.userID, err)
+				hoursByUser[c.userID] = ScanAutoDiscardDefaultHours
+				hours = ScanAutoDiscardDefaultHours
+			} else {
+				hoursByUser[c.userID] = h
+				hours = h
+			}
+		}
+		if hours <= 0 {
+			continue
+		}
+		ageCutoff := now.Add(-time.Duration(hours) * time.Hour)
+		if !c.createdAt.Before(ageCutoff) {
+			continue
+		}
+
+		newErr := scanAutoDiscardErrorMessage
+		if c.errorMessage.Valid && c.errorMessage.String != "" {
+			newErr = c.errorMessage.String
+		}
+		if _, err := db.ExecContext(ctx, `
+			UPDATE pokemon_scan_jobs
+			SET status = ?, resolved_at = ?, error_message = ?, image_path_enc = ''
+			WHERE id = ? AND resolved_at IS NULL AND status IN (?, ?, ?)
+		`, scanJobStatusDiscarded, now.UTC(), newErr, c.id,
+			scanJobStatusMatched, scanJobStatusNoMatch, scanJobStatusFailed); err != nil {
+			log.Printf("pokemon: scan cleanup discard job=%d: %v", c.id, err)
+			continue
+		}
+		deleteScanImageBestEffort(c.pathEnc)
+		result.Discarded++
+	}
+
+	return result, nil
+}
+
+// deleteScanImageBestEffort removes the on-disk scan image, ignoring missing
+// files. Errors other than ErrNotExist are logged but never abort the cleanup
+// pass — the DB row is already discarded; a leftover file can be reaped later.
+func deleteScanImageBestEffort(pathEnc string) {
+	if pathEnc == "" {
+		return
+	}
+	path, err := encryption.DecryptField(pathEnc)
+	if err != nil || path == "" {
+		return
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Printf("pokemon: scan cleanup remove image %s: %v", path, err)
+	}
+}
+
+// StartScanCleanupLoop runs RunScanCleanup once at startup and then every
+// scanCleanupInterval until ctx is cancelled. Call site: a single
+// `go pokemon.StartScanCleanupLoop(notifCtx, db)` from cmd/server/main.go
+// alongside the existing scan worker and the nightly suggestions cron.
+func StartScanCleanupLoop(ctx context.Context, db *sql.DB) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("pokemon: scan cleanup loop panic: %v", r)
+		}
+	}()
+
+	runOnce := func() {
+		runCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+		res, err := RunScanCleanup(runCtx, db, time.Now().UTC())
+		if err != nil {
+			log.Printf("pokemon: scan cleanup: %v", err)
+			return
+		}
+		if res.Discarded > 0 || res.StaleFailed > 0 {
+			log.Printf("pokemon: scan cleanup auto-discarded %d scans, failed %d stale jobs",
+				res.Discarded, res.StaleFailed)
+		}
+	}
+
+	// Best-effort startup pass so a row past its window after a restart is
+	// reaped without waiting a full interval. Matches the pattern used by the
+	// session cleanup and currency sync.
+	runOnce()
+
+	ticker := time.NewTicker(scanCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runOnce()
+		}
+	}
+}

--- a/internal/pokemon/scan_cleanup_test.go
+++ b/internal/pokemon/scan_cleanup_test.go
@@ -1,0 +1,406 @@
+package pokemon
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+// insertScanJobAt seeds a row with a caller-supplied created_at and on-disk
+// image path encrypted via the same layer as production. Returns the row id so
+// tests can assert the after-state directly.
+func insertScanJobAt(t *testing.T, db *sql.DB, userID int64, status, imagePath string, createdAt time.Time) int64 {
+	t.Helper()
+	enc := ""
+	if imagePath != "" {
+		var err error
+		enc, err = encryption.EncryptField(imagePath)
+		if err != nil {
+			t.Fatalf("encrypt path: %v", err)
+		}
+	}
+	res, err := db.Exec(`
+		INSERT INTO pokemon_scan_jobs (user_id, status, image_path_enc, image_hash, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, userID, status, enc, "deadbeef", createdAt.UTC())
+	if err != nil {
+		t.Fatalf("insert scan job: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last id: %v", err)
+	}
+	return id
+}
+
+// writeScanImageFile drops a placeholder file at <root>/pokemon-scans/<uid>/<name>
+// so the cleanup pass has something concrete to remove. Returns the absolute
+// path; the file's contents don't matter.
+func writeScanImageFile(t *testing.T, root string, userID int64, name string) string {
+	t.Helper()
+	dir := filepath.Join(root, "pokemon-scans", strconv.FormatInt(userID, 10))
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("scan-bytes"), 0600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	return path
+}
+
+func readCleanupRow(t *testing.T, db *sql.DB, id int64) (status, errMsg string, resolvedAt sql.NullTime, pathEnc string) {
+	t.Helper()
+	var em sql.NullString
+	if err := db.QueryRow(`
+		SELECT status, COALESCE(error_message, ''), resolved_at, image_path_enc
+		FROM pokemon_scan_jobs WHERE id = ?
+	`, id).Scan(&status, &em, &resolvedAt, &pathEnc); err != nil {
+		t.Fatalf("read cleanup row: %v", err)
+	}
+	return status, em.String, resolvedAt, pathEnc
+}
+
+func TestRunScanCleanup_DiscardsOldMatched(t *testing.T) {
+	root := t.TempDir()
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "old@example.com")
+
+	now := time.Now().UTC()
+	imagePath := writeScanImageFile(t, root, u.ID, "old.jpg")
+	id := insertScanJobAt(t, db, u.ID, scanJobStatusMatched, imagePath, now.Add(-25*time.Hour))
+
+	res, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+	if res.Discarded != 1 {
+		t.Errorf("expected discarded=1, got %d", res.Discarded)
+	}
+
+	status, errMsg, resolvedAt, pathEnc := readCleanupRow(t, db, id)
+	if status != scanJobStatusDiscarded {
+		t.Errorf("expected status=discarded, got %q", status)
+	}
+	if !resolvedAt.Valid {
+		t.Errorf("expected resolved_at to be set")
+	}
+	if errMsg != scanAutoDiscardErrorMessage {
+		t.Errorf("expected error_message=%q, got %q", scanAutoDiscardErrorMessage, errMsg)
+	}
+	if pathEnc != "" {
+		t.Errorf("expected image_path_enc cleared, got %q", pathEnc)
+	}
+	if _, err := os.Stat(imagePath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected image file removed, stat err=%v", err)
+	}
+}
+
+func TestRunScanCleanup_LeavesYoungMatchedAlone(t *testing.T) {
+	root := t.TempDir()
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "young@example.com")
+
+	now := time.Now().UTC()
+	imagePath := writeScanImageFile(t, root, u.ID, "young.jpg")
+	id := insertScanJobAt(t, db, u.ID, scanJobStatusMatched, imagePath, now.Add(-5*time.Hour))
+
+	res, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+	if res.Discarded != 0 {
+		t.Errorf("expected discarded=0, got %d", res.Discarded)
+	}
+
+	status, _, resolvedAt, _ := readCleanupRow(t, db, id)
+	if status != scanJobStatusMatched {
+		t.Errorf("expected status=matched (untouched), got %q", status)
+	}
+	if resolvedAt.Valid {
+		t.Errorf("expected resolved_at to remain NULL")
+	}
+	if _, err := os.Stat(imagePath); err != nil {
+		t.Errorf("expected image file preserved, got err=%v", err)
+	}
+}
+
+func TestRunScanCleanup_FailsStaleProcessing(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "stuck@example.com")
+
+	now := time.Now().UTC()
+	id := insertScanJobAt(t, db, u.ID, scanJobStatusProcessing, "", now.Add(-2*time.Hour))
+
+	res, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+	if res.StaleFailed != 1 {
+		t.Errorf("expected stale_failed=1, got %d", res.StaleFailed)
+	}
+
+	status, errMsg, _, _ := readCleanupRow(t, db, id)
+	if status != scanJobStatusFailed {
+		t.Errorf("expected status=failed, got %q", status)
+	}
+	if errMsg != scanStaleErrorMessage {
+		t.Errorf("expected error_message=%q, got %q", scanStaleErrorMessage, errMsg)
+	}
+}
+
+func TestRunScanCleanup_FailsStaleQueued(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "stuck@example.com")
+
+	now := time.Now().UTC()
+	id := insertScanJobAt(t, db, u.ID, scanJobStatusQueued, "", now.Add(-90*time.Minute))
+
+	res, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+	if res.StaleFailed != 1 {
+		t.Errorf("expected stale_failed=1, got %d", res.StaleFailed)
+	}
+
+	status, errMsg, _, _ := readCleanupRow(t, db, id)
+	if status != scanJobStatusFailed {
+		t.Errorf("expected status=failed, got %q", status)
+	}
+	if errMsg != scanStaleErrorMessage {
+		t.Errorf("expected error_message=%q, got %q", scanStaleErrorMessage, errMsg)
+	}
+}
+
+func TestRunScanCleanup_LeavesYoungProcessingAlone(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "running@example.com")
+
+	now := time.Now().UTC()
+	id := insertScanJobAt(t, db, u.ID, scanJobStatusProcessing, "", now.Add(-10*time.Minute))
+
+	res, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+	if res.StaleFailed != 0 {
+		t.Errorf("expected stale_failed=0, got %d", res.StaleFailed)
+	}
+	status, _, _, _ := readCleanupRow(t, db, id)
+	if status != scanJobStatusProcessing {
+		t.Errorf("expected status=processing (untouched), got %q", status)
+	}
+}
+
+func TestRunScanCleanup_UserPrefZeroDisables(t *testing.T) {
+	root := t.TempDir()
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "infinite@example.com")
+	if err := auth.SetPreference(db, u.ID, scanAutoDiscardPrefKey, "0"); err != nil {
+		t.Fatalf("set pref: %v", err)
+	}
+
+	now := time.Now().UTC()
+	imagePath := writeScanImageFile(t, root, u.ID, "infinite.jpg")
+	id := insertScanJobAt(t, db, u.ID, scanJobStatusMatched, imagePath, now.Add(-25*time.Hour))
+
+	res, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+	if res.Discarded != 0 {
+		t.Errorf("expected discarded=0 with pref=0, got %d", res.Discarded)
+	}
+
+	status, _, resolvedAt, _ := readCleanupRow(t, db, id)
+	if status != scanJobStatusMatched {
+		t.Errorf("expected status=matched (untouched), got %q", status)
+	}
+	if resolvedAt.Valid {
+		t.Errorf("expected resolved_at to remain NULL")
+	}
+	if _, err := os.Stat(imagePath); err != nil {
+		t.Errorf("expected image preserved with pref=0, stat err=%v", err)
+	}
+}
+
+func TestRunScanCleanup_UserPref48Hours(t *testing.T) {
+	root := t.TempDir()
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "two-day@example.com")
+	if err := auth.SetPreference(db, u.ID, scanAutoDiscardPrefKey, "48"); err != nil {
+		t.Fatalf("set pref: %v", err)
+	}
+
+	now := time.Now().UTC()
+	youngImg := writeScanImageFile(t, root, u.ID, "young.jpg")
+	oldImg := writeScanImageFile(t, root, u.ID, "old.jpg")
+	youngID := insertScanJobAt(t, db, u.ID, scanJobStatusMatched, youngImg, now.Add(-25*time.Hour))
+	oldID := insertScanJobAt(t, db, u.ID, scanJobStatusMatched, oldImg, now.Add(-49*time.Hour))
+
+	res, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+	if res.Discarded != 1 {
+		t.Errorf("expected discarded=1, got %d", res.Discarded)
+	}
+
+	youngStatus, _, _, _ := readCleanupRow(t, db, youngID)
+	if youngStatus != scanJobStatusMatched {
+		t.Errorf("expected young row untouched, got status=%q", youngStatus)
+	}
+	if _, err := os.Stat(youngImg); err != nil {
+		t.Errorf("expected young image preserved, err=%v", err)
+	}
+
+	oldStatus, _, oldResolved, _ := readCleanupRow(t, db, oldID)
+	if oldStatus != scanJobStatusDiscarded {
+		t.Errorf("expected old row discarded, got status=%q", oldStatus)
+	}
+	if !oldResolved.Valid {
+		t.Errorf("expected resolved_at set on old row")
+	}
+	if _, err := os.Stat(oldImg); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected old image removed, stat err=%v", err)
+	}
+}
+
+func TestRunScanCleanup_MissingImageFileNotFatal(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "no-image@example.com")
+
+	now := time.Now().UTC()
+	// Path that points nowhere — cleanup should still discard the DB row.
+	missingPath := filepath.Join(t.TempDir(), "never-existed.jpg")
+	id := insertScanJobAt(t, db, u.ID, scanJobStatusMatched, missingPath, now.Add(-25*time.Hour))
+
+	res, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup unexpectedly errored: %v", err)
+	}
+	if res.Discarded != 1 {
+		t.Errorf("expected discarded=1, got %d", res.Discarded)
+	}
+
+	status, _, _, _ := readCleanupRow(t, db, id)
+	if status != scanJobStatusDiscarded {
+		t.Errorf("expected status=discarded despite missing image, got %q", status)
+	}
+}
+
+func TestRunScanCleanup_PreservesExistingErrorMessage(t *testing.T) {
+	root := t.TempDir()
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "had-error@example.com")
+
+	now := time.Now().UTC()
+	imagePath := writeScanImageFile(t, root, u.ID, "noisy.jpg")
+	enc, err := encryption.EncryptField(imagePath)
+	if err != nil {
+		t.Fatalf("encrypt path: %v", err)
+	}
+	res, err := db.Exec(`
+		INSERT INTO pokemon_scan_jobs (user_id, status, image_path_enc, image_hash, error_message, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, u.ID, scanJobStatusNoMatch, enc, "deadbeef", "low confidence", now.Add(-30*time.Hour))
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	id, _ := res.LastInsertId()
+
+	if _, err := RunScanCleanup(context.Background(), db, now); err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+
+	status, errMsg, _, _ := readCleanupRow(t, db, id)
+	if status != scanJobStatusDiscarded {
+		t.Errorf("expected discarded, got %q", status)
+	}
+	if errMsg != "low confidence" {
+		t.Errorf("expected original error_message preserved, got %q", errMsg)
+	}
+}
+
+func TestRunScanCleanup_LeavesResolvedRowsAlone(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "resolved@example.com")
+
+	now := time.Now().UTC()
+	// Already resolved (matched + resolved_at): should never be touched again.
+	resolvedAt := now.Add(-26 * time.Hour)
+	res, err := db.Exec(`
+		INSERT INTO pokemon_scan_jobs (user_id, status, image_path_enc, image_hash, created_at, resolved_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, u.ID, scanJobStatusAdded, "", "deadbeef", now.Add(-30*time.Hour), resolvedAt)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	id, _ := res.LastInsertId()
+
+	cleanupRes, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+	if cleanupRes.Discarded != 0 {
+		t.Errorf("expected discarded=0 for resolved rows, got %d", cleanupRes.Discarded)
+	}
+	status, _, _, _ := readCleanupRow(t, db, id)
+	if status != scanJobStatusAdded {
+		t.Errorf("expected status=added (untouched), got %q", status)
+	}
+}
+
+func TestGetUserAutoDiscardHours_DefaultWhenMissing(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "default@example.com")
+
+	got, err := getUserAutoDiscardHours(context.Background(), db, u.ID)
+	if err != nil {
+		t.Fatalf("getUserAutoDiscardHours: %v", err)
+	}
+	if got != ScanAutoDiscardDefaultHours {
+		t.Errorf("expected default=%d, got %d", ScanAutoDiscardDefaultHours, got)
+	}
+}
+
+func TestGetUserAutoDiscardHours_ClampsAndDefaults(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "weird@example.com")
+
+	cases := []struct {
+		raw  string
+		want int
+	}{
+		{"0", 0},
+		{"48", 48},
+		{"168", 168},
+		{"500", ScanAutoDiscardMaxHours},
+		{"-5", 0},
+		{"not-a-number", ScanAutoDiscardDefaultHours},
+		{"", ScanAutoDiscardDefaultHours},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			if err := auth.SetPreference(db, u.ID, scanAutoDiscardPrefKey, tc.raw); err != nil {
+				t.Fatalf("set pref: %v", err)
+			}
+			got, err := getUserAutoDiscardHours(context.Background(), db, u.ID)
+			if err != nil {
+				t.Fatalf("getUserAutoDiscardHours: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("raw=%q: expected %d, got %d", tc.raw, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/pokemon/scan_cleanup_test.go
+++ b/internal/pokemon/scan_cleanup_test.go
@@ -201,6 +201,38 @@ func TestRunScanCleanup_LeavesYoungProcessingAlone(t *testing.T) {
 	}
 }
 
+// TestRunScanCleanup_ProcessingUsesStartedAt verifies that the stale-processing
+// check uses processing_started_at (not created_at). A job that was queued long
+// ago but only recently claimed by the worker must not be killed.
+func TestRunScanCleanup_ProcessingUsesStartedAt(t *testing.T) {
+	db := setupTestDB(t)
+	u := seedUser(t, db, 1, "recent-claim@example.com")
+
+	now := time.Now().UTC()
+	// Row is old (created 3 hours ago) but was only claimed 5 minutes ago.
+	res, err := db.Exec(`
+		INSERT INTO pokemon_scan_jobs (user_id, status, image_path_enc, image_hash, created_at, processing_started_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, u.ID, scanJobStatusProcessing, "", "deadbeef",
+		now.Add(-3*time.Hour).UTC(), now.Add(-5*time.Minute).UTC())
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	id, _ := res.LastInsertId()
+
+	cleanupRes, err := RunScanCleanup(context.Background(), db, now)
+	if err != nil {
+		t.Fatalf("RunScanCleanup: %v", err)
+	}
+	if cleanupRes.StaleFailed != 0 {
+		t.Errorf("expected stale_failed=0 (worker is active), got %d", cleanupRes.StaleFailed)
+	}
+	status, _, _, _ := readCleanupRow(t, db, id)
+	if status != scanJobStatusProcessing {
+		t.Errorf("expected status=processing (untouched), got %q", status)
+	}
+}
+
 func TestRunScanCleanup_UserPrefZeroDisables(t *testing.T) {
 	root := t.TempDir()
 	db := setupTestDB(t)

--- a/internal/pokemon/scan_worker.go
+++ b/internal/pokemon/scan_worker.go
@@ -173,15 +173,17 @@ func pollQueuedScanJobs(ctx context.Context, db *sql.DB, limit int) ([]scanJob, 
 // already picked the row (or it has moved on to a terminal state). Using
 // status as part of the WHERE clause means concurrent workers — including
 // future horizontally-scaled instances — never both process the same job.
+// processing_started_at is stamped here so the cleanup pass can distinguish
+// a briefly-processing job from one that has been stuck for over an hour.
 // processed_at is intentionally NOT set here — it is written by the finalize
 // helpers when the job reaches a terminal state so the column reflects
 // completion time, not claim time.
-func claimScanJob(ctx context.Context, db *sql.DB, jobID int64) (bool, error) {
+func claimScanJob(ctx context.Context, db *sql.DB, jobID int64, now time.Time) (bool, error) {
 	res, err := db.ExecContext(ctx, `
 		UPDATE pokemon_scan_jobs
-		SET status = ?
+		SET status = ?, processing_started_at = ?
 		WHERE id = ? AND status = ?
-	`, scanJobStatusProcessing, jobID, scanJobStatusQueued)
+	`, scanJobStatusProcessing, now.UTC(), jobID, scanJobStatusQueued)
 	if err != nil {
 		return false, fmt.Errorf("claim scan job %d: %w", jobID, err)
 	}
@@ -209,7 +211,7 @@ func processScanJob(ctx context.Context, db *sql.DB, job scanJob) {
 		}
 	}()
 
-	claimed, err := claimScanJob(ctx, db, job.ID)
+	claimed, err := claimScanJob(ctx, db, job.ID, time.Now())
 	if err != nil {
 		log.Printf("pokemon: scan worker claim job %d: %v", job.ID, err)
 		return

--- a/internal/pokemon/scan_worker_test.go
+++ b/internal/pokemon/scan_worker_test.go
@@ -441,7 +441,8 @@ func TestClaimScanJob_OnceOnly(t *testing.T) {
 	u := seedUser(t, db, 1, "scan@example.com")
 	jobID := mustInsertScanJob(t, db, u.ID, "img.png", "h", time.Now().UTC())
 
-	ok, err := claimScanJob(context.Background(), db, jobID)
+	now := time.Now().UTC()
+	ok, err := claimScanJob(context.Background(), db, jobID, now)
 	if err != nil {
 		t.Fatalf("first claim: %v", err)
 	}
@@ -449,7 +450,7 @@ func TestClaimScanJob_OnceOnly(t *testing.T) {
 		t.Fatalf("first claim should succeed")
 	}
 
-	ok, err = claimScanJob(context.Background(), db, jobID)
+	ok, err = claimScanJob(context.Background(), db, jobID, now)
 	if err != nil {
 		t.Fatalf("second claim: %v", err)
 	}


### PR DESCRIPTION
## Changes

- **Pokémon scan auto-discard** - Unresolved Pokémon scans in matched/no_match/failed status are now auto-discarded after 24 hours: the image file is removed from disk, the row is marked discarded with resolved_at stamped, and the per-user preference `pokemon_scan_auto_discard_hours` (default 24, 0 disables, max 168) can override the window. A separate pass forces queued or processing jobs stuck for more than an hour to fail with "stale — worker did not complete in time" so a crashed worker no longer blocks the queue. (Hytte-sx2t)

## Original Issue (chore): Pokémon async scanner: auto-discard unresolved scans after 24h

Housekeeping. Without auto-discard, a kid who scans 20 cards and forgets to triage them leaves images on disk indefinitely. After 24 h, any job still in status (matched | no_match | failed) without user action gets auto-discarded.

## Behaviour

- Run a periodic cleanup goroutine (separate from the scan worker — same cadence pattern as the existing nightly suggestions cron). Wake every hour.
- Find rows where status IN ('matched','no_match','failed') AND `created_at < now - 24h`.
- For each: update status to 'discarded', set resolved_at=now, set error_message="auto-discarded after 24h" if not already populated, delete the image file from disk.
- Log a summary per run: "auto-discarded N scans".
- Per-user override preference `pokemon_scan_auto_discard_hours` (default 24, 0 = disabled, max 168 = one week). Robin can set 0 for himself if he wants infinite retention.

## Stale queued jobs

Separately: if a job is stuck in 'queued' or 'processing' for > 1 h (worker died mid-job, system crash), mark it 'failed' with error_message="stale — worker did not complete in time". Same cleanup pass.

## Tests

- scan_cleanup_test.go: matched job created 25 h ago → discarded; matched job created 5 h ago → untouched.
- Stuck processing job 2 h old → failed.
- Per-user override of 0 disables auto-discard for that user.
- Image file is removed when discarded.

## Acceptance

- `make build`, `make test ./internal/pokemon/...` pass.
- After 24 h, untouched matched/no_match/failed scans are auto-discarded.
- Stuck queued/processing jobs eventually fail rather than blocking the worker.
- Image files are cleaned up.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-sx2t | Branch: forge/Hytte-sx2t
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->