### PR TITLE
Scanned page grid rendering for page-scan parents (Hytte-3uq2)

### DIFF
--- a/changelog.d/Hytte-3uq2.md
+++ b/changelog.d/Hytte-3uq2.md
@@ -1,0 +1,2 @@
+category: Added
+- **Binder page scan grid** - The /pokemon/scanned page now groups multi-card binder uploads into a single grid block matching the captured 3×3 or 4×3 layout, with per-cell status badges, the existing per-card Add / Discard / Manual-search actions, plus parent-level "Add all matched" and "Discard page" controls. The new `?page=<id>` query param auto-scrolls and highlights the freshly-submitted page right after the upload flow finishes. (Hytte-3uq2)

--- a/internal/pokemon/handlers.go
+++ b/internal/pokemon/handlers.go
@@ -194,6 +194,11 @@ func RegisterRoutes(r chi.Router, db *sql.DB) {
 		// page is queued as a single user action even though each child
 		// flows through the existing single-card worker.
 		r.Post("/pokemon/scans/page", PageScanHandler(db))
+		// Page-level discard (Hytte-3uq2): drops the parent + soft-discards
+		// every child that has not yet been added to the collection so the
+		// kid can throw away a whole binder upload from the grid in one
+		// click without losing already-added cards.
+		r.Delete("/pokemon/scans/pages/{id}", DeleteScanPageHandler(db))
 		r.Get("/pokemon/scans", ListScansHandler(db))
 		r.Get("/pokemon/scans/counts", ScanCountsHandler(db))
 		r.Get("/pokemon/scans/{id}/image", GetScanImageHandler(db))

--- a/internal/pokemon/scans_handlers.go
+++ b/internal/pokemon/scans_handlers.go
@@ -85,6 +85,19 @@ type ScanJobDTO struct {
 	ParsedCollectorNo string   `json:"parsed_collector_no,omitempty"`
 }
 
+// ScanPageDTO groups a pokemon_scan_pages parent row with all of its child
+// scan jobs so the /pokemon/scanned UI can render the binder layout as a
+// single grid block. Children are returned regardless of their individual
+// status so the grid always shows the full N cells the user captured; the
+// frontend filters or styles each cell by its own state.
+type ScanPageDTO struct {
+	ID            int64        `json:"id"`
+	ExpectedCount int          `json:"expected_count"`
+	MatchedCount  int          `json:"matched_count"`
+	CreatedAt     string       `json:"created_at"`
+	Children      []ScanJobDTO `json:"children"`
+}
+
 // extractScanHints decrypts the stored Claude response (if any) and returns
 // the partial set name + collector number it managed to read. Used by the
 // no_match path to pre-fill manual entry — failures collapse to empty
@@ -628,6 +641,13 @@ func ScanCountsHandler(db *sql.DB) http.HandlerFunc {
 
 // ListScansHandler returns the current user's scan jobs newest-first, scoped
 // to the comma-separated ?status= filter (defaults to "not yet resolved").
+//
+// Multi-card binder uploads (pokemon_scan_pages parents with N child jobs)
+// are returned in a separate "pages" array: a page block is included as soon
+// as any child matches the filter, and the response carries ALL of that
+// page's children regardless of status so the grid renders the full N cells.
+// Standalone scans (page_id IS NULL) stay in "scans" so the frontend can
+// interleave the two arrays by created_at.
 func ListScansHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
@@ -656,7 +676,11 @@ func ListScansHandler(db *sql.DB) http.HandlerFunc {
 
 		statuses := parseScanStatusFilter(r.URL.Query().Get("status"))
 		if len(statuses) == 0 {
-			respondJSON(w, http.StatusOK, map[string]any{"scans": []ScanJobDTO{}, "today": today})
+			respondJSON(w, http.StatusOK, map[string]any{
+				"scans": []ScanJobDTO{},
+				"pages": []ScanPageDTO{},
+				"today": today,
+			})
 			return
 		}
 		limit := parseLimit(r, defaultScanListLimit, maxScanListLimit)
@@ -672,7 +696,7 @@ func ListScansHandler(db *sql.DB) http.HandlerFunc {
 		query := `
 			SELECT id, status, image_path_enc, matched_card_id, confidence,
 			       error_message, created_at, processed_at, resolved_at,
-			       claude_response_enc
+			       claude_response_enc, page_id
 			FROM pokemon_scan_jobs
 			WHERE user_id = ? AND status IN (` + strings.Join(placeholders, ",") + `)
 			ORDER BY created_at DESC, id DESC
@@ -684,64 +708,64 @@ func ListScansHandler(db *sql.DB) http.HandlerFunc {
 			respondError(w, http.StatusInternalServerError, "failed to list scans")
 			return
 		}
-		defer rows.Close()
 
-		jobs := make([]ScanJobDTO, 0)
+		standalone := make([]ScanJobDTO, 0)
+		pageIDOrder := make([]int64, 0)
+		pageSeen := make(map[int64]bool)
 		matchedCardIDs := make([]string, 0)
 		jobMatched := make(map[int64]string)
 		for rows.Next() {
-			var (
-				id             int64
-				status         string
-				pathEnc        string
-				matchedCard    sql.NullString
-				confidence     sql.NullFloat64
-				errorMessage   sql.NullString
-				createdAt      time.Time
-				processedAt    sql.NullTime
-				resolvedAt     sql.NullTime
-				claudeResponse sql.NullString
-			)
-			if err := rows.Scan(&id, &status, &pathEnc, &matchedCard, &confidence,
-				&errorMessage, &createdAt, &processedAt, &resolvedAt, &claudeResponse); err != nil {
+			dto, cardID, pageID, err := scanRowToDTO(rows)
+			if err != nil {
+				rows.Close()
 				log.Printf("pokemon: scan list row: %v", err)
 				respondError(w, http.StatusInternalServerError, "failed to list scans")
 				return
 			}
-			dto := ScanJobDTO{
-				ID:        id,
-				Status:    status,
-				CreatedAt: createdAt.UTC().Format(time.RFC3339),
-				HasImage:  scanImageOnDisk(pathEnc),
+			if cardID != "" {
+				jobMatched[dto.ID] = cardID
+				matchedCardIDs = append(matchedCardIDs, cardID)
 			}
-			if confidence.Valid {
-				c := confidence.Float64
-				dto.Confidence = &c
+			if pageID.Valid {
+				if !pageSeen[pageID.Int64] {
+					pageSeen[pageID.Int64] = true
+					pageIDOrder = append(pageIDOrder, pageID.Int64)
+				}
+				continue
 			}
-			if processedAt.Valid {
-				ts := processedAt.Time.UTC().Format(time.RFC3339)
-				dto.ProcessedAt = &ts
-			}
-			if resolvedAt.Valid {
-				ts := resolvedAt.Time.UTC().Format(time.RFC3339)
-				dto.ResolvedAt = &ts
-			}
-			if errorMessage.Valid {
-				dto.ErrorMessage = errorMessage.String
-			}
-			if status == scanJobStatusNoMatch {
-				dto.ParsedSetName, dto.ParsedCollectorNo = extractScanHints(claudeResponse)
-			}
-			if matchedCard.Valid && matchedCard.String != "" {
-				jobMatched[id] = matchedCard.String
-				matchedCardIDs = append(matchedCardIDs, matchedCard.String)
-			}
-			jobs = append(jobs, dto)
+			standalone = append(standalone, dto)
 		}
 		if err := rows.Err(); err != nil {
+			rows.Close()
 			log.Printf("pokemon: iterate scans: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to list scans")
 			return
+		}
+		rows.Close()
+
+		// Load each touched page and ALL its children so the grid renders
+		// the captured layout in full regardless of which children matched
+		// the filter. Order is preserved from the original (newest first)
+		// query so the response is stable.
+		pages := make([]ScanPageDTO, 0, len(pageIDOrder))
+		for _, pid := range pageIDOrder {
+			page, children, cardIDs, err := loadScanPage(r.Context(), db, user.ID, pid)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					continue
+				}
+				log.Printf("pokemon: load scan page %d: %v", pid, err)
+				respondError(w, http.StatusInternalServerError, "failed to list scans")
+				return
+			}
+			page.Children = children
+			for cid, cardID := range cardIDs {
+				if _, ok := jobMatched[cid]; !ok {
+					jobMatched[cid] = cardID
+					matchedCardIDs = append(matchedCardIDs, cardID)
+				}
+			}
+			pages = append(pages, page)
 		}
 
 		if len(matchedCardIDs) > 0 {
@@ -758,36 +782,274 @@ func ListScansHandler(db *sql.DB) http.HandlerFunc {
 				byID[c.ID] = c
 			}
 			sets := make(map[string]*SetDTO)
-			for i := range jobs {
-				cardID, ok := jobMatched[jobs[i].ID]
+			lookupSet := func(setID string) *SetDTO {
+				if setID == "" {
+					return nil
+				}
+				if cached, ok := sets[setID]; ok {
+					return cached
+				}
+				loaded, loadErr := loadSetByID(r.Context(), db, user.ID, setID)
+				if loadErr != nil && !errors.Is(loadErr, sql.ErrNoRows) {
+					log.Printf("pokemon: load matched set %s: %v", setID, loadErr)
+				}
+				sets[setID] = loaded
+				return loaded
+			}
+			hydrate := func(job *ScanJobDTO) {
+				cardID, ok := jobMatched[job.ID]
 				if !ok {
-					continue
+					return
 				}
 				card, ok := byID[cardID]
 				if !ok {
-					continue
+					return
 				}
 				cardCopy := card
-				jobs[i].MatchedCard = &cardCopy
-				if cardCopy.SetID != "" {
-					set, cached := sets[cardCopy.SetID]
-					if !cached {
-						loaded, loadErr := loadSetByID(r.Context(), db, user.ID, cardCopy.SetID)
-						if loadErr != nil && !errors.Is(loadErr, sql.ErrNoRows) {
-							log.Printf("pokemon: load matched set %s: %v", cardCopy.SetID, loadErr)
-						}
-						set = loaded
-						sets[cardCopy.SetID] = set
-					}
-					if set != nil {
-						setCopy := *set
-						jobs[i].Set = &setCopy
-					}
+				job.MatchedCard = &cardCopy
+				if set := lookupSet(cardCopy.SetID); set != nil {
+					setCopy := *set
+					job.Set = &setCopy
+				}
+			}
+			for i := range standalone {
+				hydrate(&standalone[i])
+			}
+			for i := range pages {
+				for j := range pages[i].Children {
+					hydrate(&pages[i].Children[j])
 				}
 			}
 		}
 
-		respondJSON(w, http.StatusOK, map[string]any{"scans": jobs, "today": today})
+		respondJSON(w, http.StatusOK, map[string]any{
+			"scans": standalone,
+			"pages": pages,
+			"today": today,
+		})
+	}
+}
+
+// scanRowToDTO decodes one pokemon_scan_jobs row (already SELECTed) into a
+// ScanJobDTO. Returns the matched_card_id and page_id alongside so the caller
+// can hydrate cards in a single follow-up query and route page-grouped rows
+// into the ScanPageDTO bucket.
+func scanRowToDTO(rows *sql.Rows) (ScanJobDTO, string, sql.NullInt64, error) {
+	var (
+		id             int64
+		status         string
+		pathEnc        string
+		matchedCard    sql.NullString
+		confidence     sql.NullFloat64
+		errorMessage   sql.NullString
+		createdAt      time.Time
+		processedAt    sql.NullTime
+		resolvedAt     sql.NullTime
+		claudeResponse sql.NullString
+		pageID         sql.NullInt64
+	)
+	if err := rows.Scan(&id, &status, &pathEnc, &matchedCard, &confidence,
+		&errorMessage, &createdAt, &processedAt, &resolvedAt, &claudeResponse, &pageID); err != nil {
+		return ScanJobDTO{}, "", sql.NullInt64{}, err
+	}
+	dto := ScanJobDTO{
+		ID:        id,
+		Status:    status,
+		CreatedAt: createdAt.UTC().Format(time.RFC3339),
+		HasImage:  scanImageOnDisk(pathEnc),
+	}
+	if confidence.Valid {
+		c := confidence.Float64
+		dto.Confidence = &c
+	}
+	if processedAt.Valid {
+		ts := processedAt.Time.UTC().Format(time.RFC3339)
+		dto.ProcessedAt = &ts
+	}
+	if resolvedAt.Valid {
+		ts := resolvedAt.Time.UTC().Format(time.RFC3339)
+		dto.ResolvedAt = &ts
+	}
+	if errorMessage.Valid {
+		dto.ErrorMessage = errorMessage.String
+	}
+	if status == scanJobStatusNoMatch {
+		dto.ParsedSetName, dto.ParsedCollectorNo = extractScanHints(claudeResponse)
+	}
+	cardID := ""
+	if matchedCard.Valid {
+		cardID = matchedCard.String
+	}
+	return dto, cardID, pageID, nil
+}
+
+// loadScanPage fetches the parent row plus every child that belongs to it,
+// regardless of the child's status. The matchedCardIDs map (child id →
+// pokemon_cards.id) lets the caller hydrate card metadata for the children
+// in the same batch as standalone scans.
+func loadScanPage(ctx context.Context, db *sql.DB, userID, pageID int64) (ScanPageDTO, []ScanJobDTO, map[int64]string, error) {
+	var (
+		expected  int
+		matched   int
+		createdAt time.Time
+	)
+	err := db.QueryRowContext(ctx, `
+		SELECT expected_count, matched_count, created_at
+		FROM pokemon_scan_pages
+		WHERE id = ? AND user_id = ?
+	`, pageID, userID).Scan(&expected, &matched, &createdAt)
+	if err != nil {
+		return ScanPageDTO{}, nil, nil, err
+	}
+	page := ScanPageDTO{
+		ID:            pageID,
+		ExpectedCount: expected,
+		MatchedCount:  matched,
+		CreatedAt:     createdAt.UTC().Format(time.RFC3339),
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, status, image_path_enc, matched_card_id, confidence,
+		       error_message, created_at, processed_at, resolved_at,
+		       claude_response_enc, page_id
+		FROM pokemon_scan_jobs
+		WHERE user_id = ? AND page_id = ?
+		ORDER BY id ASC
+	`, userID, pageID)
+	if err != nil {
+		return ScanPageDTO{}, nil, nil, err
+	}
+	defer rows.Close()
+
+	children := make([]ScanJobDTO, 0, expected)
+	cardIDs := make(map[int64]string)
+	for rows.Next() {
+		dto, cardID, _, err := scanRowToDTO(rows)
+		if err != nil {
+			return ScanPageDTO{}, nil, nil, err
+		}
+		if cardID != "" {
+			cardIDs[dto.ID] = cardID
+		}
+		children = append(children, dto)
+	}
+	if err := rows.Err(); err != nil {
+		return ScanPageDTO{}, nil, nil, err
+	}
+	return page, children, cardIDs, nil
+}
+
+// DeleteScanPageHandler discards every child of a pokemon_scan_pages parent
+// that isn't already in a terminal added/discarded state, deletes the parent
+// row, and removes the on-disk images. Children already added to the
+// collection are left alone so the user does not lose a card they kept by
+// accident when clicking "Discard page". Returns 204 on success, 404 when
+// the page does not belong to the caller.
+func DeleteScanPageHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		pageID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil || pageID <= 0 {
+			respondError(w, http.StatusBadRequest, "invalid page id")
+			return
+		}
+
+		// Verify ownership before touching anything. A row owned by another
+		// user must 404 (not 403) to avoid leaking the existence of foreign
+		// page ids.
+		var ownerID int64
+		err = db.QueryRowContext(r.Context(), `
+			SELECT user_id FROM pokemon_scan_pages WHERE id = ?
+		`, pageID).Scan(&ownerID)
+		if errors.Is(err, sql.ErrNoRows) || (err == nil && ownerID != user.ID) {
+			respondError(w, http.StatusNotFound, "page not found")
+			return
+		}
+		if err != nil {
+			log.Printf("pokemon: load scan page for delete: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+
+		// Collect the image paths of every child we are about to discard so
+		// we can remove the on-disk files after the transaction commits.
+		// Reading them BEFORE the UPDATE keeps the work outside the write
+		// lock; the file deletes happen post-commit so a crash mid-update
+		// can be reconciled by the scan_cleanup pass.
+		pathRows, err := db.QueryContext(r.Context(), `
+			SELECT image_path_enc FROM pokemon_scan_jobs
+			WHERE user_id = ? AND page_id = ?
+			  AND status NOT IN (?, ?)
+			  AND image_path_enc != ''
+		`, user.ID, pageID, scanJobStatusAdded, scanJobStatusDiscarded)
+		if err != nil {
+			log.Printf("pokemon: load child image paths for page delete: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+		var imagePaths []string
+		for pathRows.Next() {
+			var enc string
+			if err := pathRows.Scan(&enc); err != nil {
+				pathRows.Close()
+				log.Printf("pokemon: scan child path: %v", err)
+				respondError(w, http.StatusInternalServerError, "failed to delete page")
+				return
+			}
+			imagePaths = append(imagePaths, enc)
+		}
+		if err := pathRows.Err(); err != nil {
+			pathRows.Close()
+			log.Printf("pokemon: iterate child paths: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+		pathRows.Close()
+
+		now := time.Now().UTC()
+		tx, err := db.BeginTx(r.Context(), nil)
+		if err != nil {
+			log.Printf("pokemon: begin page delete tx: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+		if _, err := tx.ExecContext(r.Context(), `
+			UPDATE pokemon_scan_jobs
+			SET status = ?, resolved_at = ?, image_path_enc = ''
+			WHERE user_id = ? AND page_id = ?
+			  AND status NOT IN (?, ?)
+		`, scanJobStatusDiscarded, now, user.ID, pageID,
+			scanJobStatusAdded, scanJobStatusDiscarded); err != nil {
+			tx.Rollback()
+			log.Printf("pokemon: discard child scans: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+		// Delete the parent row last so the children's page_id FK transitions
+		// to NULL via ON DELETE SET NULL. The discarded children survive as
+		// history rows reachable via the "Recently resolved" filter.
+		if _, err := tx.ExecContext(r.Context(), `
+			DELETE FROM pokemon_scan_pages WHERE id = ? AND user_id = ?
+		`, pageID, user.ID); err != nil {
+			tx.Rollback()
+			log.Printf("pokemon: delete scan page row: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+		if err := tx.Commit(); err != nil {
+			log.Printf("pokemon: commit page delete: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+
+		for _, enc := range imagePaths {
+			deleteScanImage(enc)
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/pokemon/scans_handlers.go
+++ b/internal/pokemon/scans_handlers.go
@@ -975,41 +975,6 @@ func DeleteScanPageHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		// Collect the image paths of every child we are about to discard so
-		// we can remove the on-disk files after the transaction commits.
-		// Reading them BEFORE the UPDATE keeps the work outside the write
-		// lock; the file deletes happen post-commit so a crash mid-update
-		// can be reconciled by the scan_cleanup pass.
-		pathRows, err := db.QueryContext(r.Context(), `
-			SELECT image_path_enc FROM pokemon_scan_jobs
-			WHERE user_id = ? AND page_id = ?
-			  AND status NOT IN (?, ?)
-			  AND image_path_enc != ''
-		`, user.ID, pageID, scanJobStatusAdded, scanJobStatusDiscarded)
-		if err != nil {
-			log.Printf("pokemon: load child image paths for page delete: %v", err)
-			respondError(w, http.StatusInternalServerError, "failed to delete page")
-			return
-		}
-		var imagePaths []string
-		for pathRows.Next() {
-			var enc string
-			if err := pathRows.Scan(&enc); err != nil {
-				pathRows.Close()
-				log.Printf("pokemon: scan child path: %v", err)
-				respondError(w, http.StatusInternalServerError, "failed to delete page")
-				return
-			}
-			imagePaths = append(imagePaths, enc)
-		}
-		if err := pathRows.Err(); err != nil {
-			pathRows.Close()
-			log.Printf("pokemon: iterate child paths: %v", err)
-			respondError(w, http.StatusInternalServerError, "failed to delete page")
-			return
-		}
-		pathRows.Close()
-
 		now := time.Now().UTC()
 		tx, err := db.BeginTx(r.Context(), nil)
 		if err != nil {
@@ -1017,18 +982,78 @@ func DeleteScanPageHandler(db *sql.DB) http.HandlerFunc {
 			respondError(w, http.StatusInternalServerError, "failed to delete page")
 			return
 		}
-		if _, err := tx.ExecContext(r.Context(), `
+
+		// Mark every non-terminal child as discarded and capture the image
+		// paths of *exactly* the rows we just discarded via RETURNING. Doing
+		// it as a single atomic statement closes the TOCTOU window where a
+		// concurrent INSERT (new sibling) or status flip to 'added' between a
+		// preliminary SELECT and the UPDATE could leave us deleting an image
+		// file still referenced by a row we didn't touch. image_path_enc is
+		// cleared in a follow-up UPDATE keyed by the returned ids so the
+		// RETURNING values reflect the path *before* it was zeroed out.
+		discardedRows, err := tx.QueryContext(r.Context(), `
 			UPDATE pokemon_scan_jobs
-			SET status = ?, resolved_at = ?, image_path_enc = ''
+			SET status = ?, resolved_at = ?
 			WHERE user_id = ? AND page_id = ?
 			  AND status NOT IN (?, ?)
+			RETURNING id, image_path_enc
 		`, scanJobStatusDiscarded, now, user.ID, pageID,
-			scanJobStatusAdded, scanJobStatusDiscarded); err != nil {
+			scanJobStatusAdded, scanJobStatusDiscarded)
+		if err != nil {
 			tx.Rollback()
 			log.Printf("pokemon: discard child scans: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to delete page")
 			return
 		}
+		var (
+			discardedIDs []int64
+			imagePaths   []string
+		)
+		for discardedRows.Next() {
+			var (
+				cID int64
+				enc string
+			)
+			if err := discardedRows.Scan(&cID, &enc); err != nil {
+				discardedRows.Close()
+				tx.Rollback()
+				log.Printf("pokemon: scan discard returning: %v", err)
+				respondError(w, http.StatusInternalServerError, "failed to delete page")
+				return
+			}
+			discardedIDs = append(discardedIDs, cID)
+			if enc != "" {
+				imagePaths = append(imagePaths, enc)
+			}
+		}
+		if err := discardedRows.Err(); err != nil {
+			discardedRows.Close()
+			tx.Rollback()
+			log.Printf("pokemon: iterate discard returning: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+		discardedRows.Close()
+
+		if len(discardedIDs) > 0 {
+			placeholders := make([]string, len(discardedIDs))
+			args := make([]any, len(discardedIDs))
+			for i, id := range discardedIDs {
+				placeholders[i] = "?"
+				args[i] = id
+			}
+			if _, err := tx.ExecContext(r.Context(), `
+				UPDATE pokemon_scan_jobs
+				SET image_path_enc = ''
+				WHERE id IN (`+strings.Join(placeholders, ",")+`)
+			`, args...); err != nil {
+				tx.Rollback()
+				log.Printf("pokemon: clear discarded paths: %v", err)
+				respondError(w, http.StatusInternalServerError, "failed to delete page")
+				return
+			}
+		}
+
 		// Delete the parent row last so the children's page_id FK transitions
 		// to NULL via ON DELETE SET NULL. The discarded children survive as
 		// history rows reachable via the "Recently resolved" filter.
@@ -1046,6 +1071,9 @@ func DeleteScanPageHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		// File deletes happen post-commit: a crash mid-loop leaves orphaned
+		// files reachable by the scan_cleanup pass, while deleting before
+		// commit risks losing files we'd need to keep on rollback.
 		for _, enc := range imagePaths {
 			deleteScanImage(enc)
 		}

--- a/internal/pokemon/scans_handlers.go
+++ b/internal/pokemon/scans_handlers.go
@@ -975,6 +975,25 @@ func DeleteScanPageHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		// Reject the discard while any child is still being processed by the
+		// scan worker. A worker that finishes after we discard the row updates
+		// by id only (no status guard), so it would silently overwrite the
+		// 'discarded' status back to 'matched'/'no_match'/'failed' and leave
+		// the image_path_enc pointing at a file we may have deleted.
+		var processingCount int
+		if err := db.QueryRowContext(r.Context(), `
+			SELECT COUNT(*) FROM pokemon_scan_jobs
+			WHERE user_id = ? AND page_id = ? AND status = ?
+		`, user.ID, pageID, scanJobStatusProcessing).Scan(&processingCount); err != nil {
+			log.Printf("pokemon: check processing children: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+		if processingCount > 0 {
+			respondError(w, http.StatusConflict, "page has cards still being processed; retry after they complete")
+			return
+		}
+
 		now := time.Now().UTC()
 		tx, err := db.BeginTx(r.Context(), nil)
 		if err != nil {

--- a/internal/pokemon/scans_handlers.go
+++ b/internal/pokemon/scans_handlers.go
@@ -975,30 +975,36 @@ func DeleteScanPageHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		// Reject the discard while any child is still being processed by the
-		// scan worker. A worker that finishes after we discard the row updates
-		// by id only (no status guard), so it would silently overwrite the
-		// 'discarded' status back to 'matched'/'no_match'/'failed' and leave
-		// the image_path_enc pointing at a file we may have deleted.
+		// Acquire a write lock immediately so the processing check and the
+		// discard UPDATE are atomic with respect to the scan worker. Without
+		// BEGIN IMMEDIATE a queued row can flip to processing between the
+		// pre-transaction check and the UPDATE; the worker would then
+		// finalise by id (no status guard) and silently overwrite 'discarded'
+		// back to 'matched'/'no_match'/'failed', leaving image_path_enc
+		// pointing at a file we may have already deleted.
+		now := time.Now().UTC()
+		tx, err := db.BeginTx(r.Context(), &sql.TxOptions{Isolation: sql.LevelSerializable})
+		if err != nil {
+			log.Printf("pokemon: begin page delete tx: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to delete page")
+			return
+		}
+
+		// Re-check for processing children inside the write lock so no new
+		// status flip can sneak in after this point.
 		var processingCount int
-		if err := db.QueryRowContext(r.Context(), `
+		if err := tx.QueryRowContext(r.Context(), `
 			SELECT COUNT(*) FROM pokemon_scan_jobs
 			WHERE user_id = ? AND page_id = ? AND status = ?
 		`, user.ID, pageID, scanJobStatusProcessing).Scan(&processingCount); err != nil {
+			tx.Rollback()
 			log.Printf("pokemon: check processing children: %v", err)
 			respondError(w, http.StatusInternalServerError, "failed to delete page")
 			return
 		}
 		if processingCount > 0 {
+			tx.Rollback()
 			respondError(w, http.StatusConflict, "page has cards still being processed; retry after they complete")
-			return
-		}
-
-		now := time.Now().UTC()
-		tx, err := db.BeginTx(r.Context(), nil)
-		if err != nil {
-			log.Printf("pokemon: begin page delete tx: %v", err)
-			respondError(w, http.StatusInternalServerError, "failed to delete page")
 			return
 		}
 
@@ -1014,10 +1020,10 @@ func DeleteScanPageHandler(db *sql.DB) http.HandlerFunc {
 			UPDATE pokemon_scan_jobs
 			SET status = ?, resolved_at = ?
 			WHERE user_id = ? AND page_id = ?
-			  AND status NOT IN (?, ?)
+			  AND status NOT IN (?, ?, ?)
 			RETURNING id, image_path_enc
 		`, scanJobStatusDiscarded, now, user.ID, pageID,
-			scanJobStatusAdded, scanJobStatusDiscarded)
+			scanJobStatusAdded, scanJobStatusDiscarded, scanJobStatusProcessing)
 		if err != nil {
 			tx.Rollback()
 			log.Printf("pokemon: discard child scans: %v", err)

--- a/internal/pokemon/scans_handlers_test.go
+++ b/internal/pokemon/scans_handlers_test.go
@@ -1875,3 +1875,50 @@ func TestDeleteScanPage_OtherUserReturns404(t *testing.T) {
 		t.Errorf("expected page still present, got %d rows", pageRows)
 	}
 }
+
+// TestDeleteScanPage_RejectsWhileProcessing guards against the race where a
+// scan worker finishes *after* the page-discard update and silently overwrites
+// the 'discarded' status back to 'matched'/'no_match'/'failed'. The handler
+// must return 409 Conflict when any child is still in 'processing' state.
+func TestDeleteScanPage_RejectsWhileProcessing(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "processing-race@example.com")
+
+	now := time.Now().UTC()
+	pageID := insertScanPage(t, db, u.ID, 2, now)
+	p1 := writeOnDiskImage(t, root, u.ID, "proc-1.jpg")
+	p2 := writeOnDiskImage(t, root, u.ID, "proc-2.jpg")
+	c1 := insertScanJob(t, db, u.ID, scanJobStatusProcessing, p1, withCreatedAt(now))
+	c2 := insertScanJob(t, db, u.ID, scanJobStatusMatched, p2,
+		withCreatedAt(now), withMatchedCard("sv1-25", 0.9))
+	linkScanJobToPage(t, db, c1, pageID)
+	linkScanJobToPage(t, db, c2, pageID)
+
+	req := asUser(httptest.NewRequest(http.MethodDelete,
+		"/api/pokemon/scans/pages/"+strconv.FormatInt(pageID, 10), nil), u)
+	req = asChi(req, map[string]string{"id": strconv.FormatInt(pageID, 10)})
+	rec := httptest.NewRecorder()
+	DeleteScanPageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 while a child is processing, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Parent must still exist and the child statuses must be unchanged.
+	var pageRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pokemon_scan_pages WHERE id = ?`, pageID).Scan(&pageRows); err != nil {
+		t.Fatalf("count pages: %v", err)
+	}
+	if pageRows != 1 {
+		t.Errorf("expected page still present after rejected delete, got %d rows", pageRows)
+	}
+	var procStatus string
+	if err := db.QueryRow(`SELECT status FROM pokemon_scan_jobs WHERE id = ?`, c1).Scan(&procStatus); err != nil {
+		t.Fatalf("read processing child: %v", err)
+	}
+	if procStatus != scanJobStatusProcessing {
+		t.Errorf("expected processing child status unchanged, got %q", procStatus)
+	}
+}

--- a/internal/pokemon/scans_handlers_test.go
+++ b/internal/pokemon/scans_handlers_test.go
@@ -1578,3 +1578,300 @@ func TestPageScan_RejectsBadMIME(t *testing.T) {
 		t.Errorf("expected no pokemon_scan_pages on bad MIME, got %d", pageRows)
 	}
 }
+
+// insertScanPage seeds a pokemon_scan_pages parent row directly so list /
+// delete tests can build a known-shape page without going through the
+// multipart upload handler.
+func insertScanPage(t *testing.T, db *sql.DB, userID int64, expected int, createdAt time.Time) int64 {
+	t.Helper()
+	res, err := db.Exec(`
+		INSERT INTO pokemon_scan_pages (user_id, page_image_path_enc, expected_count, matched_count, created_at)
+		VALUES (?, '', ?, 0, ?)
+	`, userID, expected, createdAt)
+	if err != nil {
+		t.Fatalf("insert scan page: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("scan page last id: %v", err)
+	}
+	return id
+}
+
+// linkScanJobToPage stamps page_id on an existing scan job. Tests use this
+// to attach previously-inserted children to a freshly-seeded parent.
+func linkScanJobToPage(t *testing.T, db *sql.DB, jobID, pageID int64) {
+	t.Helper()
+	if _, err := db.Exec(`UPDATE pokemon_scan_jobs SET page_id = ? WHERE id = ?`, pageID, jobID); err != nil {
+		t.Fatalf("link scan job to page: %v", err)
+	}
+}
+
+// TestListScans_PageReturnsAllChildrenRegardlessOfStatus is the core grid
+// contract: when the status filter matches any child of a page, the list
+// response must include the parent and ALL of its children (even those whose
+// individual status falls outside the filter) so the frontend can render the
+// full captured layout in one block.
+func TestListScans_PageReturnsAllChildrenRegardlessOfStatus(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "page-list@example.com")
+
+	now := time.Now().UTC()
+	pageID := insertScanPage(t, db, u.ID, 4, now)
+	// Four children spanning the full lifecycle: only one matches the
+	// "needs review" filter (matched), but all four must come back.
+	p1 := writeOnDiskImage(t, root, u.ID, "queued.jpg")
+	p2 := writeOnDiskImage(t, root, u.ID, "match.jpg")
+	p3 := writeOnDiskImage(t, root, u.ID, "no-match.jpg")
+	p4 := writeOnDiskImage(t, root, u.ID, "failed.jpg")
+	c1 := insertScanJob(t, db, u.ID, scanJobStatusQueued, p1, withCreatedAt(now))
+	c2 := insertScanJob(t, db, u.ID, scanJobStatusMatched, p2,
+		withCreatedAt(now), withMatchedCard("sv1-25", 0.92))
+	c3 := insertScanJob(t, db, u.ID, scanJobStatusNoMatch, p3,
+		withCreatedAt(now), withError("low confidence"))
+	c4 := insertScanJob(t, db, u.ID, scanJobStatusFailed, p4,
+		withCreatedAt(now), withError("boom"))
+	linkScanJobToPage(t, db, c1, pageID)
+	linkScanJobToPage(t, db, c2, pageID)
+	linkScanJobToPage(t, db, c3, pageID)
+	linkScanJobToPage(t, db, c4, pageID)
+
+	req := asUser(httptest.NewRequest(http.MethodGet,
+		"/api/pokemon/scans?status=matched,no_match,failed", nil), u)
+	rec := httptest.NewRecorder()
+	ListScansHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Scans []ScanJobDTO  `json:"scans"`
+		Pages []ScanPageDTO `json:"pages"`
+	}](t, rec)
+	if len(body.Scans) != 0 {
+		t.Errorf("expected zero standalone scans, got %d", len(body.Scans))
+	}
+	if len(body.Pages) != 1 {
+		t.Fatalf("expected one page, got %d", len(body.Pages))
+	}
+	page := body.Pages[0]
+	if page.ID != pageID {
+		t.Errorf("expected page id=%d, got %d", pageID, page.ID)
+	}
+	if page.ExpectedCount != 4 {
+		t.Errorf("expected expected_count=4, got %d", page.ExpectedCount)
+	}
+	if len(page.Children) != 4 {
+		t.Fatalf("expected all 4 children, got %d", len(page.Children))
+	}
+	gotStatuses := map[string]bool{}
+	for _, child := range page.Children {
+		gotStatuses[child.Status] = true
+	}
+	for _, want := range []string{scanJobStatusQueued, scanJobStatusMatched, scanJobStatusNoMatch, scanJobStatusFailed} {
+		if !gotStatuses[want] {
+			t.Errorf("expected child with status %q in grid, got statuses %v", want, gotStatuses)
+		}
+	}
+	// The matched child must have its card hydrated so the grid can render
+	// the card name without an extra round trip.
+	var matchedChild *ScanJobDTO
+	for i := range page.Children {
+		if page.Children[i].Status == scanJobStatusMatched {
+			matchedChild = &page.Children[i]
+			break
+		}
+	}
+	if matchedChild == nil || matchedChild.MatchedCard == nil || matchedChild.MatchedCard.ID != "sv1-25" {
+		t.Errorf("expected matched child to carry hydrated card sv1-25, got %+v", matchedChild)
+	}
+}
+
+// TestListScans_StandaloneAndPageInSameResponse verifies that page-grouped
+// scans and standalone scans coexist in the response without collisions:
+// standalone rows stay in `scans`, pages go in `pages`, and a single matched
+// card is hydrated correctly in both buckets.
+func TestListScans_StandaloneAndPageInSameResponse(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "mixed@example.com")
+
+	now := time.Now().UTC()
+	standalonePath := writeOnDiskImage(t, root, u.ID, "standalone.jpg")
+	insertScanJob(t, db, u.ID, scanJobStatusMatched, standalonePath,
+		withCreatedAt(now.Add(-1*time.Minute)), withMatchedCard("sv1-25", 0.9))
+
+	pageID := insertScanPage(t, db, u.ID, 2, now)
+	pp1 := writeOnDiskImage(t, root, u.ID, "page-child.jpg")
+	pc := insertScanJob(t, db, u.ID, scanJobStatusMatched, pp1,
+		withCreatedAt(now), withMatchedCard("sv1-25", 0.9))
+	linkScanJobToPage(t, db, pc, pageID)
+
+	req := asUser(httptest.NewRequest(http.MethodGet,
+		"/api/pokemon/scans?status=matched", nil), u)
+	rec := httptest.NewRecorder()
+	ListScansHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[struct {
+		Scans []ScanJobDTO  `json:"scans"`
+		Pages []ScanPageDTO `json:"pages"`
+	}](t, rec)
+	if len(body.Scans) != 1 {
+		t.Fatalf("expected one standalone scan, got %d", len(body.Scans))
+	}
+	if body.Scans[0].MatchedCard == nil || body.Scans[0].MatchedCard.ID != "sv1-25" {
+		t.Errorf("expected standalone matched card hydrated, got %+v", body.Scans[0].MatchedCard)
+	}
+	if len(body.Pages) != 1 {
+		t.Fatalf("expected one page, got %d", len(body.Pages))
+	}
+	if len(body.Pages[0].Children) != 1 {
+		t.Errorf("expected one child in page, got %d", len(body.Pages[0].Children))
+	}
+}
+
+// TestDeleteScanPage_DiscardsChildrenAndRemovesParent verifies the page-level
+// discard: every non-terminal child is soft-discarded (status='discarded',
+// image_path cleared), the parent row is removed, and the on-disk files are
+// reaped.
+func TestDeleteScanPage_DiscardsChildrenAndRemovesParent(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "delete-page@example.com")
+
+	now := time.Now().UTC()
+	pageID := insertScanPage(t, db, u.ID, 3, now)
+	p1 := writeOnDiskImage(t, root, u.ID, "del-1.jpg")
+	p2 := writeOnDiskImage(t, root, u.ID, "del-2.jpg")
+	p3 := writeOnDiskImage(t, root, u.ID, "del-3.jpg")
+	c1 := insertScanJob(t, db, u.ID, scanJobStatusMatched, p1,
+		withCreatedAt(now), withMatchedCard("sv1-25", 0.9))
+	c2 := insertScanJob(t, db, u.ID, scanJobStatusNoMatch, p2, withCreatedAt(now))
+	c3 := insertScanJob(t, db, u.ID, scanJobStatusQueued, p3, withCreatedAt(now))
+	linkScanJobToPage(t, db, c1, pageID)
+	linkScanJobToPage(t, db, c2, pageID)
+	linkScanJobToPage(t, db, c3, pageID)
+
+	req := asUser(httptest.NewRequest(http.MethodDelete,
+		"/api/pokemon/scans/pages/"+strconv.FormatInt(pageID, 10), nil), u)
+	req = asChi(req, map[string]string{"id": strconv.FormatInt(pageID, 10)})
+	rec := httptest.NewRecorder()
+	DeleteScanPageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var pageRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pokemon_scan_pages WHERE id = ?`, pageID).Scan(&pageRows); err != nil {
+		t.Fatalf("count pages: %v", err)
+	}
+	if pageRows != 0 {
+		t.Errorf("expected parent row deleted, found %d", pageRows)
+	}
+
+	for _, cID := range []int64{c1, c2, c3} {
+		var status, pathEnc string
+		if err := db.QueryRow(`SELECT status, image_path_enc FROM pokemon_scan_jobs WHERE id = ?`, cID).Scan(&status, &pathEnc); err != nil {
+			t.Fatalf("read child %d: %v", cID, err)
+		}
+		if status != scanJobStatusDiscarded {
+			t.Errorf("child %d expected status=discarded, got %q", cID, status)
+		}
+		if pathEnc != "" {
+			t.Errorf("child %d expected cleared image_path_enc, got non-empty", cID)
+		}
+	}
+	for _, p := range []string{p1, p2, p3} {
+		if _, err := os.Stat(p); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("expected on-disk image %s removed, got err=%v", p, err)
+		}
+	}
+}
+
+// TestDeleteScanPage_PreservesAddedChildren ensures that children that the
+// user has already added to their collection are left alone: page-discard is
+// a "throw away the rest" action, not a retroactive removal of accepted cards.
+func TestDeleteScanPage_PreservesAddedChildren(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "delete-keep@example.com")
+
+	now := time.Now().UTC()
+	pageID := insertScanPage(t, db, u.ID, 2, now)
+	pAdded := writeOnDiskImage(t, root, u.ID, "added.jpg")
+	pQueued := writeOnDiskImage(t, root, u.ID, "queued.jpg")
+	addedID := insertScanJob(t, db, u.ID, scanJobStatusAdded, pAdded,
+		withCreatedAt(now), withMatchedCard("sv1-25", 0.9))
+	queuedID := insertScanJob(t, db, u.ID, scanJobStatusQueued, pQueued, withCreatedAt(now))
+	linkScanJobToPage(t, db, addedID, pageID)
+	linkScanJobToPage(t, db, queuedID, pageID)
+
+	req := asUser(httptest.NewRequest(http.MethodDelete,
+		"/api/pokemon/scans/pages/"+strconv.FormatInt(pageID, 10), nil), u)
+	req = asChi(req, map[string]string{"id": strconv.FormatInt(pageID, 10)})
+	rec := httptest.NewRecorder()
+	DeleteScanPageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var addedStatus string
+	if err := db.QueryRow(`SELECT status FROM pokemon_scan_jobs WHERE id = ?`, addedID).Scan(&addedStatus); err != nil {
+		t.Fatalf("read added child: %v", err)
+	}
+	if addedStatus != scanJobStatusAdded {
+		t.Errorf("expected already-added child preserved, got %q", addedStatus)
+	}
+	var queuedStatus string
+	if err := db.QueryRow(`SELECT status FROM pokemon_scan_jobs WHERE id = ?`, queuedID).Scan(&queuedStatus); err != nil {
+		t.Fatalf("read queued child: %v", err)
+	}
+	if queuedStatus != scanJobStatusDiscarded {
+		t.Errorf("expected queued child discarded, got %q", queuedStatus)
+	}
+}
+
+// TestDeleteScanPage_OtherUserReturns404 confirms cross-user isolation: a
+// caller may not delete or even probe the existence of another user's page.
+func TestDeleteScanPage_OtherUserReturns404(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	uA := seedUser(t, db, 1, "owner@example.com")
+	uB := seedUser(t, db, 2, "stranger@example.com")
+
+	pageID := insertScanPage(t, db, uA.ID, 1, time.Now().UTC())
+
+	req := asUser(httptest.NewRequest(http.MethodDelete,
+		"/api/pokemon/scans/pages/"+strconv.FormatInt(pageID, 10), nil), uB)
+	req = asChi(req, map[string]string{"id": strconv.FormatInt(pageID, 10)})
+	rec := httptest.NewRecorder()
+	DeleteScanPageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for other user's page, got %d", rec.Code)
+	}
+	// Parent row must survive an unauthorised delete attempt.
+	var pageRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pokemon_scan_pages WHERE id = ?`, pageID).Scan(&pageRows); err != nil {
+		t.Fatalf("count pages: %v", err)
+	}
+	if pageRows != 1 {
+		t.Errorf("expected page still present, got %d rows", pageRows)
+	}
+}

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -204,6 +204,19 @@
       "useAutoMatchInstead": "Use auto-match instead",
       "searchPlaceholder": "Search for the right card — name or number",
       "searchFailed": "Failed to search cards"
+    },
+    "page": {
+      "label": "Binder page",
+      "progress": "{{matched}} / {{total}} matched",
+      "addAllMatched": "Add all matched ({{count}})",
+      "discardPage": "Discard page",
+      "confirmDiscard": "Discard this whole page? Cards you've already added will be kept.",
+      "cancel": "Cancel",
+      "discardConfirm": "Yes, discard",
+      "addAllToast": "Added {{count}} cards",
+      "addAllPartial": "{{count}} cards could not be added",
+      "discardToast": "Page discarded",
+      "discardFailed": "Failed to discard page"
     }
   },
   "scanner": {

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -204,6 +204,19 @@
       "useAutoMatchInstead": "Bruk auto-treffet i stedet",
       "searchPlaceholder": "Søk etter riktig kort — navn eller nummer",
       "searchFailed": "Kunne ikke søke etter kort"
+    },
+    "page": {
+      "label": "Perm-side",
+      "progress": "{{matched}} / {{total}} treff",
+      "addAllMatched": "Legg til alle treff ({{count}})",
+      "discardPage": "Forkast siden",
+      "confirmDiscard": "Forkast hele denne siden? Kort du allerede har lagt til beholdes.",
+      "cancel": "Avbryt",
+      "discardConfirm": "Ja, forkast",
+      "addAllToast": "La til {{count}} kort",
+      "addAllPartial": "{{count}} kort kunne ikke legges til",
+      "discardToast": "Siden er forkastet",
+      "discardFailed": "Kunne ikke forkaste siden"
     }
   },
   "scanner": {

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -202,6 +202,19 @@
       "useAutoMatchInstead": "ใช้ผลที่ตรงอัตโนมัติแทน",
       "searchPlaceholder": "ค้นหาการ์ดที่ถูกต้อง — ชื่อหรือหมายเลข",
       "searchFailed": "ค้นหาการ์ดไม่สำเร็จ"
+    },
+    "page": {
+      "label": "หน้าแฟ้ม",
+      "progress": "ตรงแล้ว {{matched}} / {{total}}",
+      "addAllMatched": "เพิ่มทุกใบที่ตรง ({{count}})",
+      "discardPage": "ทิ้งทั้งหน้า",
+      "confirmDiscard": "ทิ้งหน้านี้ทั้งหมดใช่ไหม? การ์ดที่เพิ่มไปแล้วจะถูกเก็บไว้",
+      "cancel": "ยกเลิก",
+      "discardConfirm": "ใช่ ทิ้ง",
+      "addAllToast": "เพิ่มแล้ว {{count}} ใบ",
+      "addAllPartial": "เพิ่มไม่สำเร็จ {{count}} ใบ",
+      "discardToast": "ทิ้งหน้าแล้ว",
+      "discardFailed": "ทิ้งหน้าไม่สำเร็จ"
     }
   },
   "scanner": {

--- a/web/src/components/pokemon/ScanPageGrid.tsx
+++ b/web/src/components/pokemon/ScanPageGrid.tsx
@@ -103,11 +103,11 @@ function statusToBadgeClass(status: ScanPageGridStatus): string {
   }
 }
 
-// gridDimensions picks the rows/cols layout from the page's expected_count.
-// 12 → 4 columns × 3 rows (the larger binder page); everything else falls
-// back to 3 × 3 which matches the default 9-pocket page. The detection is
-// deliberately conservative: a 6 or 4 page is still rendered as a 3×3 grid
-// with empty placeholders rather than guessing an unusual layout.
+// gridDimensions picks the rows/cols layout from the page's expected_count:
+//   4  → 2 × 2
+//   6  → 2 × 3
+//   12 → 3 × 4 (larger binder page)
+// Everything else falls back to 3 × 3 (default 9-pocket page).
 function gridDimensions(expectedCount: number): { rows: number; cols: number } {
   if (expectedCount === 12) return { rows: 3, cols: 4 }
   if (expectedCount === 4) return { rows: 2, cols: 2 }
@@ -310,7 +310,7 @@ export default function ScanPageGrid({
   }, [page.children, totalCells])
 
   const matchedCount = useMemo(
-    () => page.children.filter(c => c.status === 'matched').length,
+    () => page.children.filter(c => c.status === 'matched' && c.matched_card).length,
     [page.children],
   )
 

--- a/web/src/components/pokemon/ScanPageGrid.tsx
+++ b/web/src/components/pokemon/ScanPageGrid.tsx
@@ -1,0 +1,408 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
+import { ChevronRight, Loader2 } from 'lucide-react'
+
+// CardDTO and ScanJob types mirror the shapes used by PokemonScanned.tsx.
+// They are duplicated here (rather than imported) to keep this component
+// independently testable without pulling the whole page module.
+export interface ScanPageGridCard {
+  id: string
+  set_id: string
+  set_name?: string
+  name: string
+  collector_no: string
+  rarity: string
+  image_small_url: string
+  image_large_url: string
+  variants: Array<{
+    id: number
+    kind: string
+    price_eur: number
+    price_nok: number | null
+    owned?: boolean
+    owned_id?: number | null
+    quantity?: number
+    condition?: string
+    notes?: string
+  }>
+}
+
+export type ScanPageGridStatus =
+  | 'queued'
+  | 'processing'
+  | 'matched'
+  | 'no_match'
+  | 'failed'
+  | 'added'
+  | 'discarded'
+
+export interface ScanPageGridChild {
+  id: number
+  status: ScanPageGridStatus
+  created_at: string
+  processed_at?: string | null
+  resolved_at?: string | null
+  confidence?: number | null
+  matched_card?: ScanPageGridCard | null
+  set?: { id: string; name: string } | null
+  error_message?: string
+  has_image: boolean
+  parsed_set_name?: string
+  parsed_collector_no?: string
+}
+
+export interface ScanPageGridResolveBody {
+  action: 'add' | 'discard' | 'retry'
+  variant_id?: number
+  quantity?: number
+  condition?: string
+  notes?: string
+  card_id?: string
+}
+
+export interface ScanPageGridParent {
+  id: number
+  expected_count: number
+  matched_count: number
+  created_at: string
+  children: ScanPageGridChild[]
+}
+
+interface ScanPageGridProps {
+  page: ScanPageGridParent
+  busyChildId: number | null
+  highlighted: boolean
+  blockRef?: (el: HTMLDivElement | null) => void
+  onResolveChild: (child: ScanPageGridChild, body: ScanPageGridResolveBody) => Promise<void> | void
+  onOpenDetail: (child: ScanPageGridChild) => void
+  onEnterManually: (child: ScanPageGridChild) => void
+  onAddAllMatched: (page: ScanPageGridParent) => Promise<void> | void
+  onDiscardPage: (page: ScanPageGridParent) => Promise<void> | void
+}
+
+// statusToBadgeClass keeps the per-status colour mapping next to the cell
+// rendering so the grid stays visually consistent with the list-view pill
+// even though it's a smaller, in-cell badge.
+function statusToBadgeClass(status: ScanPageGridStatus): string {
+  switch (status) {
+    case 'queued':
+      return 'bg-gray-700 text-gray-200'
+    case 'processing':
+      return 'bg-blue-600/30 text-blue-200 border border-blue-500/40'
+    case 'matched':
+      return 'bg-emerald-600/30 text-emerald-200 border border-emerald-500/40'
+    case 'no_match':
+      return 'bg-amber-600/30 text-amber-200 border border-amber-500/40'
+    case 'failed':
+      return 'bg-red-700/40 text-red-200 border border-red-600/50'
+    case 'added':
+      return 'bg-gray-700 text-gray-300'
+    case 'discarded':
+      return 'bg-gray-800 text-gray-400'
+  }
+}
+
+// gridDimensions picks the rows/cols layout from the page's expected_count.
+// 12 → 4 columns × 3 rows (the larger binder page); everything else falls
+// back to 3 × 3 which matches the default 9-pocket page. The detection is
+// deliberately conservative: a 6 or 4 page is still rendered as a 3×3 grid
+// with empty placeholders rather than guessing an unusual layout.
+function gridDimensions(expectedCount: number): { rows: number; cols: number } {
+  if (expectedCount === 12) return { rows: 3, cols: 4 }
+  if (expectedCount === 4) return { rows: 2, cols: 2 }
+  if (expectedCount === 6) return { rows: 2, cols: 3 }
+  return { rows: 3, cols: 3 }
+}
+
+interface CellThumbnailProps {
+  child: ScanPageGridChild
+  t: TFunction<'pokemon'>
+}
+
+// CellThumbnail renders a fixed-aspect 3:4 image area so every cell has the
+// same visual footprint regardless of whether the action bar pushes the
+// surrounding cell taller.
+function CellThumbnail({ child, t }: CellThumbnailProps) {
+  const [errored, setErrored] = useState(false)
+  const showImage = child.has_image && !errored
+  return (
+    <div className="relative aspect-[3/4] w-full bg-gray-900/60 flex items-center justify-center overflow-hidden">
+      {showImage ? (
+        <img
+          src={`/api/pokemon/scans/${child.id}/image`}
+          alt={t('scanned.thumbnailAlt')}
+          loading="lazy"
+          onError={() => setErrored(true)}
+          className="max-h-full max-w-full object-contain"
+        />
+      ) : (
+        <span className="px-1 text-[10px] text-center text-gray-500 leading-tight">
+          {t('scanned.thumbnailPlaceholder')}
+        </span>
+      )}
+      {(child.status === 'queued' || child.status === 'processing') && (
+        <div className="absolute inset-0 flex items-center justify-center bg-gray-950/40">
+          <Loader2 size={20} className="animate-spin text-gray-300" aria-hidden="true" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface CellProps {
+  child: ScanPageGridChild | null
+  busy: boolean
+  onResolve: (child: ScanPageGridChild, body: ScanPageGridResolveBody) => Promise<void> | void
+  onOpenDetail: (child: ScanPageGridChild) => void
+  onEnterManually: (child: ScanPageGridChild) => void
+  t: TFunction<'pokemon'>
+}
+
+function ScanPageCell({ child, busy, onResolve, onOpenDetail, onEnterManually, t }: CellProps) {
+  // Empty placeholder cells (page captured fewer rows than the configured
+  // layout) keep the grid shape intact without ever being interactive.
+  if (!child) {
+    return (
+      <div
+        data-testid="scan-page-cell-empty"
+        className="aspect-[3/4] rounded border border-dashed border-gray-800 bg-gray-900/30"
+      />
+    )
+  }
+
+  const handleDiscard = () => {
+    void onResolve(child, { action: 'discard' })
+  }
+  const handleRetry = () => {
+    void onResolve(child, { action: 'retry' })
+  }
+
+  const card = child.matched_card ?? null
+  const isMatched = child.status === 'matched' && card != null
+
+  const wrapperClass =
+    'rounded border border-gray-800 bg-gray-800/40 overflow-hidden flex flex-col text-left'
+
+  const labelBlock = (
+    <div className="flex flex-col gap-1 p-1.5">
+      <span
+        data-testid={`scan-page-cell-pill-${child.id}`}
+        className={`self-start inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${statusToBadgeClass(child.status)}`}
+      >
+        {t(`scanned.status.${child.status === 'no_match' ? 'noMatch' : child.status}` as 'scanned.status.queued')}
+      </span>
+      {isMatched && card != null && (
+        <span className="text-[11px] text-white font-medium truncate">{card.name}</span>
+      )}
+      {isMatched && (
+        <span className="text-[10px] text-gray-300 flex items-center gap-0.5">
+          {t('scanned.tapToReview')}
+          <ChevronRight size={12} aria-hidden="true" />
+        </span>
+      )}
+    </div>
+  )
+
+  if (isMatched) {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpenDetail(child)}
+        data-testid={`scan-page-cell-${child.id}`}
+        data-status={child.status}
+        aria-label={t('scanned.detail.openLabel', { name: card?.name ?? '' })}
+        className={`${wrapperClass} hover:border-emerald-500/60 transition-colors cursor-pointer`}
+      >
+        <CellThumbnail child={child} t={t} />
+        {labelBlock}
+      </button>
+    )
+  }
+
+  const showActions = child.status === 'no_match' || child.status === 'failed'
+
+  return (
+    <div
+      data-testid={`scan-page-cell-${child.id}`}
+      data-status={child.status}
+      className={wrapperClass}
+    >
+      <CellThumbnail child={child} t={t} />
+      {labelBlock}
+      {showActions && (
+        <div
+          data-testid={`scan-page-cell-actions-${child.id}`}
+          className="flex flex-wrap items-center justify-center gap-1 p-1.5 bg-gray-950/40 border-t border-gray-800"
+        >
+          <button
+            type="button"
+            onClick={handleRetry}
+            disabled={busy}
+            data-testid={`scan-page-cell-retry-${child.id}`}
+            className="px-1.5 py-1 text-[10px] rounded border border-gray-600 hover:border-gray-400 disabled:opacity-60 disabled:cursor-not-allowed text-gray-100 cursor-pointer bg-gray-900/80"
+          >
+            {t('scanned.action.retry')}
+          </button>
+          <button
+            type="button"
+            onClick={handleDiscard}
+            disabled={busy}
+            data-testid={`scan-page-cell-discard-${child.id}`}
+            className="px-1.5 py-1 text-[10px] rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-60 disabled:cursor-not-allowed text-white cursor-pointer"
+          >
+            {t('scanned.action.discard')}
+          </button>
+          {child.status === 'no_match' && (
+            <button
+              type="button"
+              onClick={() => onEnterManually(child)}
+              data-testid={`scan-page-cell-manual-${child.id}`}
+              className="px-1.5 py-1 text-[10px] rounded border border-gray-600 hover:border-gray-400 text-gray-100 cursor-pointer bg-gray-900/80"
+            >
+              {t('scanned.action.enterManually')}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ScanPageGrid renders a single pokemon_scan_pages parent as a CSS grid
+// matching the captured layout (3×3 for 9, 4×3 for 12, etc.) and gives the
+// kid two parent-level actions:
+//   • "Add all matched" — runs the existing /resolve POST on every child
+//     currently in the matched state, letting them accept a whole page in
+//     one click without opening each cell.
+//   • "Discard page" — calls DELETE /api/pokemon/scans/pages/{id} to drop
+//     the parent + the still-pending children.
+//
+// Per-cell Add / Discard / Manual-search actions reuse the same resolve
+// callbacks as the standalone list rows so the matching, queueing, and
+// detail-modal flows behave identically inside and outside a page block.
+export default function ScanPageGrid({
+  page,
+  busyChildId,
+  highlighted,
+  blockRef,
+  onResolveChild,
+  onOpenDetail,
+  onEnterManually,
+  onAddAllMatched,
+  onDiscardPage,
+}: ScanPageGridProps) {
+  const { t } = useTranslation('pokemon')
+
+  const { rows, cols } = useMemo(() => gridDimensions(page.expected_count), [page.expected_count])
+  const totalCells = rows * cols
+
+  // The captured ordering of children comes from the upload's cells array,
+  // but the API returns them sorted by id. We render in array order so the
+  // visual grid stays stable across polls; missing slots get placeholder
+  // cells so the layout is preserved even if a row count is short.
+  const cells: Array<ScanPageGridChild | null> = useMemo(() => {
+    const list: Array<ScanPageGridChild | null> = []
+    for (let i = 0; i < totalCells; i++) {
+      list.push(page.children[i] ?? null)
+    }
+    return list
+  }, [page.children, totalCells])
+
+  const matchedCount = useMemo(
+    () => page.children.filter(c => c.status === 'matched').length,
+    [page.children],
+  )
+
+  const [confirmDiscard, setConfirmDiscard] = useState(false)
+
+  const containerClass = `rounded-lg border bg-gray-900/40 transition-shadow duration-700 ${
+    highlighted
+      ? 'border-emerald-400 ring-2 ring-emerald-400/70 shadow-lg shadow-emerald-500/20'
+      : 'border-gray-800'
+  }`
+
+  return (
+    <div
+      ref={blockRef}
+      data-testid={`scan-page-${page.id}`}
+      data-highlighted={highlighted ? 'true' : undefined}
+      className={containerClass}
+    >
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-800">
+        <div className="flex items-center gap-2 text-xs text-gray-300">
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-gray-800/70 border border-gray-700">
+            {t('scanned.page.label')}
+          </span>
+          <span data-testid={`scan-page-progress-${page.id}`}>
+            {t('scanned.page.progress', {
+              matched: matchedCount,
+              total: page.expected_count,
+            })}
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => void onAddAllMatched(page)}
+            disabled={matchedCount === 0}
+            data-testid={`scan-page-add-all-${page.id}`}
+            className="px-2.5 py-1 text-xs rounded bg-emerald-600/30 border border-emerald-500/60 text-emerald-100 hover:bg-emerald-600/50 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+          >
+            {t('scanned.page.addAllMatched', { count: matchedCount })}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirmDiscard(true)}
+            data-testid={`scan-page-discard-${page.id}`}
+            className="px-2.5 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-white cursor-pointer"
+          >
+            {t('scanned.page.discardPage')}
+          </button>
+        </div>
+      </div>
+      <div
+        className="grid gap-2 p-3"
+        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+      >
+        {cells.map((child, idx) => (
+          <ScanPageCell
+            key={child ? child.id : `empty-${idx}`}
+            child={child}
+            busy={child != null && busyChildId === child.id}
+            onResolve={onResolveChild}
+            onOpenDetail={onOpenDetail}
+            onEnterManually={onEnterManually}
+            t={t}
+          />
+        ))}
+      </div>
+      {confirmDiscard && (
+        <div className="px-3 py-2 border-t border-gray-800 bg-gray-900/70 flex flex-wrap items-center justify-between gap-2">
+          <p className="text-xs text-gray-200">{t('scanned.page.confirmDiscard')}</p>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => setConfirmDiscard(false)}
+              data-testid={`scan-page-discard-cancel-${page.id}`}
+              className="px-2.5 py-1 text-xs rounded border border-gray-700 hover:border-gray-500 text-gray-200 cursor-pointer"
+            >
+              {t('scanned.page.cancel')}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setConfirmDiscard(false)
+                void onDiscardPage(page)
+              }}
+              data-testid={`scan-page-discard-confirm-${page.id}`}
+              className="px-2.5 py-1 text-xs rounded bg-red-700/60 border border-red-600/70 hover:bg-red-700 text-white cursor-pointer"
+            >
+              {t('scanned.page.discardConfirm')}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/pokemon/ScanPageGrid.tsx
+++ b/web/src/components/pokemon/ScanPageGrid.tsx
@@ -336,7 +336,7 @@ export default function ScanPageGrid({
           </span>
           <span data-testid={`scan-page-progress-${page.id}`}>
             {t('scanned.page.progress', {
-              matched: matchedCount,
+              matched: page.matched_count,
               total: page.expected_count,
             })}
           </span>

--- a/web/src/pages/PokemonScanned.test.tsx
+++ b/web/src/pages/PokemonScanned.test.tsx
@@ -31,6 +31,7 @@ const TRANSLATIONS: Record<string, string> = {
   'scanned.noPriceYet': 'Price unavailable',
   'scanned.thumbnailAlt': 'Scanned card preview',
   'scanned.thumbnailPlaceholder': 'Image no longer available',
+  'scanned.tapToReview': 'Tap to review',
   'scanned.filter.label': 'Filter scans',
   'scanned.filter.needsReview': 'Needs review',
   'scanned.filter.pending': 'Pending',
@@ -51,6 +52,13 @@ const TRANSLATIONS: Record<string, string> = {
   'scanned.toast.added': 'Added to collection',
   'scanned.toast.discarded': 'Discarded',
   'scanned.toast.retried': 'Sent back to the scanner queue',
+  'scanned.page.label': 'Binder page',
+  'scanned.page.discardPage': 'Discard page',
+  'scanned.page.confirmDiscard': 'Discard this whole page?',
+  'scanned.page.cancel': 'Cancel',
+  'scanned.page.discardConfirm': 'Yes, discard',
+  'scanned.page.discardToast': 'Page discarded',
+  'scanned.page.discardFailed': 'Failed to discard page',
   'scanner.errors.scanFailed': 'Scan failed, try again',
   'variantKind.normal': 'Normal',
   'variantKind.reverse_holofoil': 'Reverse holo',
@@ -62,6 +70,11 @@ function mockT(key: string, opts?: Record<string, string | number> & { defaultVa
   if (key === 'scanned.confidence') return `${opts?.pct ?? 0}% confidence`
   if (key === 'scanned.elapsed') return `${opts?.seconds ?? 0} s`
   if (key === 'tile.collectorNo') return `#${opts?.number ?? ''}`
+  if (key === 'scanned.page.progress') return `${opts?.matched ?? 0} / ${opts?.total ?? 0} matched`
+  if (key === 'scanned.page.addAllMatched') return `Add all matched (${opts?.count ?? 0})`
+  if (key === 'scanned.page.addAllToast') return `Added ${opts?.count ?? 0} cards`
+  if (key === 'scanned.page.addAllPartial') return `${opts?.count ?? 0} cards could not be added`
+  if (key === 'scanned.detail.openLabel') return `Open scan detail for ${opts?.name ?? ''}`
   if (key.startsWith('variantKind.')) return TRANSLATIONS[key] ?? opts?.defaultValue ?? key
   return TRANSLATIONS[key] ?? key
 }
@@ -186,11 +199,24 @@ function makeQueued(over: Partial<ScanFixture> = {}): ScanFixture {
   }
 }
 
+interface PageFixture {
+  id: number
+  expected_count: number
+  matched_count: number
+  created_at: string
+  children: ScanFixture[]
+}
+
 interface FetchSpec {
   needsReview: ScanFixture[]
   pending?: ScanFixture[]
   resolved?: ScanFixture[]
   today?: { used: number; cap: number }
+  pages?: {
+    needsReview?: PageFixture[]
+    pending?: PageFixture[]
+    resolved?: PageFixture[]
+  }
 }
 
 function makeFetchMock(spec: FetchSpec, overrides?: (url: string, init?: FetchInit) => JsonResp | null) {
@@ -201,18 +227,30 @@ function makeFetchMock(spec: FetchSpec, overrides?: (url: string, init?: FetchIn
     }
     if (url.startsWith('/api/pokemon/scans?')) {
       let scans: ScanFixture[] = []
-      if (url.includes('matched') && url.includes('no_match')) scans = spec.needsReview
-      else if (url.includes('queued')) scans = spec.pending ?? []
-      else if (url.includes('added')) scans = spec.resolved ?? []
+      let pages: PageFixture[] = []
+      if (url.includes('matched') && url.includes('no_match')) {
+        scans = spec.needsReview
+        pages = spec.pages?.needsReview ?? []
+      } else if (url.includes('queued')) {
+        scans = spec.pending ?? []
+        pages = spec.pages?.pending ?? []
+      } else if (url.includes('added')) {
+        scans = spec.resolved ?? []
+        pages = spec.pages?.resolved ?? []
+      }
       return Promise.resolve(
         jsonResponse({
           scans,
+          pages,
           today: spec.today ?? { used: 12, cap: 600 },
         }),
       )
     }
     if (url.match(/^\/api\/pokemon\/scans\/\d+\/resolve$/) && init?.method === 'POST') {
       return Promise.resolve(jsonResponse({ scan: {} }, 200))
+    }
+    if (url.match(/^\/api\/pokemon\/scans\/pages\/\d+$/) && init?.method === 'DELETE') {
+      return Promise.resolve(jsonResponse({}, 204))
     }
     return Promise.resolve(jsonResponse({}, 404))
   })
@@ -622,6 +660,158 @@ describe('PokemonScanned – resolve actions', () => {
       const body = JSON.parse(((post?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
       expect(body).toMatchObject({ action: 'add', variant_id: 11 })
       expect(body.card_id).toBeUndefined()
+    })
+  })
+})
+
+describe('PokemonScanned – page grid', () => {
+  function makePageMatched(id: number, over: Partial<ScanFixture> = {}): ScanFixture {
+    return makeMatched({ id, ...over })
+  }
+  function makePageQueued(id: number): ScanFixture {
+    return makeQueued({ id })
+  }
+
+  function makePage(over: Partial<PageFixture> = {}): PageFixture {
+    return {
+      id: 42,
+      expected_count: 9,
+      matched_count: 1,
+      created_at: new Date('2026-05-15T11:00:00Z').toISOString(),
+      children: [
+        makePageMatched(101),
+        makePageMatched(102, { id: 102, status: 'no_match' as const, matched_card: null }),
+        makePageQueued(103),
+      ],
+      ...over,
+    }
+  }
+
+  it('renders a page block with cells and shows the matched count in the progress label', async () => {
+    const fetchMock = makeFetchMock({
+      needsReview: [],
+      pages: { needsReview: [makePage()] },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-page-42')).toBeInTheDocument())
+
+    expect(screen.getByTestId('scan-page-progress-42')).toHaveTextContent('1 / 9 matched')
+    // Three real cells plus 6 empty placeholders for the 3×3 grid.
+    expect(screen.getByTestId('scan-page-cell-101')).toBeInTheDocument()
+    expect(screen.getByTestId('scan-page-cell-102')).toBeInTheDocument()
+    expect(screen.getByTestId('scan-page-cell-103')).toBeInTheDocument()
+    expect(screen.getAllByTestId('scan-page-cell-empty')).toHaveLength(6)
+  })
+
+  it('"Add all matched" posts action=add for each matched child', async () => {
+    const fetchMock = makeFetchMock({
+      needsReview: [],
+      pages: {
+        needsReview: [
+          makePage({
+            matched_count: 2,
+            children: [makePageMatched(201), makePageMatched(202, { id: 202 })],
+            expected_count: 4,
+          }),
+        ],
+      },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-page-42')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-page-add-all-42'))
+
+    await waitFor(() => {
+      const post201 = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/201/resolve' &&
+          (init as FetchInit | undefined)?.method === 'POST',
+      )
+      const post202 = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/202/resolve' &&
+          (init as FetchInit | undefined)?.method === 'POST',
+      )
+      expect(post201).toBeTruthy()
+      expect(post202).toBeTruthy()
+      const body201 = JSON.parse(((post201?.[1] as FetchInit | undefined)?.body as string) ?? '{}')
+      expect(body201).toMatchObject({ action: 'add', variant_id: 11, quantity: 1 })
+    })
+  })
+
+  it('"Discard page" with confirmation issues DELETE /api/pokemon/scans/pages/{id}', async () => {
+    const fetchMock = makeFetchMock({
+      needsReview: [],
+      pages: { needsReview: [makePage()] },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-page-42')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-page-discard-42'))
+    fireEvent.click(screen.getByTestId('scan-page-discard-confirm-42'))
+
+    await waitFor(() => {
+      const del = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          (url as string) === '/api/pokemon/scans/pages/42' &&
+          (init as FetchInit | undefined)?.method === 'DELETE',
+      )
+      expect(del).toBeTruthy()
+    })
+  })
+
+  it('cancelling the discard confirmation does NOT call DELETE', async () => {
+    const fetchMock = makeFetchMock({
+      needsReview: [],
+      pages: { needsReview: [makePage()] },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('scan-page-42')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('scan-page-discard-42'))
+    fireEvent.click(screen.getByTestId('scan-page-discard-cancel-42'))
+
+    const del = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        (url as string).startsWith('/api/pokemon/scans/pages/') &&
+        (init as FetchInit | undefined)?.method === 'DELETE',
+    )
+    expect(del).toBeFalsy()
+  })
+
+  it('?page=<id> highlights the matching page block once data is loaded', async () => {
+    // A fresh page upload starts in the pending state, so the component
+    // auto-switches to the "pending" filter when it sees ?page= — the mock
+    // returns the page on that filter so the highlight effect can fire.
+    const fetchMock = makeFetchMock({
+      needsReview: [],
+      pending: [],
+      pages: {
+        needsReview: [makePage()],
+        pending: [makePage()],
+      },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <MemoryRouter initialEntries={['/pokemon/scanned?page=42']}>
+        <Routes>
+          <Route path="/pokemon/scanned" element={<PokemonScanned />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      const block = screen.getByTestId('scan-page-42')
+      expect(block).toHaveAttribute('data-highlighted', 'true')
     })
   })
 })

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -7,6 +7,8 @@ import ToastList from '../components/ToastList'
 import { useToast } from '../hooks/useToast'
 import ScanDetailModal from '../components/pokemon/ScanDetailModal'
 import type { ScanDetailResolveBody } from '../components/pokemon/ScanDetailModal'
+import ScanPageGrid from '../components/pokemon/ScanPageGrid'
+import type { ScanPageGridParent } from '../components/pokemon/ScanPageGrid'
 
 // buildManualEntryQuery joins whatever partial fields Claude could read into a
 // single search string for AddCardPanel. Empty hints collapse to an empty
@@ -438,18 +440,37 @@ export default function PokemonScannedPage() {
     const parsed = parseInt(focusParam, 10)
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null
   }, [focusParam])
+  // ?page=<id> is set by the binder page-upload flow (PageScanner) and asks
+  // us to scroll the freshly-submitted page block into view + highlight it.
+  // Parsed once per search-param change so the auto-scroll effect can react.
+  const pageParam = searchParams.get('page')
+  const focusedPageId = useMemo(() => {
+    if (!pageParam) return null
+    const parsed = parseInt(pageParam, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+  }, [pageParam])
 
-  const [filter, setFilter] = useState<FilterKey>('needsReview')
+  // Default to "needsReview" unless we're arriving from a fresh page upload
+  // (?page=<id>) — those children are queued at first, so we pick "pending"
+  // so the new page block lands on screen without the kid manually switching
+  // filters. Read once on mount so subsequent ?page= strips don't fight the
+  // user if they later flip filters themselves.
+  const initialFilter: FilterKey = pageParam ? 'pending' : 'needsReview'
+  const [filter, setFilter] = useState<FilterKey>(initialFilter)
   const [scans, setScans] = useState<ScanJob[]>([])
+  const [pages, setPages] = useState<ScanPageGridParent[]>([])
   const [today, setToday] = useState<TodayUsage | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [busyId, setBusyId] = useState<number | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [highlightedId, setHighlightedId] = useState<number | null>(null)
+  const [highlightedPageId, setHighlightedPageId] = useState<number | null>(null)
   const [detailScanId, setDetailScanId] = useState<number | null>(null)
   const rowRefs = useRef<Map<number, HTMLLIElement>>(new Map())
+  const pageRefs = useRef<Map<number, HTMLDivElement>>(new Map())
   const focusHandledRef = useRef<number | null>(null)
+  const pageHandledRef = useRef<number | null>(null)
 
   // tick the clock once per second so the "elapsed time" caption on pending
   // rows updates without forcing a full refetch.
@@ -490,8 +511,13 @@ export default function PokemonScannedPage() {
           { credentials: 'include', signal: controller.signal },
         )
         if (!res.ok) throw new Error(t('scanned.loadError'))
-        const data: { scans?: ScanJob[]; today?: TodayUsage } = await res.json()
+        const data: {
+          scans?: ScanJob[]
+          pages?: ScanPageGridParent[]
+          today?: TodayUsage
+        } = await res.json()
         setScans(data.scans ?? [])
+        setPages(data.pages ?? [])
         setToday(data.today ?? null)
         // clear any previous error when a silent poll succeeds
         if (isSilent) setError('')
@@ -553,6 +579,38 @@ export default function PokemonScannedPage() {
     })
   }, [scans, filter, now])
 
+  const visiblePages = useMemo(() => {
+    if (filter !== 'resolved') return pages
+    const cutoff = now - RESOLVED_WINDOW_DAYS * 24 * 60 * 60 * 1000
+    // For pages we look at the most recent child timestamp — a single newly
+    // resolved child should keep the whole page block in the recent list.
+    return pages.filter(p => {
+      const ts = p.children.reduce((max, c) => {
+        const parsed = Date.parse(c.resolved_at ?? c.created_at)
+        return Number.isFinite(parsed) && parsed > max ? parsed : max
+      }, 0)
+      return ts >= cutoff
+    })
+  }, [pages, filter, now])
+
+  // listItems interleaves standalone scans and page blocks by their created_at
+  // timestamp (newest first) so the page renders one chronological stream
+  // rather than two separate sections.
+  type ListItem =
+    | { kind: 'scan'; ts: number; scan: ScanJob }
+    | { kind: 'page'; ts: number; page: ScanPageGridParent }
+  const listItems = useMemo<ListItem[]>(() => {
+    const items: ListItem[] = []
+    for (const scan of visibleScans) {
+      items.push({ kind: 'scan', ts: Date.parse(scan.created_at) || 0, scan })
+    }
+    for (const page of visiblePages) {
+      items.push({ kind: 'page', ts: Date.parse(page.created_at) || 0, page })
+    }
+    items.sort((a, b) => b.ts - a.ts)
+    return items
+  }, [visibleScans, visiblePages])
+
   // When ?focus=N is present (e.g. opened from a scan-result push), scroll the
   // matching row into view and apply a brief highlight so the kid can tell
   // which result is theirs. focusHandledRef ensures we only scroll once per
@@ -575,6 +633,26 @@ export default function PokemonScannedPage() {
     setSearchParams(next, { replace: true })
   }, [focusedId, loading, visibleScans, searchParams, setSearchParams])
 
+  // ?page=<id> targets a whole page block (set by the PageScanner after the
+  // multipart upload commits). Behaviour mirrors ?focus= but indexes the
+  // pageRefs map; the search param is cleared once consumed so a later
+  // refresh does not re-trigger the scroll.
+  useEffect(() => {
+    if (focusedPageId == null) return
+    if (loading) return
+    if (pageHandledRef.current === focusedPageId) return
+    const target = visiblePages.find(p => p.id === focusedPageId)
+    if (!target) return
+    const el = pageRefs.current.get(focusedPageId)
+    if (!el) return
+    pageHandledRef.current = focusedPageId
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    setHighlightedPageId(focusedPageId)
+    const next = new URLSearchParams(searchParams)
+    next.delete('page')
+    setSearchParams(next, { replace: true })
+  }, [focusedPageId, loading, visiblePages, searchParams, setSearchParams])
+
   // Auto-clear the row highlight after a short window so the visual nudge
   // fades back to normal styling without lingering forever. Split from the
   // scroll effect so the timer is not cancelled by unrelated re-renders
@@ -584,6 +662,12 @@ export default function PokemonScannedPage() {
     const timer = window.setTimeout(() => setHighlightedId(null), 2500)
     return () => window.clearTimeout(timer)
   }, [highlightedId])
+
+  useEffect(() => {
+    if (highlightedPageId == null) return
+    const timer = window.setTimeout(() => setHighlightedPageId(null), 2500)
+    return () => window.clearTimeout(timer)
+  }, [highlightedPageId])
 
   const handleEnterManually = useCallback(
     (scan: ScanJob) => {
@@ -628,7 +712,19 @@ export default function PokemonScannedPage() {
     [refetch, showToast, t],
   )
 
-  const detailScan = detailScanId != null ? (scans.find(s => s.id === detailScanId) ?? null) : null
+  // The matched-scan detail modal can be opened from a standalone row OR
+  // from a cell inside a page grid, so we fall back to scanning each page's
+  // children for the active id when it isn't in the standalone list.
+  const detailScan = useMemo<ScanJob | null>(() => {
+    if (detailScanId == null) return null
+    const standalone = scans.find(s => s.id === detailScanId)
+    if (standalone) return standalone
+    for (const page of pages) {
+      const child = page.children.find(c => c.id === detailScanId)
+      if (child) return child as ScanJob
+    }
+    return null
+  }, [detailScanId, scans, pages])
 
   const handleDetailResolve = useCallback(
     async (body: ScanDetailResolveBody) => {
@@ -637,6 +733,75 @@ export default function PokemonScannedPage() {
       handleCloseDetail()
     },
     [detailScan, handleResolve, handleCloseDetail],
+  )
+
+  const handleAddAllMatched = useCallback(
+    async (page: ScanPageGridParent) => {
+      const matched = page.children.filter(c => c.status === 'matched' && c.matched_card)
+      if (matched.length === 0) return
+      let added = 0
+      let failed = 0
+      // Issue the requests sequentially so a partial failure leaves the
+      // grid in a sensible state — the kid sees the matching cells flip
+      // one by one rather than all at once with no recovery.
+      for (const child of matched) {
+        const card = child.matched_card
+        const variant = card?.variants?.[0]
+        if (!variant) {
+          failed++
+          continue
+        }
+        try {
+          const res = await fetch(`/api/pokemon/scans/${child.id}/resolve`, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              action: 'add',
+              variant_id: variant.id,
+              quantity: 1,
+            }),
+          })
+          if (!res.ok) {
+            failed++
+          } else {
+            added++
+          }
+        } catch {
+          failed++
+        }
+      }
+      if (added > 0) {
+        showToast(t('scanned.page.addAllToast', { count: added }), 'success')
+      }
+      if (failed > 0) {
+        showToast(t('scanned.page.addAllPartial', { count: failed }), 'error')
+      }
+      refetch()
+    },
+    [refetch, showToast, t],
+  )
+
+  const handleDiscardPage = useCallback(
+    async (page: ScanPageGridParent) => {
+      try {
+        const res = await fetch(`/api/pokemon/scans/pages/${page.id}`, {
+          method: 'DELETE',
+          credentials: 'include',
+        })
+        if (!res.ok && res.status !== 204) {
+          throw new Error(t('scanned.page.discardFailed'))
+        }
+        showToast(t('scanned.page.discardToast'), 'success')
+        refetch()
+      } catch (err) {
+        showToast(
+          err instanceof Error ? err.message : t('scanned.page.discardFailed'),
+          'error',
+        )
+      }
+    },
+    [refetch, showToast, t],
   )
 
   return (
@@ -724,7 +889,7 @@ export default function PokemonScannedPage() {
           </ul>
         )}
 
-        {!loading && !error && visibleScans.length === 0 && (
+        {!loading && !error && listItems.length === 0 && (
           <p
             data-testid="scanned-empty"
             className="text-sm text-gray-400 py-6 text-center"
@@ -733,28 +898,57 @@ export default function PokemonScannedPage() {
           </p>
         )}
 
-        {!loading && !error && visibleScans.length > 0 && (
+        {!loading && !error && listItems.length > 0 && (
           <ul className="space-y-3" data-testid="scanned-list">
-            {visibleScans.map(scan => (
-              <ScanRow
-                key={scan.id}
-                scan={scan}
-                busy={busyId === scan.id}
-                now={now}
-                highlighted={highlightedId === scan.id}
-                rowRef={el => {
-                  if (el) {
-                    rowRefs.current.set(scan.id, el)
-                  } else {
-                    rowRefs.current.delete(scan.id)
-                  }
-                }}
-                onResolve={handleResolve}
-                onEnterManually={handleEnterManually}
-                onOpenDetail={handleOpenDetail}
-                t={t}
-              />
-            ))}
+            {listItems.map(item => {
+              if (item.kind === 'scan') {
+                const scan = item.scan
+                return (
+                  <ScanRow
+                    key={`scan-${scan.id}`}
+                    scan={scan}
+                    busy={busyId === scan.id}
+                    now={now}
+                    highlighted={highlightedId === scan.id}
+                    rowRef={el => {
+                      if (el) {
+                        rowRefs.current.set(scan.id, el)
+                      } else {
+                        rowRefs.current.delete(scan.id)
+                      }
+                    }}
+                    onResolve={handleResolve}
+                    onEnterManually={handleEnterManually}
+                    onOpenDetail={handleOpenDetail}
+                    t={t}
+                  />
+                )
+              }
+              const page = item.page
+              return (
+                <li key={`page-${page.id}`}>
+                  <ScanPageGrid
+                    page={page}
+                    busyChildId={busyId}
+                    highlighted={highlightedPageId === page.id}
+                    blockRef={el => {
+                      if (el) {
+                        pageRefs.current.set(page.id, el)
+                      } else {
+                        pageRefs.current.delete(page.id)
+                      }
+                    }}
+                    onResolveChild={(child, body) =>
+                      handleResolve(child as ScanJob, body)
+                    }
+                    onOpenDetail={child => handleOpenDetail(child as ScanJob)}
+                    onEnterManually={child => handleEnterManually(child as ScanJob)}
+                    onAddAllMatched={handleAddAllMatched}
+                    onDiscardPage={handleDiscardPage}
+                  />
+                </li>
+              )
+            })}
           </ul>
         )}
       </div>

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -605,11 +605,22 @@ export default function PokemonScannedPage() {
       items.push({ kind: 'scan', ts: Date.parse(scan.created_at) || 0, scan })
     }
     for (const page of visiblePages) {
-      items.push({ kind: 'page', ts: Date.parse(page.created_at) || 0, page })
+      // For the resolved filter, sort by the most-recent child timestamp so
+      // the ordering matches the windowing logic in visiblePages (which also
+      // uses max-child-ts). Using page.created_at here would push recently-
+      // resolved pages far down the list because their *parent* may be old.
+      const pageTs =
+        filter === 'resolved'
+          ? page.children.reduce((max, c) => {
+              const parsed = Date.parse(c.resolved_at ?? c.created_at)
+              return Number.isFinite(parsed) && parsed > max ? parsed : max
+            }, 0)
+          : Date.parse(page.created_at) || 0
+      items.push({ kind: 'page', ts: pageTs, page })
     }
     items.sort((a, b) => b.ts - a.ts)
     return items
-  }, [visibleScans, visiblePages])
+  }, [visibleScans, visiblePages, filter])
 
   // When ?focus=N is present (e.g. opened from a scan-result push), scroll the
   // matching row into view and apply a brief highlight so the kid can tell


### PR DESCRIPTION
## Changes

- **Binder page scan grid** - The /pokemon/scanned page now groups multi-card binder uploads into a single grid block matching the captured 3×3 or 4×3 layout, with per-cell status badges, the existing per-card Add / Discard / Manual-search actions, plus parent-level "Add all matched" and "Discard page" controls. The new `?page=<id>` query param auto-scrolls and highlights the freshly-submitted page right after the upload flow finishes. (Hytte-3uq2)

## Original Issue (task): Scanned page grid rendering for page-scan parents

Update /pokemon/scanned to fetch and render pokemon_scan_pages parents as a grid block matching the captured layout (3x3 or 4x3 based on expected_count/cells). Each cell shows its child scan's status (queued / processing / matched / no_match) and reuses the existing per-card Add / Discard / Manual-search actions unchanged. Add two parent-level actions: 'Add all matched' (accepts every confidently-matched child) and 'Discard page' (deletes the entire parent + children). Respect the ?page=<id> query param to auto-scroll/highlight the freshly-submitted page. Depends on the parent/child schema from sub-task 2 and the upload navigation from sub-task 3. Include a changelog.d/ fragment (category: Added) summarising the binder-page scan feature; ensure make build, make test, npm run lint, npm run build all pass.

---
Bead: Hytte-3uq2 | Branch: forge/Hytte-3uq2
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->