### PR TITLE
Chat view: header, message list, composer (Hytte-goir)

### DIFF
--- a/changelog.d/Hytte-goir.md
+++ b/changelog.d/Hytte-goir.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat: chat view with header, message list, and composer** - The selected conversation now shows its name and member chips, lists messages oldest-to-newest with auto-scroll, and posts new messages via a controlled composer (Enter to send, Shift+Enter for newline). (Hytte-goir)

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -11,10 +11,28 @@
     "noMessages": "No messages yet"
   },
   "errors": {
-    "failedToLoad": "Failed to load conversations"
+    "failedToLoad": "Failed to load conversations",
+    "failedToLoadMessages": "Failed to load messages"
   },
   "time": {
     "justNow": "just now"
+  },
+  "chat": {
+    "back": "Back to conversations",
+    "membersLabel": "Members",
+    "memberFallback": "Member #{{id}}",
+    "you": "You",
+    "emptyMessages": "No messages yet. Say hello!",
+    "noSelectionTitle": "Pick a conversation",
+    "noSelectionHint": "Choose a chat from the list to start reading."
+  },
+  "composer": {
+    "placeholder": "Write a message…",
+    "send": "Send message",
+    "errors": {
+      "send": "Failed to send message",
+      "tooLong": "Message is too long"
+    }
   },
   "newModal": {
     "title": "New conversation",

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -12,7 +12,8 @@
   },
   "errors": {
     "failedToLoad": "Failed to load conversations",
-    "failedToLoadMessages": "Failed to load messages"
+    "failedToLoadMessages": "Failed to load messages",
+    "failedToLoadConversation": "Failed to load conversation"
   },
   "time": {
     "justNow": "just now"

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -11,10 +11,28 @@
     "noMessages": "Ingen meldinger ennå"
   },
   "errors": {
-    "failedToLoad": "Klarte ikke å laste samtaler"
+    "failedToLoad": "Klarte ikke å laste samtaler",
+    "failedToLoadMessages": "Klarte ikke å laste meldinger"
   },
   "time": {
     "justNow": "akkurat nå"
+  },
+  "chat": {
+    "back": "Tilbake til samtaler",
+    "membersLabel": "Medlemmer",
+    "memberFallback": "Medlem #{{id}}",
+    "you": "Deg",
+    "emptyMessages": "Ingen meldinger ennå. Si hei!",
+    "noSelectionTitle": "Velg en samtale",
+    "noSelectionHint": "Velg en chat fra listen for å begynne å lese."
+  },
+  "composer": {
+    "placeholder": "Skriv en melding…",
+    "send": "Send melding",
+    "errors": {
+      "send": "Klarte ikke å sende melding",
+      "tooLong": "Meldingen er for lang"
+    }
   },
   "newModal": {
     "title": "Ny samtale",

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -12,7 +12,8 @@
   },
   "errors": {
     "failedToLoad": "Klarte ikke å laste samtaler",
-    "failedToLoadMessages": "Klarte ikke å laste meldinger"
+    "failedToLoadMessages": "Klarte ikke å laste meldinger",
+    "failedToLoadConversation": "Klarte ikke å laste samtalen"
   },
   "time": {
     "justNow": "akkurat nå"

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -11,10 +11,28 @@
     "noMessages": "ยังไม่มีข้อความ"
   },
   "errors": {
-    "failedToLoad": "โหลดการสนทนาไม่สำเร็จ"
+    "failedToLoad": "โหลดการสนทนาไม่สำเร็จ",
+    "failedToLoadMessages": "โหลดข้อความไม่สำเร็จ"
   },
   "time": {
     "justNow": "เมื่อสักครู่"
+  },
+  "chat": {
+    "back": "กลับไปที่การสนทนา",
+    "membersLabel": "สมาชิก",
+    "memberFallback": "สมาชิก #{{id}}",
+    "you": "คุณ",
+    "emptyMessages": "ยังไม่มีข้อความ ลองทักทายกันสิ!",
+    "noSelectionTitle": "เลือกการสนทนา",
+    "noSelectionHint": "เลือกแชตจากรายการเพื่อเริ่มอ่าน"
+  },
+  "composer": {
+    "placeholder": "พิมพ์ข้อความ…",
+    "send": "ส่งข้อความ",
+    "errors": {
+      "send": "ส่งข้อความไม่สำเร็จ",
+      "tooLong": "ข้อความยาวเกินไป"
+    }
   },
   "newModal": {
     "title": "การสนทนาใหม่",

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -12,7 +12,8 @@
   },
   "errors": {
     "failedToLoad": "โหลดการสนทนาไม่สำเร็จ",
-    "failedToLoadMessages": "โหลดข้อความไม่สำเร็จ"
+    "failedToLoadMessages": "โหลดข้อความไม่สำเร็จ",
+    "failedToLoadConversation": "โหลดการสนทนาไม่สำเร็จ"
   },
   "time": {
     "justNow": "เมื่อสักครู่"

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
+import ChatView from './ChatView'
+
+// ── Translation mock ──────────────────────────────────────────────────────────
+
+const TRANSLATIONS: Record<string, string> = {
+  'loading': 'Loading…',
+  'unnamedConversation': 'Untitled chat',
+  'errors.failedToLoadMessages': 'Failed to load messages',
+  'errors.failedToLoadConversation': 'Failed to load conversation',
+  'time.justNow': 'just now',
+  'chat.back': 'Back to conversations',
+  'chat.membersLabel': 'Members',
+  'chat.memberFallback': 'Member #{{id}}',
+  'chat.you': 'You',
+  'chat.emptyMessages': 'No messages yet. Say hello!',
+  'chat.noSelectionTitle': 'Pick a conversation',
+  'chat.noSelectionHint': 'Choose a chat from the list to start reading.',
+  'composer.placeholder': 'Write a message…',
+  'composer.send': 'Send message',
+  'composer.errors.send': 'Failed to send message',
+  'composer.errors.tooLong': 'Message is too long',
+  'newModal.parent': 'Parent',
+}
+
+function stableT(key: string, opts?: Record<string, string | number>): string {
+  const val = TRANSLATIONS[key] ?? key
+  if (opts) return val.replace(/\{\{(\w+)\}\}/g, (_, k) => String(opts[k] ?? ''))
+  return val
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: stableT, i18n: { language: 'en' } }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// ── Auth mock ─────────────────────────────────────────────────────────────────
+
+const authState = {
+  user: { id: 1, name: 'Alice', email: 'alice@example.com' },
+  familyStatus: null as null | { is_parent: boolean; is_child: boolean },
+}
+
+vi.mock('../../auth', () => ({
+  useAuth: () => authState,
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeConversation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    name: 'Family Chat',
+    owner_user_id: 1,
+    created_at: '2026-05-01T00:00:00Z',
+    last_message_at: '2026-05-01T10:00:00Z',
+    unread_count: 0,
+    member_ids: [1],
+    ...overrides,
+  }
+}
+
+function makeMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    conversation_id: 1,
+    sender_user_id: 1,
+    body: 'Hello!',
+    created_at: '2026-05-01T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function convOk(conv = makeConversation()) {
+  return { ok: true, json: () => Promise.resolve({ conversation: conv }) }
+}
+
+function msgsOk(messages: ReturnType<typeof makeMessage>[] = []) {
+  return { ok: true, json: () => Promise.resolve({ messages }) }
+}
+
+function sendOk(msg: ReturnType<typeof makeMessage>) {
+  return { ok: true, json: () => Promise.resolve({ message: msg }) }
+}
+
+function renderChatView(conversationId: number | null = 1, onBack = vi.fn()) {
+  return render(<ChatView conversationId={conversationId} onBack={onBack} />)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ChatView – no selection', () => {
+  it('shows no-selection state when conversationId is null', () => {
+    renderChatView(null)
+    expect(screen.getByText('Pick a conversation')).toBeInTheDocument()
+  })
+})
+
+describe('ChatView – loading and error states', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('shows loading skeleton while fetching', () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+    const { container } = renderChatView()
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument()
+  })
+
+  it('renders conversation name after successful load', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk()),
+    )
+    renderChatView()
+    await waitFor(() => {
+      expect(screen.getByText('Family Chat')).toBeInTheDocument()
+    })
+  })
+
+  it('shows messages-error when messages request fails', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce({ ok: false }),
+    )
+    renderChatView()
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load messages')).toBeInTheDocument()
+    })
+  })
+
+  it('shows conversation-error when conversation request fails', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce(msgsOk()),
+    )
+    renderChatView()
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load conversation')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when there are no messages', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([])),
+    )
+    renderChatView()
+    await waitFor(() => {
+      expect(screen.getByText('No messages yet. Say hello!')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('ChatView – message rendering order', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('renders messages oldest-first (API returns newest-first, view reverses)', async () => {
+    // API returns newest-first: [third, second, first]
+    const messages = [
+      makeMessage({ id: 3, body: 'Third message', created_at: '2026-05-01T12:00:00Z' }),
+      makeMessage({ id: 2, body: 'Second message', created_at: '2026-05-01T11:00:00Z' }),
+      makeMessage({ id: 1, body: 'First message', created_at: '2026-05-01T10:00:00Z' }),
+    ]
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk(messages)),
+    )
+    renderChatView()
+    await waitFor(() => expect(screen.getByText('First message')).toBeInTheDocument())
+
+    const log = screen.getByRole('log')
+    const bubbles = Array.from(log.querySelectorAll('[class*="rounded-2xl"]'))
+    expect(bubbles[0].textContent).toBe('First message')
+    expect(bubbles[1].textContent).toBe('Second message')
+    expect(bubbles[2].textContent).toBe('Third message')
+  })
+})
+
+describe('ChatView – optimistic message append', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('appends a newly sent message to the list', async () => {
+    const newMsg = makeMessage({ id: 42, body: 'New message from me', sender_user_id: 1 })
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(sendOk(newMsg)),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'New message from me' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false })
+
+    await waitFor(() => {
+      expect(screen.getByText('New message from me')).toBeInTheDocument()
+    })
+  })
+
+  it('does not append a message whose conversation_id does not match the current view', async () => {
+    // Render conversation 1, then switch to conversation 2.
+    // Messages from conversation 1 must not appear in conversation 2.
+    const conv1msgs = [makeMessage({ id: 1, body: 'Conv1 message', conversation_id: 1 })]
+    const conv2msgs = [makeMessage({ id: 2, body: 'Conv2 message', conversation_id: 2, sender_user_id: 2 })]
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk(makeConversation({ id: 1, name: 'Chat One' })))
+      .mockResolvedValueOnce(msgsOk(conv1msgs))
+      .mockResolvedValueOnce(convOk(makeConversation({ id: 2, name: 'Chat Two' })))
+      .mockResolvedValueOnce(msgsOk(conv2msgs)),
+    )
+
+    const { rerender } = renderChatView(1)
+    await waitFor(() => expect(screen.getByText('Conv1 message')).toBeInTheDocument())
+
+    await act(async () => {
+      rerender(<ChatView conversationId={2} onBack={vi.fn()} />)
+    })
+
+    await waitFor(() => expect(screen.getByText('Conv2 message')).toBeInTheDocument())
+    expect(screen.queryByText('Conv1 message')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -148,6 +148,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // selection switch cannot race a stale response into state.
   useEffect(() => {
     if (conversationId === null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setConversation(null)
       setMessages([])
       setError('')

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -199,13 +199,16 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   }, [messages.length, conversationId])
 
   const handleMessageCreated = useCallback((msg: ChatMessage) => {
+    // Defensive: if the user switched conversations while a send was in
+    // flight, drop the message rather than leaking it into the wrong chat.
+    if (msg.conversation_id !== conversationId) return
     setMessages(prev => {
       // Guard against the rare case where SSE (sub-task 4) and the REST
       // response both deliver the same message: drop any duplicate id.
       if (prev.some(m => m.id === msg.id)) return prev
       return [...prev, msg]
     })
-  }, [])
+  }, [conversationId])
 
   const memberChips = useMemo(() => {
     if (!conversation) return []

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -169,7 +169,10 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         setMessages(sorted)
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return
-        setError(t('errors.failedToLoadMessages'))
+        const key = err instanceof Error && err.message === 'conversation failed'
+          ? 'errors.failedToLoadConversation'
+          : 'errors.failedToLoadMessages'
+        setError(t(key))
       } finally {
         if (!controller.signal.aborted) setLoading(false)
       }

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -1,8 +1,346 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronLeft, MessageSquare } from 'lucide-react'
+import { Skeleton } from '../../components/ui/skeleton'
+import { useAuth } from '../../auth'
+import Composer from './Composer'
+
 interface ChatViewProps {
   conversationId: number | null
   onBack: () => void
 }
 
-export default function ChatView(_props: ChatViewProps) {
-  return <div className="flex flex-col h-full" data-testid="family-chat-view" />
+interface Conversation {
+  id: number
+  name: string
+  owner_user_id: number
+  created_at: string
+  last_message_at: string
+  unread_count: number
+  member_ids: number[]
+}
+
+export interface ChatMessage {
+  id: number
+  conversation_id: number
+  sender_user_id: number
+  body: string
+  attachment_path?: string
+  attachment_mime?: string
+  created_at: string
+}
+
+interface MemberInfo {
+  label: string
+  emoji: string
+}
+
+interface FamilyChild {
+  child_id: number
+  nickname: string
+  avatar_emoji: string
+}
+
+interface SiblingInfo {
+  child_id: number
+  nickname: string
+  avatar_emoji: string
+}
+
+interface ParentInfo {
+  user_id: number
+  name: string
+  picture: string
+}
+
+// formatRelative renders an ISO timestamp as a localized relative-time string
+// (e.g. "2 minutes ago"). Falls back to an empty string for invalid input.
+function formatRelative(iso: string, language: string, justNow: string): string {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const now = Date.now()
+  const diffSec = Math.round((then - now) / 1000)
+  const abs = Math.abs(diffSec)
+  const rtf = new Intl.RelativeTimeFormat(language, { numeric: 'auto' })
+  if (abs < 30) return justNow
+  if (abs < 60) return rtf.format(diffSec, 'second')
+  if (abs < 60 * 60) return rtf.format(Math.round(diffSec / 60), 'minute')
+  if (abs < 60 * 60 * 24) return rtf.format(Math.round(diffSec / 3600), 'hour')
+  if (abs < 60 * 60 * 24 * 7) return rtf.format(Math.round(diffSec / 86400), 'day')
+  if (abs < 60 * 60 * 24 * 30) return rtf.format(Math.round(diffSec / (86400 * 7)), 'week')
+  if (abs < 60 * 60 * 24 * 365) return rtf.format(Math.round(diffSec / (86400 * 30)), 'month')
+  return rtf.format(Math.round(diffSec / (86400 * 365)), 'year')
+}
+
+export default function ChatView({ conversationId, onBack }: ChatViewProps) {
+  const { t, i18n } = useTranslation('familyChat')
+  const { user, familyStatus } = useAuth()
+
+  const [conversation, setConversation] = useState<Conversation | null>(null)
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [memberLookup, setMemberLookup] = useState<Map<number, MemberInfo>>(new Map())
+
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  // Build a label/emoji lookup for every user the current user can name,
+  // so member chips and sender labels render with friendly names. The
+  // current user is always included from auth context.
+  useEffect(() => {
+    if (!user) return
+    const controller = new AbortController()
+    ;(async () => {
+      const lookup = new Map<number, MemberInfo>()
+      lookup.set(user.id, { label: user.name || user.email || `#${user.id}`, emoji: '👤' })
+      try {
+        if (familyStatus?.is_parent) {
+          const res = await fetch('/api/family/children', {
+            credentials: 'include',
+            signal: controller.signal,
+          })
+          if (res.ok) {
+            const data = await res.json()
+            const kids: FamilyChild[] = data.children ?? []
+            for (const k of kids) {
+              lookup.set(k.child_id, {
+                label: k.nickname || `#${k.child_id}`,
+                emoji: k.avatar_emoji || '⭐',
+              })
+            }
+          }
+        }
+        if (familyStatus?.is_child) {
+          const res = await fetch('/api/family/my-family', {
+            credentials: 'include',
+            signal: controller.signal,
+          })
+          if (res.ok) {
+            const data = await res.json()
+            const parent: ParentInfo | undefined = data.parent
+            if (parent?.user_id) {
+              lookup.set(parent.user_id, {
+                label: parent.name || t('newModal.parent'),
+                emoji: '👤',
+              })
+            }
+            const siblings: SiblingInfo[] = data.siblings ?? []
+            for (const s of siblings) {
+              lookup.set(s.child_id, {
+                label: s.nickname || `#${s.child_id}`,
+                emoji: s.avatar_emoji || '⭐',
+              })
+            }
+          }
+        }
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        // Non-fatal: chips fall back to "Member #id" if the lookup is empty.
+      }
+      if (!controller.signal.aborted) setMemberLookup(lookup)
+    })()
+    return () => { controller.abort() }
+  }, [user, familyStatus, t])
+
+  // Load conversation metadata + initial messages whenever the selected
+  // conversation changes. Both requests share an AbortController so a fast
+  // selection switch cannot race a stale response into state.
+  useEffect(() => {
+    if (conversationId === null) {
+      setConversation(null)
+      setMessages([])
+      setError('')
+      setLoading(false)
+      return
+    }
+    const controller = new AbortController()
+    setLoading(true)
+    setError('')
+    setMessages([])
+    setConversation(null)
+    ;(async () => {
+      try {
+        const [convRes, msgRes] = await Promise.all([
+          fetch(`/api/familychat/conversations/${conversationId}`, {
+            credentials: 'include',
+            signal: controller.signal,
+          }),
+          fetch(`/api/familychat/conversations/${conversationId}/messages`, {
+            credentials: 'include',
+            signal: controller.signal,
+          }),
+        ])
+        if (!convRes.ok) throw new Error('conversation failed')
+        if (!msgRes.ok) throw new Error('messages failed')
+        const convData = await convRes.json()
+        const msgData = await msgRes.json()
+        if (controller.signal.aborted) return
+        setConversation(convData.conversation ?? null)
+        // The API returns newest-first; display oldest at top to bottom.
+        const sorted: ChatMessage[] = (msgData.messages ?? []).slice().reverse()
+        setMessages(sorted)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setError(t('errors.failedToLoadMessages'))
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    })()
+    return () => { controller.abort() }
+  }, [conversationId, t])
+
+  // Auto-scroll to the bottom whenever the message list updates. useLayoutEffect
+  // avoids a visible jump between initial paint and the scroll snap.
+  useLayoutEffect(() => {
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ block: 'end' })
+    }
+  }, [messages.length, conversationId])
+
+  const handleMessageCreated = useCallback((msg: ChatMessage) => {
+    setMessages(prev => {
+      // Guard against the rare case where SSE (sub-task 4) and the REST
+      // response both deliver the same message: drop any duplicate id.
+      if (prev.some(m => m.id === msg.id)) return prev
+      return [...prev, msg]
+    })
+  }, [])
+
+  const memberChips = useMemo(() => {
+    if (!conversation) return []
+    return conversation.member_ids.map(id => {
+      const info = memberLookup.get(id)
+      const isSelf = user?.id === id
+      return {
+        id,
+        label: isSelf
+          ? t('chat.you')
+          : info?.label ?? t('chat.memberFallback', { id }),
+        emoji: info?.emoji ?? '👤',
+        isSelf,
+      }
+    })
+  }, [conversation, memberLookup, t, user?.id])
+
+  if (conversationId === null) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center h-full text-center px-6 text-gray-400"
+        data-testid="family-chat-view"
+      >
+        <MessageSquare size={48} className="mb-3 text-gray-600" aria-hidden="true" />
+        <p className="font-medium text-gray-300">{t('chat.noSelectionTitle')}</p>
+        <p className="text-sm text-gray-500 mt-1">{t('chat.noSelectionHint')}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0" data-testid="family-chat-view">
+      <header className="flex items-center gap-2 px-3 sm:px-4 py-3 border-b border-gray-800 bg-gray-950 shrink-0">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label={t('chat.back')}
+          className="md:hidden p-1.5 -ml-1 text-gray-300 hover:text-white rounded-md cursor-pointer"
+        >
+          <ChevronLeft size={20} aria-hidden="true" />
+        </button>
+        <div className="flex-1 min-w-0">
+          <h2 className="text-base sm:text-lg font-semibold text-white truncate">
+            {loading && !conversation ? (
+              <Skeleton className="h-5 w-40" />
+            ) : (
+              conversation?.name || t('unnamedConversation')
+            )}
+          </h2>
+          {memberChips.length > 0 && (
+            <ul
+              className="flex flex-wrap gap-1.5 mt-1.5"
+              aria-label={t('chat.membersLabel')}
+              role="list"
+            >
+              {memberChips.map(chip => (
+                <li
+                  key={chip.id}
+                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border ${
+                    chip.isSelf
+                      ? 'bg-blue-500/15 border-blue-500/40 text-blue-200'
+                      : 'bg-gray-800 border-gray-700 text-gray-300'
+                  }`}
+                >
+                  <span aria-hidden="true">{chip.emoji}</span>
+                  <span className="truncate max-w-[10rem]">{chip.label}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </header>
+
+      <div
+        className="flex-1 min-h-0 overflow-y-auto px-3 sm:px-4 py-3 space-y-2"
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions"
+      >
+        {loading && (
+          <div className="space-y-3" role="status" aria-busy="true">
+            <span className="sr-only">{t('loading')}</span>
+            <Skeleton className="h-12 w-3/4" />
+            <Skeleton className="h-12 w-2/3 ml-auto" />
+            <Skeleton className="h-12 w-1/2" />
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="p-3 bg-red-900/40 border border-red-700 rounded-lg text-red-300 text-sm">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && messages.length === 0 && (
+          <div className="flex flex-col items-center justify-center h-full text-center text-gray-500 py-12">
+            <MessageSquare size={32} className="mb-2 text-gray-600" aria-hidden="true" />
+            <p className="text-sm">{t('chat.emptyMessages')}</p>
+          </div>
+        )}
+
+        {!loading && !error && messages.map(msg => {
+          const isOwn = user?.id === msg.sender_user_id
+          const senderInfo = memberLookup.get(msg.sender_user_id)
+          const senderLabel = senderInfo?.label ?? t('chat.memberFallback', { id: msg.sender_user_id })
+          const relative = formatRelative(msg.created_at, i18n.language, t('time.justNow'))
+          return (
+            <div
+              key={msg.id}
+              className={`flex flex-col ${isOwn ? 'items-end' : 'items-start'}`}
+            >
+              {!isOwn && (
+                <span className="text-xs text-gray-400 mb-0.5 px-1">{senderLabel}</span>
+              )}
+              <div
+                className={`max-w-[85%] sm:max-w-[70%] px-3 py-2 rounded-2xl text-sm whitespace-pre-wrap break-words ${
+                  isOwn
+                    ? 'bg-blue-600 text-white rounded-br-sm'
+                    : 'bg-gray-800 text-gray-100 rounded-bl-sm'
+                }`}
+              >
+                {msg.body}
+              </div>
+              {relative && (
+                <span className="text-[10px] text-gray-500 mt-0.5 px-1">{relative}</span>
+              )}
+            </div>
+          )
+        })}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="border-t border-gray-800 bg-gray-950 shrink-0">
+        <Composer conversationId={conversationId} onMessageCreated={handleMessageCreated} />
+      </div>
+    </div>
+  )
 }

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, MessageSquare } from 'lucide-react'
 import { Skeleton } from '../../components/ui/skeleton'
 import { useAuth } from '../../auth'
 import Composer from './Composer'
+import { formatRelative } from './utils'
 
 interface ChatViewProps {
   conversationId: number | null
@@ -53,26 +54,6 @@ interface ParentInfo {
   picture: string
 }
 
-// formatRelative renders an ISO timestamp as a localized relative-time string
-// (e.g. "2 minutes ago"). Falls back to an empty string for invalid input.
-function formatRelative(iso: string, language: string, justNow: string): string {
-  if (!iso) return ''
-  const then = new Date(iso).getTime()
-  if (Number.isNaN(then)) return ''
-  const now = Date.now()
-  const diffSec = Math.round((then - now) / 1000)
-  const abs = Math.abs(diffSec)
-  const rtf = new Intl.RelativeTimeFormat(language, { numeric: 'auto' })
-  if (abs < 30) return justNow
-  if (abs < 60) return rtf.format(diffSec, 'second')
-  if (abs < 60 * 60) return rtf.format(Math.round(diffSec / 60), 'minute')
-  if (abs < 60 * 60 * 24) return rtf.format(Math.round(diffSec / 3600), 'hour')
-  if (abs < 60 * 60 * 24 * 7) return rtf.format(Math.round(diffSec / 86400), 'day')
-  if (abs < 60 * 60 * 24 * 30) return rtf.format(Math.round(diffSec / (86400 * 7)), 'week')
-  if (abs < 60 * 60 * 24 * 365) return rtf.format(Math.round(diffSec / (86400 * 30)), 'month')
-  return rtf.format(Math.round(diffSec / (86400 * 365)), 'year')
-}
-
 export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const { t, i18n } = useTranslation('familyChat')
   const { user, familyStatus } = useAuth()
@@ -84,6 +65,11 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const [memberLookup, setMemberLookup] = useState<Map<number, MemberInfo>>(new Map())
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  const rtf = useMemo(
+    () => new Intl.RelativeTimeFormat(i18n.language, { numeric: 'auto' }),
+    [i18n.language],
+  )
 
   // Build a label/emoji lookup for every user the current user can name,
   // so member chips and sender labels render with friendly names. The
@@ -315,7 +301,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
           const isOwn = user?.id === msg.sender_user_id
           const senderInfo = memberLookup.get(msg.sender_user_id)
           const senderLabel = senderInfo?.label ?? t('chat.memberFallback', { id: msg.sender_user_id })
-          const relative = formatRelative(msg.created_at, i18n.language, t('time.justNow'))
+          const relative = formatRelative(msg.created_at, rtf, t('time.justNow'))
           return (
             <div
               key={msg.id}

--- a/web/src/pages/familychat/Composer.test.tsx
+++ b/web/src/pages/familychat/Composer.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import Composer from './Composer'
+import type { ChatMessage } from './ChatView'
+
+// ── Translation mock ──────────────────────────────────────────────────────────
+
+const TRANSLATIONS: Record<string, string> = {
+  'composer.placeholder': 'Write a message…',
+  'composer.send': 'Send message',
+  'composer.errors.send': 'Failed to send message',
+  'composer.errors.tooLong': 'Message is too long',
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => TRANSLATIONS[key] ?? key,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 1,
+    conversation_id: 1,
+    sender_user_id: 1,
+    body: 'Hello!',
+    created_at: '2026-05-01T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function sendOk(msg: ChatMessage) {
+  return { ok: true, json: () => Promise.resolve({ message: msg }) }
+}
+
+function renderComposer(conversationId = 1, onMessageCreated = vi.fn()) {
+  return render(
+    <Composer conversationId={conversationId} onMessageCreated={onMessageCreated} />,
+  )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Composer – keyboard behavior', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('submits when Enter is pressed without Shift', async () => {
+    const msg = makeMessage({ body: 'Hello world' })
+    vi.stubGlobal('fetch', vi.fn(() => sendOk(msg)))
+    const onMessageCreated = vi.fn()
+    renderComposer(1, onMessageCreated)
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Hello world' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false })
+
+    await waitFor(() => {
+      expect(onMessageCreated).toHaveBeenCalledWith(msg)
+    })
+  })
+
+  it('does not submit when Shift+Enter is pressed', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+    renderComposer()
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Hello world' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true })
+
+    // Give async effects a chance to run
+    await new Promise(r => setTimeout(r, 50))
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled()
+  })
+})
+
+describe('Composer – successful send', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('clears the textarea after a successful send', async () => {
+    const msg = makeMessage({ body: 'My message' })
+    vi.stubGlobal('fetch', vi.fn(() => sendOk(msg)))
+    renderComposer()
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'My message' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    await waitFor(() => {
+      expect((textarea as HTMLTextAreaElement).value).toBe('')
+    })
+  })
+
+  it('calls onMessageCreated with the returned message', async () => {
+    const msg = makeMessage({ id: 99, body: 'Ping' })
+    vi.stubGlobal('fetch', vi.fn(() => sendOk(msg)))
+    const onMessageCreated = vi.fn()
+    renderComposer(1, onMessageCreated)
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Ping' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    await waitFor(() => {
+      expect(onMessageCreated).toHaveBeenCalledWith(msg)
+    })
+  })
+})
+
+describe('Composer – error handling', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('shows error message when server responds with non-2xx', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => ({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Server unavailable' }),
+    })))
+    renderComposer()
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Test message' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Server unavailable')
+    })
+  })
+
+  it('shows fallback error when server error has no message', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => ({
+      ok: false,
+      json: () => Promise.resolve({}),
+    })))
+    renderComposer()
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Test message' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to send message')
+    })
+  })
+
+  it('send button is disabled when textarea is empty', () => {
+    vi.stubGlobal('fetch', vi.fn())
+    renderComposer()
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled()
+  })
+
+  it('send button is disabled when only whitespace is entered', () => {
+    vi.stubGlobal('fetch', vi.fn())
+    renderComposer()
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '   ' } })
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled()
+  })
+})

--- a/web/src/pages/familychat/Composer.tsx
+++ b/web/src/pages/familychat/Composer.tsx
@@ -47,7 +47,7 @@ export default function Composer({ conversationId, onMessageCreated }: ComposerP
   async function submit() {
     const trimmed = body.trim()
     if (!trimmed || sending) return
-    if (trimmed.length > MAX_BODY_LEN) {
+    if ([...trimmed].length > MAX_BODY_LEN) {
       setError(t('composer.errors.tooLong'))
       return
     }
@@ -127,7 +127,6 @@ export default function Composer({ conversationId, onMessageCreated }: ComposerP
           placeholder={t('composer.placeholder')}
           rows={1}
           disabled={sending}
-          maxLength={MAX_BODY_LEN}
           className="flex-1 resize-none bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-60"
         />
         <button

--- a/web/src/pages/familychat/Composer.tsx
+++ b/web/src/pages/familychat/Composer.tsx
@@ -1,8 +1,130 @@
+import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Send, Loader2 } from 'lucide-react'
+import type { ChatMessage } from './ChatView'
+
 interface ComposerProps {
   conversationId: number
-  onMessageSent?: () => void
+  onMessageCreated: (msg: ChatMessage) => void
 }
 
-export default function Composer(_props: ComposerProps) {
-  return <div data-testid="family-chat-composer" />
+// Match the backend cap so we surface "too long" errors locally instead of
+// round-tripping a 400. See maxBodyLen in internal/familychat/handlers.go.
+const MAX_BODY_LEN = 8000
+
+export default function Composer({ conversationId, onMessageCreated }: ComposerProps) {
+  const { t } = useTranslation('familyChat')
+  const [body, setBody] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Clear draft + focus the textarea when the conversation changes so the
+  // composer doesn't carry a half-typed message to a different chat.
+  useEffect(() => {
+    setBody('')
+    setError('')
+    textareaRef.current?.focus()
+  }, [conversationId])
+
+  // Auto-grow the textarea up to a max height; collapse back when emptied.
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+  }, [body])
+
+  async function submit() {
+    const trimmed = body.trim()
+    if (!trimmed || sending) return
+    if (trimmed.length > MAX_BODY_LEN) {
+      setError(t('composer.errors.tooLong'))
+      return
+    }
+    setSending(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/familychat/conversations/${conversationId}/messages`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: trimmed }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.error || t('composer.errors.send'))
+      }
+      const data = await res.json()
+      const msg = data?.message as ChatMessage | undefined
+      if (!msg || typeof msg.id !== 'number') {
+        throw new Error(t('composer.errors.send'))
+      }
+      onMessageCreated(msg)
+      setBody('')
+      textareaRef.current?.focus()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('composer.errors.send'))
+    } finally {
+      setSending(false)
+    }
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    submit()
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    // Enter sends; Shift+Enter inserts a newline. Matches the other Hytte
+    // chat surfaces (see Chat.tsx, HomeworkChat.tsx).
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      submit()
+    }
+  }
+
+  const disabled = sending || body.trim().length === 0
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="px-3 sm:px-4 py-2 flex flex-col gap-1.5"
+      data-testid="family-chat-composer"
+    >
+      {error && (
+        <p role="alert" className="text-xs text-red-400">{error}</p>
+      )}
+      <div className="flex items-end gap-2">
+        <label htmlFor="family-chat-composer-input" className="sr-only">
+          {t('composer.placeholder')}
+        </label>
+        <textarea
+          id="family-chat-composer-input"
+          ref={textareaRef}
+          value={body}
+          onChange={e => setBody(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={t('composer.placeholder')}
+          rows={1}
+          disabled={sending}
+          maxLength={MAX_BODY_LEN}
+          className="flex-1 resize-none bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-60"
+        />
+        <button
+          type="submit"
+          disabled={disabled}
+          aria-label={t('composer.send')}
+          title={t('composer.send')}
+          className="flex items-center justify-center w-10 h-10 rounded-lg bg-blue-600 hover:bg-blue-500 text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+        >
+          {sending ? (
+            <Loader2 size={18} className="animate-spin" aria-hidden="true" />
+          ) : (
+            <Send size={18} aria-hidden="true" />
+          )}
+        </button>
+      </div>
+    </form>
+  )
 }

--- a/web/src/pages/familychat/Composer.tsx
+++ b/web/src/pages/familychat/Composer.tsx
@@ -18,13 +18,21 @@ export default function Composer({ conversationId, onMessageCreated }: ComposerP
   const [sending, setSending] = useState(false)
   const [error, setError] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const abortRef = useRef<AbortController | null>(null)
 
   // Clear draft + focus the textarea when the conversation changes so the
-  // composer doesn't carry a half-typed message to a different chat.
+  // composer doesn't carry a half-typed message to a different chat. Also
+  // abort any in-flight send so its response cannot leak the message into
+  // the newly selected conversation. The cleanup also runs on unmount.
   useEffect(() => {
     setBody('')
     setError('')
+    setSending(false)
     textareaRef.current?.focus()
+    return () => {
+      abortRef.current?.abort()
+      abortRef.current = null
+    }
   }, [conversationId])
 
   // Auto-grow the textarea up to a max height; collapse back when emptied.
@@ -42,20 +50,27 @@ export default function Composer({ conversationId, onMessageCreated }: ComposerP
       setError(t('composer.errors.tooLong'))
       return
     }
+    const controller = new AbortController()
+    abortRef.current?.abort()
+    abortRef.current = controller
+    const targetConversationId = conversationId
     setSending(true)
     setError('')
     try {
-      const res = await fetch(`/api/familychat/conversations/${conversationId}/messages`, {
+      const res = await fetch(`/api/familychat/conversations/${targetConversationId}/messages`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ body: trimmed }),
+        signal: controller.signal,
       })
+      if (controller.signal.aborted) return
       if (!res.ok) {
         const data = await res.json().catch(() => null)
         throw new Error(data?.error || t('composer.errors.send'))
       }
       const data = await res.json()
+      if (controller.signal.aborted) return
       const msg = data?.message as ChatMessage | undefined
       if (!msg || typeof msg.id !== 'number') {
         throw new Error(t('composer.errors.send'))
@@ -64,9 +79,12 @@ export default function Composer({ conversationId, onMessageCreated }: ComposerP
       setBody('')
       textareaRef.current?.focus()
     } catch (err) {
+      if (controller.signal.aborted) return
+      if (err instanceof Error && err.name === 'AbortError') return
       setError(err instanceof Error ? err.message : t('composer.errors.send'))
     } finally {
-      setSending(false)
+      if (!controller.signal.aborted) setSending(false)
+      if (abortRef.current === controller) abortRef.current = null
     }
   }
 

--- a/web/src/pages/familychat/Composer.tsx
+++ b/web/src/pages/familychat/Composer.tsx
@@ -25,6 +25,7 @@ export default function Composer({ conversationId, onMessageCreated }: ComposerP
   // abort any in-flight send so its response cannot leak the message into
   // the newly selected conversation. The cleanup also runs on unmount.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setBody('')
     setError('')
     setSending(false)

--- a/web/src/pages/familychat/ConversationList.tsx
+++ b/web/src/pages/familychat/ConversationList.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Plus, MessageSquarePlus } from 'lucide-react'
 import { Skeleton } from '../../components/ui/skeleton'
+import { formatRelative } from './utils'
 
 interface ConversationListProps {
   selectedConversationId: number | null
@@ -22,26 +23,6 @@ interface Conversation {
   last_message_sender_id?: number
 }
 
-// formatRelative renders a date as a localized relative-time string
-// (e.g. "2 minutes ago"). Falls back to an empty string for invalid input.
-function formatRelative(iso: string, language: string, justNow: string): string {
-  if (!iso) return ''
-  const then = new Date(iso).getTime()
-  if (Number.isNaN(then)) return ''
-  const now = Date.now()
-  const diffSec = Math.round((then - now) / 1000)
-  const abs = Math.abs(diffSec)
-  const rtf = new Intl.RelativeTimeFormat(language, { numeric: 'auto' })
-  if (abs < 30) return justNow
-  if (abs < 60) return rtf.format(diffSec, 'second')
-  if (abs < 60 * 60) return rtf.format(Math.round(diffSec / 60), 'minute')
-  if (abs < 60 * 60 * 24) return rtf.format(Math.round(diffSec / 3600), 'hour')
-  if (abs < 60 * 60 * 24 * 7) return rtf.format(Math.round(diffSec / 86400), 'day')
-  if (abs < 60 * 60 * 24 * 30) return rtf.format(Math.round(diffSec / (86400 * 7)), 'week')
-  if (abs < 60 * 60 * 24 * 365) return rtf.format(Math.round(diffSec / (86400 * 30)), 'month')
-  return rtf.format(Math.round(diffSec / (86400 * 365)), 'year')
-}
-
 export default function ConversationList({
   selectedConversationId,
   onSelectConversation,
@@ -52,6 +33,11 @@ export default function ConversationList({
   const [conversations, setConversations] = useState<Conversation[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+
+  const rtf = useMemo(
+    () => new Intl.RelativeTimeFormat(i18n.language, { numeric: 'auto' }),
+    [i18n.language],
+  )
 
   useEffect(() => {
     const controller = new AbortController()
@@ -121,7 +107,7 @@ export default function ConversationList({
             {conversations.map(conv => {
               const isSelected = conv.id === selectedConversationId
               const timestamp = conv.last_message_at || conv.created_at
-              const relative = formatRelative(timestamp, i18n.language, t('time.justNow'))
+              const relative = formatRelative(timestamp, rtf, t('time.justNow'))
               const previewText = conv.last_message_preview || t('empty.noMessages')
               return (
                 <li key={conv.id}>

--- a/web/src/pages/familychat/utils.ts
+++ b/web/src/pages/familychat/utils.ts
@@ -1,0 +1,19 @@
+// formatRelative renders an ISO timestamp as a localized relative-time string
+// (e.g. "2 minutes ago"). Falls back to an empty string for invalid input.
+// The caller is responsible for creating and memoizing the rtf instance.
+export function formatRelative(iso: string, rtf: Intl.RelativeTimeFormat, justNow: string): string {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const now = Date.now()
+  const diffSec = Math.round((then - now) / 1000)
+  const abs = Math.abs(diffSec)
+  if (abs < 30) return justNow
+  if (abs < 60) return rtf.format(diffSec, 'second')
+  if (abs < 60 * 60) return rtf.format(Math.round(diffSec / 60), 'minute')
+  if (abs < 60 * 60 * 24) return rtf.format(Math.round(diffSec / 3600), 'hour')
+  if (abs < 60 * 60 * 24 * 7) return rtf.format(Math.round(diffSec / 86400), 'day')
+  if (abs < 60 * 60 * 24 * 30) return rtf.format(Math.round(diffSec / (86400 * 7)), 'week')
+  if (abs < 60 * 60 * 24 * 365) return rtf.format(Math.round(diffSec / (86400 * 30)), 'month')
+  return rtf.format(Math.round(diffSec / (86400 * 365)), 'year')
+}


### PR DESCRIPTION
## Changes

- **Family Chat: chat view with header, message list, and composer** - The selected conversation now shows its name and member chips, lists messages oldest-to-newest with auto-scroll, and posts new messages via a controlled composer (Enter to send, Shift+Enter for newline). (Hytte-goir)

## Original Issue (task): Chat view: header, message list, composer

Implement the right-column chat view in `FamilyChat.tsx`. Header: conversation name + member chips. Message list: scrollable, oldest at top, newest at bottom, auto-scroll on new message; bubbles show sender, decrypted body, sent_at relative time; own messages right-aligned, others left-aligned. Composer: controlled textarea + send button; submit posts the message via the backend endpoint and clears the textarea on success; disable while in-flight. Fetch initial messages via GET `/messages` for the selected conversation. Consumes selection state from sub-task 1; SSE wiring is sub-task 4.

---
Bead: Hytte-goir | Branch: forge/Hytte-goir
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->