### PR TITLE
Family Chat: i18n + sidebar polish + e2e smoke (Hytte-zvpy)

### DIFF
--- a/changelog.d/Hytte-zvpy.md
+++ b/changelog.d/Hytte-zvpy.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat connection status indicator** - The chat header now shows a localized "Reconnecting…" badge while the SSE stream is dropped, so users on flaky networks can tell why new messages may be delayed. All three locales (en/nb/th) carry the new key. (Hytte-zvpy)

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -30,7 +30,10 @@
     "attachmentAudioAlt": "Attached audio",
     "attachmentFileLabel": "Download attachment ({{mime}})",
     "lightboxTitle": "Image preview",
-    "lightboxClose": "Close preview"
+    "lightboxClose": "Close preview",
+    "connection": {
+      "reconnecting": "Reconnecting…"
+    }
   },
   "composer": {
     "placeholder": "Write a message…",

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -30,7 +30,10 @@
     "attachmentAudioAlt": "Vedlagt lyd",
     "attachmentFileLabel": "Last ned vedlegg ({{mime}})",
     "lightboxTitle": "Forhåndsvisning av bilde",
-    "lightboxClose": "Lukk forhåndsvisning"
+    "lightboxClose": "Lukk forhåndsvisning",
+    "connection": {
+      "reconnecting": "Kobler til på nytt…"
+    }
   },
   "composer": {
     "placeholder": "Skriv en melding…",

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -30,7 +30,10 @@
     "attachmentAudioAlt": "เสียงที่แนบ",
     "attachmentFileLabel": "ดาวน์โหลดไฟล์แนบ ({{mime}})",
     "lightboxTitle": "ดูตัวอย่างรูปภาพ",
-    "lightboxClose": "ปิดการดูตัวอย่าง"
+    "lightboxClose": "ปิดการดูตัวอย่าง",
+    "connection": {
+      "reconnecting": "กำลังเชื่อมต่อใหม่…"
+    }
   },
   "composer": {
     "placeholder": "พิมพ์ข้อความ…",

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -32,6 +32,7 @@ const TRANSLATIONS: Record<string, string> = {
   'chat.attachmentFileLabel': 'Download attachment ({{mime}})',
   'chat.lightboxTitle': 'Image preview',
   'chat.lightboxClose': 'Close preview',
+  'chat.connection.reconnecting': 'Reconnecting…',
   'newModal.parent': 'Parent',
 }
 
@@ -471,6 +472,44 @@ describe('ChatView – reconnect gap-fill', () => {
     const texts = bubbles.map(b => b.textContent)
     expect(texts.indexOf('Before disconnect')).toBeLessThan(texts.indexOf('Gap one'))
     expect(texts.indexOf('Gap one')).toBeLessThan(texts.indexOf('Gap two'))
+  }, 15000)
+
+  it('shows a Reconnecting badge in the header while the SSE stream is dropped', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    let closeStream: (() => void) | null = null
+    const firstStream = new ReadableStream<Uint8Array>({
+      start(c) { closeStream = () => c.close() },
+    })
+    // Park the second connect on a never-resolving promise so the badge stays
+    // visible long enough to assert on. The test cleans up via unmount.
+    const stuckStreamFetch = new Promise<never>(() => {})
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce({ ok: true, body: firstStream })
+      .mockResolvedValueOnce(msgsOk([]))         // gap-fill
+      .mockReturnValueOnce(stuckStreamFetch)     // second connect hangs
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    expect(screen.queryByTestId('family-chat-reconnecting')).not.toBeInTheDocument()
+
+    await act(async () => {
+      closeStream!()
+      await Promise.resolve()
+    })
+    // Advance past the first reconnect backoff (2s for attempt #1).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('family-chat-reconnecting')).toBeInTheDocument()
+    })
   }, 15000)
 
   it('gap-fills without a since param when the initial message list is empty', async () => {

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronLeft, MessageSquare, Download, X } from 'lucide-react'
+import { ChevronLeft, MessageSquare, Download, X, WifiOff } from 'lucide-react'
 import { Skeleton } from '../../components/ui/skeleton'
 import { useAuth } from '../../auth'
 import Composer from './Composer'
@@ -64,6 +64,11 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const [error, setError] = useState('')
   const [memberLookup, setMemberLookup] = useState<Map<number, MemberInfo>>(new Map())
   const [lightbox, setLightbox] = useState<{ url: string; alt: string } | null>(null)
+  // streamDropped flips to true while the SSE reconnect backoff is in flight.
+  // It only ever shows the indicator after we've successfully connected once,
+  // so the initial-load skeleton isn't shadowed by a "Reconnecting" badge.
+  const [streamDropped, setStreamDropped] = useState(false)
+  const [hasConnected, setHasConnected] = useState(false)
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
@@ -158,6 +163,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     setError('')
     setMessages([])
     setConversation(null)
+    setStreamDropped(false)
+    setHasConnected(false)
 
     // appendIncoming deduplicates by id so a message that arrives via both
     // SSE and the POST response (the sender path) or via SSE and gap-fill
@@ -193,6 +200,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
 
     const scheduleReconnect = () => {
       if (controller.signal.aborted) return
+      setStreamDropped(true)
       reconnectAttempts += 1
       // Exponential backoff capped at 30s to keep a server outage from
       // hammering the endpoint while still recovering quickly from a
@@ -224,6 +232,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         reconnectAttempts = 0
         reader = res.body.getReader()
         activeReader = reader
+        setStreamDropped(false)
+        setHasConnected(true)
         const decoder = new TextDecoder()
         let buffer = ''
         let eventName = 'message'
@@ -425,6 +435,19 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
             </ul>
           )}
         </div>
+        {hasConnected && streamDropped && (
+          <span
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-amber-500/15 border border-amber-500/40 text-amber-200 shrink-0"
+            role="status"
+            aria-live="polite"
+            title={t('chat.connection.reconnecting')}
+            data-testid="family-chat-reconnecting"
+          >
+            <WifiOff size={12} aria-hidden="true" />
+            <span className="hidden sm:inline">{t('chat.connection.reconnecting')}</span>
+            <span className="sr-only sm:hidden">{t('chat.connection.reconnecting')}</span>
+          </span>
+        )}
       </header>
 
       <div

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -444,8 +444,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
             data-testid="family-chat-reconnecting"
           >
             <WifiOff size={12} aria-hidden="true" />
-            <span className="hidden sm:inline">{t('chat.connection.reconnecting')}</span>
-            <span className="sr-only sm:hidden">{t('chat.connection.reconnecting')}</span>
+            <span className="truncate max-w-[8rem] sm:max-w-none">{t('chat.connection.reconnecting')}</span>
           </span>
         )}
       </header>


### PR DESCRIPTION
## Changes

- **Family Chat connection status indicator** - The chat header now shows a localized "Reconnecting…" badge while the SSE stream is dropped, so users on flaky networks can tell why new messages may be delayed. All three locales (en/nb/th) carry the new key. (Hytte-zvpy)

## Original Issue (chore): Family Chat: i18n + sidebar polish + e2e smoke

Part of the Family Chat chain seeded from Suggestions id=145. See that suggestion's plan in the Suggestions page for the full architecture, trust model, and phase plan. Trust model: at-rest encryption with the server holding the key (same as Notes), NOT Signal-style E2EE.

This bead is step 7/7: i18n + polish of the chain.

## Scope

Final polish slice. Brings the feature to shippable state with full i18n coverage and a small smoke test.

### i18n

- New namespace `familychat` in `web/public/locales/{en,nb,th}/familychat.json` plus any new keys in the existing `common.json` for shared nav strings.
- Keys to cover (non-exhaustive — audit the components and use a string-extraction sweep):
    - Nav label "Family chat" / "Familiechat" / Thai equivalent.
    - Page title, empty-list state, new-conversation modal labels, composer placeholder, send button, attach button, attachment-too-large error, attachment-wrong-type error, online/offline indicators, typing nothing, send-failure toast.
- `Intl.DateTimeFormat` uses `i18n.language` for timestamps.

### Polish

- Audit the chat view for hardcoded English strings — replace with `t('familychat:key')`.
- Audit accessibility: `aria-label` on icon-only buttons, focus order on the conversation list, keyboard send on Cmd/Ctrl+Enter.

### E2E smoke test

- Optional: a QuestGiver E2E quest that signs in via test-login, navigates to /family-chat, creates a conversation, sends a message, asserts it appears. If QuestGiver scaffolding feels too heavy, a Vitest+RTL smoke covering the create-and-send flow is fine.

### Acceptance

- `npm run lint`, `npm run build`, `npm test` pass.
- All three locales have the new keys.
- Mobile 375px works end-to-end.
- Changelog fragment in changelog.d/ (category: Added).


---
Bead: Hytte-zvpy | Branch: forge/Hytte-zvpy
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->