### PR TITLE
Family Chat: REST handlers (Hytte-56j7)

### DIFF
--- a/changelog.d/Hytte-56j7.md
+++ b/changelog.d/Hytte-56j7.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat REST endpoints** - Added `/api/familychat/conversations` and message routes (list/create/get/delete conversation, list/post messages, mark-read) gated by the new `family_chat` feature flag. Message bodies and attachment paths are encrypted at rest, and every endpoint resolves membership via `family_chat_members` so non-members receive 404 instead of 403 to avoid leaking conversation existence. (Hytte-56j7)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -538,14 +538,16 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/chat/conversations/{id}/messages", chat.SendMessageHandler(db))
 			})
 
-			// Family Chat — gated by "family_chat" feature.
-			// The SSE live-delivery stream is the only route registered here so
-			// far; REST endpoints (list/create conversations, send/read messages)
-			// land in companion beads and will join this group. Message and read
-			// handlers publish into familychat.DefaultHub() so subscribers see
-			// updates within milliseconds of the row being persisted.
+			// Family Chat — gated by "family_chat" feature (Hytte-56j7).
 			r.Group(func(r chi.Router) {
 				r.Use(auth.RequireFeature(db, "family_chat"))
+				r.Get("/familychat/conversations", familychat.ListConversationsHandler(db))
+				r.Post("/familychat/conversations", familychat.CreateConversationHandler(db))
+				r.Get("/familychat/conversations/{id}", familychat.GetConversationHandler(db))
+				r.Delete("/familychat/conversations/{id}", familychat.DeleteConversationHandler(db))
+				r.Get("/familychat/conversations/{id}/messages", familychat.ListMessagesHandler(db))
+				r.Post("/familychat/conversations/{id}/messages", familychat.PostMessageHandler(db))
+				r.Post("/familychat/conversations/{id}/read", familychat.MarkReadHandler(db))
 				r.Get("/familychat/conversations/{id}/stream", familychat.StreamHandlerWithDB(db))
 			})
 

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -36,7 +36,6 @@ var FeatureDefaults = map[string]bool{
 	"grocery":          false,
 	"homework":         false,
 	"regnemester":      false,
-	"pokemon":          false,
 }
 
 // FeatureKeys is a sorted list of all known feature keys, used for stable

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -36,6 +36,7 @@ var FeatureDefaults = map[string]bool{
 	"grocery":          false,
 	"homework":         false,
 	"regnemester":      false,
+	"pokemon":          false,
 }
 
 // FeatureKeys is a sorted list of all known feature keys, used for stable

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1713,38 +1713,40 @@ func createSchema(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_pokemon_scan_jobs_user_status ON pokemon_scan_jobs(user_id, status);
 	CREATE INDEX IF NOT EXISTS idx_pokemon_scan_jobs_queued ON pokemon_scan_jobs(status, created_at) WHERE status = 'queued';
 
-	-- family_chat_* (Hytte-0w3d): conversations, members, and messages for the
-	-- Family Chat feature. Free-text fields (name, message body, attachment
-	-- path) are stored encrypted at rest via internal/encryption.
+	-- Family Chat (Hytte-56j7): conversations, members, and encrypted messages.
+	-- Trust model is at-rest encryption with the server holding the key (same
+	-- as Notes); body and attachment_path are stored as enc:... ciphertext.
 	CREATE TABLE IF NOT EXISTS family_chat_conversations (
-		id          INTEGER PRIMARY KEY AUTOINCREMENT,
-		name_enc    TEXT NOT NULL DEFAULT '',
-		owner_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-		created_at  TIMESTAMP NOT NULL,
-		updated_at  TIMESTAMP NOT NULL
+		id              INTEGER PRIMARY KEY,
+		name            TEXT NOT NULL DEFAULT '',
+		owner_user_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+		last_message_at TEXT NOT NULL DEFAULT ''
 	);
+
+	CREATE INDEX IF NOT EXISTS idx_family_chat_conversations_owner ON family_chat_conversations(owner_user_id);
 
 	CREATE TABLE IF NOT EXISTS family_chat_members (
 		conversation_id INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
 		user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-		role            TEXT NOT NULL DEFAULT 'member',
-		joined_at       TIMESTAMP NOT NULL,
-		last_read_at    TIMESTAMP,
+		joined_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+		last_read_at    TEXT NOT NULL DEFAULT '',
 		PRIMARY KEY (conversation_id, user_id)
 	);
-	CREATE INDEX IF NOT EXISTS idx_family_chat_members_user ON family_chat_members(user_id, conversation_id);
+
+	CREATE INDEX IF NOT EXISTS idx_family_chat_members_user ON family_chat_members(user_id);
 
 	CREATE TABLE IF NOT EXISTS family_chat_messages (
-		id              INTEGER PRIMARY KEY AUTOINCREMENT,
-		conversation_id INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
-		sender_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-		body_enc        TEXT NOT NULL,
-		attachment_path_enc TEXT,
-		attachment_mime TEXT,
-		sent_at         TIMESTAMP NOT NULL
+		id                INTEGER PRIMARY KEY,
+		conversation_id   INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
+		sender_user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		body              TEXT NOT NULL DEFAULT '',
+		attachment_path   TEXT NOT NULL DEFAULT '',
+		attachment_mime   TEXT NOT NULL DEFAULT '',
+		created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 	);
-	CREATE INDEX IF NOT EXISTS idx_family_chat_messages_conv ON family_chat_messages(conversation_id, sent_at);
-	CREATE INDEX IF NOT EXISTS idx_family_chat_messages_conv_id ON family_chat_messages(conversation_id, id);
+
+	CREATE INDEX IF NOT EXISTS idx_family_chat_messages_conversation_id ON family_chat_messages(conversation_id, id DESC);
 
 	`
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2490,6 +2490,27 @@ func createSchema(db *sql.DB) error {
 		}
 	}
 
+	// Migrate family_chat tables from the schema-bead column names to the REST
+	// bead column names (Hytte-56j7). Detect old schema via presence of
+	// name_enc on family_chat_conversations; if found, rename all affected
+	// columns so existing installs don't break at runtime.
+	var hasFCNameEnc int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('family_chat_conversations') WHERE name = 'name_enc'`).Scan(&hasFCNameEnc); err != nil {
+		return fmt.Errorf("check family_chat_conversations name_enc: %w", err)
+	}
+	if hasFCNameEnc != 0 {
+		for _, stmt := range []string{
+			`ALTER TABLE family_chat_conversations RENAME COLUMN name_enc TO name`,
+			`ALTER TABLE family_chat_conversations RENAME COLUMN owner_id TO owner_user_id`,
+			`ALTER TABLE family_chat_messages RENAME COLUMN body_enc TO body`,
+			`ALTER TABLE family_chat_messages RENAME COLUMN attachment_path_enc TO attachment_path`,
+		} {
+			if _, err := db.Exec(stmt); err != nil {
+				return fmt.Errorf("migrate family_chat columns: %w", err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -112,18 +112,15 @@ func CreateConversationHandler(db *sql.DB) http.HandlerFunc {
 				return
 			}
 		}
-		// Pre-validate that referenced users exist so FK failures map to 400.
-		for _, uid := range body.MemberUserIDs {
-			var exists int
-			if err := db.QueryRow(`SELECT 1 FROM users WHERE id = ?`, uid).Scan(&exists); err != nil {
-				if errors.Is(err, sql.ErrNoRows) {
-					writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("user %d not found", uid)})
-					return
-				}
-				log.Printf("familychat: lookup user %d: %v", uid, err)
-				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to validate members"})
-				return
-			}
+		// Pre-validate that referenced users exist (single IN query) so FK
+		// failures map to 400 rather than 500.
+		if missing, err := ValidateMemberIDs(db, body.MemberUserIDs); err != nil {
+			log.Printf("familychat: validate members: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to validate members"})
+			return
+		} else if missing != 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("user %d not found", missing)})
+			return
 		}
 
 		c, err := CreateConversation(db, user.ID, body.Name, body.MemberUserIDs)
@@ -255,6 +252,16 @@ func PostMessageHandler(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to post message"})
 			return
 		}
+		DefaultHub().Publish(convID, Event{
+			Type: EventMessageNew,
+			Data: map[string]any{
+				"id":              msg.ID,
+				"conversation_id": msg.ConversationID,
+				"sender_user_id":  msg.SenderUserID,
+				"body":            msg.Body,
+				"created_at":      msg.CreatedAt,
+			},
+		})
 		writeJSON(w, http.StatusCreated, map[string]any{"message": msg})
 	}
 }
@@ -296,6 +303,11 @@ func MarkReadHandler(db *sql.DB) http.HandlerFunc {
 			}
 			at = t.UTC().Format(timeFormat)
 		}
+		// Pre-compute server time so the same value goes into the DB and the
+		// read-receipt event, avoiding a race between MarkRead's own default.
+		if at == "" {
+			at = time.Now().UTC().Format(timeFormat)
+		}
 
 		if err := MarkRead(db, convID, user.ID, at); err != nil {
 			if errors.Is(err, ErrForbidden) {
@@ -306,6 +318,14 @@ func MarkReadHandler(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mark read"})
 			return
 		}
+		DefaultHub().Publish(convID, Event{
+			Type: EventReadReceipt,
+			Data: map[string]any{
+				"conversation_id": convID,
+				"user_id":         user.ID,
+				"at":              at,
+			},
+		})
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	}
 }

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -1,0 +1,251 @@
+package familychat
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("familychat: writeJSON encode: %v", err)
+	}
+}
+
+func notFound(w http.ResponseWriter) {
+	writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+}
+
+// parseConvID extracts and validates the {id} path parameter for the
+// conversation routes. On failure we respond 404 (not 400) because an
+// unparseable id may simply be a probe for a conversation that does not
+// exist, and we never want to leak that signal.
+func parseConvID(r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
+}
+
+// ListConversationsHandler returns every conversation the authenticated user
+// is a member of.
+func ListConversationsHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convos, err := ListConversations(db, user.ID)
+		if err != nil {
+			log.Printf("familychat: list conversations for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list conversations"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"conversations": convos})
+	}
+}
+
+// CreateConversationHandler creates a new conversation with the requesting
+// user as owner. The body shape is {name, member_user_ids}.
+func CreateConversationHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		var body struct {
+			Name          string  `json:"name"`
+			MemberUserIDs []int64 `json:"member_user_ids"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+		body.Name = strings.TrimSpace(body.Name)
+		if body.Name == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+			return
+		}
+
+		c, err := CreateConversation(db, user.ID, body.Name, body.MemberUserIDs)
+		if err != nil {
+			log.Printf("familychat: create conversation for user %d: %v", user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create conversation"})
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"conversation": c})
+	}
+}
+
+// GetConversationHandler returns full metadata for a single conversation.
+// Non-members get 404 to avoid revealing existence.
+func GetConversationHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+		c, err := GetConversation(db, convID, user.ID)
+		if err != nil {
+			if errors.Is(err, ErrNotMember) || errors.Is(err, sql.ErrNoRows) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: get conversation %d for user %d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get conversation"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"conversation": c})
+	}
+}
+
+// ListMessagesHandler returns messages, newest first. Optional query params:
+//
+//	since=<id>  - return only messages with id > since
+//	limit=<n>   - cap the response size (default 50, max 500)
+func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+
+		var since int64
+		if v := strings.TrimSpace(r.URL.Query().Get("since")); v != "" {
+			n, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || n < 0 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid since parameter"})
+				return
+			}
+			since = n
+		}
+		limit := 50
+		if v := strings.TrimSpace(r.URL.Query().Get("limit")); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n <= 0 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid limit parameter"})
+				return
+			}
+			limit = n
+		}
+
+		msgs, err := ListMessages(db, convID, user.ID, since, limit)
+		if err != nil {
+			if errors.Is(err, ErrNotMember) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: list messages conv=%d user=%d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list messages"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"messages": msgs})
+	}
+}
+
+// PostMessageHandler appends a message to a conversation and returns the
+// inserted row decrypted.
+func PostMessageHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+
+		var body struct {
+			Body           string `json:"body"`
+			AttachmentPath string `json:"attachment_path"`
+			AttachmentMime string `json:"attachment_mime"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+		body.Body = strings.TrimSpace(body.Body)
+		if body.Body == "" && body.AttachmentPath == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body or attachment_path is required"})
+			return
+		}
+
+		msg, err := CreateMessage(db, convID, user.ID, body.Body, body.AttachmentPath, body.AttachmentMime)
+		if err != nil {
+			if errors.Is(err, ErrNotMember) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: post message conv=%d user=%d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to post message"})
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"message": msg})
+	}
+}
+
+// MarkReadHandler updates the requesting member's last_read_at to {at}.
+// Missing/empty `at` defaults to the current server time.
+func MarkReadHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+
+		var body struct {
+			At string `json:"at"`
+		}
+		// An empty body is valid: it just means "mark read up to now".
+		if r.ContentLength > 0 {
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+				return
+			}
+		}
+
+		if err := MarkRead(db, convID, user.ID, strings.TrimSpace(body.At)); err != nil {
+			if errors.Is(err, ErrNotMember) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: mark read conv=%d user=%d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mark read"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+}
+
+// DeleteConversationHandler removes a conversation. Only the owner may
+// delete; non-owners (including members) get 404.
+func DeleteConversationHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+		if err := DeleteConversation(db, convID, user.ID); err != nil {
+			if errors.Is(err, ErrNotMember) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: delete conversation %d for user %d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete conversation"})
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -107,6 +109,19 @@ func CreateConversationHandler(db *sql.DB) http.HandlerFunc {
 		for _, uid := range body.MemberUserIDs {
 			if uid <= 0 {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid member id"})
+				return
+			}
+		}
+		// Pre-validate that referenced users exist so FK failures map to 400.
+		for _, uid := range body.MemberUserIDs {
+			var exists int
+			if err := db.QueryRow(`SELECT 1 FROM users WHERE id = ?`, uid).Scan(&exists); err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("user %d not found", uid)})
+					return
+				}
+				log.Printf("familychat: lookup user %d: %v", uid, err)
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to validate members"})
 				return
 			}
 		}
@@ -258,23 +273,28 @@ func MarkReadHandler(db *sql.DB) http.HandlerFunc {
 		var body struct {
 			At string `json:"at"`
 		}
-		// An empty body is valid: it just means "mark read up to now".
-		if r.ContentLength > 0 {
-			if !decodeJSON(w, r, &body) {
-				return
-			}
+		// Decode the body unconditionally; an empty body (io.EOF) means "mark
+		// read up to now". Relying on ContentLength is unreliable for chunked
+		// requests where ContentLength == -1.
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
 		}
 		at := strings.TrimSpace(body.At)
 		if at != "" {
-			// Accept RFC3339 with optional sub-second precision. Reject anything
-			// unparseable so we never store garbage in last_read_at, which is
-			// compared as a string for unread-count ordering.
-			if _, err := time.Parse(time.RFC3339Nano, at); err != nil {
-				if _, err2 := time.Parse(time.RFC3339, at); err2 != nil {
-					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid at timestamp (expected RFC3339)"})
-					return
-				}
+			// Parse RFC3339 (with or without sub-second precision), then
+			// normalize to UTC with the same fixed-width timeFormat used for
+			// stored created_at values so that string comparisons stay correct.
+			t, err := time.Parse(time.RFC3339Nano, at)
+			if err != nil {
+				t, err = time.Parse(time.RFC3339, at)
 			}
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid at timestamp (expected RFC3339)"})
+				return
+			}
+			at = t.UTC().Format(timeFormat)
 		}
 
 		if err := MarkRead(db, convID, user.ID, at); err != nil {

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -8,9 +8,24 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/go-chi/chi/v5"
+)
+
+// Input validation bounds for the Family Chat handlers. The body cap is a
+// generous safety net to keep one client from filling the DB with one
+// request; clients should enforce friendlier UI limits well below these.
+const (
+	maxNameLen        = 200
+	maxBodyLen        = 8000
+	maxAttachmentPath = 1024
+	maxAttachmentMime = 128
+	maxMembersPerConv = 100
+	defaultMsgLimit   = 50
+	maxMsgLimit       = 500
+	maxRequestBytes   = 1 << 20 // 1 MiB
 )
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
@@ -23,6 +38,17 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func notFound(w http.ResponseWriter) {
 	writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+}
+
+// decodeJSON enforces a body-size cap and parses JSON into dst. Returns true
+// on success; on failure it writes a 400 response and returns false.
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return false
+	}
+	return true
 }
 
 // parseConvID extracts and validates the {id} path parameter for the
@@ -62,14 +88,27 @@ func CreateConversationHandler(db *sql.DB) http.HandlerFunc {
 			Name          string  `json:"name"`
 			MemberUserIDs []int64 `json:"member_user_ids"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		if !decodeJSON(w, r, &body) {
 			return
 		}
 		body.Name = strings.TrimSpace(body.Name)
 		if body.Name == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
 			return
+		}
+		if len([]rune(body.Name)) > maxNameLen {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is too long"})
+			return
+		}
+		if len(body.MemberUserIDs) > maxMembersPerConv {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "too many members"})
+			return
+		}
+		for _, uid := range body.MemberUserIDs {
+			if uid <= 0 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid member id"})
+				return
+			}
 		}
 
 		c, err := CreateConversation(db, user.ID, body.Name, body.MemberUserIDs)
@@ -128,10 +167,10 @@ func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
 			}
 			since = n
 		}
-		limit := 50
+		limit := defaultMsgLimit
 		if v := strings.TrimSpace(r.URL.Query().Get("limit")); v != "" {
 			n, err := strconv.Atoi(v)
-			if err != nil || n <= 0 {
+			if err != nil || n <= 0 || n > maxMsgLimit {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid limit parameter"})
 				return
 			}
@@ -168,13 +207,26 @@ func PostMessageHandler(db *sql.DB) http.HandlerFunc {
 			AttachmentPath string `json:"attachment_path"`
 			AttachmentMime string `json:"attachment_mime"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		if !decodeJSON(w, r, &body) {
 			return
 		}
 		body.Body = strings.TrimSpace(body.Body)
+		body.AttachmentPath = strings.TrimSpace(body.AttachmentPath)
+		body.AttachmentMime = strings.TrimSpace(body.AttachmentMime)
 		if body.Body == "" && body.AttachmentPath == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body or attachment_path is required"})
+			return
+		}
+		if len([]rune(body.Body)) > maxBodyLen {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body is too long"})
+			return
+		}
+		if len(body.AttachmentPath) > maxAttachmentPath {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "attachment_path is too long"})
+			return
+		}
+		if len(body.AttachmentMime) > maxAttachmentMime {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "attachment_mime is too long"})
 			return
 		}
 
@@ -208,13 +260,24 @@ func MarkReadHandler(db *sql.DB) http.HandlerFunc {
 		}
 		// An empty body is valid: it just means "mark read up to now".
 		if r.ContentLength > 0 {
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			if !decodeJSON(w, r, &body) {
 				return
 			}
 		}
+		at := strings.TrimSpace(body.At)
+		if at != "" {
+			// Accept RFC3339 with optional sub-second precision. Reject anything
+			// unparseable so we never store garbage in last_read_at, which is
+			// compared as a string for unread-count ordering.
+			if _, err := time.Parse(time.RFC3339Nano, at); err != nil {
+				if _, err2 := time.Parse(time.RFC3339, at); err2 != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid at timestamp (expected RFC3339)"})
+					return
+				}
+			}
+		}
 
-		if err := MarkRead(db, convID, user.ID, strings.TrimSpace(body.At)); err != nil {
+		if err := MarkRead(db, convID, user.ID, at); err != nil {
 			if errors.Is(err, ErrNotMember) {
 				notFound(w)
 				return

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -94,10 +94,6 @@ func CreateConversationHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 		body.Name = strings.TrimSpace(body.Name)
-		if body.Name == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
-			return
-		}
 		if len([]rune(body.Name)) > maxNameLen {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is too long"})
 			return

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -148,7 +148,7 @@ func GetConversationHandler(db *sql.DB) http.HandlerFunc {
 		}
 		c, err := GetConversation(db, convID, user.ID)
 		if err != nil {
-			if errors.Is(err, ErrNotMember) || errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, ErrForbidden) || errors.Is(err, sql.ErrNoRows) {
 				notFound(w)
 				return
 			}
@@ -194,7 +194,7 @@ func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
 
 		msgs, err := ListMessages(db, convID, user.ID, since, limit)
 		if err != nil {
-			if errors.Is(err, ErrNotMember) {
+			if errors.Is(err, ErrForbidden) {
 				notFound(w)
 				return
 			}
@@ -247,7 +247,7 @@ func PostMessageHandler(db *sql.DB) http.HandlerFunc {
 
 		msg, err := CreateMessage(db, convID, user.ID, body.Body, body.AttachmentPath, body.AttachmentMime)
 		if err != nil {
-			if errors.Is(err, ErrNotMember) {
+			if errors.Is(err, ErrForbidden) {
 				notFound(w)
 				return
 			}
@@ -298,7 +298,7 @@ func MarkReadHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		if err := MarkRead(db, convID, user.ID, at); err != nil {
-			if errors.Is(err, ErrNotMember) {
+			if errors.Is(err, ErrForbidden) {
 				notFound(w)
 				return
 			}
@@ -321,7 +321,7 @@ func DeleteConversationHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 		if err := DeleteConversation(db, convID, user.ID); err != nil {
-			if errors.Is(err, ErrNotMember) {
+			if errors.Is(err, ErrForbidden) {
 				notFound(w)
 				return
 			}

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -27,6 +27,9 @@ func setupTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	t.Cleanup(func() { _ = db.Close() })
 	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
 		t.Fatalf("enable fk: %v", err)
 	}
@@ -161,17 +164,19 @@ func TestCreateConversationHandler_Success(t *testing.T) {
 	}
 }
 
-func TestCreateConversationHandler_MissingName(t *testing.T) {
+func TestCreateConversationHandler_EmptyNameAllowed(t *testing.T) {
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com")
 
+	// Empty name is valid — the schema allows it (unnamed/1:1 chats derive
+	// their display name client-side).
 	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(`{"name":""}`)), 1)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	CreateConversationHandler(db).ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", rec.Code)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for empty name, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -298,6 +303,49 @@ func TestPostMessageHandler_EmptyBodyRejected(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestPostMessageHandler_AttachmentEncryption(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	payload := `{"body":"","attachment_path":"/uploads/photo.jpg","attachment_mime":"image/jpeg"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Message Message `json:"message"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Response returns plaintext values.
+	if body.Message.AttachmentPath != "/uploads/photo.jpg" {
+		t.Errorf("response attachment_path = %q, want plaintext", body.Message.AttachmentPath)
+	}
+	if body.Message.AttachmentMime != "image/jpeg" {
+		t.Errorf("response attachment_mime = %q", body.Message.AttachmentMime)
+	}
+
+	// DB stores attachment_path encrypted, attachment_mime as plaintext.
+	var storedPath, storedMime string
+	if err := db.QueryRow(`SELECT attachment_path, attachment_mime FROM family_chat_messages WHERE id = ?`, body.Message.ID).Scan(&storedPath, &storedMime); err != nil {
+		t.Fatalf("read stored row: %v", err)
+	}
+	if !strings.HasPrefix(storedPath, "enc:") {
+		t.Errorf("attachment_path not encrypted at rest: %q", storedPath)
+	}
+	if storedMime != "image/jpeg" {
+		t.Errorf("attachment_mime should be plaintext, got %q", storedMime)
 	}
 }
 

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -562,6 +562,91 @@ func TestDeleteConversationHandler_NonOwnerMember(t *testing.T) {
 	}
 }
 
+func TestCreateConversationHandler_NameTooLong(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+
+	longName := strings.Repeat("a", maxNameLen+1)
+	payload := fmt.Sprintf(`{"name":%q}`, longName)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestCreateConversationHandler_InvalidMemberID(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+
+	payload := `{"name":"Family","member_user_ids":[0]}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestPostMessageHandler_BodyTooLong(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	longBody := strings.Repeat("x", maxBodyLen+1)
+	payload := fmt.Sprintf(`{"body":%q}`, longBody)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestListMessagesHandler_LimitTooLarge(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	url := fmt.Sprintf("/api/familychat/conversations/%s/messages?limit=%d", idStr, maxMsgLimit+1)
+	req := withUser(httptest.NewRequest("GET", url, nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestMarkReadHandler_InvalidTimestamp(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	payload := `{"at":"not-a-real-timestamp"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/read", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	MarkReadHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestDeleteConversationHandler_NonMember(t *testing.T) {
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com")

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -1,0 +1,581 @@
+package familychat
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/go-chi/chi/v5"
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-key-for-familychat-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
+		t.Fatalf("enable fk: %v", err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE users (
+			id         INTEGER PRIMARY KEY,
+			email      TEXT UNIQUE NOT NULL,
+			name       TEXT NOT NULL,
+			picture    TEXT NOT NULL DEFAULT '',
+			google_id  TEXT UNIQUE NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			is_admin   INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE family_chat_conversations (
+			id              INTEGER PRIMARY KEY,
+			name            TEXT NOT NULL DEFAULT '',
+			owner_user_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			created_at      TEXT NOT NULL DEFAULT '',
+			last_message_at TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE family_chat_members (
+			conversation_id INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
+			user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			joined_at       TEXT NOT NULL DEFAULT '',
+			last_read_at    TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (conversation_id, user_id)
+		);
+		CREATE TABLE family_chat_messages (
+			id              INTEGER PRIMARY KEY,
+			conversation_id INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
+			sender_user_id  INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			body            TEXT NOT NULL DEFAULT '',
+			attachment_path TEXT NOT NULL DEFAULT '',
+			attachment_mime TEXT NOT NULL DEFAULT '',
+			created_at      TEXT NOT NULL DEFAULT ''
+		);
+	`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+func makeUser(t *testing.T, db *sql.DB, id int64, email string) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO users (id, email, name, google_id) VALUES (?, ?, ?, ?)`,
+		id, email, email, fmt.Sprintf("google-%d", id),
+	); err != nil {
+		t.Fatalf("insert user %d: %v", id, err)
+	}
+}
+
+func withUser(r *http.Request, userID int64) *http.Request {
+	user := &auth.User{ID: userID, Email: fmt.Sprintf("u%d@example.com", userID), Name: "Test"}
+	return r.WithContext(auth.ContextWithUser(r.Context(), user))
+}
+
+func withChiParam(r *http.Request, key, value string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, value)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+// seedConversation creates a conversation owned by ownerID with extra members
+// listed in members. Returns the conversation ID.
+func seedConversation(t *testing.T, db *sql.DB, ownerID int64, name string, members ...int64) int64 {
+	t.Helper()
+	c, err := CreateConversation(db, ownerID, name, members)
+	if err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+	return c.ID
+}
+
+func TestListConversationsHandler_OnlyOwnMemberships(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+
+	// alice + bob conversation; carol is excluded.
+	seedConversation(t, db, 1, "Alice/Bob", 2)
+	// bob owns a chat with carol; alice should not see it.
+	seedConversation(t, db, 2, "Bob/Carol", 3)
+
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations", nil), 1)
+	rec := httptest.NewRecorder()
+	ListConversationsHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Conversations []Conversation `json:"conversations"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Conversations) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(body.Conversations))
+	}
+	if body.Conversations[0].Name != "Alice/Bob" {
+		t.Errorf("unexpected name: %q", body.Conversations[0].Name)
+	}
+}
+
+func TestCreateConversationHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+
+	payload := `{"name":"Family","member_user_ids":[2]}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Conversation Conversation `json:"conversation"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Conversation.Name != "Family" {
+		t.Errorf("name = %q", body.Conversation.Name)
+	}
+	if len(body.Conversation.MemberIDs) != 2 {
+		t.Errorf("expected 2 members, got %d: %v", len(body.Conversation.MemberIDs), body.Conversation.MemberIDs)
+	}
+}
+
+func TestCreateConversationHandler_MissingName(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(`{"name":""}`)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestGetConversationHandler_MemberAndNonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Member (bob, id=2) sees 200.
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr, nil), 2)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	GetConversationHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("member: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Non-member (carol, id=3) sees 404.
+	req = withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr, nil), 3)
+	req = withChiParam(req, "id", idStr)
+	rec = httptest.NewRecorder()
+	GetConversationHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("non-member: expected 404, got %d", rec.Code)
+	}
+}
+
+func TestGetConversationHandler_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/9999", nil), 1)
+	req = withChiParam(req, "id", "9999")
+	rec := httptest.NewRecorder()
+	GetConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestPostMessageHandler_Success(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	idStr := strconv.FormatInt(convID, 10)
+	payload := `{"body":"hello there"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Message Message `json:"message"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Message.Body != "hello there" {
+		t.Errorf("body = %q", body.Message.Body)
+	}
+	if body.Message.SenderUserID != 1 {
+		t.Errorf("sender = %d", body.Message.SenderUserID)
+	}
+
+	// Stored body should be encrypted (prefixed with enc:).
+	var stored string
+	if err := db.QueryRow(`SELECT body FROM family_chat_messages WHERE id = ?`, body.Message.ID).Scan(&stored); err != nil {
+		t.Fatalf("read stored body: %v", err)
+	}
+	if !strings.HasPrefix(stored, "enc:") {
+		t.Errorf("body not encrypted at rest: %q", stored)
+	}
+}
+
+func TestPostMessageHandler_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(`{"body":"sneaky"}`)), 3)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-member, got %d", rec.Code)
+	}
+
+	// No row should have been written.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ?`, convID).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("non-member message persisted (%d rows)", count)
+	}
+}
+
+func TestPostMessageHandler_EmptyBodyRejected(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(`{"body":""}`)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestListMessagesHandler_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+	if _, err := CreateMessage(db, convID, 1, "hi", "", ""); err != nil {
+		t.Fatalf("seed message: %v", err)
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages", nil), 3)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestListMessagesHandler_PaginationWithSince(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Seed 7 messages.
+	const total = 7
+	for i := 1; i <= total; i++ {
+		if _, err := CreateMessage(db, convID, 1, fmt.Sprintf("msg %d", i), "", ""); err != nil {
+			t.Fatalf("seed message %d: %v", i, err)
+		}
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+
+	// Page 1: limit=3, no since -> newest 3 messages, ids 7..5.
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages?limit=3", nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("page1: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Messages []Message `json:"messages"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode page1: %v", err)
+	}
+	if len(body.Messages) != 3 {
+		t.Fatalf("page1 len = %d", len(body.Messages))
+	}
+	if body.Messages[0].ID != 7 || body.Messages[2].ID != 5 {
+		t.Errorf("page1 ids = %d..%d, want 7..5", body.Messages[0].ID, body.Messages[2].ID)
+	}
+
+	page1IDs := []int64{body.Messages[0].ID, body.Messages[1].ID, body.Messages[2].ID}
+
+	// Page 2: limit=10 to fetch everything; ids should be 7..1 in order.
+	req = withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages?limit=10", nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec = httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("full: expected 200, got %d", rec.Code)
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode full: %v", err)
+	}
+	if len(body.Messages) != total {
+		t.Fatalf("full len = %d, want %d", len(body.Messages), total)
+	}
+	for i, want := range []int64{7, 6, 5, 4, 3, 2, 1} {
+		if body.Messages[i].ID != want {
+			t.Errorf("full[%d] = %d, want %d", i, body.Messages[i].ID, want)
+		}
+	}
+
+	// since filter: since=4 returns the 3 messages with id > 4 (i.e. 7,6,5).
+	req = withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages?since=4&limit=10", nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec = httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("since: expected 200, got %d", rec.Code)
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode since: %v", err)
+	}
+	if len(body.Messages) != 3 {
+		t.Fatalf("since len = %d, want 3", len(body.Messages))
+	}
+	for i, want := range []int64{7, 6, 5} {
+		if body.Messages[i].ID != want {
+			t.Errorf("since[%d] = %d, want %d", i, body.Messages[i].ID, want)
+		}
+	}
+
+	// Walking forward with `since` (incremental load scenario): the
+	// first page returns newest k messages. After a new message is posted,
+	// querying with since=<highest seen id> returns only the new message.
+	highestSeen := page1IDs[0]
+	if _, err := CreateMessage(db, convID, 1, "after page1", "", ""); err != nil {
+		t.Fatalf("seed new message: %v", err)
+	}
+	url := fmt.Sprintf("/api/familychat/conversations/%s/messages?since=%d&limit=10", idStr, highestSeen)
+	req = withUser(httptest.NewRequest("GET", url, nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec = httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("incremental: expected 200, got %d", rec.Code)
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode incremental: %v", err)
+	}
+	if len(body.Messages) != 1 {
+		t.Fatalf("incremental len = %d, want 1", len(body.Messages))
+	}
+	if body.Messages[0].Body != "after page1" {
+		t.Errorf("incremental body = %q", body.Messages[0].Body)
+	}
+}
+
+func TestMarkReadHandler(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Alice posts 3 messages; Bob should see unread_count=3 before MarkRead.
+	for i := 0; i < 3; i++ {
+		if _, err := CreateMessage(db, convID, 1, fmt.Sprintf("msg %d", i), "", ""); err != nil {
+			t.Fatalf("seed message: %v", err)
+		}
+	}
+
+	// Sanity check the unread count before MarkRead.
+	c, err := GetConversation(db, convID, 2)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if c.UnreadCount != 3 {
+		t.Errorf("unread before MarkRead = %d, want 3", c.UnreadCount)
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+
+	// Bob marks read with an explicit far-future watermark so we are not
+	// vulnerable to millisecond-precision ties between CreateMessage and the
+	// implicit "now" in MarkRead.
+	payload := `{"at":"9999-12-31T23:59:59.999Z"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/read", strings.NewReader(payload)), 2)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	MarkReadHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Now Bob's view should show unread_count = 0.
+	c, err = GetConversation(db, convID, 2)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if c.UnreadCount != 0 {
+		t.Errorf("unread after MarkRead = %d, want 0", c.UnreadCount)
+	}
+}
+
+func TestMarkReadHandler_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/read", nil), 3)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	MarkReadHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestDeleteConversationHandler_OwnerSucceeds(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Seed a message so cascade can be verified.
+	if _, err := CreateMessage(db, convID, 1, "soon to die", "", ""); err != nil {
+		t.Fatalf("seed message: %v", err)
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/familychat/conversations/"+idStr, nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	DeleteConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Conversation row, members, and messages must all be gone.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_conversations WHERE id = ?`, convID).Scan(&n); err != nil {
+		t.Fatalf("count conv: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("conversation row still present (n=%d)", n)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_members WHERE conversation_id = ?`, convID).Scan(&n); err != nil {
+		t.Fatalf("count members: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("member rows not cascaded (n=%d)", n)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ?`, convID).Scan(&n); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("message rows not cascaded (n=%d)", n)
+	}
+}
+
+func TestDeleteConversationHandler_NonOwnerMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// Bob is a member but not the owner — DELETE must 404.
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/familychat/conversations/"+idStr, nil), 2)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	DeleteConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Conversation must still exist.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_conversations WHERE id = ?`, convID).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("conversation should still exist (n=%d)", n)
+	}
+}
+
+func TestDeleteConversationHandler_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("DELETE", "/api/familychat/conversations/"+idStr, nil), 3)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	DeleteConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -593,6 +593,21 @@ func TestCreateConversationHandler_InvalidMemberID(t *testing.T) {
 	}
 }
 
+func TestCreateConversationHandler_NonExistentMemberID(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	// user 9999 does not exist — should get 400, not 500.
+	payload := `{"name":"Family","member_user_ids":[9999]}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	CreateConversationHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-existent user, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestPostMessageHandler_BodyTooLong(t *testing.T) {
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com")

--- a/internal/familychat/models.go
+++ b/internal/familychat/models.go
@@ -10,10 +10,3 @@ import (
 // prefer to hide existence).
 var ErrForbidden = errors.New("familychat: not a conversation member")
 
-// Role values for family_chat_members.role. Owners are members who can later
-// be granted moderation actions (rename, delete, add/remove members); for the
-// schema bead they are stored but not yet enforced anywhere.
-const (
-	RoleOwner  = "owner"
-	RoleMember = "member"
-)

--- a/internal/familychat/models.go
+++ b/internal/familychat/models.go
@@ -2,7 +2,6 @@ package familychat
 
 import (
 	"errors"
-	"time"
 )
 
 // ErrForbidden is returned by store helpers when the requesting user is not a
@@ -18,36 +17,3 @@ const (
 	RoleOwner  = "owner"
 	RoleMember = "member"
 )
-
-// Conversation mirrors a row in family_chat_conversations. Name is the
-// decrypted display name (empty for an unnamed 1:1 chat).
-type Conversation struct {
-	ID        int64     `json:"id"`
-	Name      string    `json:"name"`
-	OwnerID   int64     `json:"owner_id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-}
-
-// Member mirrors a row in family_chat_members. LastReadAt is nil when the
-// member has never read the conversation.
-type Member struct {
-	ConversationID int64      `json:"conversation_id"`
-	UserID         int64      `json:"user_id"`
-	Role           string     `json:"role"`
-	JoinedAt       time.Time  `json:"joined_at"`
-	LastReadAt     *time.Time `json:"last_read_at,omitempty"`
-}
-
-// Message mirrors a row in family_chat_messages. Body and AttachmentPath are
-// the decrypted plaintext values. AttachmentPath/AttachmentMime are empty when
-// the message has no attachment.
-type Message struct {
-	ID             int64     `json:"id"`
-	ConversationID int64     `json:"conversation_id"`
-	SenderID       int64     `json:"sender_id"`
-	Body           string    `json:"body"`
-	AttachmentPath string    `json:"attachment_path,omitempty"`
-	AttachmentMime string    `json:"attachment_mime,omitempty"`
-	SentAt         time.Time `json:"sent_at"`
-}

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -41,11 +41,6 @@ type Message struct {
 	CreatedAt      string `json:"created_at"`
 }
 
-// ErrNotMember is returned when the requesting user is not a member of the
-// target conversation. Handlers convert this into 404 to avoid leaking the
-// existence of conversations the user is not part of.
-var ErrNotMember = errors.New("familychat: not a member")
-
 // IsMember reports whether userID belongs to convID.
 func IsMember(db *sql.DB, convID, userID int64) (bool, error) {
 	var one int
@@ -175,14 +170,14 @@ func CreateConversation(db *sql.DB, ownerID int64, name string, memberIDs []int6
 }
 
 // GetConversation returns the conversation if userID is a member, otherwise
-// returns ErrNotMember (handlers map to 404).
+// returns ErrForbidden (handlers map to 404).
 func GetConversation(db *sql.DB, convID, userID int64) (*Conversation, error) {
 	ok, err := IsMember(db, convID, userID)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
-		return nil, ErrNotMember
+		return nil, ErrForbidden
 	}
 
 	var c Conversation
@@ -210,7 +205,7 @@ func GetConversation(db *sql.DB, convID, userID int64) (*Conversation, error) {
 }
 
 // DeleteConversation removes the conversation, but only if userID is its
-// owner. Non-owners (including other members) receive ErrNotMember so the
+// owner. Non-owners (including other members) receive ErrForbidden so the
 // existence of conversations they do not own is not leaked.
 func DeleteConversation(db *sql.DB, convID, userID int64) error {
 	res, err := db.Exec(
@@ -225,7 +220,7 @@ func DeleteConversation(db *sql.DB, convID, userID int64) error {
 		return err
 	}
 	if n == 0 {
-		return ErrNotMember
+		return ErrForbidden
 	}
 	return nil
 }
@@ -239,7 +234,7 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 		return nil, err
 	}
 	if !ok {
-		return nil, ErrNotMember
+		return nil, ErrForbidden
 	}
 
 	if limit <= 0 {
@@ -299,14 +294,14 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 
 // CreateMessage inserts a new message authored by senderID into convID,
 // touches the conversation's last_message_at, and returns the inserted row
-// in plaintext form. Returns ErrNotMember if the sender is not a member.
+// in plaintext form. Returns ErrForbidden if the sender is not a member.
 func CreateMessage(db *sql.DB, convID, senderID int64, body, attachmentPath, attachmentMime string) (*Message, error) {
 	ok, err := IsMember(db, convID, senderID)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
-		return nil, ErrNotMember
+		return nil, ErrForbidden
 	}
 
 	encBody, err := encryption.EncryptField(body)
@@ -359,7 +354,7 @@ func CreateMessage(db *sql.DB, convID, senderID int64, body, attachmentPath, att
 }
 
 // MarkRead sets the requesting member's last_read_at to at. Returns
-// ErrNotMember if the user is not a member of convID.
+// ErrForbidden if the user is not a member of convID.
 func MarkRead(db *sql.DB, convID, userID int64, at string) error {
 	if at == "" {
 		at = time.Now().UTC().Format(timeFormat)
@@ -376,7 +371,7 @@ func MarkRead(db *sql.DB, convID, userID int64, at string) error {
 		return err
 	}
 	if n == 0 {
-		return ErrNotMember
+		return ErrForbidden
 	}
 	return nil
 }

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -8,15 +8,15 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"sort"
+	"strings"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
 )
 
-// timeFormat is a fixed-width UTC timestamp with millisecond precision so
-// that string comparisons sort chronologically.
-const timeFormat = "2006-01-02T15:04:05.000Z07:00"
+// timeFormat is a fixed-width UTC timestamp with nanosecond precision so
+// that string comparisons sort chronologically without same-millisecond ties.
+const timeFormat = "2006-01-02T15:04:05.000000000Z07:00"
 
 // Conversation is a single family chat conversation as returned to the client.
 type Conversation struct {
@@ -63,11 +63,11 @@ func IsMember(db *sql.DB, convID, userID int64) (bool, error) {
 }
 
 // ListConversations returns every conversation the user belongs to, newest
-// activity first. The unread_count for each conversation is computed against
-// the member's last_read_at watermark.
+// activity first. Member IDs and unread counts are fetched with two batched
+// queries (not N per-conversation queries) to keep response time predictable.
 func ListConversations(db *sql.DB, userID int64) ([]Conversation, error) {
 	rows, err := db.Query(
-		`SELECT c.id, c.name, c.owner_user_id, c.created_at, c.last_message_at, m.last_read_at
+		`SELECT c.id, c.name, c.owner_user_id, c.created_at, c.last_message_at
 		 FROM family_chat_conversations c
 		 JOIN family_chat_members m ON m.conversation_id = c.id
 		 WHERE m.user_id = ?
@@ -79,35 +79,43 @@ func ListConversations(db *sql.DB, userID int64) ([]Conversation, error) {
 	}
 	defer rows.Close()
 
-	type convoRow struct {
-		c          Conversation
-		lastReadAt string
-	}
-	var rowsBuf []convoRow
+	var convBuf []Conversation
 	for rows.Next() {
-		var cr convoRow
-		if err := rows.Scan(&cr.c.ID, &cr.c.Name, &cr.c.OwnerUserID, &cr.c.CreatedAt, &cr.c.LastMessageAt, &cr.lastReadAt); err != nil {
+		var c Conversation
+		if err := rows.Scan(&c.ID, &c.Name, &c.OwnerUserID, &c.CreatedAt, &c.LastMessageAt); err != nil {
 			return nil, err
 		}
-		rowsBuf = append(rowsBuf, cr)
+		convBuf = append(convBuf, c)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	if len(convBuf) == 0 {
+		return []Conversation{}, nil
+	}
 
-	out := make([]Conversation, 0, len(rowsBuf))
-	for _, cr := range rowsBuf {
-		members, err := listMemberIDs(db, cr.c.ID)
-		if err != nil {
-			return nil, err
+	convIDs := make([]int64, len(convBuf))
+	for i, c := range convBuf {
+		convIDs[i] = c.ID
+	}
+
+	membersByConv, err := batchMemberIDs(db, convIDs)
+	if err != nil {
+		return nil, err
+	}
+	unreadByConv, err := batchUnreadCounts(db, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Conversation, 0, len(convBuf))
+	for _, c := range convBuf {
+		c.MemberIDs = membersByConv[c.ID]
+		if c.MemberIDs == nil {
+			c.MemberIDs = []int64{}
 		}
-		unread, err := unreadCount(db, cr.c.ID, userID, cr.lastReadAt)
-		if err != nil {
-			return nil, err
-		}
-		cr.c.MemberIDs = members
-		cr.c.UnreadCount = unread
-		out = append(out, cr.c)
+		c.UnreadCount = unreadByConv[c.ID]
+		out = append(out, c)
 	}
 	return out, nil
 }
@@ -373,11 +381,11 @@ func MarkRead(db *sql.DB, convID, userID int64, at string) error {
 	return nil
 }
 
-// listMemberIDs returns every user_id in convID sorted ascending. Sorting
-// gives the JSON response a stable order regardless of insertion order.
+// listMemberIDs returns every user_id in convID sorted ascending. Used by
+// single-conversation paths (GetConversation, CreateConversation).
 func listMemberIDs(db *sql.DB, convID int64) ([]int64, error) {
 	rows, err := db.Query(
-		`SELECT user_id FROM family_chat_members WHERE conversation_id = ?`,
+		`SELECT user_id FROM family_chat_members WHERE conversation_id = ? ORDER BY user_id`,
 		convID,
 	)
 	if err != nil {
@@ -393,16 +401,71 @@ func listMemberIDs(db *sql.DB, convID int64) ([]int64, error) {
 		}
 		out = append(out, uid)
 	}
-	if err := rows.Err(); err != nil {
+	return out, rows.Err()
+}
+
+// batchMemberIDs fetches all member user IDs for the given conversation IDs in
+// a single query, returning a map keyed by conversation ID.
+func batchMemberIDs(db *sql.DB, convIDs []int64) (map[int64][]int64, error) {
+	result := make(map[int64][]int64, len(convIDs))
+	if len(convIDs) == 0 {
+		return result, nil
+	}
+	placeholders := strings.Repeat("?,", len(convIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(convIDs))
+	for i, id := range convIDs {
+		args[i] = id
+		result[id] = []int64{}
+	}
+	rows, err := db.Query(
+		`SELECT conversation_id, user_id FROM family_chat_members WHERE conversation_id IN (`+placeholders+`) ORDER BY user_id`,
+		args...,
+	)
+	if err != nil {
 		return nil, err
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
-	return out, nil
+	defer rows.Close()
+	for rows.Next() {
+		var convID, userID int64
+		if err := rows.Scan(&convID, &userID); err != nil {
+			return nil, err
+		}
+		result[convID] = append(result[convID], userID)
+	}
+	return result, rows.Err()
+}
+
+// batchUnreadCounts returns unread message counts for every conversation the
+// user belongs to in a single JOIN query, keyed by conversation ID.
+func batchUnreadCounts(db *sql.DB, userID int64) (map[int64]int64, error) {
+	result := make(map[int64]int64)
+	rows, err := db.Query(`
+		SELECT m.conversation_id, COUNT(msg.id)
+		FROM family_chat_members m
+		LEFT JOIN family_chat_messages msg
+			ON  msg.conversation_id  = m.conversation_id
+			AND msg.sender_user_id  <> m.user_id
+			AND (m.last_read_at = '' OR msg.created_at > m.last_read_at)
+		WHERE m.user_id = ?
+		GROUP BY m.conversation_id
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var convID, count int64
+		if err := rows.Scan(&convID, &count); err != nil {
+			return nil, err
+		}
+		result[convID] = count
+	}
+	return result, rows.Err()
 }
 
 // unreadCount returns the number of messages in convID newer than lastReadAt
-// that were not authored by userID. An empty lastReadAt counts every message
-// from someone other than the user.
+// that were not authored by userID. Used by single-conversation paths.
 func unreadCount(db *sql.DB, convID, userID int64, lastReadAt string) (int64, error) {
 	var count int64
 	if lastReadAt == "" {

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -1,314 +1,420 @@
+// Package familychat implements the REST handlers and storage for the Family
+// Chat feature. Conversations live in family_chat_conversations, membership in
+// family_chat_members, and messages in family_chat_messages. Message bodies
+// and attachment paths are encrypted at rest via internal/encryption.
 package familychat
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
 )
 
-// isMember reports whether userID is a member of conversationID. It uses the
-// supplied executor (sql.DB or sql.Tx) so callers can check membership inside
-// a transaction. Returns (false, nil) when the user is not a member; any
-// other error is propagated.
-func isMember(ctx context.Context, q sqlQuerier, conversationID, userID int64) (bool, error) {
+// timeFormat is a fixed-width UTC timestamp with millisecond precision so
+// that string comparisons sort chronologically.
+const timeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+// Conversation is a single family chat conversation as returned to the client.
+type Conversation struct {
+	ID            int64   `json:"id"`
+	Name          string  `json:"name"`
+	OwnerUserID   int64   `json:"owner_user_id"`
+	CreatedAt     string  `json:"created_at"`
+	LastMessageAt string  `json:"last_message_at"`
+	UnreadCount   int64   `json:"unread_count"`
+	MemberIDs     []int64 `json:"member_ids"`
+}
+
+// Message is a single chat message returned to the client. Body and
+// AttachmentPath are returned in plaintext after decryption.
+type Message struct {
+	ID             int64  `json:"id"`
+	ConversationID int64  `json:"conversation_id"`
+	SenderUserID   int64  `json:"sender_user_id"`
+	Body           string `json:"body"`
+	AttachmentPath string `json:"attachment_path,omitempty"`
+	AttachmentMime string `json:"attachment_mime,omitempty"`
+	CreatedAt      string `json:"created_at"`
+}
+
+// ErrNotMember is returned when the requesting user is not a member of the
+// target conversation. Handlers convert this into 404 to avoid leaking the
+// existence of conversations the user is not part of.
+var ErrNotMember = errors.New("familychat: not a member")
+
+// IsMember reports whether userID belongs to convID.
+func IsMember(db *sql.DB, convID, userID int64) (bool, error) {
 	var one int
-	err := q.QueryRowContext(ctx,
+	err := db.QueryRow(
 		`SELECT 1 FROM family_chat_members WHERE conversation_id = ? AND user_id = ?`,
-		conversationID, userID,
+		convID, userID,
 	).Scan(&one)
-	if err == nil {
-		return true, nil
-	}
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
-	return false, err
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
-// sqlQuerier is the minimal interface satisfied by both *sql.DB and *sql.Tx
-// that the store helpers need.
-type sqlQuerier interface {
-	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
-}
-
-// CreateConversation inserts a new conversation with the given (plaintext)
-// name and a membership row for the owner plus each memberID. memberIDs that
-// duplicate ownerID are silently skipped. Returns the new conversation ID.
-func CreateConversation(ctx context.Context, db *sql.DB, ownerID int64, name string, memberIDs []int64) (int64, error) {
-	now := time.Now().UTC()
-	encName, err := encryption.EncryptField(name)
-	if err != nil {
-		return 0, fmt.Errorf("encrypt name: %w", err)
-	}
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return 0, fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-
-	res, err := tx.ExecContext(ctx,
-		`INSERT INTO family_chat_conversations (name_enc, owner_id, created_at, updated_at)
-		 VALUES (?, ?, ?, ?)`,
-		encName, ownerID, now, now,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("insert conversation: %w", err)
-	}
-	id, err := res.LastInsertId()
-	if err != nil {
-		return 0, fmt.Errorf("last insert id: %w", err)
-	}
-
-	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO family_chat_members (conversation_id, user_id, role, joined_at)
-		 VALUES (?, ?, ?, ?)`,
-		id, ownerID, RoleOwner, now,
-	); err != nil {
-		return 0, fmt.Errorf("insert owner member: %w", err)
-	}
-
-	for _, mid := range memberIDs {
-		if mid == ownerID {
-			continue
-		}
-		if _, err := tx.ExecContext(ctx,
-			`INSERT OR IGNORE INTO family_chat_members (conversation_id, user_id, role, joined_at)
-			 VALUES (?, ?, ?, ?)`,
-			id, mid, RoleMember, now,
-		); err != nil {
-			return 0, fmt.Errorf("insert member %d: %w", mid, err)
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit: %w", err)
-	}
-	return id, nil
-}
-
-// ListUserConversations returns every conversation userID is a member of,
-// most-recently-updated first. Names are decrypted.
-func ListUserConversations(ctx context.Context, db *sql.DB, userID int64) ([]Conversation, error) {
-	rows, err := db.QueryContext(ctx,
-		`SELECT c.id, c.name_enc, c.owner_id, c.created_at, c.updated_at
+// ListConversations returns every conversation the user belongs to, newest
+// activity first. The unread_count for each conversation is computed against
+// the member's last_read_at watermark.
+func ListConversations(db *sql.DB, userID int64) ([]Conversation, error) {
+	rows, err := db.Query(
+		`SELECT c.id, c.name, c.owner_user_id, c.created_at, c.last_message_at, m.last_read_at
 		 FROM family_chat_conversations c
 		 JOIN family_chat_members m ON m.conversation_id = c.id
 		 WHERE m.user_id = ?
-		 ORDER BY c.updated_at DESC, c.id DESC`,
+		 ORDER BY CASE WHEN c.last_message_at = '' THEN c.created_at ELSE c.last_message_at END DESC, c.id DESC`,
 		userID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("query conversations: %w", err)
+		return nil, err
 	}
 	defer rows.Close()
 
-	var out []Conversation
+	type convoRow struct {
+		c          Conversation
+		lastReadAt string
+	}
+	var rowsBuf []convoRow
 	for rows.Next() {
-		var c Conversation
-		var nameEnc string
-		if err := rows.Scan(&c.ID, &nameEnc, &c.OwnerID, &c.CreatedAt, &c.UpdatedAt); err != nil {
-			return nil, fmt.Errorf("scan conversation: %w", err)
+		var cr convoRow
+		if err := rows.Scan(&cr.c.ID, &cr.c.Name, &cr.c.OwnerUserID, &cr.c.CreatedAt, &cr.c.LastMessageAt, &cr.lastReadAt); err != nil {
+			return nil, err
 		}
-		name, err := encryption.DecryptField(nameEnc)
-		if err != nil {
-			return nil, fmt.Errorf("decrypt conversation %d name: %w", c.ID, err)
-		}
-		c.Name = name
-		out = append(out, c)
+		rowsBuf = append(rowsBuf, cr)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	if out == nil {
-		out = []Conversation{}
+
+	out := make([]Conversation, 0, len(rowsBuf))
+	for _, cr := range rowsBuf {
+		members, err := listMemberIDs(db, cr.c.ID)
+		if err != nil {
+			return nil, err
+		}
+		unread, err := unreadCount(db, cr.c.ID, userID, cr.lastReadAt)
+		if err != nil {
+			return nil, err
+		}
+		cr.c.MemberIDs = members
+		cr.c.UnreadCount = unread
+		out = append(out, cr.c)
 	}
 	return out, nil
 }
 
-// GetConversation returns the conversation if askerID is a member of it.
-// Returns ErrForbidden when askerID is not a member or the conversation does
-// not exist — existence is not revealed to non-members.
-func GetConversation(ctx context.Context, db *sql.DB, conversationID, askerID int64) (Conversation, error) {
-	ok, err := isMember(ctx, db, conversationID, askerID)
-	if err != nil {
-		return Conversation{}, fmt.Errorf("check membership: %w", err)
-	}
-	if !ok {
-		return Conversation{}, ErrForbidden
-	}
+// CreateConversation inserts a new conversation owned by ownerID and adds
+// every user in memberIDs (plus the owner) as a member. Duplicate or invalid
+// member IDs are silently coalesced.
+func CreateConversation(db *sql.DB, ownerID int64, name string, memberIDs []int64) (*Conversation, error) {
+	now := time.Now().UTC().Format(timeFormat)
 
-	var c Conversation
-	var nameEnc string
-	err = db.QueryRowContext(ctx,
-		`SELECT id, name_enc, owner_id, created_at, updated_at
-		 FROM family_chat_conversations WHERE id = ?`,
-		conversationID,
-	).Scan(&c.ID, &nameEnc, &c.OwnerID, &c.CreatedAt, &c.UpdatedAt)
+	tx, err := db.Begin()
 	if err != nil {
-		return Conversation{}, err
+		return nil, fmt.Errorf("begin tx: %w", err)
 	}
-	name, err := encryption.DecryptField(nameEnc)
-	if err != nil {
-		return Conversation{}, fmt.Errorf("decrypt name: %w", err)
-	}
-	c.Name = name
-	return c, nil
-}
+	defer func() { _ = tx.Rollback() }()
 
-// AppendMessage inserts a new message into the conversation. senderID must be
-// a member of the conversation, otherwise ErrForbidden is returned. body and
-// attachmentPath are encrypted before storage. attachmentMime is stored as-is
-// (it is not user-secret and may be used by attachment-serving handlers).
-// Returns the new message ID.
-func AppendMessage(ctx context.Context, db *sql.DB, conversationID, senderID int64, body, attachmentPath, attachmentMime string) (int64, error) {
-	encBody, err := encryption.EncryptField(body)
-	if err != nil {
-		return 0, fmt.Errorf("encrypt body: %w", err)
-	}
-	encPath, err := encryption.EncryptField(attachmentPath)
-	if err != nil {
-		return 0, fmt.Errorf("encrypt attachment path: %w", err)
-	}
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return 0, fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-
-	ok, err := isMember(ctx, tx, conversationID, senderID)
-	if err != nil {
-		return 0, fmt.Errorf("check membership: %w", err)
-	}
-	if !ok {
-		return 0, ErrForbidden
-	}
-
-	now := time.Now().UTC()
-	var pathArg any
-	if attachmentPath == "" {
-		pathArg = nil
-	} else {
-		pathArg = encPath
-	}
-	var mimeArg any
-	if attachmentMime == "" {
-		mimeArg = nil
-	} else {
-		mimeArg = attachmentMime
-	}
-
-	res, err := tx.ExecContext(ctx,
-		`INSERT INTO family_chat_messages (conversation_id, sender_id, body_enc, attachment_path_enc, attachment_mime, sent_at)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
-		conversationID, senderID, encBody, pathArg, mimeArg, now,
+	res, err := tx.Exec(
+		`INSERT INTO family_chat_conversations (name, owner_user_id, created_at, last_message_at) VALUES (?, ?, ?, ?)`,
+		name, ownerID, now, "",
 	)
 	if err != nil {
-		return 0, fmt.Errorf("insert message: %w", err)
+		return nil, fmt.Errorf("insert conversation: %w", err)
 	}
-	id, err := res.LastInsertId()
+	convID, err := res.LastInsertId()
 	if err != nil {
-		return 0, fmt.Errorf("last insert id: %w", err)
+		return nil, fmt.Errorf("last insert id: %w", err)
 	}
 
-	if _, err := tx.ExecContext(ctx,
-		`UPDATE family_chat_conversations SET updated_at = ? WHERE id = ?`,
-		now, conversationID,
+	seen := map[int64]struct{}{ownerID: {}}
+	if _, err := tx.Exec(
+		`INSERT INTO family_chat_members (conversation_id, user_id, joined_at, last_read_at) VALUES (?, ?, ?, ?)`,
+		convID, ownerID, now, "",
 	); err != nil {
-		return 0, fmt.Errorf("bump updated_at: %w", err)
+		return nil, fmt.Errorf("insert owner member: %w", err)
+	}
+	for _, uid := range memberIDs {
+		if uid <= 0 {
+			continue
+		}
+		if _, dup := seen[uid]; dup {
+			continue
+		}
+		seen[uid] = struct{}{}
+		if _, err := tx.Exec(
+			`INSERT INTO family_chat_members (conversation_id, user_id, joined_at, last_read_at) VALUES (?, ?, ?, ?)`,
+			convID, uid, now, "",
+		); err != nil {
+			return nil, fmt.Errorf("insert member %d: %w", uid, err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit: %w", err)
+		return nil, fmt.Errorf("commit: %w", err)
 	}
-	return id, nil
+
+	return GetConversation(db, convID, ownerID)
 }
 
-// ListMessages returns messages from the conversation whose ID is greater
-// than sinceID (use 0 to start from the beginning), ordered by ID ascending,
-// capped at limit. askerID must be a member of the conversation.
-// limit <= 0 returns an empty slice.
-func ListMessages(ctx context.Context, db *sql.DB, conversationID, askerID, sinceID int64, limit int) ([]Message, error) {
-	ok, err := isMember(ctx, db, conversationID, askerID)
+// GetConversation returns the conversation if userID is a member, otherwise
+// returns ErrNotMember (handlers map to 404).
+func GetConversation(db *sql.DB, convID, userID int64) (*Conversation, error) {
+	ok, err := IsMember(db, convID, userID)
 	if err != nil {
-		return nil, fmt.Errorf("check membership: %w", err)
+		return nil, err
 	}
 	if !ok {
-		return nil, ErrForbidden
-	}
-	if limit <= 0 {
-		return []Message{}, nil
+		return nil, ErrNotMember
 	}
 
-	rows, err := db.QueryContext(ctx,
-		`SELECT id, conversation_id, sender_id, body_enc, attachment_path_enc, attachment_mime, sent_at
-		 FROM family_chat_messages
-		 WHERE conversation_id = ? AND id > ?
-		 ORDER BY id ASC
-		 LIMIT ?`,
-		conversationID, sinceID, limit,
+	var c Conversation
+	var lastReadAt string
+	err = db.QueryRow(
+		`SELECT c.id, c.name, c.owner_user_id, c.created_at, c.last_message_at, m.last_read_at
+		 FROM family_chat_conversations c
+		 JOIN family_chat_members m ON m.conversation_id = c.id
+		 WHERE c.id = ? AND m.user_id = ?`,
+		convID, userID,
+	).Scan(&c.ID, &c.Name, &c.OwnerUserID, &c.CreatedAt, &c.LastMessageAt, &lastReadAt)
+	if err != nil {
+		return nil, err
+	}
+
+	c.MemberIDs, err = listMemberIDs(db, convID)
+	if err != nil {
+		return nil, err
+	}
+	c.UnreadCount, err = unreadCount(db, convID, userID, lastReadAt)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// DeleteConversation removes the conversation, but only if userID is its
+// owner. Non-owners (including other members) receive ErrNotMember so the
+// existence of conversations they do not own is not leaked.
+func DeleteConversation(db *sql.DB, convID, userID int64) error {
+	res, err := db.Exec(
+		`DELETE FROM family_chat_conversations WHERE id = ? AND owner_user_id = ?`,
+		convID, userID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("query messages: %w", err)
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrNotMember
+	}
+	return nil
+}
+
+// ListMessages returns up to limit messages from convID, newest-first.
+// If since > 0, only messages with id > since are returned (still newest-first)
+// — this lets the client poll for new messages incrementally.
+func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message, error) {
+	ok, err := IsMember(db, convID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNotMember
+	}
+
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+
+	var (
+		rows     *sql.Rows
+		queryErr error
+	)
+	if since > 0 {
+		rows, queryErr = db.Query(
+			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at
+			 FROM family_chat_messages
+			 WHERE conversation_id = ? AND id > ?
+			 ORDER BY id DESC
+			 LIMIT ?`,
+			convID, since, limit,
+		)
+	} else {
+		rows, queryErr = db.Query(
+			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at
+			 FROM family_chat_messages
+			 WHERE conversation_id = ?
+			 ORDER BY id DESC
+			 LIMIT ?`,
+			convID, limit,
+		)
+	}
+	if queryErr != nil {
+		return nil, queryErr
 	}
 	defer rows.Close()
 
-	var out []Message
+	out := []Message{}
 	for rows.Next() {
 		var m Message
-		var bodyEnc string
-		var pathEnc, mime sql.NullString
-		if err := rows.Scan(&m.ID, &m.ConversationID, &m.SenderID, &bodyEnc, &pathEnc, &mime, &m.SentAt); err != nil {
-			return nil, fmt.Errorf("scan message: %w", err)
+		if err := rows.Scan(&m.ID, &m.ConversationID, &m.SenderUserID, &m.Body, &m.AttachmentPath, &m.AttachmentMime, &m.CreatedAt); err != nil {
+			return nil, err
 		}
-		body, err := encryption.DecryptField(bodyEnc)
-		if err != nil {
-			return nil, fmt.Errorf("decrypt message %d body: %w", m.ID, err)
+		if m.Body, err = encryption.DecryptField(m.Body); err != nil {
+			return nil, fmt.Errorf("decrypt body: %w", err)
 		}
-		m.Body = body
-		if pathEnc.Valid && pathEnc.String != "" {
-			path, err := encryption.DecryptField(pathEnc.String)
-			if err != nil {
-				return nil, fmt.Errorf("decrypt message %d attachment path: %w", m.ID, err)
-			}
-			m.AttachmentPath = path
-		}
-		if mime.Valid {
-			m.AttachmentMime = mime.String
+		if m.AttachmentPath, err = encryption.DecryptField(m.AttachmentPath); err != nil {
+			return nil, fmt.Errorf("decrypt attachment path: %w", err)
 		}
 		out = append(out, m)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	if out == nil {
-		out = []Message{}
-	}
 	return out, nil
 }
 
-// MarkRead updates the membership row's last_read_at timestamp. Returns
-// ErrForbidden if the user is not a member of the conversation.
-func MarkRead(ctx context.Context, db *sql.DB, conversationID, userID int64, ts time.Time) error {
-	res, err := db.ExecContext(ctx,
-		`UPDATE family_chat_members SET last_read_at = ?
-		 WHERE conversation_id = ? AND user_id = ?`,
-		ts.UTC(), conversationID, userID,
+// CreateMessage inserts a new message authored by senderID into convID,
+// touches the conversation's last_message_at, and returns the inserted row
+// in plaintext form. Returns ErrNotMember if the sender is not a member.
+func CreateMessage(db *sql.DB, convID, senderID int64, body, attachmentPath, attachmentMime string) (*Message, error) {
+	ok, err := IsMember(db, convID, senderID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrNotMember
+	}
+
+	encBody, err := encryption.EncryptField(body)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt body: %w", err)
+	}
+	encPath, err := encryption.EncryptField(attachmentPath)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt attachment path: %w", err)
+	}
+	now := time.Now().UTC().Format(timeFormat)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.Exec(
+		`INSERT INTO family_chat_messages (conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		convID, senderID, encBody, encPath, attachmentMime, now,
 	)
 	if err != nil {
-		return fmt.Errorf("update last_read_at: %w", err)
+		return nil, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tx.Exec(
+		`UPDATE family_chat_conversations SET last_message_at = ? WHERE id = ?`,
+		now, convID,
+	); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &Message{
+		ID:             id,
+		ConversationID: convID,
+		SenderUserID:   senderID,
+		Body:           body,
+		AttachmentPath: attachmentPath,
+		AttachmentMime: attachmentMime,
+		CreatedAt:      now,
+	}, nil
+}
+
+// MarkRead sets the requesting member's last_read_at to at. Returns
+// ErrNotMember if the user is not a member of convID.
+func MarkRead(db *sql.DB, convID, userID int64, at string) error {
+	if at == "" {
+		at = time.Now().UTC().Format(timeFormat)
+	}
+	res, err := db.Exec(
+		`UPDATE family_chat_members SET last_read_at = ? WHERE conversation_id = ? AND user_id = ?`,
+		at, convID, userID,
+	)
+	if err != nil {
+		return err
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("rows affected: %w", err)
+		return err
 	}
 	if n == 0 {
-		return ErrForbidden
+		return ErrNotMember
 	}
 	return nil
+}
+
+// listMemberIDs returns every user_id in convID sorted ascending. Sorting
+// gives the JSON response a stable order regardless of insertion order.
+func listMemberIDs(db *sql.DB, convID int64) ([]int64, error) {
+	rows, err := db.Query(
+		`SELECT user_id FROM family_chat_members WHERE conversation_id = ?`,
+		convID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []int64{}
+	for rows.Next() {
+		var uid int64
+		if err := rows.Scan(&uid); err != nil {
+			return nil, err
+		}
+		out = append(out, uid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+// unreadCount returns the number of messages in convID newer than lastReadAt
+// that were not authored by userID. An empty lastReadAt counts every message
+// from someone other than the user.
+func unreadCount(db *sql.DB, convID, userID int64, lastReadAt string) (int64, error) {
+	var count int64
+	if lastReadAt == "" {
+		err := db.QueryRow(
+			`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ? AND sender_user_id <> ?`,
+			convID, userID,
+		).Scan(&count)
+		return count, err
+	}
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ? AND sender_user_id <> ? AND created_at > ?`,
+		convID, userID, lastReadAt,
+	).Scan(&count)
+	return count, err
 }

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -6,7 +6,6 @@ package familychat
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -14,9 +13,10 @@ import (
 	"github.com/Robin831/Hytte/internal/encryption"
 )
 
-// timeFormat is a fixed-width UTC timestamp with nanosecond precision so
-// that string comparisons sort chronologically without same-millisecond ties.
-const timeFormat = "2006-01-02T15:04:05.000000000Z07:00"
+// timeFormat is a fixed-width UTC timestamp with millisecond precision,
+// matching the convention used by other stores in this repo (e.g. chat/store.go).
+// An (id) tie-breaker in ORDER BY clauses handles same-millisecond writes.
+const timeFormat = "2006-01-02T15:04:05.000Z07:00"
 
 // Conversation is a single family chat conversation as returned to the client.
 type Conversation struct {
@@ -41,20 +41,48 @@ type Message struct {
 	CreatedAt      string `json:"created_at"`
 }
 
-// IsMember reports whether userID belongs to convID.
+// IsMember reports whether userID belongs to convID. It delegates to
+// DefaultMembership so there is a single SQL implementation shared with the
+// SSE stream's membership check.
 func IsMember(db *sql.DB, convID, userID int64) (bool, error) {
-	var one int
-	err := db.QueryRow(
-		`SELECT 1 FROM family_chat_members WHERE conversation_id = ? AND user_id = ?`,
-		convID, userID,
-	).Scan(&one)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
+	return DefaultMembership(db)(userID, convID)
+}
+
+// ValidateMemberIDs checks that every id in ids exists in the users table
+// using a single IN query. It returns the first missing id (and nil error) so
+// callers can map it to a 400 response, or (0, error) on a DB failure.
+func ValidateMemberIDs(db *sql.DB, ids []int64) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
 	}
+	placeholders := strings.Repeat("?,", len(ids))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	rows, err := db.Query(`SELECT id FROM users WHERE id IN (`+placeholders+`)`, args...)
 	if err != nil {
-		return false, err
+		return 0, err
 	}
-	return true, nil
+	defer rows.Close()
+	found := make(map[int64]struct{}, len(ids))
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return 0, err
+		}
+		found[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	for _, id := range ids {
+		if _, ok := found[id]; !ok {
+			return id, nil
+		}
+	}
+	return 0, nil
 }
 
 // ListConversations returns every conversation the user belongs to, newest

--- a/internal/familychat/store_test.go
+++ b/internal/familychat/store_test.go
@@ -1,452 +1,268 @@
 package familychat
 
 import (
-	"context"
-	"database/sql"
 	"errors"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/Robin831/Hytte/internal/db"
-	"github.com/Robin831/Hytte/internal/encryption"
 )
 
-func setupTestDB(t *testing.T) *sql.DB {
-	t.Helper()
-	t.Setenv("ENCRYPTION_KEY", "test-key-for-familychat-tests")
-	encryption.ResetEncryptionKey()
-	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+func TestStoreCreateAndGetConversation(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
 
-	d, err := db.Init(":memory:")
-	if err != nil {
-		t.Fatalf("init test db: %v", err)
-	}
-	// Pin to a single connection so :memory: stays consistent across queries.
-	d.SetMaxOpenConns(1)
-	d.SetMaxIdleConns(1)
-	t.Cleanup(func() { d.Close() })
-
-	for _, u := range []struct {
-		id      int64
-		google  string
-		email   string
-		name    string
-	}{
-		{1, "g1", "alice@example.com", "Alice"},
-		{2, "g2", "bob@example.com", "Bob"},
-		{3, "g3", "carol@example.com", "Carol"},
-	} {
-		_, err := d.Exec(
-			`INSERT INTO users (id, google_id, email, name, picture) VALUES (?, ?, ?, ?, '')`,
-			u.id, u.google, u.email, u.name,
-		)
-		if err != nil {
-			t.Fatalf("create user %d: %v", u.id, err)
-		}
-	}
-	return d
-}
-
-func TestCreateConversationAndGet(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
-
-	id, err := CreateConversation(ctx, d, 1, "Family Dinner", []int64{2})
+	c, err := CreateConversation(db, 1, "Family Dinner", []int64{2})
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	if id <= 0 {
-		t.Fatalf("expected positive id, got %d", id)
+	if c.ID <= 0 {
+		t.Fatalf("expected positive id, got %d", c.ID)
+	}
+	if c.Name != "Family Dinner" {
+		t.Errorf("name = %q, want %q", c.Name, "Family Dinner")
+	}
+	if c.OwnerUserID != 1 {
+		t.Errorf("owner = %d, want 1", c.OwnerUserID)
+	}
+	if len(c.MemberIDs) != 2 {
+		t.Errorf("expected 2 members, got %d: %v", len(c.MemberIDs), c.MemberIDs)
 	}
 
-	got, err := GetConversation(ctx, d, id, 1)
-	if err != nil {
-		t.Fatalf("get as owner: %v", err)
-	}
-	if got.Name != "Family Dinner" {
-		t.Errorf("name = %q, want %q", got.Name, "Family Dinner")
-	}
-	if got.OwnerID != 1 {
-		t.Errorf("owner = %d, want 1", got.OwnerID)
-	}
-
-	got2, err := GetConversation(ctx, d, id, 2)
+	got, err := GetConversation(db, c.ID, 2)
 	if err != nil {
 		t.Fatalf("get as member: %v", err)
 	}
-	if got2.Name != "Family Dinner" {
-		t.Errorf("member sees name %q, want %q", got2.Name, "Family Dinner")
+	if got.Name != "Family Dinner" {
+		t.Errorf("member sees name %q, want %q", got.Name, "Family Dinner")
 	}
 }
 
-func TestGetConversation_NonMember(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
+func TestStoreGetConversation_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
 
-	id, err := CreateConversation(ctx, d, 1, "Private", []int64{2})
+	c, err := CreateConversation(db, 1, "Private", []int64{2})
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
 
-	_, err = GetConversation(ctx, d, id, 3)
+	_, err = GetConversation(db, c.ID, 3)
 	if !errors.Is(err, ErrForbidden) {
 		t.Errorf("expected ErrForbidden, got %v", err)
 	}
 }
 
-func TestListUserConversations(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
+func TestStoreListConversations(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
 
-	c1, err := CreateConversation(ctx, d, 1, "First", []int64{2})
+	c1, err := CreateConversation(db, 1, "First", []int64{2})
 	if err != nil {
 		t.Fatalf("create 1: %v", err)
 	}
-	// Ensure distinct updated_at ordering.
 	time.Sleep(2 * time.Millisecond)
-	c2, err := CreateConversation(ctx, d, 1, "Second", []int64{2, 3})
+	c2, err := CreateConversation(db, 1, "Second", []int64{2, 3})
 	if err != nil {
 		t.Fatalf("create 2: %v", err)
 	}
 
-	convos, err := ListUserConversations(ctx, d, 1)
+	convos, err := ListConversations(db, 1)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
 	if len(convos) != 2 {
 		t.Fatalf("got %d conversations, want 2", len(convos))
 	}
-	// Newest first.
-	if convos[0].ID != c2 || convos[1].ID != c1 {
-		t.Errorf("order = [%d %d], want [%d %d]", convos[0].ID, convos[1].ID, c2, c1)
+	if convos[0].ID != c2.ID || convos[1].ID != c1.ID {
+		t.Errorf("order = [%d %d], want [%d %d]", convos[0].ID, convos[1].ID, c2.ID, c1.ID)
 	}
 
-	convos3, err := ListUserConversations(ctx, d, 3)
+	convos3, err := ListConversations(db, 3)
 	if err != nil {
-		t.Fatalf("list as 3: %v", err)
+		t.Fatalf("list as carol: %v", err)
 	}
-	if len(convos3) != 1 || convos3[0].ID != c2 {
-		t.Errorf("user 3 sees %v, want only conversation %d", convos3, c2)
+	if len(convos3) != 1 || convos3[0].ID != c2.ID {
+		t.Errorf("carol sees %v, want only conversation %d", convos3, c2.ID)
 	}
 
-	convos4, err := ListUserConversations(ctx, d, 999)
+	convos999, err := ListConversations(db, 999)
 	if err != nil {
-		t.Fatalf("list as 999: %v", err)
+		t.Fatalf("list as non-member: %v", err)
 	}
-	if len(convos4) != 0 {
-		t.Errorf("non-member sees %d conversations, want 0", len(convos4))
+	if len(convos999) != 0 {
+		t.Errorf("non-member sees %d conversations, want 0", len(convos999))
 	}
 }
 
-func TestAppendAndListMessages(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
+func TestStoreCreateMessage_EncryptedAtRest(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
 
-	convID, err := CreateConversation(ctx, d, 1, "", []int64{2})
+	c, err := CreateConversation(db, 1, "", []int64{2})
 	if err != nil {
-		t.Fatalf("create: %v", err)
-	}
-
-	m1, err := AppendMessage(ctx, d, convID, 1, "hello bob", "", "")
-	if err != nil {
-		t.Fatalf("append 1: %v", err)
-	}
-	m2, err := AppendMessage(ctx, d, convID, 2, "hi alice", "", "")
-	if err != nil {
-		t.Fatalf("append 2: %v", err)
-	}
-	if m2 <= m1 {
-		t.Errorf("expected ascending IDs, got %d then %d", m1, m2)
-	}
-
-	msgs, err := ListMessages(ctx, d, convID, 1, 0, 100)
-	if err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("got %d messages, want 2", len(msgs))
-	}
-	if msgs[0].Body != "hello bob" || msgs[1].Body != "hi alice" {
-		t.Errorf("bodies = [%q %q], want [hello bob, hi alice]", msgs[0].Body, msgs[1].Body)
-	}
-	if msgs[0].ID >= msgs[1].ID {
-		t.Errorf("expected ascending order, got %d then %d", msgs[0].ID, msgs[1].ID)
-	}
-}
-
-func TestMessageEncryptedAtRest(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
-
-	convID, err := CreateConversation(ctx, d, 1, "", []int64{2})
-	if err != nil {
-		t.Fatalf("create: %v", err)
+		t.Fatalf("create conv: %v", err)
 	}
 
 	const plaintext = "this is a secret message"
-	if _, err := AppendMessage(ctx, d, convID, 1, plaintext, "", ""); err != nil {
-		t.Fatalf("append: %v", err)
+	msg, err := CreateMessage(db, c.ID, 1, plaintext, "", "")
+	if err != nil {
+		t.Fatalf("create msg: %v", err)
+	}
+	if msg.Body != plaintext {
+		t.Errorf("returned body = %q, want %q", msg.Body, plaintext)
 	}
 
 	var raw string
-	if err := d.QueryRow(`SELECT body_enc FROM family_chat_messages WHERE conversation_id = ?`, convID).Scan(&raw); err != nil {
-		t.Fatalf("select body_enc: %v", err)
+	if err := db.QueryRow(`SELECT body FROM family_chat_messages WHERE id = ?`, msg.ID).Scan(&raw); err != nil {
+		t.Fatalf("select body: %v", err)
 	}
 	if raw == plaintext {
 		t.Fatalf("body stored as plaintext: %q", raw)
 	}
 	if !strings.HasPrefix(raw, "enc:") {
-		t.Fatalf("body_enc missing ciphertext prefix: %q", raw)
-	}
-
-	// And ensure decrypt round-trips.
-	msgs, err := ListMessages(ctx, d, convID, 1, 0, 10)
-	if err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if len(msgs) != 1 || msgs[0].Body != plaintext {
-		t.Fatalf("decrypted body = %v, want one message with body %q", msgs, plaintext)
+		t.Fatalf("body missing ciphertext prefix: %q", raw)
 	}
 }
 
-func TestConversationNameEncryptedAtRest(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
+func TestStoreCreateMessage_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
 
-	const name = "Top Secret Family Plans"
-	convID, err := CreateConversation(ctx, d, 1, name, []int64{2})
+	c, err := CreateConversation(db, 1, "", []int64{2})
 	if err != nil {
-		t.Fatalf("create: %v", err)
+		t.Fatalf("create conv: %v", err)
 	}
 
-	var raw string
-	if err := d.QueryRow(`SELECT name_enc FROM family_chat_conversations WHERE id = ?`, convID).Scan(&raw); err != nil {
-		t.Fatalf("select name_enc: %v", err)
-	}
-	if raw == name {
-		t.Fatalf("name stored as plaintext: %q", raw)
-	}
-	if !strings.HasPrefix(raw, "enc:") {
-		t.Fatalf("name_enc missing ciphertext prefix: %q", raw)
-	}
-}
-
-func TestAppendMessage_NonMember(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
-
-	convID, err := CreateConversation(ctx, d, 1, "", []int64{2})
-	if err != nil {
-		t.Fatalf("create: %v", err)
-	}
-
-	_, err = AppendMessage(ctx, d, convID, 3, "I should not be able to do this", "", "")
+	_, err = CreateMessage(db, c.ID, 3, "I should not be able to do this", "", "")
 	if !errors.Is(err, ErrForbidden) {
 		t.Errorf("expected ErrForbidden, got %v", err)
 	}
 
-	// And no message should have been written.
 	var count int
-	if err := d.QueryRow(`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ?`, convID).Scan(&count); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ?`, c.ID).Scan(&count); err != nil {
 		t.Fatalf("count: %v", err)
 	}
 	if count != 0 {
-		t.Errorf("expected 0 messages after forbidden append, got %d", count)
+		t.Errorf("expected 0 messages after forbidden create, got %d", count)
 	}
 }
 
-func TestListMessages_NonMember(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
+func TestStoreListMessages_SinceAndLimit(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
 
-	convID, err := CreateConversation(ctx, d, 1, "", []int64{2})
+	c, err := CreateConversation(db, 1, "", []int64{2})
 	if err != nil {
-		t.Fatalf("create: %v", err)
-	}
-	if _, err := AppendMessage(ctx, d, convID, 1, "hello", "", ""); err != nil {
-		t.Fatalf("append: %v", err)
-	}
-
-	_, err = ListMessages(ctx, d, convID, 3, 0, 100)
-	if !errors.Is(err, ErrForbidden) {
-		t.Errorf("expected ErrForbidden, got %v", err)
-	}
-}
-
-func TestListMessages_SinceAndLimit(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
-
-	convID, err := CreateConversation(ctx, d, 1, "", []int64{2})
-	if err != nil {
-		t.Fatalf("create: %v", err)
+		t.Fatalf("create conv: %v", err)
 	}
 
 	var ids []int64
 	for i := 0; i < 5; i++ {
-		id, err := AppendMessage(ctx, d, convID, 1, "msg", "", "")
+		msg, err := CreateMessage(db, c.ID, 1, "msg", "", "")
 		if err != nil {
-			t.Fatalf("append %d: %v", i, err)
+			t.Fatalf("create msg %d: %v", i, err)
 		}
-		ids = append(ids, id)
+		ids = append(ids, msg.ID)
 	}
 
-	// limit only.
-	msgs, err := ListMessages(ctx, d, convID, 1, 0, 2)
+	// Default order is newest-first. limit=2 returns the 2 most recently inserted.
+	msgs, err := ListMessages(db, c.ID, 1, 0, 2)
 	if err != nil {
-		t.Fatalf("list limit: %v", err)
+		t.Fatalf("list limit=2: %v", err)
 	}
-	if len(msgs) != 2 || msgs[0].ID != ids[0] || msgs[1].ID != ids[1] {
-		t.Errorf("limit=2 returned %v, want [%d %d]", msgs, ids[0], ids[1])
+	if len(msgs) != 2 {
+		t.Fatalf("limit=2 returned %d messages, want 2", len(msgs))
+	}
+	if msgs[0].ID != ids[4] || msgs[1].ID != ids[3] {
+		t.Errorf("limit=2 ids = [%d %d], want [%d %d]", msgs[0].ID, msgs[1].ID, ids[4], ids[3])
 	}
 
-	// sinceID + limit.
-	msgs, err = ListMessages(ctx, d, convID, 1, ids[1], 10)
+	// since=ids[1] returns ids > ids[1], newest-first: ids[4], ids[3], ids[2].
+	msgs, err = ListMessages(db, c.ID, 1, ids[1], 10)
 	if err != nil {
 		t.Fatalf("list since: %v", err)
 	}
 	if len(msgs) != 3 {
-		t.Fatalf("sinceID returned %d messages, want 3", len(msgs))
-	}
-	if msgs[0].ID != ids[2] {
-		t.Errorf("first id = %d, want %d", msgs[0].ID, ids[2])
-	}
-
-	// limit <= 0 returns empty.
-	msgs, err = ListMessages(ctx, d, convID, 1, 0, 0)
-	if err != nil {
-		t.Fatalf("list limit=0: %v", err)
-	}
-	if len(msgs) != 0 {
-		t.Errorf("limit=0 returned %d messages, want 0", len(msgs))
+		t.Fatalf("since returned %d messages, want 3", len(msgs))
 	}
 }
 
-func TestAppendMessage_BumpsConversationUpdatedAt(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
+func TestStoreListMessages_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
 
-	convID, err := CreateConversation(ctx, d, 1, "", []int64{2})
+	c, err := CreateConversation(db, 1, "", []int64{2})
 	if err != nil {
-		t.Fatalf("create: %v", err)
+		t.Fatalf("create conv: %v", err)
 	}
 
-	first, err := GetConversation(ctx, d, convID, 1)
-	if err != nil {
-		t.Fatalf("get first: %v", err)
-	}
-
-	time.Sleep(2 * time.Millisecond)
-	if _, err := AppendMessage(ctx, d, convID, 1, "hi", "", ""); err != nil {
-		t.Fatalf("append: %v", err)
-	}
-
-	second, err := GetConversation(ctx, d, convID, 1)
-	if err != nil {
-		t.Fatalf("get second: %v", err)
-	}
-	if !second.UpdatedAt.After(first.UpdatedAt) {
-		t.Errorf("UpdatedAt did not advance: first=%s second=%s", first.UpdatedAt, second.UpdatedAt)
+	_, err = ListMessages(db, c.ID, 3, 0, 100)
+	if !errors.Is(err, ErrForbidden) {
+		t.Errorf("expected ErrForbidden, got %v", err)
 	}
 }
 
-func TestAppendMessage_WithAttachment(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
+func TestStoreMarkRead_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
 
-	convID, err := CreateConversation(ctx, d, 1, "", []int64{2})
+	c, err := CreateConversation(db, 1, "", []int64{2})
 	if err != nil {
-		t.Fatalf("create: %v", err)
+		t.Fatalf("create conv: %v", err)
 	}
 
-	const path = "/data/attachments/1.jpg"
-	const mime = "image/jpeg"
-	if _, err := AppendMessage(ctx, d, convID, 1, "see pic", path, mime); err != nil {
-		t.Fatalf("append: %v", err)
-	}
-
-	// attachment_path_enc should be ciphertext, mime stored plaintext.
-	var rawPath, rawMime sql.NullString
-	if err := d.QueryRow(
-		`SELECT attachment_path_enc, attachment_mime FROM family_chat_messages WHERE conversation_id = ?`,
-		convID,
-	).Scan(&rawPath, &rawMime); err != nil {
-		t.Fatalf("select attachment: %v", err)
-	}
-	if !rawPath.Valid || rawPath.String == path {
-		t.Fatalf("attachment_path_enc not encrypted: %+v", rawPath)
-	}
-	if !strings.HasPrefix(rawPath.String, "enc:") {
-		t.Fatalf("attachment_path_enc missing prefix: %q", rawPath.String)
-	}
-	if !rawMime.Valid || rawMime.String != mime {
-		t.Fatalf("attachment_mime = %+v, want %q", rawMime, mime)
-	}
-
-	msgs, err := ListMessages(ctx, d, convID, 1, 0, 10)
-	if err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("got %d messages, want 1", len(msgs))
-	}
-	if msgs[0].AttachmentPath != path {
-		t.Errorf("attachment path = %q, want %q", msgs[0].AttachmentPath, path)
-	}
-	if msgs[0].AttachmentMime != mime {
-		t.Errorf("attachment mime = %q, want %q", msgs[0].AttachmentMime, mime)
+	err = MarkRead(db, c.ID, 3, "")
+	if !errors.Is(err, ErrForbidden) {
+		t.Errorf("expected ErrForbidden, got %v", err)
 	}
 }
 
-func TestMarkRead(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
+func TestStoreUnreadCount(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
 
-	convID, err := CreateConversation(ctx, d, 1, "", []int64{2})
+	c, err := CreateConversation(db, 1, "", []int64{2})
 	if err != nil {
-		t.Fatalf("create: %v", err)
+		t.Fatalf("create conv: %v", err)
 	}
 
-	// Before MarkRead, last_read_at is NULL.
-	var ts sql.NullTime
-	if err := d.QueryRow(
-		`SELECT last_read_at FROM family_chat_members WHERE conversation_id = ? AND user_id = ?`,
-		convID, 2,
-	).Scan(&ts); err != nil {
-		t.Fatalf("scan last_read_at: %v", err)
-	}
-	if ts.Valid {
-		t.Fatalf("expected NULL last_read_at, got %v", ts)
+	for i := 0; i < 3; i++ {
+		if _, err := CreateMessage(db, c.ID, 1, "hi", "", ""); err != nil {
+			t.Fatalf("create msg: %v", err)
+		}
 	}
 
-	now := time.Now().UTC()
-	if err := MarkRead(ctx, d, convID, 2, now); err != nil {
+	got, err := GetConversation(db, c.ID, 2)
+	if err != nil {
+		t.Fatalf("get conv: %v", err)
+	}
+	if got.UnreadCount != 3 {
+		t.Errorf("unread = %d, want 3", got.UnreadCount)
+	}
+
+	if err := MarkRead(db, c.ID, 2, "9999-12-31T23:59:59.000000000Z"); err != nil {
 		t.Fatalf("mark read: %v", err)
 	}
 
-	if err := d.QueryRow(
-		`SELECT last_read_at FROM family_chat_members WHERE conversation_id = ? AND user_id = ?`,
-		convID, 2,
-	).Scan(&ts); err != nil {
-		t.Fatalf("scan after mark: %v", err)
-	}
-	if !ts.Valid {
-		t.Fatal("expected last_read_at to be set")
-	}
-}
-
-func TestMarkRead_NonMember(t *testing.T) {
-	d := setupTestDB(t)
-	ctx := context.Background()
-
-	convID, err := CreateConversation(ctx, d, 1, "", []int64{2})
+	got, err = GetConversation(db, c.ID, 2)
 	if err != nil {
-		t.Fatalf("create: %v", err)
+		t.Fatalf("get conv after mark: %v", err)
 	}
-
-	err = MarkRead(ctx, d, convID, 3, time.Now())
-	if !errors.Is(err, ErrForbidden) {
-		t.Errorf("expected ErrForbidden, got %v", err)
+	if got.UnreadCount != 0 {
+		t.Errorf("unread after mark = %d, want 0", got.UnreadCount)
 	}
 }

--- a/internal/familychat/stream.go
+++ b/internal/familychat/stream.go
@@ -18,12 +18,6 @@ import (
 // connection.
 const heartbeatInterval = 30 * time.Second
 
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
-}
-
 // StreamHandler returns an SSE handler at
 // GET /api/familychat/conversations/{id}/stream that pushes message_new,
 // message_deleted, and read_receipt events as they are published into hub.


### PR DESCRIPTION
## Original Issue (feature): Family Chat: REST handlers

Part of the Family Chat chain seeded from Suggestions id=145. See that suggestion's plan in the Suggestions page for the full architecture, trust model, and phase plan. Trust model: at-rest encryption with the server holding the key (same as Notes), NOT Signal-style E2EE.

This bead is step 2/7: REST handlers of the chain.

## Scope

REST handlers under `/api/familychat/...` wired in `internal/api/router.go` inside `RequireAuth` + `RequireFeature(db, "family_chat")`:

- GET /api/familychat/conversations → list current user's conversations (id, name, last_message_at, unread_count, member ids).
- POST /api/familychat/conversations → body { name, member_user_ids } → create + return.
- GET /api/familychat/conversations/{id} → full conversation metadata.
- GET /api/familychat/conversations/{id}/messages?since=<id>&limit=<n> → list messages, default newest first; `since` for incremental loads.
- POST /api/familychat/conversations/{id}/messages → body { body, attachment_path?, attachment_mime? } → append; returns the inserted message decrypted.
- POST /api/familychat/conversations/{id}/read → body { at: timestamp } → updates `last_read_at`.
- DELETE /api/familychat/conversations/{id} → owner only; cascade-delete.

Member auth: every endpoint resolves membership via `family_chat_members`; non-members get 404 (not 403, to avoid leaking existence).

### Tests

- `handlers_test.go` covers each handler success + cross-user 404 path.
- Pagination `since` + `limit` works correctly across multiple pages.

### Acceptance

- All endpoints behind feature flag.
- 404 for non-members, 200 for members.
- `make build`, `make test ./internal/familychat/...` pass.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-56j7 | Branch: forge/Hytte-56j7
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->