### PR TITLE
SSE live updates + reconnect gap-fill (Hytte-c0cw)

### DIFF
--- a/changelog.d/Hytte-c0cw.md
+++ b/changelog.d/Hytte-c0cw.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat live updates over SSE** - The chat view now subscribes to the conversation's SSE stream so new messages appear in real time. On reconnect after a dropped stream, the client gap-fills via `GET /messages?since=…` so no messages are lost while disconnected. (Hytte-c0cw)

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -347,3 +347,98 @@ describe('ChatView – SSE live updates', () => {
     expect(screen.getByText('No messages yet. Say hello!')).toBeInTheDocument()
   })
 })
+
+describe('ChatView – reconnect gap-fill', () => {
+  afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('issues a gap-fill fetch after stream disconnect and appends messages in order', async () => {
+    // shouldAdvanceTime lets real time flow so waitFor retries work, while
+    // advanceTimersByTimeAsync can still fast-forward the reconnect delay.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    let closeStream: (() => void) | null = null
+    const firstStream = new ReadableStream<Uint8Array>({
+      start(c) { closeStream = () => c.close() },
+    })
+
+    const initialMsg = makeMessage({ id: 10, body: 'Before disconnect', conversation_id: 1 })
+    const gapMsg1 = makeMessage({ id: 11, body: 'Gap one', conversation_id: 1, created_at: '2026-05-01T10:11:00Z' })
+    const gapMsg2 = makeMessage({ id: 12, body: 'Gap two', conversation_id: 1, created_at: '2026-05-01T10:12:00Z' })
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([initialMsg]))
+      .mockResolvedValueOnce({ ok: true, body: firstStream })
+      .mockResolvedValueOnce(msgsOk([gapMsg2, gapMsg1]))  // API newest-first
+      .mockResolvedValueOnce(streamOk())
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderChatView()
+    await waitFor(() => expect(screen.getByText('Before disconnect')).toBeInTheDocument())
+
+    // Close the first stream to trigger scheduleReconnect
+    await act(async () => {
+      closeStream!()
+      await Promise.resolve()
+    })
+
+    // Fast-forward past the first reconnect delay (2000 ms for attempt #1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+
+    // Verify that a gap-fill fetch with since=10 was issued
+    const fetchedUrls = fetchMock.mock.calls.map(([url]) => url as string)
+    expect(fetchedUrls.some(url => url.includes('/messages?since=10'))).toBe(true)
+
+    // Both gap messages should appear in ascending order after the pre-disconnect message
+    await waitFor(() => {
+      expect(screen.getByText('Gap one')).toBeInTheDocument()
+      expect(screen.getByText('Gap two')).toBeInTheDocument()
+    })
+
+    const log = screen.getByRole('log')
+    const bubbles = Array.from(log.querySelectorAll('[class*="rounded-2xl"]'))
+    const texts = bubbles.map(b => b.textContent)
+    expect(texts.indexOf('Before disconnect')).toBeLessThan(texts.indexOf('Gap one'))
+    expect(texts.indexOf('Gap one')).toBeLessThan(texts.indexOf('Gap two'))
+  }, 15000)
+
+  it('gap-fills without a since param when the initial message list is empty', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    let closeStream: (() => void) | null = null
+    const firstStream = new ReadableStream<Uint8Array>({
+      start(c) { closeStream = () => c.close() },
+    })
+
+    const reconnectMsg = makeMessage({ id: 1, body: 'Arrived during disconnect', conversation_id: 1 })
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce({ ok: true, body: firstStream })
+      .mockResolvedValueOnce(msgsOk([reconnectMsg]))
+      .mockResolvedValueOnce(streamOk())
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    await act(async () => {
+      closeStream!()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+
+    // Gap-fill URL must not include ?since when lastId was 0
+    const fetchedUrls = fetchMock.mock.calls.map(([url]) => url as string)
+    const msgUrls = fetchedUrls.filter(url => url.includes('/messages'))
+    expect(msgUrls.some(url => !url.includes('?since'))).toBe(true)
+
+    await waitFor(() => expect(screen.getByText('Arrived during disconnect')).toBeInTheDocument())
+  }, 15000)
+})

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -85,6 +85,37 @@ function sendOk(msg: ReturnType<typeof makeMessage>) {
   return { ok: true, json: () => Promise.resolve({ message: msg }) }
 }
 
+// streamOk returns a Response-shaped object whose body is a never-completing
+// ReadableStream. The SSE subscription opens this stream after the initial
+// load and reads until the test unmounts (which cancels the reader). Callers
+// who need to push frames into the live stream can use streamWithController
+// instead.
+function streamOk() {
+  const stream = new ReadableStream<Uint8Array>({
+    start() { /* hold open; cancel() will close it */ },
+  })
+  return { ok: true, body: stream }
+}
+
+function streamWithController() {
+  let streamController: ReadableStreamDefaultController<Uint8Array> | null = null
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) { streamController = c },
+  })
+  return {
+    response: { ok: true, body: stream },
+    push(event: string, data: unknown) {
+      const encoder = new TextEncoder()
+      streamController?.enqueue(
+        encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+      )
+    },
+    close() {
+      streamController?.close()
+    },
+  }
+}
+
 function renderChatView(conversationId: number | null = 1, onBack = vi.fn()) {
   return render(<ChatView conversationId={conversationId} onBack={onBack} />)
 }
@@ -110,7 +141,8 @@ describe('ChatView – loading and error states', () => {
   it('renders conversation name after successful load', async () => {
     vi.stubGlobal('fetch', vi.fn()
       .mockResolvedValueOnce(convOk())
-      .mockResolvedValueOnce(msgsOk()),
+      .mockResolvedValueOnce(msgsOk())
+      .mockResolvedValueOnce(streamOk()),
     )
     renderChatView()
     await waitFor(() => {
@@ -143,7 +175,8 @@ describe('ChatView – loading and error states', () => {
   it('shows empty state when there are no messages', async () => {
     vi.stubGlobal('fetch', vi.fn()
       .mockResolvedValueOnce(convOk())
-      .mockResolvedValueOnce(msgsOk([])),
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(streamOk()),
     )
     renderChatView()
     await waitFor(() => {
@@ -164,7 +197,8 @@ describe('ChatView – message rendering order', () => {
     ]
     vi.stubGlobal('fetch', vi.fn()
       .mockResolvedValueOnce(convOk())
-      .mockResolvedValueOnce(msgsOk(messages)),
+      .mockResolvedValueOnce(msgsOk(messages))
+      .mockResolvedValueOnce(streamOk()),
     )
     renderChatView()
     await waitFor(() => expect(screen.getByText('First message')).toBeInTheDocument())
@@ -185,6 +219,7 @@ describe('ChatView – optimistic message append', () => {
     vi.stubGlobal('fetch', vi.fn()
       .mockResolvedValueOnce(convOk())
       .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(streamOk())
       .mockResolvedValueOnce(sendOk(newMsg)),
     )
     renderChatView()
@@ -207,8 +242,10 @@ describe('ChatView – optimistic message append', () => {
     vi.stubGlobal('fetch', vi.fn()
       .mockResolvedValueOnce(convOk(makeConversation({ id: 1, name: 'Chat One' })))
       .mockResolvedValueOnce(msgsOk(conv1msgs))
+      .mockResolvedValueOnce(streamOk())
       .mockResolvedValueOnce(convOk(makeConversation({ id: 2, name: 'Chat Two' })))
-      .mockResolvedValueOnce(msgsOk(conv2msgs)),
+      .mockResolvedValueOnce(msgsOk(conv2msgs))
+      .mockResolvedValueOnce(streamOk()),
     )
 
     const { rerender } = renderChatView(1)
@@ -220,5 +257,93 @@ describe('ChatView – optimistic message append', () => {
 
     await waitFor(() => expect(screen.getByText('Conv2 message')).toBeInTheDocument())
     expect(screen.queryByText('Conv1 message')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatView – SSE live updates', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('appends a message_new event delivered via the SSE stream', async () => {
+    const sse = streamWithController()
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(sse.response),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    await act(async () => {
+      sse.push('message_new', {
+        message: makeMessage({
+          id: 50,
+          body: 'Live from SSE',
+          conversation_id: 1,
+          sender_user_id: 2,
+          created_at: '2026-05-01T11:00:00Z',
+        }),
+      })
+      // Yield so the read loop can process the enqueued frame.
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Live from SSE')).toBeInTheDocument()
+    })
+  })
+
+  it('deduplicates a message delivered via both POST response and SSE', async () => {
+    const sse = streamWithController()
+    const newMsg = makeMessage({ id: 7, body: 'Dedup me', sender_user_id: 1 })
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(sse.response)
+      .mockResolvedValueOnce(sendOk(newMsg)),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Dedup me' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false })
+
+    await waitFor(() => screen.getByText('Dedup me'))
+
+    await act(async () => {
+      sse.push('message_new', { message: newMsg })
+      await Promise.resolve()
+    })
+
+    // Still exactly one bubble for "Dedup me" after the duplicate SSE event.
+    const matches = screen.getAllByText('Dedup me')
+    expect(matches).toHaveLength(1)
+  })
+
+  it('ignores message_new events whose conversation_id does not match the view', async () => {
+    const sse = streamWithController()
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(sse.response),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    await act(async () => {
+      sse.push('message_new', {
+        message: makeMessage({
+          id: 99,
+          body: 'Wrong conversation',
+          conversation_id: 999,
+          sender_user_id: 2,
+        }),
+      })
+      await Promise.resolve()
+    })
+
+    // The misrouted message must not bleed into the open view.
+    expect(screen.queryByText('Wrong conversation')).not.toBeInTheDocument()
+    expect(screen.getByText('No messages yet. Say hello!')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -171,12 +171,12 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     }
 
     const fillGap = async () => {
-      if (lastId <= 0 || controller.signal.aborted) return
+      if (controller.signal.aborted) return
       try {
-        const res = await fetch(
-          `/api/familychat/conversations/${conversationId}/messages?since=${lastId}`,
-          { credentials: 'include', signal: controller.signal },
-        )
+        const url = lastId > 0
+          ? `/api/familychat/conversations/${conversationId}/messages?since=${lastId}`
+          : `/api/familychat/conversations/${conversationId}/messages`
+        const res = await fetch(url, { credentials: 'include', signal: controller.signal })
         if (!res.ok) return
         const data = await res.json()
         const msgs: ChatMessage[] = data.messages ?? []

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -129,9 +129,12 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     return () => { controller.abort() }
   }, [user, familyStatus, t])
 
-  // Load conversation metadata + initial messages whenever the selected
-  // conversation changes. Both requests share an AbortController so a fast
-  // selection switch cannot race a stale response into state.
+  // Load conversation metadata + initial messages, then subscribe to the SSE
+  // stream so new messages arrive without a refetch. The initial load and the
+  // SSE subscription share a single AbortController so switching conversation
+  // tears both down atomically; the SSE reader is also canceled explicitly so
+  // tests (and the rare browser that doesn't propagate abort to a streaming
+  // body) terminate the read loop deterministically.
   useEffect(() => {
     if (conversationId === null) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -142,10 +145,132 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       return
     }
     const controller = new AbortController()
+    // lastId is the highest message id this client has rendered for the
+    // current conversation. It seeds gap-fill queries on reconnect and is
+    // updated by initial load, SSE events, and gap-fill responses.
+    let lastId = 0
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let reconnectAttempts = 0
+    let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null
+
     setLoading(true)
     setError('')
     setMessages([])
     setConversation(null)
+
+    // appendIncoming deduplicates by id so a message that arrives via both
+    // SSE and the POST response (the sender path) or via SSE and gap-fill
+    // shows up exactly once.
+    const appendIncoming = (msg: ChatMessage) => {
+      if (msg.conversation_id !== conversationId) return
+      if (msg.id > lastId) lastId = msg.id
+      setMessages(prev => {
+        if (prev.some(m => m.id === msg.id)) return prev
+        return [...prev, msg]
+      })
+    }
+
+    const fillGap = async () => {
+      if (lastId <= 0 || controller.signal.aborted) return
+      try {
+        const res = await fetch(
+          `/api/familychat/conversations/${conversationId}/messages?since=${lastId}`,
+          { credentials: 'include', signal: controller.signal },
+        )
+        if (!res.ok) return
+        const data = await res.json()
+        const msgs: ChatMessage[] = data.messages ?? []
+        // API returns newest-first; sort ascending so lastId climbs
+        // monotonically as we replay the burst.
+        msgs.sort((a, b) => a.id - b.id)
+        for (const m of msgs) appendIncoming(m)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        // Non-fatal: the next reconnect attempt will retry.
+      }
+    }
+
+    const scheduleReconnect = () => {
+      if (controller.signal.aborted) return
+      reconnectAttempts += 1
+      // Exponential backoff capped at 30s to keep a server outage from
+      // hammering the endpoint while still recovering quickly from a
+      // transient blip.
+      const delay = Math.min(30000, 1000 * 2 ** Math.min(reconnectAttempts, 5))
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null
+        void connect(false)
+      }, delay)
+    }
+
+    const connect = async (firstConnect: boolean) => {
+      if (controller.signal.aborted) return
+      // Skip the gap-fill on the very first connect: the initial /messages
+      // fetch already covered everything up to lastId. On reconnects we
+      // re-issue it so a disconnect window can't lose messages.
+      if (!firstConnect) await fillGap()
+      if (controller.signal.aborted) return
+      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
+      try {
+        const res = await fetch(
+          `/api/familychat/conversations/${conversationId}/stream`,
+          { credentials: 'include', signal: controller.signal },
+        )
+        if (!res.ok || !res.body) {
+          scheduleReconnect()
+          return
+        }
+        reconnectAttempts = 0
+        reader = res.body.getReader()
+        activeReader = reader
+        const decoder = new TextDecoder()
+        let buffer = ''
+        let eventName = 'message'
+        let dataLines: string[] = []
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          let nl = buffer.indexOf('\n')
+          while (nl >= 0) {
+            let line = buffer.slice(0, nl)
+            buffer = buffer.slice(nl + 1)
+            if (line.endsWith('\r')) line = line.slice(0, -1)
+            if (line === '') {
+              if (dataLines.length > 0) {
+                try {
+                  const payload = JSON.parse(dataLines.join('\n'))
+                  if (eventName === 'message_new' && payload?.message) {
+                    appendIncoming(payload.message as ChatMessage)
+                  }
+                } catch {
+                  // Ignore a malformed payload; the server should never emit
+                  // one, but we don't want to tear down the whole stream over
+                  // a single bad frame.
+                }
+              }
+              eventName = 'message'
+              dataLines = []
+            } else if (line.startsWith(':')) {
+              // SSE comment / heartbeat — ignore.
+            } else if (line.startsWith('event:')) {
+              eventName = line.slice(6).trimStart()
+            } else if (line.startsWith('data:')) {
+              const v = line.slice(5)
+              dataLines.push(v.startsWith(' ') ? v.slice(1) : v)
+            }
+            nl = buffer.indexOf('\n')
+          }
+        }
+        if (!controller.signal.aborted) scheduleReconnect()
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        if (!controller.signal.aborted) scheduleReconnect()
+      } finally {
+        if (activeReader === reader) activeReader = null
+      }
+    }
+
     ;(async () => {
       try {
         const [convRes, msgRes] = await Promise.all([
@@ -166,7 +291,9 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         setConversation(convData.conversation ?? null)
         // The API returns newest-first; display oldest at top to bottom.
         const sorted: ChatMessage[] = (msgData.messages ?? []).slice().reverse()
+        if (sorted.length > 0) lastId = sorted[sorted.length - 1].id
         setMessages(sorted)
+        void connect(true)
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return
         const key = err instanceof Error && err.message === 'conversation failed'
@@ -177,7 +304,21 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         if (!controller.signal.aborted) setLoading(false)
       }
     })()
-    return () => { controller.abort() }
+
+    return () => {
+      controller.abort()
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      // Cancel the reader so the read loop exits even when the fetch mock
+      // doesn't propagate abort to the body (notably in tests). The catch is
+      // intentional — cancel can throw if the reader is already detached.
+      if (activeReader) {
+        activeReader.cancel().catch(() => {})
+        activeReader = null
+      }
+    }
   }, [conversationId, t])
 
   // Auto-scroll to the bottom whenever the message list updates. useLayoutEffect


### PR DESCRIPTION
## Changes

- **Family Chat live updates over SSE** - The chat view now subscribes to the conversation's SSE stream so new messages appear in real time. On reconnect after a dropped stream, the client gap-fills via `GET /messages?since=…` so no messages are lost while disconnected. (Hytte-c0cw)

## Original Issue (task): SSE live updates + reconnect gap-fill

Subscribe to `/api/familychat/conversations/{id}/stream` when a conversation is selected, following the existing Hytte SSE convention (check `web/src/pages/Webhooks.tsx` — likely fetch+ReadableStream rather than `EventSource`). On `message_new`, append to the visible message list in the chat view from sub-task 3. Track the latest `sent_at`/id as `since`; on reconnect, issue a fresh GET `/messages?since=…` to fill gaps before resuming the stream. Tear down the subscription on conversation change or unmount. Depends on sub-task 3 for the message list state it mutates.

---
Bead: Hytte-c0cw | Branch: forge/Hytte-c0cw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->