### PR TITLE
Family Chat: webpush on incoming message (Hytte-6clp)

### DIFF
--- a/changelog.d/Hytte-6clp.md
+++ b/changelog.d/Hytte-6clp.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat: webpush on incoming message** - When a new message arrives and a recipient does not currently have a live SSE stream open for the conversation, a webpush notification is sent so their device wakes up. The notification uses the sender's display name as the title, the first ~80 chars of the message as the body, and a `familychat-<conversation_id>` tag so a second message replaces the first banner instead of stacking. Stale (410 Gone) push subscriptions are removed automatically. (Hytte-6clp)

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -120,20 +120,6 @@ func CreateConversationHandler(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("user %d not found", missing)})
 			return
 		}
-		if len([]rune(body.Name)) > maxNameLen {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is too long"})
-			return
-		}
-		if len(body.MemberUserIDs) > maxMembersPerConv {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "too many members"})
-			return
-		}
-		for _, uid := range body.MemberUserIDs {
-			if uid <= 0 {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid member id"})
-				return
-			}
-		}
 
 		c, err := CreateConversation(db, user.ID, body.Name, body.MemberUserIDs)
 		if err != nil {
@@ -215,9 +201,18 @@ func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
-// PostMessageHandler appends a message to a conversation and returns the
-// inserted row decrypted.
+// PostMessageHandler appends a message to a conversation, broadcasts it on
+// the SSE hub for any live subscriber, and fans webpush notifications out to
+// every recipient who is not currently subscribed via SSE.
 func PostMessageHandler(db *sql.DB) http.HandlerFunc {
+	return postMessageHandler(db, DefaultHub(), defaultPushSender(db), false /* notify async */)
+}
+
+// postMessageHandler is the testable inner constructor. When notifySync is
+// true the webpush fan-out runs inline so tests can assert on it after
+// ServeHTTP returns; in production it runs in a goroutine so a slow push
+// gateway cannot stall the HTTP response.
+func postMessageHandler(db *sql.DB, hub *Hub, sender PushSenderFunc, notifySync bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
 		convID, ok := parseConvID(r)
@@ -264,16 +259,26 @@ func PostMessageHandler(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to post message"})
 			return
 		}
-		DefaultHub().Publish(convID, Event{
-			Type: EventMessageNew,
-			Data: map[string]any{
-				"id":              msg.ID,
-				"conversation_id": msg.ConversationID,
-				"sender_user_id":  msg.SenderUserID,
-				"body":            msg.Body,
-				"created_at":      msg.CreatedAt,
-			},
-		})
+
+		// Publish to any live SSE subscribers first so they see the message
+		// without waiting for the webpush round trip.
+		if hub != nil {
+			hub.Publish(convID, Event{Type: EventMessageNew, Data: map[string]any{"message": msg}})
+		}
+
+		// Fan webpush out to recipients who are not currently on SSE. Done
+		// after the DB write and hub publish so the recipient cannot get a
+		// notification for a message that failed to persist.
+		if sender != nil {
+			senderName := senderDisplayName(user)
+			if notifySync {
+				notifyOfflineRecipients(db, hub, sender, convID, msg, senderName)
+			} else {
+				go notifyOfflineRecipients(db, hub, sender, convID, msg, senderName)
+			}
+		}
+
+
 		writeJSON(w, http.StatusCreated, map[string]any{"message": msg})
 	}
 }

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -30,6 +30,7 @@ const (
 	maxRequestBytes   = 1 << 20 // 1 MiB
 )
 
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -52,6 +53,7 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 	}
 	return true
 }
+
 
 // parseConvID extracts and validates the {id} path parameter for the
 // conversation routes. On failure we respond 404 (not 400) because an

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -28,7 +28,16 @@ const (
 	defaultMsgLimit   = 50
 	maxMsgLimit       = 500
 	maxRequestBytes   = 1 << 20 // 1 MiB
+
+	// pushWorkerLimit caps the number of concurrently running webpush fan-out
+	// goroutines so slow or unreachable push endpoints cannot grow the goroutine
+	// count without bound under high message volume.
+	pushWorkerLimit = 16
 )
+
+// pushSem is a counting semaphore that enforces pushWorkerLimit. Each async
+// push goroutine acquires one slot before starting DB + HTTP work.
+var pushSem = make(chan struct{}, pushWorkerLimit)
 
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
@@ -274,7 +283,12 @@ func postMessageHandler(db *sql.DB, hub *Hub, sender PushSenderFunc, notifySync 
 			if notifySync {
 				notifyOfflineRecipients(db, hub, sender, convID, msg, senderName)
 			} else {
-				go notifyOfflineRecipients(db, hub, sender, convID, msg, senderName)
+				sn := senderName
+				go func() {
+					pushSem <- struct{}{}
+					defer func() { <-pushSem }()
+					notifyOfflineRecipients(db, hub, sender, convID, msg, sn)
+				}()
 			}
 		}
 

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -120,6 +120,20 @@ func CreateConversationHandler(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("user %d not found", missing)})
 			return
 		}
+		if len([]rune(body.Name)) > maxNameLen {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is too long"})
+			return
+		}
+		if len(body.MemberUserIDs) > maxMembersPerConv {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "too many members"})
+			return
+		}
+		for _, uid := range body.MemberUserIDs {
+			if uid <= 0 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid member id"})
+				return
+			}
+		}
 
 		c, err := CreateConversation(db, user.ID, body.Name, body.MemberUserIDs)
 		if err != nil {

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -71,6 +71,20 @@ func setupTestDB(t *testing.T) *sql.DB {
 			attachment_mime TEXT NOT NULL DEFAULT '',
 			created_at      TEXT NOT NULL DEFAULT ''
 		);
+		CREATE TABLE IF NOT EXISTS vapid_keys (
+			id          INTEGER PRIMARY KEY,
+			public_key  TEXT NOT NULL,
+			private_key TEXT NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS push_subscriptions (
+			id         INTEGER PRIMARY KEY,
+			user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			endpoint   TEXT NOT NULL,
+			p256dh     TEXT NOT NULL,
+			auth       TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT '',
+			UNIQUE(user_id, endpoint)
+		);
 	`); err != nil {
 		t.Fatalf("create schema: %v", err)
 	}
@@ -736,31 +750,6 @@ func TestDeleteConversationHandler_NonMember(t *testing.T) {
 	}
 }
 
-// addPushTables creates the vapid_keys and push_subscriptions tables on a
-// test DB that was originally built without them. Used by the push fan-out
-// tests below.
-func addPushTables(t *testing.T, db *sql.DB) {
-	t.Helper()
-	if _, err := db.Exec(`
-		CREATE TABLE vapid_keys (
-			id          INTEGER PRIMARY KEY,
-			public_key  TEXT NOT NULL,
-			private_key TEXT NOT NULL
-		);
-		CREATE TABLE push_subscriptions (
-			id         INTEGER PRIMARY KEY,
-			user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-			endpoint   TEXT NOT NULL,
-			p256dh     TEXT NOT NULL,
-			auth       TEXT NOT NULL,
-			created_at TEXT NOT NULL DEFAULT '',
-			UNIQUE(user_id, endpoint)
-		);
-	`); err != nil {
-		t.Fatalf("add push tables: %v", err)
-	}
-}
-
 func TestPostMessageHandler_NotifiesOnlyOfflineRecipients(t *testing.T) {
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com") // sender
@@ -873,7 +862,6 @@ func TestPostMessageHandler_TruncatesLongBodyInPush(t *testing.T) {
 
 func TestPostMessageHandler_StaleSubscriptionRemovedOn410(t *testing.T) {
 	db := setupTestDB(t)
-	addPushTables(t, db)
 	makeUser(t, db, 1, "alice@example.com")
 	makeUser(t, db, 2, "bob@example.com")
 	convID := seedConversation(t, db, 1, "Family", 2)

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -657,6 +657,7 @@ func TestCreateConversationHandler_NonExistentMemberID(t *testing.T) {
 	}
 }
 
+
 func TestPostMessageHandler_BodyTooLong(t *testing.T) {
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com")

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -2,17 +2,22 @@ package familychat
 
 import (
 	"context"
+	"crypto/ecdh"
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/Robin831/Hytte/internal/push"
 	"github.com/go-chi/chi/v5"
 	_ "modernc.org/sqlite"
 )
@@ -728,5 +733,242 @@ func TestDeleteConversationHandler_NonMember(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// addPushTables creates the vapid_keys and push_subscriptions tables on a
+// test DB that was originally built without them. Used by the push fan-out
+// tests below.
+func addPushTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if _, err := db.Exec(`
+		CREATE TABLE vapid_keys (
+			id          INTEGER PRIMARY KEY,
+			public_key  TEXT NOT NULL,
+			private_key TEXT NOT NULL
+		);
+		CREATE TABLE push_subscriptions (
+			id         INTEGER PRIMARY KEY,
+			user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			endpoint   TEXT NOT NULL,
+			p256dh     TEXT NOT NULL,
+			auth       TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT '',
+			UNIQUE(user_id, endpoint)
+		);
+	`); err != nil {
+		t.Fatalf("add push tables: %v", err)
+	}
+}
+
+func TestPostMessageHandler_NotifiesOnlyOfflineRecipients(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com") // sender
+	makeUser(t, db, 2, "bob@example.com")   // online via SSE
+	makeUser(t, db, 3, "carol@example.com") // offline
+	convID := seedConversation(t, db, 1, "Family", 2, 3)
+
+	hub := NewHub()
+	// Bob is live on SSE — fan-out must skip him.
+	bobSub := hub.Subscribe(2, convID)
+	defer hub.Unsubscribe(convID, bobSub)
+	// Drain Bob's events so the hub buffer cannot fill mid-test.
+	go func() {
+		for range bobSub.Events() {
+		}
+	}()
+
+	type call struct {
+		userID  int64
+		payload []byte
+	}
+	var mu sync.Mutex
+	var calls []call
+	sender := func(userID int64, payload []byte) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, call{userID: userID, payload: append([]byte(nil), payload...)})
+		return nil
+	}
+
+	handler := postMessageHandler(db, hub, sender, true /* notifySync */)
+
+	idStr := strconv.FormatInt(convID, 10)
+	payloadStr := `{"body":"hello family"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payloadStr)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 push call (offline recipient), got %d", len(calls))
+	}
+	if calls[0].userID != 3 {
+		t.Fatalf("push went to user %d, want 3 (offline recipient)", calls[0].userID)
+	}
+
+	var note push.Notification
+	if err := json.Unmarshal(calls[0].payload, &note); err != nil {
+		t.Fatalf("decode push payload: %v", err)
+	}
+	// withUser builds users with Name="Test"; that's the sender's display name.
+	if note.Title != "Test" {
+		t.Errorf("title = %q, want %q", note.Title, "Test")
+	}
+	if note.Body != "hello family" {
+		t.Errorf("body = %q, want %q", note.Body, "hello family")
+	}
+	wantTag := fmt.Sprintf("familychat-%d", convID)
+	if note.Tag != wantTag {
+		t.Errorf("tag = %q, want %q", note.Tag, wantTag)
+	}
+}
+
+func TestPostMessageHandler_TruncatesLongBodyInPush(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	var captured []byte
+	sender := func(userID int64, payload []byte) error {
+		captured = append([]byte(nil), payload...)
+		return nil
+	}
+	handler := postMessageHandler(db, NewHub(), sender, true)
+
+	long := strings.Repeat("a", 200)
+	idStr := strconv.FormatInt(convID, 10)
+	payloadStr := fmt.Sprintf(`{"body":%q}`, long)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payloadStr)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if captured == nil {
+		t.Fatal("push sender was not called")
+	}
+	var note push.Notification
+	if err := json.Unmarshal(captured, &note); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if len([]rune(note.Body)) > notificationBodyLimit+1 {
+		t.Errorf("body rune length = %d, want at most %d (limit + ellipsis)", len([]rune(note.Body)), notificationBodyLimit+1)
+	}
+	if !strings.HasSuffix(note.Body, "…") {
+		t.Errorf("expected ellipsis on truncated body, got %q", note.Body)
+	}
+}
+
+func TestPostMessageHandler_StaleSubscriptionRemovedOn410(t *testing.T) {
+	db := setupTestDB(t)
+	addPushTables(t, db)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	// A push endpoint that signals the subscription is gone. The internal/push
+	// package is responsible for deleting the row when this happens; this test
+	// verifies the family-chat fan-out exercises that path end to end.
+	var hitsMu sync.Mutex
+	var hits int
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitsMu.Lock()
+		hits++
+		hitsMu.Unlock()
+		w.WriteHeader(http.StatusGone)
+	}))
+	defer ts.Close()
+
+	// Real P-256 keypair so the encryption step succeeds before the HTTP layer.
+	curve := ecdh.P256()
+	priv, err := curve.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	p256dh := base64.RawURLEncoding.EncodeToString(priv.PublicKey().Bytes())
+	authSecret := base64.RawURLEncoding.EncodeToString(make([]byte, 16))
+	if _, err := push.SaveSubscription(db, 2, ts.URL, p256dh, authSecret); err != nil {
+		t.Fatalf("save subscription: %v", err)
+	}
+
+	sender := func(userID int64, payload []byte) error {
+		_, err := push.SendToUser(db, ts.Client(), userID, payload)
+		return err
+	}
+	handler := postMessageHandler(db, NewHub(), sender, true)
+
+	idStr := strconv.FormatInt(convID, 10)
+	payloadStr := `{"body":"hi"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payloadStr)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	hitsMu.Lock()
+	gotHits := hits
+	hitsMu.Unlock()
+	if gotHits == 0 {
+		t.Fatal("test push endpoint received no requests")
+	}
+
+	var remaining int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM push_subscriptions WHERE user_id = ?`, int64(2)).Scan(&remaining); err != nil {
+		t.Fatalf("count subs: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("expected stale subscription deleted after 410 Gone, still have %d", remaining)
+	}
+}
+
+func TestPostMessageHandler_SkipsPushWhenAllRecipientsOnline(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	hub := NewHub()
+	bobSub := hub.Subscribe(2, convID)
+	defer hub.Unsubscribe(convID, bobSub)
+	go func() {
+		for range bobSub.Events() {
+		}
+	}()
+
+	var calls int
+	sender := func(userID int64, payload []byte) error {
+		calls++
+		return nil
+	}
+	handler := postMessageHandler(db, hub, sender, true)
+
+	idStr := strconv.FormatInt(convID, 10)
+	payloadStr := `{"body":"yo"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payloadStr)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
+	}
+	if calls != 0 {
+		t.Errorf("expected no push (every recipient on SSE), got %d", calls)
 	}
 }

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -349,6 +349,7 @@ func TestPostMessageHandler_AttachmentEncryption(t *testing.T) {
 	}
 }
 
+
 func TestListMessagesHandler_NonMember(t *testing.T) {
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com")
@@ -709,6 +710,7 @@ func TestMarkReadHandler_InvalidTimestamp(t *testing.T) {
 		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
 
 func TestDeleteConversationHandler_NonMember(t *testing.T) {
 	db := setupTestDB(t)

--- a/internal/familychat/hub.go
+++ b/internal/familychat/hub.go
@@ -30,9 +30,12 @@ const (
 // Subscriber is a single SSE client subscription. The channel is buffered so
 // a publisher can fan out without blocking on a slow consumer; if the buffer
 // fills up the publish for that Subscriber is dropped (the client will pick
-// up the next event or reconnect).
+// up the next event or reconnect). The userID is recorded so callers fanning
+// out external notifications (e.g. webpush) can skip recipients who are
+// already live on SSE.
 type Subscriber struct {
-	ch chan Event
+	userID int64
+	ch     chan Event
 }
 
 // SubscriberBufferSize is the per-Subscriber channel buffer. Sized to absorb
@@ -54,17 +57,35 @@ func NewHub() *Hub {
 	}
 }
 
-// Subscribe registers a new Subscriber for the given conversation and returns
-// it. The caller must Unsubscribe when finished, typically via defer.
-func (h *Hub) Subscribe(convID int64) *Subscriber {
+// Subscribe registers a new Subscriber for the given user and conversation
+// and returns it. The caller must Unsubscribe when finished, typically via
+// defer. The userID is stored on the Subscriber so other code paths (such as
+// the webpush fan-out for incoming messages) can ask whether a user already
+// has a live SSE stream open.
+func (h *Hub) Subscribe(userID, convID int64) *Subscriber {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	s := &Subscriber{ch: make(chan Event, SubscriberBufferSize)}
+	s := &Subscriber{userID: userID, ch: make(chan Event, SubscriberBufferSize)}
 	if h.subs[convID] == nil {
 		h.subs[convID] = make(map[*Subscriber]struct{})
 	}
 	h.subs[convID][s] = struct{}{}
 	return s
+}
+
+// HasSubscriber reports whether userID currently has any live SSE
+// subscription for convID. Used by the message-post fan-out to decide
+// whether a recipient also needs a webpush notification (they do not if
+// they already have a streaming connection).
+func (h *Hub) HasSubscriber(userID, convID int64) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for s := range h.subs[convID] {
+		if s.userID == userID {
+			return true
+		}
+	}
+	return false
 }
 
 // Unsubscribe removes the Subscriber and closes its channel. Idempotent and

--- a/internal/familychat/hub_test.go
+++ b/internal/familychat/hub_test.go
@@ -38,9 +38,9 @@ func recvWithin(t *testing.T, sub *Subscriber, d time.Duration) Event {
 
 func TestHub_PublishFanout(t *testing.T) {
 	h := NewHub()
-	a := h.Subscribe(42)
+	a := h.Subscribe(1, 42)
 	defer h.Unsubscribe(42, a)
-	b := h.Subscribe(42)
+	b := h.Subscribe(2, 42)
 	defer h.Unsubscribe(42, b)
 
 	h.Publish(42, Event{Type: EventMessageNew, Data: map[string]any{"id": 1}})
@@ -54,9 +54,9 @@ func TestHub_PublishFanout(t *testing.T) {
 
 func TestHub_IsolationBetweenConvs(t *testing.T) {
 	h := NewHub()
-	a := h.Subscribe(1)
+	a := h.Subscribe(10, 1)
 	defer h.Unsubscribe(1, a)
-	b := h.Subscribe(2)
+	b := h.Subscribe(11, 2)
 	defer h.Unsubscribe(2, b)
 
 	h.Publish(2, Event{Type: EventMessageNew, Data: map[string]any{"v": "for-b"}})
@@ -77,8 +77,8 @@ func TestHub_IsolationBetweenConvs(t *testing.T) {
 
 func TestHub_UnsubscribeCleanup(t *testing.T) {
 	h := NewHub()
-	a := h.Subscribe(7)
-	b := h.Subscribe(7)
+	a := h.Subscribe(1, 7)
+	b := h.Subscribe(2, 7)
 
 	if got := h.subscriberCount(7); got != 2 {
 		t.Fatalf("expected 2 subscribers, got %d", got)
@@ -114,13 +114,13 @@ func TestHub_UnsubscribeUnknownSubscriberNoPanic(t *testing.T) {
 	// Unsubscribe with a nil subscriber and one from an unknown conversation
 	// should both be no-ops.
 	h.Unsubscribe(9, nil)
-	stranger := &Subscriber{ch: make(chan Event, 1)}
+	stranger := &Subscriber{userID: 1, ch: make(chan Event, 1)}
 	h.Unsubscribe(9, stranger)
 }
 
 func TestHub_SlowSubscriberDoesNotBlock(t *testing.T) {
 	h := NewHub()
-	slow := h.Subscribe(3)
+	slow := h.Subscribe(1, 3)
 	defer h.Unsubscribe(3, slow)
 
 	// Saturate the slow subscriber's buffer so any further publish would
@@ -130,7 +130,7 @@ func TestHub_SlowSubscriberDoesNotBlock(t *testing.T) {
 	}
 
 	// Add a fast subscriber with an empty buffer.
-	fast := h.Subscribe(3)
+	fast := h.Subscribe(2, 3)
 	defer h.Unsubscribe(3, fast)
 
 	// Publish must return promptly even though slow is full.

--- a/internal/familychat/notify.go
+++ b/internal/familychat/notify.go
@@ -1,0 +1,102 @@
+package familychat
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/push"
+)
+
+// PushSenderFunc delivers a marshaled webpush payload to every push
+// subscription owned by userID. Production implementations are expected to
+// clean up subscriptions that respond with 410 Gone (the internal/push
+// package's SendToUser already does this). Returning an error does not stop
+// the wider fan-out: the caller logs and continues.
+type PushSenderFunc func(userID int64, payload []byte) error
+
+// defaultPushSender returns a PushSenderFunc backed by the internal/push
+// package and the shared push HTTP client. Stale (410 Gone / 404 Not Found)
+// subscriptions are deleted automatically by push.SendToUser.
+func defaultPushSender(db *sql.DB) PushSenderFunc {
+	return func(userID int64, payload []byte) error {
+		_, err := push.SendToUser(db, push.DefaultHTTPClient, userID, payload)
+		return err
+	}
+}
+
+// notificationBodyLimit caps the message preview surfaced in the push
+// notification body so the banner stays within typical OS limits.
+const notificationBodyLimit = 80
+
+// truncate clips s to at most n runes (not bytes), appending an ellipsis
+// when truncation occurs so the recipient can tell the message continues.
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
+}
+
+// notifyOfflineRecipients fans out a webpush notification to every member of
+// convID except the sender who is not currently subscribed via SSE for that
+// conversation. Per-recipient errors are logged and swallowed so one stale
+// or slow subscription cannot block delivery to the others. Returns once
+// every recipient has been processed.
+func notifyOfflineRecipients(db *sql.DB, hub *Hub, sender PushSenderFunc, convID int64, msg *Message, senderName string) {
+	if msg == nil {
+		return
+	}
+	members, err := listMemberIDs(db, convID)
+	if err != nil {
+		log.Printf("familychat: notify: list members conv=%d: %v", convID, err)
+		return
+	}
+
+	body := truncate(msg.Body, notificationBodyLimit)
+	if body == "" && msg.AttachmentPath != "" {
+		body = "Sent an attachment"
+	}
+	note := push.Notification{
+		Title: senderName,
+		Body:  body,
+		URL:   fmt.Sprintf("/familychat/%d", convID),
+		Tag:   fmt.Sprintf("familychat-%d", convID),
+	}
+	payload, err := json.Marshal(note)
+	if err != nil {
+		log.Printf("familychat: notify: marshal payload conv=%d: %v", convID, err)
+		return
+	}
+
+	for _, uid := range members {
+		if uid == msg.SenderUserID {
+			continue
+		}
+		if hub.HasSubscriber(uid, convID) {
+			continue
+		}
+		if err := sender(uid, payload); err != nil {
+			log.Printf("familychat: notify: send to user=%d conv=%d: %v", uid, convID, err)
+		}
+	}
+}
+
+// senderDisplayName returns a friendly label for the message sender. It
+// prefers the stored name and falls back to the email address (used by the
+// rare account with an empty display name).
+func senderDisplayName(u *auth.User) string {
+	if u == nil {
+		return ""
+	}
+	if u.Name != "" {
+		return u.Name
+	}
+	return u.Email
+}

--- a/internal/familychat/notify.go
+++ b/internal/familychat/notify.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/push"
@@ -22,8 +23,21 @@ type PushSenderFunc func(userID int64, payload []byte) error
 // subscriptions are deleted automatically by push.SendToUser.
 func defaultPushSender(db *sql.DB) PushSenderFunc {
 	return func(userID int64, payload []byte) error {
-		_, err := push.SendToUser(db, push.DefaultHTTPClient, userID, payload)
-		return err
+		results, err := push.SendToUser(db, push.DefaultHTTPClient, userID, payload)
+		if err != nil {
+			return err
+		}
+		for _, r := range results {
+			switch {
+			case r.Err != nil:
+				log.Printf("familychat: push send sub=%d user=%d: %v", r.SubscriptionID, userID, r.Err)
+			case r.StatusCode >= http.StatusBadRequest &&
+				r.StatusCode != http.StatusNotFound &&
+				r.StatusCode != http.StatusGone:
+				log.Printf("familychat: push send sub=%d user=%d: unexpected status %d", r.SubscriptionID, userID, r.StatusCode)
+			}
+		}
+		return nil
 	}
 }
 
@@ -79,7 +93,7 @@ func notifyOfflineRecipients(db *sql.DB, hub *Hub, sender PushSenderFunc, convID
 		if uid == msg.SenderUserID {
 			continue
 		}
-		if hub.HasSubscriber(uid, convID) {
+		if hub != nil && hub.HasSubscriber(uid, convID) {
 			continue
 		}
 		if err := sender(uid, payload); err != nil {

--- a/internal/familychat/stream.go
+++ b/internal/familychat/stream.go
@@ -66,7 +66,7 @@ func StreamHandler(hub *Hub, membership MembershipFn) http.HandlerFunc {
 		w.Header().Set("X-Accel-Buffering", "no")
 		flusher.Flush()
 
-		sub := hub.Subscribe(convID)
+		sub := hub.Subscribe(user.ID, convID)
 		defer hub.Unsubscribe(convID, sub)
 
 		ticker := time.NewTicker(heartbeatInterval)


### PR DESCRIPTION
## Original Issue (feature): Family Chat: webpush on incoming message

Part of the Family Chat chain seeded from Suggestions id=145. See that suggestion's plan in the Suggestions page for the full architecture, trust model, and phase plan. Trust model: at-rest encryption with the server holding the key (same as Notes), NOT Signal-style E2EE.

This PR covers two beads from the Family Chat chain:

- **Hytte-56j7** (step 3/7): Family Chat REST API — conversations, membership, encrypted messages, schema, routes
- **Hytte-6clp** (step 4/7): Webpush on incoming message — SSE hub online/offline detection, push fan-out to offline recipients

## Scope

### Hytte-56j7: Family Chat REST API
REST endpoints for creating/listing/getting/deleting conversations and posting/listing messages. Message bodies and attachment paths are encrypted at rest (same encryption as Notes). Routes are gated behind the `family_chat` feature flag.

### Hytte-6clp: Webpush on incoming message
When a message arrives for a recipient who is NOT currently subscribed via SSE for that conversation, send a webpush notification so the kid's phone wakes up.

- In the POST /messages handler (after hub publish), iterate the conversation's members minus the sender. For each member:
    - Check if the SSE hub has an active subscription for that user x conversation. If yes, skip (live delivery handled).
    - If no, look up webpush subscriptions in the existing `push_subscriptions` table.
    - Send a notification with title = sender's display name, body = first ~80 chars of decrypted message body (truncated), tag = `familychat-<conversation_id>` (so a second message replaces the first instead of stacking).
- Reuse `internal/push/` package and existing VAPID setup. No new keys needed.
- Per-subscription send errors are logged individually; one stale subscription must not block the others.

### Tests

- `handlers_test.go` extended: post a message while one recipient is SSE-subscribed and one is not; assert push fires only for the offline recipient (mock the push send).
- 410 Gone on a push subscription removes it from the table.

### Acceptance

- `make build`, `make test ./internal/familychat/...` pass.
- Offline kid receives a notification when parent sends a message.
- Tag collapsing works (second message replaces banner instead of stacking).
- Changelog fragments in changelog.d/ for both beads.


---
Beads: Hytte-56j7, Hytte-6clp | Branch: forge/Hytte-6clp
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith -> Temper -> Warden)
<!-- forge-managed: hytte-prod -->
