### PR TITLE
Pokémon scanned: tap-to-detail view + manual reassign on wrong match (Hytte-1mtg)

### DIFF
--- a/changelog.d/Hytte-1mtg.md
+++ b/changelog.d/Hytte-1mtg.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Pokémon scanned: tap-to-detail view + manual reassign on wrong match** - Matched scan tiles are now a tap target that opens a fuller detail view with the large scan image, match info, variant buttons, and Discard. A "Wrong match?" section lets you search and reassign the scan to a different card before adding it to your collection — no more discard-and-rescan when the auto-match was off. (Hytte-1mtg)

--- a/internal/pokemon/scans_handlers.go
+++ b/internal/pokemon/scans_handlers.go
@@ -581,12 +581,20 @@ func ResolveScanHandler(db *sql.DB) http.HandlerFunc {
 			Condition string `json:"condition"`
 			Notes     string `json:"notes"`
 			Quantity  int    `json:"quantity"`
+			// CardID, when non-empty on action=add, overrides the auto-matched
+			// card. Used by the scan detail "Wrong match?" flow so the user can
+			// reassign a misclassified scan to the right card without
+			// discarding it. The override card is also persisted back to
+			// pokemon_scan_jobs.matched_card_id so the resolved row reflects
+			// what was actually added.
+			CardID string `json:"card_id"`
 		}
 		if !decodeBody(w, r, &body) {
 			return
 		}
 		body.Action = strings.TrimSpace(strings.ToLower(body.Action))
 		body.Condition = strings.TrimSpace(body.Condition)
+		body.CardID = strings.TrimSpace(body.CardID)
 
 		var (
 			status      string
@@ -623,12 +631,36 @@ func ResolveScanHandler(db *sql.DB) http.HandlerFunc {
 				respondError(w, http.StatusBadRequest, "variant_id is required for action=add")
 				return
 			}
+			// Resolve the effective card: when the client overrides via
+			// body.CardID (the "Wrong match?" flow), validate the override
+			// exists in the catalogue before touching the job. A bad id is a
+			// 404 — same shape the collection endpoint would return.
+			targetCardID := matchedCard.String
+			if body.CardID != "" {
+				var exists bool
+				if err := db.QueryRowContext(r.Context(),
+					`SELECT EXISTS(SELECT 1 FROM pokemon_cards WHERE id = ?)`, body.CardID,
+				).Scan(&exists); err != nil {
+					log.Printf("pokemon: resolve add lookup override card: %v", err)
+					respondError(w, http.StatusInternalServerError, "failed to resolve scan")
+					return
+				}
+				if !exists {
+					respondError(w, http.StatusNotFound, "override card not found")
+					return
+				}
+				targetCardID = body.CardID
+			}
 			// Run the conditional status flip and the collection upsert in
 			// one transaction so two concurrent /resolve calls can't both
 			// observe status='matched' from the earlier SELECT and both
 			// double-add. The UPDATE's `status = scanJobStatusMatched`
 			// predicate is the atomic claim: only one tx will see a row
 			// affected; the loser sees 0 rows and returns 409.
+			//
+			// When the client overrides the auto-match we also rewrite
+			// matched_card_id in the same UPDATE so the resolved row reflects
+			// what was actually added rather than the original (wrong) guess.
 			tx, err := db.BeginTx(r.Context(), nil)
 			if err != nil {
 				log.Printf("pokemon: resolve add begin tx: %v", err)
@@ -637,9 +669,9 @@ func ResolveScanHandler(db *sql.DB) http.HandlerFunc {
 			}
 			res, err := tx.ExecContext(r.Context(), `
 				UPDATE pokemon_scan_jobs
-				SET status = ?, matched_variant_id = ?, resolved_at = ?, image_path_enc = ''
+				SET status = ?, matched_card_id = ?, matched_variant_id = ?, resolved_at = ?, image_path_enc = ''
 				WHERE id = ? AND user_id = ? AND status = ?
-			`, scanJobStatusAdded, body.VariantID, now, jobID, user.ID, scanJobStatusMatched)
+			`, scanJobStatusAdded, targetCardID, body.VariantID, now, jobID, user.ID, scanJobStatusMatched)
 			if err != nil {
 				tx.Rollback()
 				log.Printf("pokemon: resolve add claim: %v", err)
@@ -658,7 +690,7 @@ func ResolveScanHandler(db *sql.DB) http.HandlerFunc {
 				respondError(w, http.StatusConflict, "scan is no longer in 'matched' status")
 				return
 			}
-			if _, err := upsertCollection(r.Context(), tx, user.ID, matchedCard.String, body.VariantID, body.Quantity, body.Condition, body.Notes); err != nil {
+			if _, err := upsertCollection(r.Context(), tx, user.ID, targetCardID, body.VariantID, body.Quantity, body.Condition, body.Notes); err != nil {
 				tx.Rollback()
 				switch {
 				case errors.Is(err, errVariantNotFound):

--- a/internal/pokemon/scans_handlers.go
+++ b/internal/pokemon/scans_handlers.go
@@ -667,11 +667,23 @@ func ResolveScanHandler(db *sql.DB) http.HandlerFunc {
 				respondError(w, http.StatusInternalServerError, "failed to resolve scan")
 				return
 			}
-			res, err := tx.ExecContext(r.Context(), `
-				UPDATE pokemon_scan_jobs
-				SET status = ?, matched_card_id = ?, matched_variant_id = ?, resolved_at = ?, image_path_enc = ''
-				WHERE id = ? AND user_id = ? AND status = ?
-			`, scanJobStatusAdded, targetCardID, body.VariantID, now, jobID, user.ID, scanJobStatusMatched)
+			// When the client overrides the matched card, confidence no longer
+			// corresponds to the stored card, so clear it to avoid inconsistency.
+			clearConfidence := body.CardID != "" && body.CardID != matchedCard.String
+			var res sql.Result
+			if clearConfidence {
+				res, err = tx.ExecContext(r.Context(), `
+					UPDATE pokemon_scan_jobs
+					SET status = ?, matched_card_id = ?, matched_variant_id = ?, resolved_at = ?, image_path_enc = '', confidence = NULL
+					WHERE id = ? AND user_id = ? AND status = ?
+				`, scanJobStatusAdded, targetCardID, body.VariantID, now, jobID, user.ID, scanJobStatusMatched)
+			} else {
+				res, err = tx.ExecContext(r.Context(), `
+					UPDATE pokemon_scan_jobs
+					SET status = ?, matched_card_id = ?, matched_variant_id = ?, resolved_at = ?, image_path_enc = ''
+					WHERE id = ? AND user_id = ? AND status = ?
+				`, scanJobStatusAdded, targetCardID, body.VariantID, now, jobID, user.ID, scanJobStatusMatched)
+			}
 			if err != nil {
 				tx.Rollback()
 				log.Printf("pokemon: resolve add claim: %v", err)

--- a/internal/pokemon/scans_handlers_test.go
+++ b/internal/pokemon/scans_handlers_test.go
@@ -1193,6 +1193,125 @@ func TestScanCounts_AggregatesUnresolvedAndToday(t *testing.T) {
 	}
 }
 
+// TestResolveScanAdd_WithCardOverride exercises the "Wrong match?" reassign
+// flow: the scan was auto-matched to card A but the user picks card B during
+// review. The collection upsert must land on B, the job row must be rewritten
+// so matched_card_id reflects B, and the image must be deleted as on a normal
+// add.
+func TestResolveScanAdd_WithCardOverride(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "override@example.com")
+	path := writeOnDiskImage(t, root, u.ID, "matched.jpg")
+	// Auto-match landed on sv1-25, but the actual card was sv1-100.
+	jobID := insertScanJob(t, db, u.ID, scanJobStatusMatched, path, withMatchedCard("sv1-25", 0.55))
+	overrideVid := variantID(t, db, "sv1-100", "normal")
+
+	rec := callJSON(t, http.MethodPost, "/api/pokemon/scans/"+strconv.FormatInt(jobID, 10)+"/resolve",
+		map[string]any{"action": "add", "card_id": "sv1-100", "variant_id": overrideVid, "quantity": 1, "condition": "near_mint"},
+		u, map[string]string{"id": strconv.FormatInt(jobID, 10)}, ResolveScanHandler(db))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Collection row should be on the override card, not the original.
+	var qty int
+	if err := db.QueryRow(
+		`SELECT quantity FROM pokemon_collections WHERE user_id = ? AND card_id = ? AND variant_id = ?`,
+		u.ID, "sv1-100", overrideVid,
+	).Scan(&qty); err != nil {
+		t.Fatalf("expected collection row on override card sv1-100: %v", err)
+	}
+	if qty != 1 {
+		t.Errorf("expected quantity=1 on override card, got %d", qty)
+	}
+
+	// And no row should exist for the original (wrong) match.
+	var leak int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pokemon_collections WHERE user_id = ? AND card_id = ?`,
+		u.ID, "sv1-25",
+	).Scan(&leak); err != nil {
+		t.Fatalf("count leak: %v", err)
+	}
+	if leak != 0 {
+		t.Errorf("expected no collection row on auto-matched card, got %d", leak)
+	}
+
+	// Job row should be 'added' with matched_card_id rewritten to the override.
+	status, pathEnc, _, resolvedAt, matchedCard, matchedVariant := readScanJobByID(t, db, jobID)
+	if status != scanJobStatusAdded {
+		t.Errorf("expected status=added, got %q", status)
+	}
+	if !matchedCard.Valid || matchedCard.String != "sv1-100" {
+		t.Errorf("expected matched_card_id rewritten to override sv1-100, got %+v", matchedCard)
+	}
+	if !matchedVariant.Valid || matchedVariant.Int64 != overrideVid {
+		t.Errorf("expected matched_variant_id=%d, got %+v", overrideVid, matchedVariant)
+	}
+	if !resolvedAt.Valid {
+		t.Errorf("expected resolved_at to be set")
+	}
+	if pathEnc != "" {
+		t.Errorf("expected image_path_enc to be cleared, got %q", pathEnc)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected image file to be deleted: stat err=%v", err)
+	}
+}
+
+// TestResolveScanAdd_OverrideUnknownCard_404 covers the case where the client
+// supplies an override card_id that does not exist in the catalogue.
+func TestResolveScanAdd_OverrideUnknownCard_404(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "override404@example.com")
+	path := writeOnDiskImage(t, root, u.ID, "matched.jpg")
+	jobID := insertScanJob(t, db, u.ID, scanJobStatusMatched, path, withMatchedCard("sv1-25", 0.9))
+	vid := variantID(t, db, "sv1-25", "normal")
+
+	rec := callJSON(t, http.MethodPost, "/api/pokemon/scans/"+strconv.FormatInt(jobID, 10)+"/resolve",
+		map[string]any{"action": "add", "card_id": "definitely-not-a-card", "variant_id": vid, "quantity": 1},
+		u, map[string]string{"id": strconv.FormatInt(jobID, 10)}, ResolveScanHandler(db))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown override card, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Job row should be untouched — still matched, image still on disk.
+	status, _, _, _, _, _ := readScanJobByID(t, db, jobID)
+	if status != scanJobStatusMatched {
+		t.Errorf("expected status to stay matched after 404, got %q", status)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected image preserved on 404, got %v", err)
+	}
+}
+
+// TestResolveScanAdd_OverrideVariantMismatch_400 covers the case where the
+// supplied variant_id belongs to a different card than the override card.
+func TestResolveScanAdd_OverrideVariantMismatch_400(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "overrideMismatch@example.com")
+	path := writeOnDiskImage(t, root, u.ID, "matched.jpg")
+	jobID := insertScanJob(t, db, u.ID, scanJobStatusMatched, path, withMatchedCard("sv1-25", 0.9))
+	// Variant belongs to sv1-25 (auto-match), but we override to sv1-100.
+	wrongVid := variantID(t, db, "sv1-25", "normal")
+
+	rec := callJSON(t, http.MethodPost, "/api/pokemon/scans/"+strconv.FormatInt(jobID, 10)+"/resolve",
+		map[string]any{"action": "add", "card_id": "sv1-100", "variant_id": wrongVid, "quantity": 1},
+		u, map[string]string{"id": strconv.FormatInt(jobID, 10)}, ResolveScanHandler(db))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for variant mismatch with override, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestScanCounts_OtherUsersDoNotLeak(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("UPLOAD_ROOT", root)

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -156,6 +156,7 @@
     "elapsed": "{{seconds}} s",
     "loadError": "Failed to load scans",
     "noPriceYet": "Price unavailable",
+    "tapToReview": "Tap to review",
     "filter": {
       "label": "Filter scans",
       "needsReview": "Needs review",
@@ -183,6 +184,22 @@
       "added": "Added to collection",
       "discarded": "Discarded",
       "retried": "Sent back to the scanner queue"
+    },
+    "detail": {
+      "title": "Scan detail",
+      "dialogLabel": "Scan detail",
+      "openLabel": "Open scan detail for {{name}}",
+      "close": "Close scan detail",
+      "autoMatchLabel": "Auto-match",
+      "noMatchInfo": "No match details available.",
+      "addToAutoMatch": "Add this card",
+      "addToOverride": "Add via the picked card",
+      "wrongMatch": "Wrong match?",
+      "autoMatchHint": "Auto-match: {{match}}",
+      "overrideActive": "Adding via {{name}} instead of the auto-match.",
+      "useAutoMatchInstead": "Use auto-match instead",
+      "searchPlaceholder": "Search for the right card — name or number",
+      "searchFailed": "Failed to search cards"
     }
   },
   "scanner": {

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -156,6 +156,7 @@
     "elapsed": "{{seconds}} s",
     "loadError": "Kunne ikke laste skanninger",
     "noPriceYet": "Pris utilgjengelig",
+    "tapToReview": "Trykk for å se gjennom",
     "filter": {
       "label": "Filtrer skanninger",
       "needsReview": "Trenger gjennomgang",
@@ -183,6 +184,22 @@
       "added": "Lagt til i samlingen",
       "discarded": "Forkastet",
       "retried": "Lagt tilbake i skannerkøen"
+    },
+    "detail": {
+      "title": "Skannedetaljer",
+      "dialogLabel": "Skannedetaljer",
+      "openLabel": "Åpne skannedetaljer for {{name}}",
+      "close": "Lukk skannedetaljer",
+      "autoMatchLabel": "Auto-treff",
+      "noMatchInfo": "Ingen treffdetaljer tilgjengelig.",
+      "addToAutoMatch": "Legg til dette kortet",
+      "addToOverride": "Legg til via valgt kort",
+      "wrongMatch": "Feil treff?",
+      "autoMatchHint": "Auto-treff: {{match}}",
+      "overrideActive": "Legger til via {{name}} i stedet for auto-treffet.",
+      "useAutoMatchInstead": "Bruk auto-treffet i stedet",
+      "searchPlaceholder": "Søk etter riktig kort — navn eller nummer",
+      "searchFailed": "Kunne ikke søke etter kort"
     }
   },
   "scanner": {

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -154,6 +154,7 @@
     "elapsed": "{{seconds}} วินาที",
     "loadError": "โหลดรายการสแกนไม่สำเร็จ",
     "noPriceYet": "ไม่มีราคา",
+    "tapToReview": "แตะเพื่อตรวจสอบ",
     "filter": {
       "label": "กรองการสแกน",
       "needsReview": "ต้องตรวจสอบ",
@@ -181,6 +182,22 @@
       "added": "เพิ่มเข้าคอลเลกชันแล้ว",
       "discarded": "ทิ้งแล้ว",
       "retried": "ส่งกลับเข้าคิวสแกนแล้ว"
+    },
+    "detail": {
+      "title": "รายละเอียดการสแกน",
+      "dialogLabel": "รายละเอียดการสแกน",
+      "openLabel": "เปิดรายละเอียดการสแกนของ {{name}}",
+      "close": "ปิดรายละเอียดการสแกน",
+      "autoMatchLabel": "ผลที่ตรงอัตโนมัติ",
+      "noMatchInfo": "ไม่มีข้อมูลการจับคู่",
+      "addToAutoMatch": "เพิ่มการ์ดนี้",
+      "addToOverride": "เพิ่มผ่านการ์ดที่เลือก",
+      "wrongMatch": "ตรงผิดใบ?",
+      "autoMatchHint": "ผลตรงอัตโนมัติ: {{match}}",
+      "overrideActive": "กำลังเพิ่มผ่าน {{name}} แทนผลที่ตรงอัตโนมัติ",
+      "useAutoMatchInstead": "ใช้ผลที่ตรงอัตโนมัติแทน",
+      "searchPlaceholder": "ค้นหาการ์ดที่ถูกต้อง — ชื่อหรือหมายเลข",
+      "searchFailed": "ค้นหาการ์ดไม่สำเร็จ"
     }
   },
   "scanner": {

--- a/web/src/components/pokemon/ScanDetailModal.tsx
+++ b/web/src/components/pokemon/ScanDetailModal.tsx
@@ -116,7 +116,7 @@ export default function ScanDetailModal({ scan, busy, onClose, onResolve }: Scan
           const data: { cards?: ScanDetailCard[] } = await res.json()
           setResults(data.cards ?? [])
         } catch (err) {
-          if (err instanceof Error && err.name === 'AbortError') return
+          if ((err as { name?: string })?.name === 'AbortError' || controller.signal.aborted) return
           setSearchError(err instanceof Error ? err.message : t('scanned.detail.searchFailed'))
           setResults([])
         } finally {

--- a/web/src/components/pokemon/ScanDetailModal.tsx
+++ b/web/src/components/pokemon/ScanDetailModal.tsx
@@ -1,0 +1,416 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react'
+import { formatNumber } from '../../utils/formatDate'
+
+const SEARCH_DEBOUNCE_MS = 250
+const SEARCH_LIMIT = 20
+
+export interface ScanDetailVariant {
+  id: number
+  kind: string
+  price_eur: number
+  price_nok: number | null
+  owned?: boolean
+}
+
+export interface ScanDetailCard {
+  id: string
+  set_id: string
+  set_name?: string
+  name: string
+  collector_no: string
+  rarity: string
+  image_small_url: string
+  image_large_url: string
+  variants: ScanDetailVariant[]
+}
+
+export interface ScanDetailSet {
+  id: string
+  name: string
+}
+
+export interface ScanDetailScan {
+  id: number
+  status: string
+  confidence?: number | null
+  matched_card?: ScanDetailCard | null
+  set?: ScanDetailSet | null
+  has_image: boolean
+}
+
+export interface ScanDetailResolveBody {
+  action: 'add' | 'discard'
+  variant_id?: number
+  quantity?: number
+  condition?: string
+  notes?: string
+  card_id?: string
+}
+
+interface ScanDetailModalProps {
+  scan: ScanDetailScan
+  busy: boolean
+  onClose: () => void
+  onResolve: (body: ScanDetailResolveBody) => void | Promise<void>
+}
+
+function formatNok(amount: number | null | undefined): string {
+  if (amount == null) return '—'
+  return formatNumber(amount, {
+    style: 'currency',
+    currency: 'NOK',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+function confidencePercent(confidence: number | null | undefined): number | null {
+  if (confidence == null || !Number.isFinite(confidence)) return null
+  const pct = Math.round(confidence * 100)
+  return Math.max(0, Math.min(100, pct))
+}
+
+// ScanDetailModal opens from a matched scan tile and gives the kid a fuller
+// view of what the worker matched: a large scan image, the matched card
+// metadata, variant pickers + Discard, and an opt-in "Wrong match?" section
+// that lets them reassign the scan to a different card without having to
+// discard and re-shoot. The reassignment posts a `card_id` override on the
+// existing resolve endpoint.
+export default function ScanDetailModal({ scan, busy, onClose, onResolve }: ScanDetailModalProps) {
+  const { t } = useTranslation('pokemon')
+  const [wrongMatchOpen, setWrongMatchOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<ScanDetailCard[]>([])
+  const [searching, setSearching] = useState(false)
+  const [searchError, setSearchError] = useState('')
+  const [overrideCard, setOverrideCard] = useState<ScanDetailCard | null>(null)
+
+  const autoCard = scan.matched_card ?? null
+  const activeCard = overrideCard ?? autoCard
+  const autoVariant = autoCard?.variants?.[0]
+  const pct = confidencePercent(scan.confidence)
+
+  // Lock body scroll while the modal is open so the underlying list doesn't
+  // peek through on long pages.
+  useEffect(() => {
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [])
+
+  // Escape closes the modal so the kid can dismiss with a single tap.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  // Debounced /cards/search lookup. The previous timer and the in-flight
+  // request are cancelled on every keystroke so stale results never overwrite
+  // a fresher query.
+  useEffect(() => {
+    if (!wrongMatchOpen) return
+    const q = query.trim()
+    if (q === '') {
+      setResults([])
+      setSearchError('')
+      setSearching(false)
+      return
+    }
+    const controller = new AbortController()
+    const timer = window.setTimeout(() => {
+      setSearching(true)
+      setSearchError('')
+      void (async () => {
+        try {
+          const res = await fetch(
+            `/api/pokemon/cards/search?q=${encodeURIComponent(q)}&limit=${SEARCH_LIMIT}`,
+            { credentials: 'include', signal: controller.signal },
+          )
+          if (!res.ok) throw new Error(t('scanned.detail.searchFailed'))
+          const data: { cards?: ScanDetailCard[] } = await res.json()
+          setResults(data.cards ?? [])
+        } catch (err) {
+          if (err instanceof Error && err.name === 'AbortError') return
+          setSearchError(err instanceof Error ? err.message : t('scanned.detail.searchFailed'))
+          setResults([])
+        } finally {
+          if (!controller.signal.aborted) setSearching(false)
+        }
+      })()
+    }, SEARCH_DEBOUNCE_MS)
+    return () => {
+      controller.abort()
+      window.clearTimeout(timer)
+    }
+  }, [query, wrongMatchOpen, t])
+
+  const handleSelectOverride = useCallback((card: ScanDetailCard) => {
+    setOverrideCard(card)
+  }, [])
+
+  const handleRevertOverride = useCallback(() => {
+    setOverrideCard(null)
+  }, [])
+
+  const handleAddVariant = useCallback(
+    (variantId: number) => {
+      const body: ScanDetailResolveBody = {
+        action: 'add',
+        variant_id: variantId,
+        quantity: 1,
+        condition: '',
+        notes: '',
+      }
+      if (overrideCard) body.card_id = overrideCard.id
+      void onResolve(body)
+    },
+    [onResolve, overrideCard],
+  )
+
+  const handleDiscard = useCallback(() => {
+    void onResolve({ action: 'discard' })
+  }, [onResolve])
+
+  const variantsToShow = activeCard?.variants ?? []
+
+  // Auto-match summary line shared by the header and the override revert hint.
+  const autoMatchSummary = useMemo(() => {
+    if (!autoCard) return ''
+    const setLabel = scan.set?.name ?? autoCard.set_name ?? autoCard.set_id
+    return `${autoCard.name} · ${setLabel} · ${t('tile.collectorNo', { number: autoCard.collector_no })}`
+  }, [autoCard, scan.set?.name, t])
+
+  const dialog = (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/70 p-0 sm:p-4"
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+      data-testid="scan-detail-modal"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('scanned.detail.dialogLabel')}
+        className="w-full sm:max-w-lg max-h-[95vh] sm:max-h-[90vh] flex flex-col bg-gray-900 border border-gray-800 rounded-t-2xl sm:rounded-2xl shadow-xl"
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800 shrink-0">
+          <h2 className="text-base font-semibold text-white">{t('scanned.detail.title')}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('scanned.detail.close')}
+            data-testid="scan-detail-close"
+            className="p-1.5 text-gray-400 hover:text-white cursor-pointer"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+          <div className="flex justify-center bg-black/40 rounded-lg overflow-hidden">
+            {scan.has_image ? (
+              <img
+                src={`/api/pokemon/scans/${scan.id}/image`}
+                alt={t('scanned.thumbnailAlt')}
+                loading="eager"
+                data-testid="scan-detail-image"
+                className="max-h-[55vh] w-auto object-contain"
+              />
+            ) : (
+              <div
+                data-testid="scan-detail-image-placeholder"
+                className="py-12 px-4 text-sm text-gray-500"
+              >
+                {t('scanned.thumbnailPlaceholder')}
+              </div>
+            )}
+          </div>
+
+          {autoCard ? (
+            <div className="space-y-1" data-testid="scan-detail-automatch">
+              <p className="text-xs uppercase tracking-wide text-gray-500">
+                {t('scanned.detail.autoMatchLabel')}
+              </p>
+              <p className="text-base font-medium text-white truncate" title={autoCard.name}>
+                {autoCard.name}
+              </p>
+              <p className="text-sm text-gray-400">
+                {scan.set?.name ?? autoCard.set_name ?? autoCard.set_id}
+                {' · '}
+                {t('tile.collectorNo', { number: autoCard.collector_no })}
+              </p>
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-gray-300">
+                {pct != null && <span>{t('scanned.confidence', { pct })}</span>}
+                {autoVariant && <span>{formatNok(autoVariant.price_nok)}</span>}
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-400">{t('scanned.detail.noMatchInfo')}</p>
+          )}
+
+          {overrideCard && (
+            <div
+              data-testid="scan-detail-override-banner"
+              className="px-3 py-2 rounded border border-amber-500/40 bg-amber-500/10 text-xs text-amber-100 flex flex-wrap items-center gap-x-3 gap-y-1"
+            >
+              <span>
+                {t('scanned.detail.overrideActive', { name: overrideCard.name })}
+              </span>
+              <button
+                type="button"
+                onClick={handleRevertOverride}
+                disabled={busy}
+                data-testid="scan-detail-revert"
+                className="underline hover:text-white disabled:opacity-60 cursor-pointer"
+              >
+                {t('scanned.detail.useAutoMatchInstead')}
+              </button>
+            </div>
+          )}
+
+          {activeCard && variantsToShow.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-wide text-gray-500">
+                {overrideCard ? t('scanned.detail.addToOverride') : t('scanned.detail.addToAutoMatch')}
+              </p>
+              <div
+                role="group"
+                aria-label={t('scanned.action.pickVariant')}
+                data-testid="scan-detail-variants"
+                className="flex flex-wrap gap-2"
+              >
+                {variantsToShow.map(v => (
+                  <button
+                    key={v.id}
+                    type="button"
+                    onClick={() => handleAddVariant(v.id)}
+                    disabled={busy}
+                    data-testid={`scan-detail-variant-${v.id}`}
+                    className="flex items-center gap-2 px-3 py-1.5 rounded border border-gray-700 hover:border-emerald-500 hover:bg-emerald-500/10 disabled:cursor-not-allowed text-sm text-white cursor-pointer"
+                  >
+                    <span>{t(`variantKind.${v.kind}`, { defaultValue: v.kind })}</span>
+                    <span className="text-xs text-gray-400">{formatNok(v.price_nok)}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="pt-2">
+            <button
+              type="button"
+              onClick={() => setWrongMatchOpen(prev => !prev)}
+              aria-expanded={wrongMatchOpen}
+              data-testid="scan-detail-wrong-match-toggle"
+              className="flex items-center gap-2 text-sm text-gray-300 hover:text-white cursor-pointer"
+            >
+              {wrongMatchOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+              <span>{t('scanned.detail.wrongMatch')}</span>
+            </button>
+
+            {wrongMatchOpen && (
+              <div
+                data-testid="scan-detail-wrong-match-panel"
+                className="mt-3 space-y-3 border-t border-gray-800 pt-3"
+              >
+                {autoCard && (
+                  <p className="text-xs text-gray-500">
+                    {t('scanned.detail.autoMatchHint', { match: autoMatchSummary })}
+                  </p>
+                )}
+                <div className="flex items-center gap-2 px-3 py-2 rounded border border-gray-800 bg-gray-800/60">
+                  <Search size={16} className="text-gray-400 shrink-0" aria-hidden="true" />
+                  <input
+                    type="text"
+                    value={query}
+                    onChange={e => setQuery(e.target.value)}
+                    placeholder={t('scanned.detail.searchPlaceholder')}
+                    aria-label={t('scanned.detail.searchPlaceholder')}
+                    data-testid="scan-detail-search-input"
+                    className="flex-1 min-w-0 bg-transparent border-0 outline-none text-sm text-white placeholder-gray-500"
+                  />
+                </div>
+                {searchError && (
+                  <p role="alert" className="text-sm text-red-300">
+                    {searchError}
+                  </p>
+                )}
+                {!searchError && searching && (
+                  <p className="text-sm text-gray-400">{t('addCard.searching')}</p>
+                )}
+                {!searchError && !searching && query.trim() !== '' && results.length === 0 && (
+                  <p className="text-sm text-gray-400">{t('addCard.noResults')}</p>
+                )}
+                {results.length > 0 && (
+                  <ul
+                    aria-label={t('addCard.results')}
+                    data-testid="scan-detail-search-results"
+                    className="divide-y divide-gray-800 border border-gray-800 rounded"
+                  >
+                    {results.map(card => (
+                      <li key={card.id} className="flex items-center gap-3 px-2 py-2 hover:bg-gray-800/60">
+                        <div className="h-14 w-10 shrink-0 flex items-center justify-center bg-gray-800/40 rounded overflow-hidden">
+                          {card.image_small_url ? (
+                            <img
+                              src={card.image_small_url}
+                              alt=""
+                              loading="lazy"
+                              className="max-h-full max-w-full object-contain"
+                            />
+                          ) : null}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => handleSelectOverride(card)}
+                          disabled={busy}
+                          data-testid={`scan-detail-pick-${card.id}`}
+                          className="flex-1 min-w-0 text-left cursor-pointer disabled:cursor-not-allowed"
+                        >
+                          <p className="text-sm font-medium text-white truncate" title={card.name}>
+                            {card.name}
+                          </p>
+                          <p className="text-xs text-gray-500 truncate">
+                            {card.set_name ?? card.set_id}
+                            {' · '}
+                            {t('tile.collectorNo', { number: card.collector_no })}
+                          </p>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-gray-800 shrink-0">
+          <button
+            type="button"
+            onClick={handleDiscard}
+            disabled={busy}
+            data-testid="scan-detail-discard"
+            className="px-3 py-1.5 text-sm rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-60 disabled:cursor-not-allowed text-white cursor-pointer"
+          >
+            {t('scanned.action.discard')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+
+  if (typeof document === 'undefined') return dialog
+  return createPortal(dialog, document.body)
+}

--- a/web/src/components/pokemon/ScanDetailModal.tsx
+++ b/web/src/components/pokemon/ScanDetailModal.tsx
@@ -101,12 +101,7 @@ export default function ScanDetailModal({ scan, busy, onClose, onResolve }: Scan
   useEffect(() => {
     if (!wrongMatchOpen) return
     const q = query.trim()
-    if (q === '') {
-      setResults([])
-      setSearchError('')
-      setSearching(false)
-      return
-    }
+    if (q === '') return
     const controller = new AbortController()
     const timer = window.setTimeout(() => {
       setSearching(true)
@@ -163,6 +158,11 @@ export default function ScanDetailModal({ scan, busy, onClose, onResolve }: Scan
   }, [onResolve])
 
   const variantsToShow = activeCard?.variants ?? []
+
+  const trimmedQuery = query.trim()
+  const displayResults = trimmedQuery !== '' ? results : []
+  const displaySearching = trimmedQuery !== '' ? searching : false
+  const displaySearchError = trimmedQuery !== '' ? searchError : ''
 
   // Auto-match summary line shared by the header and the override revert hint.
   const autoMatchSummary = useMemo(() => {
@@ -312,24 +312,24 @@ export default function ScanDetailModal({ scan, busy, onClose, onResolve }: Scan
                     className="flex-1 min-w-0 bg-transparent border-0 outline-none text-sm text-white placeholder-gray-500"
                   />
                 </div>
-                {searchError && (
+                {displaySearchError && (
                   <p role="alert" className="text-sm text-red-300">
-                    {searchError}
+                    {displaySearchError}
                   </p>
                 )}
-                {!searchError && searching && (
+                {!displaySearchError && displaySearching && (
                   <p className="text-sm text-gray-400">{t('addCard.searching')}</p>
                 )}
-                {!searchError && !searching && query.trim() !== '' && results.length === 0 && (
+                {!displaySearchError && !displaySearching && trimmedQuery !== '' && displayResults.length === 0 && (
                   <p className="text-sm text-gray-400">{t('addCard.noResults')}</p>
                 )}
-                {results.length > 0 && (
+                {displayResults.length > 0 && (
                   <ul
                     aria-label={t('addCard.results')}
                     data-testid="scan-detail-search-results"
                     className="divide-y divide-gray-800 border border-gray-800 rounded"
                   >
-                    {results.map(card => (
+                    {displayResults.map(card => (
                       <li key={card.id} className="flex items-center gap-3 px-2 py-2 hover:bg-gray-800/60">
                         <div className="h-14 w-10 shrink-0 flex items-center justify-center bg-gray-800/40 rounded overflow-hidden">
                           {card.image_small_url ? (

--- a/web/src/components/pokemon/ScanDetailModal.tsx
+++ b/web/src/components/pokemon/ScanDetailModal.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { useCallback, useEffect, useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, ChevronUp, Search, X } from 'lucide-react'
+import { ChevronDown, ChevronUp, Search } from 'lucide-react'
+import { Dialog, DialogHeader, DialogBody, DialogFooter } from '../ui/dialog'
 import { formatNumber } from '../../utils/formatDate'
 
 const SEARCH_DEBOUNCE_MS = 250
@@ -78,9 +78,11 @@ function confidencePercent(confidence: number | null | undefined): number | null
 // metadata, variant pickers + Discard, and an opt-in "Wrong match?" section
 // that lets them reassign the scan to a different card without having to
 // discard and re-shoot. The reassignment posts a `card_id` override on the
-// existing resolve endpoint.
+// existing resolve endpoint. Scaffolding (focus trap, focus restoration,
+// scroll lock, escape-to-close) is delegated to the shared Dialog component.
 export default function ScanDetailModal({ scan, busy, onClose, onResolve }: ScanDetailModalProps) {
   const { t } = useTranslation('pokemon')
+  const titleId = useId()
   const [wrongMatchOpen, setWrongMatchOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<ScanDetailCard[]>([])
@@ -92,28 +94,6 @@ export default function ScanDetailModal({ scan, busy, onClose, onResolve }: Scan
   const activeCard = overrideCard ?? autoCard
   const autoVariant = autoCard?.variants?.[0]
   const pct = confidencePercent(scan.confidence)
-
-  // Lock body scroll while the modal is open so the underlying list doesn't
-  // peek through on long pages.
-  useEffect(() => {
-    const previous = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = previous
-    }
-  }, [])
-
-  // Escape closes the modal so the kid can dismiss with a single tap.
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        onClose()
-      }
-    }
-    document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
-  }, [onClose])
 
   // Debounced /cards/search lookup. The previous timer and the in-flight
   // request are cancelled on every keystroke so stale results never overwrite
@@ -191,34 +171,24 @@ export default function ScanDetailModal({ scan, busy, onClose, onResolve }: Scan
     return `${autoCard.name} · ${setLabel} · ${t('tile.collectorNo', { number: autoCard.collector_no })}`
   }, [autoCard, scan.set?.name, t])
 
-  const dialog = (
-    <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/70 p-0 sm:p-4"
-      onClick={e => {
-        if (e.target === e.currentTarget) onClose()
-      }}
-      data-testid="scan-detail-modal"
+  return (
+    <Dialog
+      open={true}
+      onClose={onClose}
+      maxWidth="sm:max-w-lg"
+      overlayClassName="items-end sm:items-center p-0 sm:p-4 bg-black/70"
+      className="rounded-t-2xl sm:rounded-2xl border-gray-800 max-h-[95vh] sm:max-h-[90vh]"
+      aria-labelledby={titleId}
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label={t('scanned.detail.dialogLabel')}
-        className="w-full sm:max-w-lg max-h-[95vh] sm:max-h-[90vh] flex flex-col bg-gray-900 border border-gray-800 rounded-t-2xl sm:rounded-2xl shadow-xl"
-      >
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800 shrink-0">
-          <h2 className="text-base font-semibold text-white">{t('scanned.detail.title')}</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label={t('scanned.detail.close')}
-            data-testid="scan-detail-close"
-            className="p-1.5 text-gray-400 hover:text-white cursor-pointer"
-          >
-            <X size={20} />
-          </button>
-        </div>
+      <div data-testid="scan-detail-modal" className="contents">
+        <DialogHeader
+          id={titleId}
+          title={t('scanned.detail.title')}
+          onClose={onClose}
+          closeLabel={t('scanned.detail.close')}
+        />
 
-        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+        <DialogBody className="space-y-4">
           <div className="flex justify-center bg-black/40 rounded-lg overflow-hidden">
             {scan.has_image ? (
               <img
@@ -394,9 +364,9 @@ export default function ScanDetailModal({ scan, busy, onClose, onResolve }: Scan
               </div>
             )}
           </div>
-        </div>
+        </DialogBody>
 
-        <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-gray-800 shrink-0">
+        <DialogFooter>
           <button
             type="button"
             onClick={handleDiscard}
@@ -406,11 +376,8 @@ export default function ScanDetailModal({ scan, busy, onClose, onResolve }: Scan
           >
             {t('scanned.action.discard')}
           </button>
-        </div>
+        </DialogFooter>
       </div>
-    </div>
+    </Dialog>
   )
-
-  if (typeof document === 'undefined') return dialog
-  return createPortal(dialog, document.body)
 }

--- a/web/src/components/pokemon/ScanDetailModal.tsx
+++ b/web/src/components/pokemon/ScanDetailModal.tsx
@@ -127,6 +127,7 @@ export default function ScanDetailModal({ scan, busy, onClose, onResolve }: Scan
     return () => {
       controller.abort()
       window.clearTimeout(timer)
+      setSearching(false)
     }
   }, [query, wrongMatchOpen, t])
 

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -29,7 +29,10 @@ function Dialog({
   const dialogRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<Element | null>(null)
 
-  // Save previously focused element and lock body scroll on open
+  // Save previously focused element and lock body scroll on open. Focus
+  // restoration also runs in the cleanup so consumers that conditionally
+  // mount/unmount the Dialog (instead of toggling `open`) still hand focus
+  // back to whatever was focused before the dialog appeared.
   useEffect(() => {
     if (open) {
       previousFocusRef.current = document.activeElement
@@ -42,6 +45,9 @@ function Dialog({
     }
     return () => {
       document.body.style.overflow = ''
+      if (open && previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus()
+      }
     }
   }, [open])
 

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -40,7 +40,7 @@ function Dialog({
     }
     return () => {
       document.body.style.overflow = ''
-      if (open && previousFocusRef.current instanceof HTMLElement) {
+      if (open && previousFocusRef.current instanceof HTMLElement && document.contains(previousFocusRef.current)) {
         previousFocusRef.current.focus()
       }
     }

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -37,11 +37,6 @@ function Dialog({
     if (open) {
       previousFocusRef.current = document.activeElement
       document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = ''
-      if (previousFocusRef.current instanceof HTMLElement) {
-        previousFocusRef.current.focus()
-      }
     }
     return () => {
       document.body.style.overflow = ''

--- a/web/src/pages/PokemonScanned.test.tsx
+++ b/web/src/pages/PokemonScanned.test.tsx
@@ -537,8 +537,12 @@ describe('PokemonScanned – resolve actions', () => {
     fireEvent.click(screen.getByTestId('scan-detail-wrong-match-toggle'))
     expect(screen.getByTestId('scan-detail-wrong-match-panel')).toBeInTheDocument()
 
-    // Typing triggers the debounced /cards/search call.
+    // Typing triggers the debounced /cards/search call — use fake timers to
+    // advance past the debounce deterministically without real-time waiting.
+    vi.useFakeTimers()
     fireEvent.change(screen.getByTestId('scan-detail-search-input'), { target: { value: 'eevee' } })
+    vi.advanceTimersByTime(250)
+    vi.useRealTimers()
 
     await waitFor(() => {
       const searchCall = fetchMock.mock.calls.find(
@@ -594,7 +598,10 @@ describe('PokemonScanned – resolve actions', () => {
 
     fireEvent.click(screen.getByTestId('scan-open-detail-1'))
     fireEvent.click(screen.getByTestId('scan-detail-wrong-match-toggle'))
+    vi.useFakeTimers()
     fireEvent.change(screen.getByTestId('scan-detail-search-input'), { target: { value: 'eevee' } })
+    vi.advanceTimersByTime(250)
+    vi.useRealTimers()
     await waitFor(() => expect(screen.getByTestId('scan-detail-pick-sv1-100')).toBeInTheDocument())
     fireEvent.click(screen.getByTestId('scan-detail-pick-sv1-100'))
     await waitFor(() => expect(screen.getByTestId('scan-detail-override-banner')).toBeInTheDocument())

--- a/web/src/pages/PokemonScanned.test.tsx
+++ b/web/src/pages/PokemonScanned.test.tsx
@@ -328,7 +328,7 @@ describe('PokemonScanned – filter chips', () => {
 })
 
 describe('PokemonScanned – resolve actions', () => {
-  it('Add posts action=add with variant_id and refetches the list', async () => {
+  it('Add via the detail modal posts action=add with variant_id (no override) and refetches the list', async () => {
     const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
     vi.stubGlobal('fetch', fetchMock)
 
@@ -339,7 +339,12 @@ describe('PokemonScanned – resolve actions', () => {
       ([url]) => typeof url === 'string' && (url as string).startsWith('/api/pokemon/scans?'),
     ).length
 
-    fireEvent.click(screen.getByTestId('scan-action-add-1'))
+    // Matched tile is a clickable launchpad — opening it surfaces the modal.
+    fireEvent.click(screen.getByTestId('scan-open-detail-1'))
+    expect(screen.getByTestId('scan-detail-modal')).toBeInTheDocument()
+
+    // Variant picker now lives in the modal.
+    fireEvent.click(screen.getByTestId('scan-detail-variant-11'))
 
     await waitFor(() => {
       const post = fetchMock.mock.calls.find(
@@ -350,6 +355,8 @@ describe('PokemonScanned – resolve actions', () => {
       expect(post).toBeTruthy()
       const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
       expect(body).toMatchObject({ action: 'add', variant_id: 11, quantity: 1 })
+      // No override card_id when the auto-match is accepted.
+      expect(body.card_id).toBeUndefined()
     })
 
     // Refetched after resolve.
@@ -358,6 +365,28 @@ describe('PokemonScanned – resolve actions', () => {
         ([url]) => typeof url === 'string' && (url as string).startsWith('/api/pokemon/scans?'),
       ).length
       expect(afterCalls).toBeGreaterThan(initialListCalls)
+    })
+  })
+
+  it('Discarding from the detail modal posts action=discard', async () => {
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-1')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-open-detail-1'))
+    fireEvent.click(screen.getByTestId('scan-detail-discard'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/1/resolve' &&
+          (init as FetchInit | undefined)?.method === 'POST',
+      )
+      expect(post).toBeTruthy()
+      const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
+      expect(body).toMatchObject({ action: 'discard' })
     })
   })
 
@@ -438,7 +467,7 @@ describe('PokemonScanned – resolve actions', () => {
     expect(probe).toHaveAttribute('data-addcard-query', '')
   })
 
-  it('shows the variant picker on a matched row with multiple variants', async () => {
+  it('detail modal lists all variants for a matched card and posts the picked variant', async () => {
     const matched = makeMatched({
       matched_card: {
         id: 'sv1-1',
@@ -461,11 +490,12 @@ describe('PokemonScanned – resolve actions', () => {
     renderPage()
     await waitFor(() => expect(screen.getByTestId('scan-row-1')).toBeInTheDocument())
 
-    // First click opens the picker; the POST should not have fired yet.
-    fireEvent.click(screen.getByTestId('scan-action-add-1'))
-    expect(screen.getByTestId('scan-variant-picker-1')).toBeInTheDocument()
+    // Open the detail modal — the variant buttons live inside it now.
+    fireEvent.click(screen.getByTestId('scan-open-detail-1'))
+    expect(screen.getByTestId('scan-detail-variant-11')).toBeInTheDocument()
+    expect(screen.getByTestId('scan-detail-variant-12')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByTestId('scan-variant-1-12'))
+    fireEvent.click(screen.getByTestId('scan-detail-variant-12'))
 
     await waitFor(() => {
       const post = fetchMock.mock.calls.find(
@@ -476,6 +506,115 @@ describe('PokemonScanned – resolve actions', () => {
       expect(post).toBeTruthy()
       const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
       expect(body).toMatchObject({ action: 'add', variant_id: 12 })
+      expect(body.card_id).toBeUndefined()
+    })
+  })
+
+  it('expanding "Wrong match?" lets the user pick a different card and adds via that card with card_id in the body', async () => {
+    const overrideCard = {
+      id: 'sv1-100',
+      set_id: 'sv1',
+      set_name: 'Scarlet & Violet Base',
+      name: 'Eevee',
+      collector_no: '100',
+      rarity: 'Common',
+      image_small_url: 'https://example.com/eevee.png',
+      image_large_url: 'https://example.com/eevee-l.png',
+      variants: [{ id: 99, kind: 'normal', price_eur: 3, price_nok: 30 }],
+    }
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] }, (url) => {
+      if (url.startsWith('/api/pokemon/cards/search?')) {
+        return jsonResponse({ cards: [overrideCard] })
+      }
+      return null
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-1')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-open-detail-1'))
+    fireEvent.click(screen.getByTestId('scan-detail-wrong-match-toggle'))
+    expect(screen.getByTestId('scan-detail-wrong-match-panel')).toBeInTheDocument()
+
+    // Typing triggers the debounced /cards/search call.
+    fireEvent.change(screen.getByTestId('scan-detail-search-input'), { target: { value: 'eevee' } })
+
+    await waitFor(() => {
+      const searchCall = fetchMock.mock.calls.find(
+        ([url]) => typeof url === 'string' && (url as string).startsWith('/api/pokemon/cards/search?'),
+      )
+      expect(searchCall).toBeTruthy()
+    })
+
+    await waitFor(() => expect(screen.getByTestId('scan-detail-pick-sv1-100')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('scan-detail-pick-sv1-100'))
+
+    // The variant row now reflects the override card's variants.
+    await waitFor(() => expect(screen.getByTestId('scan-detail-variant-99')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-detail-variant-99'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/1/resolve' &&
+          (init as FetchInit | undefined)?.method === 'POST',
+      )
+      expect(post).toBeTruthy()
+      const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
+      // Override path: the POST body must carry the picked card_id alongside
+      // the variant_id from that card.
+      expect(body).toMatchObject({ action: 'add', variant_id: 99, card_id: 'sv1-100', quantity: 1 })
+    })
+  })
+
+  it('"Use auto-match instead" reverts the override and adds without a card_id', async () => {
+    const overrideCard = {
+      id: 'sv1-100',
+      set_id: 'sv1',
+      set_name: 'Scarlet & Violet Base',
+      name: 'Eevee',
+      collector_no: '100',
+      rarity: 'Common',
+      image_small_url: 'https://example.com/eevee.png',
+      image_large_url: 'https://example.com/eevee-l.png',
+      variants: [{ id: 99, kind: 'normal', price_eur: 3, price_nok: 30 }],
+    }
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] }, (url) => {
+      if (url.startsWith('/api/pokemon/cards/search?')) {
+        return jsonResponse({ cards: [overrideCard] })
+      }
+      return null
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-row-1')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-open-detail-1'))
+    fireEvent.click(screen.getByTestId('scan-detail-wrong-match-toggle'))
+    fireEvent.change(screen.getByTestId('scan-detail-search-input'), { target: { value: 'eevee' } })
+    await waitFor(() => expect(screen.getByTestId('scan-detail-pick-sv1-100')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('scan-detail-pick-sv1-100'))
+    await waitFor(() => expect(screen.getByTestId('scan-detail-override-banner')).toBeInTheDocument())
+
+    // Revert restores the auto-match's variants.
+    fireEvent.click(screen.getByTestId('scan-detail-revert'))
+    expect(screen.queryByTestId('scan-detail-override-banner')).not.toBeInTheDocument()
+    expect(screen.getByTestId('scan-detail-variant-11')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('scan-detail-variant-11'))
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/1/resolve' &&
+          (init as FetchInit | undefined)?.method === 'POST',
+      )
+      expect(post).toBeTruthy()
+      const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
+      expect(body).toMatchObject({ action: 'add', variant_id: 11 })
+      expect(body.card_id).toBeUndefined()
     })
   })
 })

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -628,6 +628,17 @@ export default function PokemonScannedPage() {
     [refetch, showToast, t],
   )
 
+  const detailScan = detailScanId != null ? (scans.find(s => s.id === detailScanId) ?? null) : null
+
+  const handleDetailResolve = useCallback(
+    async (body: ScanDetailResolveBody) => {
+      if (!detailScan) return
+      await handleResolve(detailScan, body)
+      handleCloseDetail()
+    },
+    [detailScan, handleResolve, handleCloseDetail],
+  )
+
   return (
     <div className="min-h-screen bg-gray-900 text-white">
       <div className="max-w-3xl mx-auto px-4 py-6 space-y-5">
@@ -747,21 +758,14 @@ export default function PokemonScannedPage() {
           </ul>
         )}
       </div>
-      {detailScanId != null && (() => {
-        const scan = scans.find(s => s.id === detailScanId)
-        if (!scan) return null
-        return (
-          <ScanDetailModal
-            scan={scan}
-            busy={busyId === scan.id}
-            onClose={handleCloseDetail}
-            onResolve={async (body: ScanDetailResolveBody) => {
-              await handleResolve(scan, body)
-              handleCloseDetail()
-            }}
-          />
-        )
-      })()}
+      {detailScan != null && (
+        <ScanDetailModal
+          scan={detailScan}
+          busy={busyId === detailScan.id}
+          onClose={handleCloseDetail}
+          onResolve={handleDetailResolve}
+        />
+      )}
       <ToastList toasts={toasts} />
     </div>
   )

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -374,7 +374,7 @@ function ScanRow({ scan, busy, now, highlighted, rowRef, onResolve, onEnterManua
     return null
   }
 
-  const isMatched = scan.status === 'matched' && scan.matched_card
+  const isMatched = scan.status === 'matched' && scan.matched_card != null
   const containerClass = `flex flex-col sm:flex-row gap-3 p-3 bg-gray-800/40 border rounded-lg transition-shadow duration-700 ${
     highlighted
       ? 'border-emerald-400 ring-2 ring-emerald-400/70 shadow-lg shadow-emerald-500/20'

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -2,10 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
-import { ArrowLeft, Loader2 } from 'lucide-react'
+import { ArrowLeft, ChevronRight, Loader2 } from 'lucide-react'
 import ToastList from '../components/ToastList'
 import { useToast } from '../hooks/useToast'
-import { formatNumber } from '../utils/formatDate'
+import ScanDetailModal from '../components/pokemon/ScanDetailModal'
+import type { ScanDetailResolveBody } from '../components/pokemon/ScanDetailModal'
 
 // buildManualEntryQuery joins whatever partial fields Claude could read into a
 // single search string for AddCardPanel. Empty hints collapse to an empty
@@ -105,16 +106,6 @@ function statusForFilter(filter: FilterKey): string[] {
     case 'resolved':
       return ['added', 'discarded']
   }
-}
-
-function formatNok(amount: number | null | undefined): string {
-  if (amount == null) return '—'
-  return formatNumber(amount, {
-    style: 'currency',
-    currency: 'NOK',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  })
 }
 
 // elapsedSeconds returns the integer seconds elapsed between `since` and now,
@@ -221,6 +212,7 @@ interface ScanRowProps {
   rowRef?: (el: HTMLLIElement | null) => void
   onResolve: (scan: ScanJob, body: ResolveBody) => Promise<void>
   onEnterManually: (scan: ScanJob) => void
+  onOpenDetail: (scan: ScanJob) => void
   t: TFunction<'pokemon'>
 }
 
@@ -230,36 +222,13 @@ interface ResolveBody {
   quantity?: number
   condition?: string
   notes?: string
+  // card_id, when set on action=add, asks the backend to override the
+  // auto-matched card with this one before adding to the collection. Used by
+  // the scan detail modal's "Wrong match?" flow.
+  card_id?: string
 }
 
-function ScanRow({ scan, busy, now, highlighted, rowRef, onResolve, onEnterManually, t }: ScanRowProps) {
-  const [pickingVariant, setPickingVariant] = useState(false)
-  const variants = scan.matched_card?.variants ?? []
-  const hasMultiVariant = variants.length > 1
-
-  const handleAddSingle = () => {
-    const v = variants[0]
-    if (!v) return
-    void onResolve(scan, {
-      action: 'add',
-      variant_id: v.id,
-      quantity: 1,
-      condition: '',
-      notes: '',
-    })
-  }
-
-  const handleAddVariant = (variantId: number) => {
-    setPickingVariant(false)
-    void onResolve(scan, {
-      action: 'add',
-      variant_id: variantId,
-      quantity: 1,
-      condition: '',
-      notes: '',
-    })
-  }
-
+function ScanRow({ scan, busy, now, highlighted, rowRef, onResolve, onEnterManually, onOpenDetail, t }: ScanRowProps) {
   const handleDiscard = () => {
     void onResolve(scan, { action: 'discard' })
   }
@@ -271,7 +240,6 @@ function ScanRow({ scan, busy, now, highlighted, rowRef, onResolve, onEnterManua
   const renderBody = () => {
     if (scan.status === 'matched' && scan.matched_card) {
       const card = scan.matched_card
-      const variant = variants[0]
       const pct = confidencePercent(scan.confidence)
       return (
         <div className="min-w-0 flex flex-col gap-0.5">
@@ -283,10 +251,10 @@ function ScanRow({ scan, busy, now, highlighted, rowRef, onResolve, onEnterManua
             {' · '}
             {t('tile.collectorNo', { number: card.collector_no })}
           </p>
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-300">
-            {pct != null && <span>{t('scanned.confidence', { pct })}</span>}
-            <span>{variant ? formatNok(variant.price_nok) : t('scanned.noPriceYet')}</span>
-          </div>
+          {pct != null && (
+            <p className="text-xs text-gray-300">{t('scanned.confidence', { pct })}</p>
+          )}
+          <p className="text-xs text-gray-500">{t('scanned.tapToReview')}</p>
         </div>
       )
     }
@@ -342,65 +310,10 @@ function ScanRow({ scan, busy, now, highlighted, rowRef, onResolve, onEnterManua
 
   const renderActions = () => {
     if (scan.status === 'matched') {
-      return (
-        <div className="flex flex-wrap items-center gap-2 mt-2">
-          {hasMultiVariant ? (
-            <>
-              <button
-                type="button"
-                onClick={() => setPickingVariant(prev => !prev)}
-                disabled={busy}
-                data-testid={`scan-action-add-${scan.id}`}
-                aria-expanded={pickingVariant}
-                className="px-3 py-1.5 text-xs rounded bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-white cursor-pointer"
-              >
-                {t('scanned.action.add')}
-              </button>
-              {pickingVariant && (
-                <div
-                  data-testid={`scan-variant-picker-${scan.id}`}
-                  role="group"
-                  aria-label={t('scanned.action.pickVariant')}
-                  className="flex flex-wrap gap-1.5 basis-full"
-                >
-                  {variants.map(v => (
-                    <button
-                      key={v.id}
-                      type="button"
-                      onClick={() => handleAddVariant(v.id)}
-                      disabled={busy}
-                      data-testid={`scan-variant-${scan.id}-${v.id}`}
-                      className="flex items-center gap-1.5 px-2.5 py-1 rounded border border-gray-700 hover:border-emerald-500 hover:bg-emerald-500/10 disabled:cursor-not-allowed text-xs text-white cursor-pointer"
-                    >
-                      <span>{t(`variantKind.${v.kind}`, { defaultValue: v.kind })}</span>
-                      <span className="text-[10px] text-gray-400">{formatNok(v.price_nok)}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </>
-          ) : (
-            <button
-              type="button"
-              onClick={handleAddSingle}
-              disabled={busy || variants.length === 0}
-              data-testid={`scan-action-add-${scan.id}`}
-              className="px-3 py-1.5 text-xs rounded bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800/60 disabled:cursor-not-allowed text-white cursor-pointer"
-            >
-              {t('scanned.action.add')}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={handleDiscard}
-            disabled={busy}
-            data-testid={`scan-action-discard-${scan.id}`}
-            className="px-3 py-1.5 text-xs rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-60 disabled:cursor-not-allowed text-white cursor-pointer"
-          >
-            {t('scanned.action.discard')}
-          </button>
-        </div>
-      )
+      // The matched-tile action row was moved into the detail modal so the
+      // tile is just a clickable launchpad. The detail modal owns the variant
+      // picker, Discard, and the "Wrong match?" reassign flow.
+      return null
     }
     if (scan.status === 'no_match') {
       return (
@@ -461,30 +374,54 @@ function ScanRow({ scan, busy, now, highlighted, rowRef, onResolve, onEnterManua
     return null
   }
 
+  const isMatched = scan.status === 'matched' && scan.matched_card
+  const containerClass = `flex flex-col sm:flex-row gap-3 p-3 bg-gray-800/40 border rounded-lg transition-shadow duration-700 ${
+    highlighted
+      ? 'border-emerald-400 ring-2 ring-emerald-400/70 shadow-lg shadow-emerald-500/20'
+      : 'border-gray-800'
+  }`
+
   return (
     <li
       ref={rowRef}
       data-testid={`scan-row-${scan.id}`}
       data-status={scan.status}
       data-highlighted={highlighted ? 'true' : undefined}
-      className={`flex flex-col sm:flex-row gap-3 p-3 bg-gray-800/40 border rounded-lg transition-shadow duration-700 ${
-        highlighted
-          ? 'border-emerald-400 ring-2 ring-emerald-400/70 shadow-lg shadow-emerald-500/20'
-          : 'border-gray-800'
-      }`}
+      className={containerClass}
     >
-      <div className="flex gap-3 min-w-0 flex-1">
-        <Thumbnail
-          scan={scan}
-          alt={t('scanned.thumbnailAlt')}
-          placeholder={t('scanned.thumbnailPlaceholder')}
-        />
-        <div className="flex flex-col gap-1.5 min-w-0 flex-1">
-          <StatusPill status={scan.status} t={t} />
-          {renderBody()}
-          {renderActions()}
+      {isMatched ? (
+        <button
+          type="button"
+          onClick={() => onOpenDetail(scan)}
+          aria-label={t('scanned.detail.openLabel', { name: scan.matched_card?.name ?? '' })}
+          data-testid={`scan-open-detail-${scan.id}`}
+          className="flex gap-3 min-w-0 flex-1 text-left cursor-pointer hover:bg-gray-800/20 -m-1 p-1 rounded"
+        >
+          <Thumbnail
+            scan={scan}
+            alt={t('scanned.thumbnailAlt')}
+            placeholder={t('scanned.thumbnailPlaceholder')}
+          />
+          <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+            <StatusPill status={scan.status} t={t} />
+            {renderBody()}
+          </div>
+          <ChevronRight size={18} className="self-center text-gray-500 shrink-0" aria-hidden="true" />
+        </button>
+      ) : (
+        <div className="flex gap-3 min-w-0 flex-1">
+          <Thumbnail
+            scan={scan}
+            alt={t('scanned.thumbnailAlt')}
+            placeholder={t('scanned.thumbnailPlaceholder')}
+          />
+          <div className="flex flex-col gap-1.5 min-w-0 flex-1">
+            <StatusPill status={scan.status} t={t} />
+            {renderBody()}
+            {renderActions()}
+          </div>
         </div>
-      </div>
+      )}
     </li>
   )
 }
@@ -510,6 +447,7 @@ export default function PokemonScannedPage() {
   const [busyId, setBusyId] = useState<number | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [highlightedId, setHighlightedId] = useState<number | null>(null)
+  const [detailScanId, setDetailScanId] = useState<number | null>(null)
   const rowRefs = useRef<Map<number, HTMLLIElement>>(new Map())
   const focusHandledRef = useRef<number | null>(null)
 
@@ -655,6 +593,14 @@ export default function PokemonScannedPage() {
     [navigate],
   )
 
+  const handleOpenDetail = useCallback((scan: ScanJob) => {
+    setDetailScanId(scan.id)
+  }, [])
+
+  const handleCloseDetail = useCallback(() => {
+    setDetailScanId(null)
+  }, [])
+
   const handleResolve = useCallback(
     async (scan: ScanJob, body: ResolveBody) => {
       setBusyId(scan.id)
@@ -794,12 +740,28 @@ export default function PokemonScannedPage() {
                 }}
                 onResolve={handleResolve}
                 onEnterManually={handleEnterManually}
+                onOpenDetail={handleOpenDetail}
                 t={t}
               />
             ))}
           </ul>
         )}
       </div>
+      {detailScanId != null && (() => {
+        const scan = scans.find(s => s.id === detailScanId)
+        if (!scan) return null
+        return (
+          <ScanDetailModal
+            scan={scan}
+            busy={busyId === scan.id}
+            onClose={handleCloseDetail}
+            onResolve={async (body: ScanDetailResolveBody) => {
+              await handleResolve(scan, body)
+              handleCloseDetail()
+            }}
+          />
+        )
+      })()}
       <ToastList toasts={toasts} />
     </div>
   )


### PR DESCRIPTION
## Changes

- **Pokémon scanned: tap-to-detail view + manual reassign on wrong match** - Matched scan tiles are now a tap target that opens a fuller detail view with the large scan image, match info, variant buttons, and Discard. A "Wrong match?" section lets you search and reassign the scan to a different card before adding it to your collection — no more discard-and-rescan when the auto-match was off. (Hytte-1mtg)

## Original Issue (feature): Pokémon scanned: tap-to-detail view + manual reassign on wrong match

Builds on the async-scanner chain. Today a matched scan tile in `/pokemon/scanned` shows a small thumbnail + name + collector + variant buttons + Discard. When Claude's auto-match is wrong, the only recourse is Discard + re-scan. Make the scan tile a launchpad into a fuller detail view that also supports correcting a wrong match in-place.

## Scope

### 1. Backend — accept a `card_id` override on `action=add`

`internal/pokemon/scans_handlers.go::ResolveScanHandler`'s `case "add":`

- Add optional `card_id` field to the resolve body. When non-empty, use it as the target card instead of the scan's `matched_card_id`.
- Validation: the supplied `card_id` must exist in `pokemon_cards`, and the supplied `variant_id` must belong to that card (existing `errVariantMismatch` covers this, just point it at the override card).
- Persist the override: when `card_id` overrides, also set `pokemon_scan_jobs.matched_card_id = <card_id>` in the same transaction so the resolved row reflects what was actually added (so the history view is honest).
- Keep the conditional-update guard intact (only flip if `status='matched'`).
- The existing collection upsert should use the override `card_id` when supplied.

### 2. Frontend — scan detail view

- Make each matched-scan tile in `PokemonScanned.tsx` clickable (whole tile or an explicit "View" button) — open a modal or in-page detail (modal is fine; reuse the lightbox pattern from `CardLightbox.tsx` if convenient).
- Detail view content:
    - Large scan image via `/api/pokemon/scans/{id}/image` (with the same `thumbnailPlaceholder` fallback for resolved scans where the image is already deleted).
    - Match info: card name, set, collector number, confidence percentage.
    - Variant buttons (Add per variant) and Discard — move these out of the tile into the detail view. The tile keeps only the thumbnail + name + confidence + a hint that the row is clickable. The Add and Discard wire to the existing `handleResolve` callback unchanged when the auto-match is accepted.
- "Wrong match?" section in the detail view (collapsed by default, expand-on-click to keep the happy path uncluttered):
    - Search input. As the user types (debounce 250ms), `GET /api/pokemon/cards/search?q=...` populates a result list with thumbnails + name + set + collector_no.
    - Picking a result swaps the variant-button row to show the **selected card's** variants; the Add buttons in that state pass `card_id` of the selected card in the resolve body. The original auto-match info stays visible so the user can revert by tapping "Use auto-match instead".

### 3. Frontend — drop the now-stale tile-level action row

After moving Add/Discard into the detail view, the matched-status branch of the tile-action renderer is empty for matched scans — collapse it so the tile is just the clickable surface. The `no_match` and `failed` branches keep their current action rows (those flows still resolve from the tile).

### 4. Tests

- Backend: `scans_handlers_test.go` — new TestResolveScanAdd_WithCardOverride exercises happy-path override (matched card A, override to card B, variant from B). Add coverage for the error paths: card_id refers to a non-existent card → 404; variant_id doesn't belong to the override card → 400 `errVariantMismatch`.
- Backend: existing TestResolveScanAdd_* tests should pass unchanged (override is opt-in).
- Frontend: `PokemonScanned.test.tsx` — opening the detail view from a matched tile, adding via a variant button (no override path: existing behaviour), expanding "Wrong match?", typing into the search box, picking a result and adding via that card's variant (override path: assert the POST body includes `card_id`).

## Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build` pass.
- Tapping a matched scan in `/pokemon/scanned` on the production phone opens the detail view with a clearly larger image, match info, variants, Discard.
- Expanding "Wrong match?" lets you search, pick a different card, and add the scan to that card's collection instead.
- The tile-level Retry button on matched scans is gone (already removed in the preceding hotfix).
- Changelog fragment in changelog.d/ (category: Changed).
- i18n keys added to all three locales (en/nb/th).

## Reference

- internal/pokemon/scans_handlers.go ResolveScanHandler — extend `add` case.
- internal/pokemon/handlers.go SearchCardsHandler — already exists at `/api/pokemon/cards/search?q=`, reuse for the search box.
- web/src/pages/PokemonScanned.tsx — current tile renderer.
- web/src/components/pokemon/CardLightbox.tsx — existing modal pattern for large card images.
- web/src/components/pokemon/AddCardPanel.tsx — search UX pattern to mirror.


---
Bead: Hytte-1mtg | Branch: forge/Hytte-1mtg
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->