### PR TITLE
Pokémon sets page: 'Owned only' filter toggle (Hytte-l91m)

### DIFF
--- a/changelog.d/Hytte-l91m.md
+++ b/changelog.d/Hytte-l91m.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon sets "Owned only" filter** - Added a toggle on the Pokémon sets browser that narrows the list to only sets where you own at least one card. The state is mirrored to the URL query string so reload and shared links preserve the filter. (Hytte-l91m)

--- a/internal/pokemon/handlers.go
+++ b/internal/pokemon/handlers.go
@@ -247,10 +247,12 @@ func applyNOK(w http.ResponseWriter, cards []CardDTO, rate float64, rateOK bool)
 }
 
 // ListSetsHandler returns the catalogue of sets, ordered newest-first and
-// optionally filtered by series via ?era=<name>. The OwnedCount column is
-// computed per set for the authenticated user via a correlated subquery — the
-// catalogue is small (a few dozen sets), so the extra cost is negligible
-// compared to making a follow-up request per set.
+// optionally filtered by series via ?era=<name>. When ?owned=true is set,
+// only sets containing at least one card in the authenticated user's
+// collection are returned. The OwnedCount column is computed per set for the
+// authenticated user via a correlated subquery — the catalogue is small (a
+// few dozen sets), so the extra cost is negligible compared to making a
+// follow-up request per set.
 func ListSetsHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
@@ -259,37 +261,48 @@ func ListSetsHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 		era := strings.TrimSpace(r.URL.Query().Get("era"))
+		ownedOnly := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("owned")), "true")
 		limit := parseLimit(r, defaultListLimit, maxListLimit)
 		offset := parseOffset(r)
 
+		// Build the WHERE clause and argument list dynamically so the era +
+		// owned filters can combine freely. The owned_count subquery argument
+		// is always first (it appears in SELECT before WHERE).
 		var (
-			rows *sql.Rows
-			err  error
+			whereParts []string
+			args       []any
 		)
+		args = append(args, user.ID) // owned_count subquery
 		if era != "" {
-			rows, err = db.QueryContext(r.Context(), `
-				SELECT s.id, s.name, s.series, s.release_date, s.total_cards, s.symbol_url, s.logo_url,
-				       (SELECT COUNT(DISTINCT pc.card_id)
-				        FROM pokemon_collections pc
-				        JOIN pokemon_cards c ON c.id = pc.card_id
-				        WHERE c.set_id = s.id AND pc.user_id = ? AND pc.quantity > 0) AS owned_count
-				FROM pokemon_sets s
-				WHERE s.series = ?
-				ORDER BY s.release_date DESC, s.id DESC
-				LIMIT ? OFFSET ?
-			`, user.ID, era, limit, offset)
-		} else {
-			rows, err = db.QueryContext(r.Context(), `
-				SELECT s.id, s.name, s.series, s.release_date, s.total_cards, s.symbol_url, s.logo_url,
-				       (SELECT COUNT(DISTINCT pc.card_id)
-				        FROM pokemon_collections pc
-				        JOIN pokemon_cards c ON c.id = pc.card_id
-				        WHERE c.set_id = s.id AND pc.user_id = ? AND pc.quantity > 0) AS owned_count
-				FROM pokemon_sets s
-				ORDER BY s.release_date DESC, s.id DESC
-				LIMIT ? OFFSET ?
-			`, user.ID, limit, offset)
+			whereParts = append(whereParts, "s.series = ?")
+			args = append(args, era)
 		}
+		if ownedOnly {
+			whereParts = append(whereParts, `EXISTS (
+				SELECT 1 FROM pokemon_collections col
+				JOIN pokemon_cards c ON c.id = col.card_id
+				WHERE col.user_id = ? AND c.set_id = s.id AND col.quantity > 0
+			)`)
+			args = append(args, user.ID)
+		}
+		where := ""
+		if len(whereParts) > 0 {
+			where = "WHERE " + strings.Join(whereParts, " AND ")
+		}
+		args = append(args, limit, offset)
+
+		query := `
+			SELECT s.id, s.name, s.series, s.release_date, s.total_cards, s.symbol_url, s.logo_url,
+			       (SELECT COUNT(DISTINCT pc.card_id)
+			        FROM pokemon_collections pc
+			        JOIN pokemon_cards c ON c.id = pc.card_id
+			        WHERE c.set_id = s.id AND pc.user_id = ? AND pc.quantity > 0) AS owned_count
+			FROM pokemon_sets s
+			` + where + `
+			ORDER BY s.release_date DESC, s.id DESC
+			LIMIT ? OFFSET ?
+		`
+		rows, err := db.QueryContext(r.Context(), query, args...)
 		if err != nil {
 			log.Printf("pokemon: list sets: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to list sets")

--- a/internal/pokemon/handlers.go
+++ b/internal/pokemon/handlers.go
@@ -250,8 +250,8 @@ func applyNOK(w http.ResponseWriter, cards []CardDTO, rate float64, rateOK bool)
 // optionally filtered by series via ?era=<name>. When ?owned=true is set,
 // only sets containing at least one card in the authenticated user's
 // collection are returned. The OwnedCount column is computed per set for the
-// authenticated user via a correlated subquery — the catalogue is small (a
-// few dozen sets), so the extra cost is negligible compared to making a
+// authenticated user via a correlated subquery — the catalogue is a few
+// hundred sets at most, so the extra cost is negligible compared to making a
 // follow-up request per set.
 func ListSetsHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/pokemon/handlers_test.go
+++ b/internal/pokemon/handlers_test.go
@@ -260,6 +260,94 @@ func TestListSetsHandler_OwnedCount(t *testing.T) {
 	}
 }
 
+func TestListSetsHandler_OwnedFilter(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+	other := seedUser(t, db, 2, "b@example.com")
+
+	// User 1 owns one card from sv1; nothing from swsh1.
+	pikaNormal := variantID(t, db, "sv1-25", "normal")
+	if _, err := db.Exec(`
+		INSERT INTO pokemon_collections (user_id, card_id, variant_id, quantity, condition, acquired_at, notes_enc)
+		VALUES (?, ?, ?, 1, '', ?, NULL)
+	`, u.ID, "sv1-25", pikaNormal, time.Now().UTC()); err != nil {
+		t.Fatalf("seed collection: %v", err)
+	}
+	// Other user owns a swsh1 card — must not leak into user 1's filtered list.
+	celebiNormal := variantID(t, db, "swsh1-1", "normal")
+	if _, err := db.Exec(`
+		INSERT INTO pokemon_collections (user_id, card_id, variant_id, quantity, condition, acquired_at, notes_enc)
+		VALUES (?, ?, ?, 1, '', ?, NULL)
+	`, other.ID, "swsh1-1", celebiNormal, time.Now().UTC()); err != nil {
+		t.Fatalf("seed other collection: %v", err)
+	}
+
+	t.Run("owned=true returns only sets the user owns cards in", func(t *testing.T) {
+		req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets?owned=true", nil), u)
+		rec := httptest.NewRecorder()
+		ListSetsHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		body := decode[struct {
+			Sets []SetDTO `json:"sets"`
+		}](t, rec)
+		if len(body.Sets) != 1 || body.Sets[0].ID != "sv1" {
+			t.Errorf("expected only sv1, got %+v", body.Sets)
+		}
+		if body.Sets[0].OwnedCount != 1 {
+			t.Errorf("expected owned_count=1, got %d", body.Sets[0].OwnedCount)
+		}
+	})
+
+	t.Run("no owned param returns all sets", func(t *testing.T) {
+		req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets", nil), u)
+		rec := httptest.NewRecorder()
+		ListSetsHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		body := decode[struct {
+			Sets []SetDTO `json:"sets"`
+		}](t, rec)
+		if len(body.Sets) != 2 {
+			t.Errorf("expected 2 sets, got %d", len(body.Sets))
+		}
+	})
+
+	t.Run("owned=false returns all sets", func(t *testing.T) {
+		req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets?owned=false", nil), u)
+		rec := httptest.NewRecorder()
+		ListSetsHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		body := decode[struct {
+			Sets []SetDTO `json:"sets"`
+		}](t, rec)
+		if len(body.Sets) != 2 {
+			t.Errorf("expected 2 sets, got %d", len(body.Sets))
+		}
+	})
+
+	t.Run("owned=true combines with era filter", func(t *testing.T) {
+		// Filter to Sword & Shield while owned=true → user 1 owns nothing there.
+		req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/sets?owned=true&era=Sword+%26+Shield", nil), u)
+		rec := httptest.NewRecorder()
+		ListSetsHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		body := decode[struct {
+			Sets []SetDTO `json:"sets"`
+		}](t, rec)
+		if len(body.Sets) != 0 {
+			t.Errorf("expected zero sets, got %+v", body.Sets)
+		}
+	})
+}
+
 func TestListSetsHandler_Unauthorized(t *testing.T) {
 	db := setupTestDB(t)
 	seedCatalogue(t, db)

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -3,6 +3,10 @@
   "showOlder": "Show older sets",
   "hideOlder": "Hide older sets",
   "olderSets": "Older sets",
+  "sets": {
+    "filterOwnedOnly": "Owned only",
+    "emptyOwned": "You don't own any cards yet — go scan some!"
+  },
   "tile": {
     "totalCards_one": "{{count}} card",
     "totalCards_other": "{{count}} cards",

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -3,6 +3,10 @@
   "showOlder": "Vis eldre sett",
   "hideOlder": "Skjul eldre sett",
   "olderSets": "Eldre sett",
+  "sets": {
+    "filterOwnedOnly": "Bare eide",
+    "emptyOwned": "Du eier ingen kort enda — gå og scan noen!"
+  },
   "tile": {
     "totalCards_one": "{{count}} kort",
     "totalCards_other": "{{count}} kort",

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -3,6 +3,10 @@
   "showOlder": "แสดงชุดเก่ากว่า",
   "hideOlder": "ซ่อนชุดเก่ากว่า",
   "olderSets": "ชุดเก่ากว่า",
+  "sets": {
+    "filterOwnedOnly": "เฉพาะที่มี",
+    "emptyOwned": "คุณยังไม่มีการ์ดเลย — ไปสแกนก่อนสิ!"
+  },
   "tile": {
     "totalCards_one": "{{count}} ใบ",
     "totalCards_other": "{{count}} ใบ",

--- a/web/src/pages/PokemonSets.test.tsx
+++ b/web/src/pages/PokemonSets.test.tsx
@@ -12,6 +12,8 @@ const TRANSLATIONS: Record<string, string> = {
   'errors.failedToLoad': 'Failed to load Pokémon sets',
   'retry': 'Retry',
   'setDetail.comingSoon': 'Set detail coming soon',
+  'sets.filterOwnedOnly': 'Owned only',
+  'sets.emptyOwned': "You don't own any cards yet — go scan some!",
 }
 
 function mockT(key: string, opts?: Record<string, string | number>): string {
@@ -61,9 +63,9 @@ function setsResponse(sets: SetShape[]) {
   return { ok: true, json: () => Promise.resolve({ sets }) }
 }
 
-function renderPage() {
+function renderPage(initialEntries: string[] = ['/pokemon/sets']) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <PokemonSets />
     </MemoryRouter>,
   )
@@ -230,6 +232,87 @@ describe('PokemonSets – tile link', () => {
 
     const link = screen.getByRole('link', { name: 'Open SV Base' })
     expect(link).toHaveAttribute('href', '/pokemon/sets/sv1')
+  })
+})
+
+describe('PokemonSets – owned-only filter', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  function setsUrls(mock: ReturnType<typeof vi.fn>): string[] {
+    return mock.mock.calls
+      .map(c => String(c[0]))
+      .filter(u => u.startsWith('/api/pokemon/sets'))
+  }
+
+  it('toggling owned only re-fetches with ?owned=true and back', async () => {
+    const sv = makeSet({ id: 'sv1', name: 'SV Base', owned_count: 3 })
+    const swsh = makeSet({ id: 'swsh1', name: 'SWSH Base', series: 'Sword & Shield', release_date: '2020/02/07' })
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/api/pokemon/sets')) return Promise.resolve(setsResponse([sv, swsh]))
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ unresolved: 0 }) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('SV Base')).toBeInTheDocument())
+
+    // Initial sets fetch must not include owned=true.
+    const initialSetsUrls = setsUrls(fetchMock)
+    expect(initialSetsUrls.length).toBeGreaterThan(0)
+    expect(initialSetsUrls.every(u => !u.includes('owned=true'))).toBe(true)
+
+    fetchMock.mockClear()
+    const toggle = screen.getByTestId('pokemon-sets-owned-toggle') as HTMLInputElement
+    expect(toggle.checked).toBe(false)
+    fireEvent.click(toggle)
+
+    await waitFor(() => {
+      expect(setsUrls(fetchMock).some(u => u.includes('owned=true'))).toBe(true)
+    })
+    expect((screen.getByTestId('pokemon-sets-owned-toggle') as HTMLInputElement).checked).toBe(true)
+
+    // Toggle off restores the unfiltered fetch.
+    fetchMock.mockClear()
+    fireEvent.click(screen.getByTestId('pokemon-sets-owned-toggle'))
+    await waitFor(() => {
+      const urls = setsUrls(fetchMock)
+      expect(urls.length).toBeGreaterThan(0)
+      expect(urls.every(u => !u.includes('owned=true'))).toBe(true)
+    })
+    expect((screen.getByTestId('pokemon-sets-owned-toggle') as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('initialises the toggle from ?owned=true in the URL', async () => {
+    const sv = makeSet({ id: 'sv1', name: 'SV Base', owned_count: 3 })
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/api/pokemon/sets')) return Promise.resolve(setsResponse([sv]))
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ unresolved: 0 }) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage(['/pokemon/sets?owned=true'])
+
+    await waitFor(() => expect(screen.getByText('SV Base')).toBeInTheDocument())
+    expect((screen.getByTestId('pokemon-sets-owned-toggle') as HTMLInputElement).checked).toBe(true)
+    expect(setsUrls(fetchMock).every(u => u.includes('owned=true'))).toBe(true)
+  })
+
+  it('shows the empty state when owned filter is on and no sets match', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/api/pokemon/sets')) return Promise.resolve(setsResponse([]))
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ unresolved: 0 }) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage(['/pokemon/sets?owned=true'])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pokemon-sets-empty-owned')).toBeInTheDocument()
+    })
+    expect(screen.getByText("You don't own any cards yet — go scan some!")).toBeInTheDocument()
   })
 })
 

--- a/web/src/pages/PokemonSets.test.tsx
+++ b/web/src/pages/PokemonSets.test.tsx
@@ -320,9 +320,16 @@ describe('PokemonSets – error state', () => {
   afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
 
   it('shows an inline alert with a retry button when the API fails', async () => {
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce({ ok: false })
-      .mockResolvedValueOnce(setsResponse([makeSet({ id: 'sv1', name: 'SV Base' })]))
+    let setsCallCount = 0
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/api/pokemon/sets')) {
+        setsCallCount++
+        if (setsCallCount === 1) return Promise.resolve({ ok: false })
+        return Promise.resolve(setsResponse([makeSet({ id: 'sv1', name: 'SV Base' })]))
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ unresolved: 0 }) })
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     renderPage()

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -142,6 +142,14 @@ export default function PokemonSets() {
   const location = useLocation()
   const navigate = useNavigate()
 
+  // Owned-only filter state is mirrored to ?owned=true in the URL so a reload
+  // or a shared link preserves the toggle. The toggle reads its initial value
+  // from the current URL on every render of the search string.
+  const ownedOnly = useMemo(() => {
+    const params = new URLSearchParams(location.search)
+    return params.get('owned') === 'true'
+  }, [location.search])
+
   const [sets, setSets] = useState<PokemonSet[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -151,6 +159,17 @@ export default function PokemonSets() {
 
   const locState = location.state as PokemonSetsLocationState | null
   const initialAddCardQuery = locState?.addCardQuery ?? undefined
+
+  const toggleOwnedOnly = useCallback(() => {
+    const params = new URLSearchParams(location.search)
+    if (ownedOnly) {
+      params.delete('owned')
+    } else {
+      params.set('owned', 'true')
+    }
+    const next = params.toString()
+    navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false })
+  }, [ownedOnly, navigate, location.pathname, location.search])
 
   // After the AddCardPanel consumes its initialQuery we strip the hint from
   // history so a subsequent back/forward navigation doesn't re-open the
@@ -170,14 +189,21 @@ export default function PokemonSets() {
   useEffect(() => {
     const controller = new AbortController()
     const limit = 50
+    setLoading(true)
+    setError('')
 
     ;(async () => {
       try {
         const allSets: PokemonSet[] = []
         let offset = 0
         while (true) {
+          const params = new URLSearchParams({
+            limit: String(limit),
+            offset: String(offset),
+          })
+          if (ownedOnly) params.set('owned', 'true')
           const res = await fetch(
-            `/api/pokemon/sets?limit=${limit}&offset=${offset}`,
+            `/api/pokemon/sets?${params.toString()}`,
             { credentials: 'include', signal: controller.signal },
           )
           if (!res.ok) throw new Error(t('errors.failedToLoad'))
@@ -196,7 +222,7 @@ export default function PokemonSets() {
       }
     })()
     return () => { controller.abort() }
-  }, [t, attempt])
+  }, [t, attempt, ownedOnly])
 
   // Fetch the unresolved scan count once when the page mounts (and after a
   // reload triggered by AddCardPanel) so the banner reflects scans that
@@ -244,17 +270,29 @@ export default function PokemonSets() {
   return (
     <div className="min-h-screen bg-gray-900 text-white">
       <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
-        <header className="flex items-center justify-between gap-3">
+        <header className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="text-2xl font-semibold">{t('pageTitle')}</h1>
-          <Link
-            to="/pokemon/top"
-            aria-label={t('top.entryLabel')}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm bg-amber-600/20 hover:bg-amber-600/30 border border-amber-500/40 text-amber-200 rounded transition-colors"
-            data-testid="pokemon-top-link"
-          >
-            <Trophy size={16} aria-hidden="true" />
-            <span>{t('top.entryButton')}</span>
-          </Link>
+          <div className="flex items-center gap-3 flex-wrap">
+            <label className="inline-flex items-center gap-2 text-sm text-gray-300 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={ownedOnly}
+                onChange={toggleOwnedOnly}
+                className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-amber-500 focus:ring-amber-500"
+                data-testid="pokemon-sets-owned-toggle"
+              />
+              <span>{t('sets.filterOwnedOnly')}</span>
+            </label>
+            <Link
+              to="/pokemon/top"
+              aria-label={t('top.entryLabel')}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm bg-amber-600/20 hover:bg-amber-600/30 border border-amber-500/40 text-amber-200 rounded transition-colors"
+              data-testid="pokemon-top-link"
+            >
+              <Trophy size={16} aria-hidden="true" />
+              <span>{t('top.entryButton')}</span>
+            </Link>
+          </div>
         </header>
 
         {unresolvedCount > 0 && (
@@ -286,7 +324,16 @@ export default function PokemonSets() {
 
         {loading && !error && <SkeletonGrid />}
 
-        {!loading && !error && (
+        {!loading && !error && ownedOnly && sets.length === 0 && (
+          <p
+            data-testid="pokemon-sets-empty-owned"
+            className="text-sm text-gray-400 px-3 py-8 text-center"
+          >
+            {t('sets.emptyOwned')}
+          </p>
+        )}
+
+        {!loading && !error && !(ownedOnly && sets.length === 0) && (
           <>
             {recent.map(([era, list]) => {
               const slug = eraSlug(era)

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -189,10 +189,10 @@ export default function PokemonSets() {
   useEffect(() => {
     const controller = new AbortController()
     const limit = 50
-    setLoading(true)
-    setError('')
 
     ;(async () => {
+      setLoading(true)
+      setError('')
       try {
         const allSets: PokemonSet[] = []
         let offset = 0

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -147,7 +147,7 @@ export default function PokemonSets() {
   // from the current URL on every render of the search string.
   const ownedOnly = useMemo(() => {
     const params = new URLSearchParams(location.search)
-    return params.get('owned') === 'true'
+    return params.get('owned')?.toLowerCase() === 'true'
   }, [location.search])
 
   const [sets, setSets] = useState<PokemonSet[]>([])
@@ -168,7 +168,7 @@ export default function PokemonSets() {
       params.set('owned', 'true')
     }
     const next = params.toString()
-    navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false })
+    navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false, state: location.state })
   }, [ownedOnly, navigate, location.pathname, location.search])
 
   // After the AddCardPanel consumes its initialQuery we strip the hint from


### PR DESCRIPTION
## Changes

- **Pokémon sets "Owned only" filter** - Added a toggle on the Pokémon sets browser that narrows the list to only sets where you own at least one card. The state is mirrored to the URL query string so reload and shared links preserve the filter. (Hytte-l91m)

## Original Issue (feature): Pokémon sets page: 'Owned only' filter toggle

With 172 sets in the registry, the sets browser is overwhelming when a kid only owns cards from a handful of sets. Add a toggle to filter the list to only those sets where the user owns at least one card.

## Backend

`internal/pokemon/handlers.go` `ListSetsHandler` accepts a new query parameter `?owned=true|false` (default false = unchanged behaviour).

When `owned=true`: filter the returned sets to those where the current user owns at least one card. Implementation:

    SELECT s.* FROM pokemon_sets s
    WHERE EXISTS (
      SELECT 1 FROM pokemon_collections col
      JOIN pokemon_cards c ON c.id = col.card_id
      WHERE col.user_id = ? AND c.set_id = s.id
    )
    ORDER BY ... -- same ORDER BY as the unfiltered query

Add the per-set `owned_count` to the response so the UI can show "12 / 195" inline on each tile (this may already be present from a previous bead — verify; if not, add it).

## Frontend

`web/src/pages/PokemonSets.tsx`:

- Add a small toggle in the header row: `☐ Owned only` (label via i18n).
- Initial state `false`. Toggling triggers a re-fetch with `?owned=true`.
- Reflect the state in the URL query string so reload/share preserves it.
- When toggled on:
    - The sets list re-renders, hidden eras don't expand to show what's been filtered (just show what matches).
    - The "Show older sets" expander still works on the filtered set.
    - Empty state if zero sets match: "You don't own any cards yet — go scan some!".

## i18n

Add to `web/public/locales/{en,nb,th}/pokemon.json`:
- sets.filterOwnedOnly — "Owned only" / "Bare eide" / Thai
- sets.emptyOwned — "You don't own any cards yet — go scan some!"

## Tests

- handlers_test.go: GET /api/pokemon/sets?owned=true returns only sets where the user has collection rows. Returns all sets when owned is missing.
- PokemonSets.test.tsx: toggle changes the fetch URL; toggling off restores the full list; URL query round-trips.

## Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build`, `npm test -- --run src/pages/PokemonSets` pass.
- Toggling "Owned only" narrows the sets browser to only sets containing at least one owned card.
- Reloading the page preserves the toggle state via URL query.
- Mobile 375px works.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-l91m | Branch: forge/Hytte-l91m
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->