### PR TITLE
DB migration order: family_chat rename must precede new index creation (Hytte-oe7p)

### DIFF
--- a/changelog.d/Hytte-oe7p.md
+++ b/changelog.d/Hytte-oe7p.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Family Chat schema migration crash loop** - Hytte no longer crashes on startup against databases that still have the original Hytte-0w3d family_chat column names. Column renames (name_enc/owner_id on family_chat_conversations and body_enc/attachment_path_enc/sender_id on family_chat_messages) now run before the main schema block, so the new `idx_family_chat_conversations_owner` index can reference owner_user_id on legacy installs. The previously-missing `sender_id` → `sender_user_id` rename is now included. (Hytte-oe7p)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -41,7 +41,66 @@ func Init(path string) (*sql.DB, error) {
 	return db, nil
 }
 
+// preCreateMigrations runs ALTER TABLE renames that the main schema block in
+// createSchema assumes are already in place. The schema block is idempotent
+// for tables (CREATE TABLE IF NOT EXISTS) but the CREATE INDEX statements
+// reference column names directly — if a legacy install still has the old
+// column name, the schema block fails. Anything that renames a column the
+// schema block then references must live here, not in the post-schema
+// migration pass at the bottom of createSchema.
+func preCreateMigrations(db *sql.DB) error {
+	// family_chat_* (Hytte-56j7): the initial schema bead used *_enc column
+	// names for fields stored encrypted at rest, plus owner_id / sender_id.
+	// The REST handlers bead switched to plain column names (the encryption
+	// happens in application code, the column type doesn't change) and to
+	// *_user_id for the FKs to users(id). Each rename is idempotent via a
+	// pragma_table_info check.
+	renames := []struct {
+		table   string
+		oldName string
+		newName string
+	}{
+		{"family_chat_conversations", "name_enc", "name"},
+		{"family_chat_conversations", "owner_id", "owner_user_id"},
+		{"family_chat_messages", "body_enc", "body"},
+		{"family_chat_messages", "attachment_path_enc", "attachment_path"},
+		{"family_chat_messages", "sender_id", "sender_user_id"},
+	}
+	for _, r := range renames {
+		if err := renameColumnIfExists(db, r.table, r.oldName, r.newName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renameColumnIfExists renames a column if (and only if) the table exists and
+// still has the old column name. It is a no-op on fresh installs (where the
+// table was just created with the new column name) and on already-migrated
+// installs.
+func renameColumnIfExists(db *sql.DB, table, oldName, newName string) error {
+	var hasOld int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`,
+		table, oldName,
+	).Scan(&hasOld); err != nil {
+		return fmt.Errorf("check %s.%s: %w", table, oldName, err)
+	}
+	if hasOld == 0 {
+		return nil
+	}
+	stmt := fmt.Sprintf(`ALTER TABLE %s RENAME COLUMN %s TO %s`, table, oldName, newName)
+	if _, err := db.Exec(stmt); err != nil {
+		return fmt.Errorf("rename %s.%s -> %s: %w", table, oldName, newName, err)
+	}
+	return nil
+}
+
 func createSchema(db *sql.DB) error {
+	if err := preCreateMigrations(db); err != nil {
+		return err
+	}
+
 	schema := `
 	-- schema_migrations stores global one-time migration sentinels (e.g. data
 	-- encryption). It is separate from user_preferences (which is per-user)
@@ -2505,27 +2564,6 @@ func createSchema(db *sql.DB) error {
 	if hasPrintedTotal == 0 {
 		if _, err := db.Exec(`ALTER TABLE pokemon_sets ADD COLUMN printed_total INTEGER NOT NULL DEFAULT 0`); err != nil {
 			return fmt.Errorf("add pokemon_sets printed_total column: %w", err)
-		}
-	}
-
-	// Migrate family_chat tables from the schema-bead column names to the REST
-	// bead column names (Hytte-56j7). Detect old schema via presence of
-	// name_enc on family_chat_conversations; if found, rename all affected
-	// columns so existing installs don't break at runtime.
-	var hasFCNameEnc int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('family_chat_conversations') WHERE name = 'name_enc'`).Scan(&hasFCNameEnc); err != nil {
-		return fmt.Errorf("check family_chat_conversations name_enc: %w", err)
-	}
-	if hasFCNameEnc != 0 {
-		for _, stmt := range []string{
-			`ALTER TABLE family_chat_conversations RENAME COLUMN name_enc TO name`,
-			`ALTER TABLE family_chat_conversations RENAME COLUMN owner_id TO owner_user_id`,
-			`ALTER TABLE family_chat_messages RENAME COLUMN body_enc TO body`,
-			`ALTER TABLE family_chat_messages RENAME COLUMN attachment_path_enc TO attachment_path`,
-		} {
-			if _, err := db.Exec(stmt); err != nil {
-				return fmt.Errorf("migrate family_chat columns: %w", err)
-			}
 		}
 	}
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -830,6 +830,185 @@ func TestSuggestionRunsTable(t *testing.T) {
 	}
 }
 
+// TestCreateSchema_LegacyFamilyChatConversations simulates a database that
+// still has the original Hytte-0w3d column names on family_chat_conversations
+// (name_enc, owner_id) and verifies that createSchema migrates the columns to
+// the new names before the schema block tries to create
+// idx_family_chat_conversations_owner on owner_user_id. Prior to Hytte-oe7p,
+// the index creation lived in the schema block and ran before the rename,
+// causing the binary to crash-loop on every install that hadn't been upgraded.
+func TestCreateSchema_LegacyFamilyChatConversations(t *testing.T) {
+	database, err := sql.Open("sqlite", "file::memory:?_pragma=foreign_keys(ON)")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	t.Cleanup(func() { database.Close() })
+
+	// Seed the legacy family_chat_conversations schema (pre-Hytte-56j7).
+	_, err = database.Exec(`
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY,
+			email TEXT UNIQUE NOT NULL,
+			name TEXT NOT NULL,
+			picture TEXT NOT NULL DEFAULT '',
+			google_id TEXT UNIQUE NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE family_chat_conversations (
+			id              INTEGER PRIMARY KEY,
+			name_enc        TEXT NOT NULL DEFAULT '',
+			owner_id        INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			created_at      TEXT NOT NULL DEFAULT '',
+			last_message_at TEXT NOT NULL DEFAULT ''
+		);
+	`)
+	if err != nil {
+		t.Fatalf("seed legacy schema: %v", err)
+	}
+
+	if err := createSchema(database); err != nil {
+		t.Fatalf("createSchema with legacy family_chat_conversations: %v", err)
+	}
+
+	// Old columns are gone; new columns exist.
+	for _, c := range []struct {
+		col     string
+		want    int
+		message string
+	}{
+		{"name_enc", 0, "legacy name_enc should have been renamed"},
+		{"owner_id", 0, "legacy owner_id should have been renamed"},
+		{"name", 1, "expected new column name"},
+		{"owner_user_id", 1, "expected new column owner_user_id"},
+	} {
+		var n int
+		if err := database.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('family_chat_conversations') WHERE name = ?`, c.col,
+		).Scan(&n); err != nil {
+			t.Fatalf("pragma_table_info %s: %v", c.col, err)
+		}
+		if n != c.want {
+			t.Errorf("%s: column %q count=%d want %d", c.message, c.col, n, c.want)
+		}
+	}
+
+	// Index on the renamed column must exist.
+	var idxName string
+	err = database.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_family_chat_conversations_owner'`,
+	).Scan(&idxName)
+	if err != nil {
+		t.Fatalf("expected idx_family_chat_conversations_owner to exist: %v", err)
+	}
+}
+
+// TestCreateSchema_LegacyFamilyChatMessages exercises the symmetric rename
+// path for family_chat_messages: legacy installs had sender_id, body_enc and
+// attachment_path_enc; the new schema declares sender_user_id, body, and
+// attachment_path. The sender_id rename in particular was missing from the
+// PR #756 migration block — without it, application queries against
+// sender_user_id would fail at runtime on upgraded installs.
+func TestCreateSchema_LegacyFamilyChatMessages(t *testing.T) {
+	database, err := sql.Open("sqlite", "file::memory:?_pragma=foreign_keys(ON)")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	t.Cleanup(func() { database.Close() })
+
+	_, err = database.Exec(`
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY,
+			email TEXT UNIQUE NOT NULL,
+			name TEXT NOT NULL,
+			picture TEXT NOT NULL DEFAULT '',
+			google_id TEXT UNIQUE NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE family_chat_conversations (
+			id              INTEGER PRIMARY KEY,
+			name_enc        TEXT NOT NULL DEFAULT '',
+			owner_id        INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			created_at      TEXT NOT NULL DEFAULT '',
+			last_message_at TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE family_chat_messages (
+			id                  INTEGER PRIMARY KEY,
+			conversation_id     INTEGER NOT NULL REFERENCES family_chat_conversations(id) ON DELETE CASCADE,
+			sender_id           INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			body_enc            TEXT NOT NULL DEFAULT '',
+			attachment_path_enc TEXT NOT NULL DEFAULT '',
+			attachment_mime     TEXT NOT NULL DEFAULT '',
+			created_at          TEXT NOT NULL DEFAULT ''
+		);
+	`)
+	if err != nil {
+		t.Fatalf("seed legacy schema: %v", err)
+	}
+
+	if err := createSchema(database); err != nil {
+		t.Fatalf("createSchema with legacy family_chat_messages: %v", err)
+	}
+
+	for _, c := range []struct {
+		col  string
+		want int
+	}{
+		{"sender_id", 0},
+		{"body_enc", 0},
+		{"attachment_path_enc", 0},
+		{"sender_user_id", 1},
+		{"body", 1},
+		{"attachment_path", 1},
+	} {
+		var n int
+		if err := database.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('family_chat_messages') WHERE name = ?`, c.col,
+		).Scan(&n); err != nil {
+			t.Fatalf("pragma_table_info %s: %v", c.col, err)
+		}
+		if n != c.want {
+			t.Errorf("column %q count=%d want %d", c.col, n, c.want)
+		}
+	}
+
+	// After the migration we must be able to write a row using the new column
+	// names — the application queries depend on this.
+	if _, err := database.Exec(
+		`INSERT INTO users (id, email, name, google_id) VALUES (1, 'a@b', 'A', 'g1')`,
+	); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if _, err := database.Exec(
+		`INSERT INTO family_chat_conversations (id, name, owner_user_id, created_at, last_message_at) VALUES (1, 'Family', 1, '2026-01-01', '')`,
+	); err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+	if _, err := database.Exec(
+		`INSERT INTO family_chat_messages (conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at) VALUES (1, 1, 'hi', '', '', '2026-01-01')`,
+	); err != nil {
+		t.Fatalf("insert message with new column names: %v", err)
+	}
+}
+
+// TestPreCreateMigrationsFreshInstall verifies that the pre-phase is a no-op
+// on a clean database (no legacy tables present). Each rename's table_info
+// check returns 0, so nothing is altered and the function returns nil.
+func TestPreCreateMigrationsFreshInstall(t *testing.T) {
+	database, err := sql.Open("sqlite", "file::memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	if err := preCreateMigrations(database); err != nil {
+		t.Fatalf("preCreateMigrations on empty db: %v", err)
+	}
+}
+
 func TestSuggestionRunsIndexExists(t *testing.T) {
 	database := initTestDB(t)
 


### PR DESCRIPTION
## Changes

- **Family Chat schema migration crash loop** - Hytte no longer crashes on startup against databases that still have the original Hytte-0w3d family_chat column names. Column renames (name_enc/owner_id on family_chat_conversations and body_enc/attachment_path_enc/sender_id on family_chat_messages) now run before the main schema block, so the new `idx_family_chat_conversations_owner` index can reference owner_user_id on legacy installs. The previously-missing `sender_id` → `sender_user_id` rename is now included. (Hytte-oe7p)

## Original Issue (bug): DB migration order: family_chat rename must precede new index creation

A new `CREATE INDEX IF NOT EXISTS idx_family_chat_conversations_owner ON family_chat_conversations(owner_user_id)` was added to the initial schema block (`internal/db/db.go` ~line 1745) as part of Hytte-56j7 (PR #756). But the migration that renames the legacy `owner_id` column to `owner_user_id` on existing installs lives in the later migration block (~line 2520) and only runs AFTER the initial schema block. Result: on any install that still has the pre-rename schema, the initial-block index creation references a column that doesn't exist yet, `createSchema` returns an error, the binary exits, and systemd crash-loops Hytte every 5 s.

Triggered on prod on 2026-05-19 at 15:59 UTC. Worked around by hand:
- Renamed `family_chat_conversations.name_enc → name` and `owner_id → owner_user_id` directly via `sqlite3`.
- Dropped the three empty `family_chat_*` tables and let `CREATE TABLE IF NOT EXISTS` recreate them with the new schema on the next start.

The same crash will fire on any other instance still on the old schema next time it deploys. Pre-empt that.

## Scope

### 1. Reorder the migration to run BEFORE the schema block uses the new column

The cleanest fix is to lift the family_chat rename block (and any future "rename column then index it" migration) into a "pre-schema" pass that runs before the main `CREATE TABLE / CREATE INDEX` statements in `createSchema`. The function is one long sequence today; introduce a small `preCreateMigrations(db)` (or rename `migrateColumns` into two phases) that handles renames that the new schema then assumes are in place.

Alternative if a structural refactor is too invasive: defer the specific `CREATE INDEX idx_family_chat_conversations_owner` line out of the initial block and re-add it inside the migration block immediately AFTER the rename, with `IF NOT EXISTS`. Fresh installs still get the index (table is created with `owner_user_id`, the migration's `hasFCNameEnc` check is 0, the deferred CREATE INDEX still runs because it's outside the conditional). Old installs get rename → then index. Either way, the offending CREATE INDEX must move OUT of the schema block until after the rename.

Also rename the `family_chat_messages.sender_id` column to `sender_user_id` in the same migration — the new schema declares `sender_user_id` but the migration in PR #756 didn't include that rename, only `body_enc`/`attachment_path_enc`. Existing installs with messages would crash on application queries even past the index issue.

### 2. Tests

`internal/db/db_test.go`:
- Test that simulates the legacy schema (`CREATE TABLE family_chat_conversations (id INTEGER PRIMARY KEY, name_enc TEXT, owner_id INTEGER, ...)` etc) before running `createSchema`, then asserts the schema initialises cleanly, the table has the new columns, and the index exists.
- Symmetric test for `family_chat_messages` legacy `sender_id` / `body_enc` / `attachment_path_enc` → new columns.
- The fresh-install test (already passing) must still pass.

### 3. Acceptance

- `go build`, `go test ./internal/db/...` pass.
- An old DB dump (with the pre-rename columns) starts cleanly on the new binary — no crash loop.
- Changelog fragment in `changelog.d/` (category: Fixed).

## Reference

- internal/db/db.go ~line 1734–1768 — family_chat_conversations CREATE block including the offending index.
- internal/db/db.go ~line 2510–2530 — current rename migration that runs too late.
- PR #756 / Hytte-56j7 — introducing commit.


---
Bead: Hytte-oe7p | Branch: forge/Hytte-oe7p
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->