### PR TITLE
Family Chat: emoji reactions on messages (Hytte-hp9b)

### DIFF
--- a/changelog.d/Hytte-hp9b.md
+++ b/changelog.d/Hytte-hp9b.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat emoji reactions** - Members can now react to messages with emoji. Reactions live in a new `family_chat_message_reactions` table, surface as toggleable chips under each bubble, and stream in real time over the existing SSE hub so other clients update without a refetch. (Hytte-hp9b)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -547,6 +547,8 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Delete("/familychat/conversations/{id}", familychat.DeleteConversationHandler(db))
 				r.Get("/familychat/conversations/{id}/messages", familychat.ListMessagesHandler(db))
 				r.Post("/familychat/conversations/{id}/messages", familychat.PostMessageHandler(db))
+				r.Post("/familychat/conversations/{id}/messages/{messageID}/reactions", familychat.AddReactionHandler(db))
+				r.Delete("/familychat/conversations/{id}/messages/{messageID}/reactions", familychat.RemoveReactionHandler(db))
 				r.Post("/familychat/conversations/{id}/read", familychat.MarkReadHandler(db))
 				r.Get("/familychat/conversations/{id}/stream", familychat.StreamHandlerWithDB(db))
 				r.Post("/familychat/conversations/{id}/upload", familychat.UploadAttachmentHandler(db))

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1825,6 +1825,19 @@ func createSchema(db *sql.DB) error {
 
 	CREATE INDEX IF NOT EXISTS idx_family_chat_messages_conversation_id ON family_chat_messages(conversation_id, id DESC);
 
+	-- family_chat_message_reactions (Hytte-hp9b): one row per (message, user, emoji).
+	-- The composite primary key enforces idempotent add (ON CONFLICT DO NOTHING)
+	-- and makes "remove my reaction" an O(1) delete.
+	CREATE TABLE IF NOT EXISTS family_chat_message_reactions (
+		message_id  INTEGER NOT NULL REFERENCES family_chat_messages(id) ON DELETE CASCADE,
+		user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		emoji       TEXT NOT NULL,
+		reacted_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+		PRIMARY KEY (message_id, user_id, emoji)
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_family_chat_message_reactions_message ON family_chat_message_reactions(message_id);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -87,6 +87,13 @@ func setupTestDB(t *testing.T) *sql.DB {
 			created_at TEXT NOT NULL DEFAULT '',
 			UNIQUE(user_id, endpoint)
 		);
+		CREATE TABLE family_chat_message_reactions (
+			message_id  INTEGER NOT NULL REFERENCES family_chat_messages(id) ON DELETE CASCADE,
+			user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			emoji       TEXT NOT NULL,
+			reacted_at  TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (message_id, user_id, emoji)
+		);
 	`); err != nil {
 		t.Fatalf("create schema: %v", err)
 	}

--- a/internal/familychat/reactions.go
+++ b/internal/familychat/reactions.go
@@ -1,0 +1,452 @@
+package familychat
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+// ErrInvalidEmoji is returned by validateEmoji when the input is not a single
+// emoji grapheme cluster or an allow-listed `:shortcode:`. Handlers map this
+// to a 400 response so clients see a clear error rather than a generic
+// "bad request".
+var ErrInvalidEmoji = errors.New("familychat: invalid emoji")
+
+// maxEmojiBytes caps the byte length we accept for a single emoji value.
+// Compound emoji with skin tones, ZWJ sequences and variation selectors stay
+// well under this; longer inputs are almost certainly spam.
+const maxEmojiBytes = 64
+
+// maxReactionUsers caps the per-emoji user list returned to clients so the
+// /messages response stays bounded for large conversations. Anything past the
+// cap is summarized in extra_count.
+const maxReactionUsers = 20
+
+// allowedShortcodes is the explicit set of `:shortcode:` aliases the API
+// accepts. Keeping the list short avoids the need to ship a full emoji
+// database in the binary while still letting clients that prefer textual
+// shortcodes (legacy keyboards, accessibility tools) react to messages.
+var allowedShortcodes = map[string]struct{}{
+	"thumbsup": {},
+	"thumbsdown": {},
+	"heart": {},
+	"tada": {},
+	"laugh": {},
+	"cry": {},
+	"fire": {},
+	"clap": {},
+	"eyes": {},
+	"smile": {},
+	"sob": {},
+	"angry": {},
+	"thinking": {},
+	"100": {},
+	"pray": {},
+	"rocket": {},
+}
+
+// ReactionSummary is the per-emoji bucket attached to each message in the
+// list response. Users is the (possibly truncated) list of user IDs that
+// reacted with the emoji; ExtraCount is the number of additional users
+// not represented in Users.
+type ReactionSummary struct {
+	Count      int     `json:"count"`
+	Users      []int64 `json:"users"`
+	ExtraCount int     `json:"extra_count,omitempty"`
+	Me         bool    `json:"me"`
+}
+
+// validateEmoji accepts either a single Unicode emoji grapheme cluster or a
+// `:shortcode:` whose body is on the allowlist above. Anything else (empty,
+// too long, multiple clusters, plain ASCII letters, etc.) is rejected.
+//
+// The grapheme heuristic is intentionally conservative: we walk runes, fold
+// trailing combining marks and emoji modifiers into the leading cluster, and
+// require that at least one rune in the input is a symbol/pictograph rune
+// (so a plain word like "hi" cannot pass).
+func validateEmoji(s string) error {
+	if s == "" {
+		return ErrInvalidEmoji
+	}
+	if len(s) > maxEmojiBytes {
+		return ErrInvalidEmoji
+	}
+	if !utf8.ValidString(s) {
+		return ErrInvalidEmoji
+	}
+
+	// :shortcode: path.
+	if strings.HasPrefix(s, ":") && strings.HasSuffix(s, ":") && len(s) >= 3 {
+		name := s[1 : len(s)-1]
+		if name == "" {
+			return ErrInvalidEmoji
+		}
+		for _, r := range name {
+			if !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9') && r != '_' && r != '-' && r != '+' {
+				return ErrInvalidEmoji
+			}
+		}
+		if _, ok := allowedShortcodes[name]; !ok {
+			return ErrInvalidEmoji
+		}
+		return nil
+	}
+
+	// Single grapheme-cluster path. Walk runes; the first rune must be a
+	// pictographic/symbol/punctuation rune (covers emoji, hearts, etc.).
+	// Subsequent runes are only allowed if they're combining marks,
+	// variation selectors, ZWJs, or further symbol runes that compose with
+	// the lead (skin-tone modifiers, regional indicators, etc.).
+	first := true
+	gotSymbol := false
+	for _, r := range s {
+		if first {
+			first = false
+			if !isEmojiLead(r) {
+				return ErrInvalidEmoji
+			}
+			gotSymbol = true
+			continue
+		}
+		if !isEmojiCombiner(r) && !isEmojiLead(r) {
+			return ErrInvalidEmoji
+		}
+	}
+	if !gotSymbol {
+		return ErrInvalidEmoji
+	}
+	return nil
+}
+
+// isEmojiLead reports whether r is a rune that may stand alone as the start
+// of an emoji grapheme. We deliberately allow common BMP symbols
+// (★ ❤ ☀ etc.) and the supplementary planes where the vast majority of
+// emoji live, but reject letters and digits so plain text can't slip through.
+func isEmojiLead(r rune) bool {
+	if r >= 0x1F300 && r <= 0x1FAFF {
+		return true // misc symbols & pictographs, supplemental symbols
+	}
+	if r >= 0x2600 && r <= 0x27BF {
+		return true // misc symbols + dingbats (includes ❤, ★, ☀)
+	}
+	if r >= 0x2300 && r <= 0x23FF {
+		return true // misc technical (⏰ etc.)
+	}
+	if r >= 0x2700 && r <= 0x27BF {
+		return true // dingbats (overlap above; keeps intent clear)
+	}
+	if r >= 0x1F1E6 && r <= 0x1F1FF {
+		return true // regional indicator (flags)
+	}
+	if unicode.Is(unicode.So, r) || unicode.Is(unicode.Sk, r) {
+		// other-symbol / modifier-symbol — catches anything we missed above.
+		return true
+	}
+	return false
+}
+
+// isEmojiCombiner reports whether r is a rune that legitimately follows an
+// emoji lead inside a single grapheme cluster (variation selectors, ZWJ,
+// skin-tone modifiers, combining marks).
+func isEmojiCombiner(r rune) bool {
+	switch r {
+	case 0x200D: // ZERO WIDTH JOINER
+		return true
+	case 0xFE0E, 0xFE0F: // VARIATION SELECTORS 15/16
+		return true
+	}
+	if r >= 0x1F3FB && r <= 0x1F3FF {
+		return true // skin tone modifiers
+	}
+	if unicode.Is(unicode.Mn, r) || unicode.Is(unicode.Me, r) || unicode.Is(unicode.Mc, r) {
+		return true
+	}
+	return false
+}
+
+// reactionEventPayload is the JSON envelope broadcast over SSE for reaction
+// add/remove events. Recipients compute the `me` flag themselves by comparing
+// UserID to the viewer.
+type reactionEventPayload struct {
+	MessageID      int64  `json:"message_id"`
+	ConversationID int64  `json:"conversation_id"`
+	UserID         int64  `json:"user_id"`
+	Emoji          string `json:"emoji"`
+	Count          int    `json:"count"`
+}
+
+// Known reaction event types. Kept as constants so callers cannot typo a name silently.
+const (
+	EventReactionAdded   = "reaction_added"
+	EventReactionRemoved = "reaction_removed"
+)
+
+// AddReactionHandler inserts a reaction (idempotent on the (message,user,emoji)
+// primary key) and broadcasts a reaction_added event. Non-members get 404.
+func AddReactionHandler(db *sql.DB) http.HandlerFunc {
+	return addReactionHandler(db, DefaultHub())
+}
+
+func addReactionHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+		msgID, ok := parseMessageID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+
+		var body struct {
+			Emoji string `json:"emoji"`
+		}
+		if !decodeJSON(w, r, &body) {
+			return
+		}
+		emoji := strings.TrimSpace(body.Emoji)
+		if err := validateEmoji(emoji); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid emoji"})
+			return
+		}
+
+		count, err := addReaction(db, convID, msgID, user.ID, emoji)
+		if err != nil {
+			if errors.Is(err, ErrForbidden) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: add reaction conv=%d msg=%d user=%d: %v", convID, msgID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to add reaction"})
+			return
+		}
+
+		if hub != nil {
+			hub.Publish(convID, Event{
+				Type: EventReactionAdded,
+				Data: reactionEventPayload{
+					MessageID:      msgID,
+					ConversationID: convID,
+					UserID:         user.ID,
+					Emoji:          emoji,
+					Count:          count,
+				},
+			})
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// RemoveReactionHandler removes the requesting user's reaction with the given
+// emoji and broadcasts a reaction_removed event. Non-members get 404.
+func RemoveReactionHandler(db *sql.DB) http.HandlerFunc {
+	return removeReactionHandler(db, DefaultHub())
+}
+
+func removeReactionHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+		msgID, ok := parseMessageID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+
+		emoji := strings.TrimSpace(r.URL.Query().Get("emoji"))
+		if err := validateEmoji(emoji); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid emoji"})
+			return
+		}
+
+		count, err := removeReaction(db, convID, msgID, user.ID, emoji)
+		if err != nil {
+			if errors.Is(err, ErrForbidden) {
+				notFound(w)
+				return
+			}
+			log.Printf("familychat: remove reaction conv=%d msg=%d user=%d: %v", convID, msgID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to remove reaction"})
+			return
+		}
+
+		if hub != nil {
+			hub.Publish(convID, Event{
+				Type: EventReactionRemoved,
+				Data: reactionEventPayload{
+					MessageID:      msgID,
+					ConversationID: convID,
+					UserID:         user.ID,
+					Emoji:          emoji,
+					Count:          count,
+				},
+			})
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// addReaction validates membership + message ownership of the conversation,
+// inserts the reaction row (ignoring PK conflicts), and returns the new
+// count for that emoji on that message.
+func addReaction(db *sql.DB, convID, msgID, userID int64, emoji string) (int, error) {
+	if err := requireMessageInConversation(db, convID, msgID, userID); err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC().Format(timeFormat)
+	if _, err := db.Exec(
+		`INSERT INTO family_chat_message_reactions (message_id, user_id, emoji, reacted_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(message_id, user_id, emoji) DO NOTHING`,
+		msgID, userID, emoji, now,
+	); err != nil {
+		return 0, fmt.Errorf("insert reaction: %w", err)
+	}
+	return reactionCount(db, msgID, emoji)
+}
+
+// removeReaction validates membership + message ownership of the conversation,
+// deletes the (user, emoji) row, and returns the new count for that emoji.
+// Removing a reaction that does not exist is not an error (still returns the
+// current count of 0).
+func removeReaction(db *sql.DB, convID, msgID, userID int64, emoji string) (int, error) {
+	if err := requireMessageInConversation(db, convID, msgID, userID); err != nil {
+		return 0, err
+	}
+	if _, err := db.Exec(
+		`DELETE FROM family_chat_message_reactions
+		 WHERE message_id = ? AND user_id = ? AND emoji = ?`,
+		msgID, userID, emoji,
+	); err != nil {
+		return 0, fmt.Errorf("delete reaction: %w", err)
+	}
+	return reactionCount(db, msgID, emoji)
+}
+
+// requireMessageInConversation returns ErrForbidden when userID is not a
+// member of convID, or when msgID does not belong to convID. Hides
+// existence: an attacker probing for a foreign message id cannot tell
+// "not a member" apart from "not in this conversation".
+func requireMessageInConversation(db *sql.DB, convID, msgID, userID int64) error {
+	ok, err := IsMember(db, convID, userID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrForbidden
+	}
+	var convInMsg int64
+	err = db.QueryRow(
+		`SELECT conversation_id FROM family_chat_messages WHERE id = ?`,
+		msgID,
+	).Scan(&convInMsg)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrForbidden
+		}
+		return err
+	}
+	if convInMsg != convID {
+		return ErrForbidden
+	}
+	return nil
+}
+
+func reactionCount(db *sql.DB, msgID int64, emoji string) (int, error) {
+	var n int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM family_chat_message_reactions WHERE message_id = ? AND emoji = ?`,
+		msgID, emoji,
+	).Scan(&n)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// batchReactions fetches every reaction for the given message ids in a
+// single query and returns them keyed by message id then emoji. The user
+// list for each emoji is capped at maxReactionUsers; anything past the cap
+// is rolled into extra_count. The me flag is set when meUserID appears in
+// the user list (even if they are past the cap).
+func batchReactions(db *sql.DB, msgIDs []int64, meUserID int64) (map[int64]map[string]*ReactionSummary, error) {
+	result := make(map[int64]map[string]*ReactionSummary, len(msgIDs))
+	if len(msgIDs) == 0 {
+		return result, nil
+	}
+	placeholders := strings.Repeat("?,", len(msgIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(msgIDs))
+	for i, id := range msgIDs {
+		args[i] = id
+	}
+	rows, err := db.Query(
+		`SELECT message_id, emoji, user_id
+		 FROM family_chat_message_reactions
+		 WHERE message_id IN (`+placeholders+`)
+		 ORDER BY message_id, emoji, reacted_at, user_id`,
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var msgID, userID int64
+		var emoji string
+		if err := rows.Scan(&msgID, &emoji, &userID); err != nil {
+			return nil, err
+		}
+		byEmoji, ok := result[msgID]
+		if !ok {
+			byEmoji = make(map[string]*ReactionSummary)
+			result[msgID] = byEmoji
+		}
+		sum, ok := byEmoji[emoji]
+		if !ok {
+			sum = &ReactionSummary{Users: []int64{}}
+			byEmoji[emoji] = sum
+		}
+		sum.Count++
+		if userID == meUserID {
+			sum.Me = true
+		}
+		if len(sum.Users) < maxReactionUsers {
+			sum.Users = append(sum.Users, userID)
+		} else {
+			sum.ExtraCount++
+		}
+	}
+	return result, rows.Err()
+}
+
+// parseMessageID extracts and validates the {messageID} URL parameter. 404
+// on failure for the same reason as parseConvID — don't leak existence.
+func parseMessageID(r *http.Request) (int64, bool) {
+	val := chi.URLParam(r, "messageID")
+	if val == "" {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(val, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
+}

--- a/internal/familychat/reactions.go
+++ b/internal/familychat/reactions.go
@@ -70,10 +70,13 @@ type ReactionSummary struct {
 // `:shortcode:` whose body is on the allowlist above. Anything else (empty,
 // too long, multiple clusters, plain ASCII letters, etc.) is rejected.
 //
-// The grapheme heuristic is intentionally conservative: we walk runes, fold
-// trailing combining marks and emoji modifiers into the leading cluster, and
-// require that at least one rune in the input is a symbol/pictograph rune
-// (so a plain word like "hi" cannot pass).
+// The grapheme heuristic covers:
+//   - Standard emoji in the supplementary planes (👍, 🎉, etc.)
+//   - Emoji with variation selector 16 (❤️)
+//   - Skin-tone modifier sequences (👍🏽)
+//   - ZWJ sequences (👨‍👩‍👧)
+//   - Regional indicator flag pairs (🇳🇴)
+//   - Keycap sequences ([0-9#*] + U+FE0F? + U+20E3, e.g. 1️⃣)
 func validateEmoji(s string) error {
 	if s == "" {
 		return ErrInvalidEmoji
@@ -102,13 +105,28 @@ func validateEmoji(s string) error {
 		return nil
 	}
 
-	// Single grapheme-cluster path. Walk runes; the first rune must be a
-	// pictographic/symbol/punctuation rune (covers emoji, hearts, etc.).
-	// Subsequent runes are only allowed if they're combining marks,
-	// variation selectors, ZWJs, or further symbol runes that compose with
-	// the lead (skin-tone modifiers, regional indicators, etc.).
+	// Keycap sequences: [0-9#*] + optional U+FE0F (VS16) + U+20E3 (enclosing keycap).
+	// These start with an ASCII rune so we handle them before the general walk.
+	runes := []rune(s)
+	if isKeycapBase(runes[0]) {
+		if (len(runes) == 2 && runes[1] == 0x20E3) ||
+			(len(runes) == 3 && runes[1] == 0xFE0F && runes[2] == 0x20E3) {
+			return nil
+		}
+		return ErrInvalidEmoji
+	}
+
+	// Single grapheme-cluster walk. State tracks whether we just saw a ZWJ
+	// (so the next emoji lead may continue a ZWJ sequence) or a regional
+	// indicator (so one more regional indicator completes a flag pair).
+	// A second standalone emoji lead — i.e. one that is neither a ZWJ
+	// continuation nor the second half of a flag pair — is rejected so that
+	// inputs like "👍👍" or "👍🎉" cannot slip through.
 	first := true
 	gotSymbol := false
+	afterZWJ := false
+	lastWasRegional := false
+	consumedFlagPair := false
 	for _, r := range s {
 		if first {
 			first = false
@@ -116,11 +134,33 @@ func validateEmoji(s string) error {
 				return ErrInvalidEmoji
 			}
 			gotSymbol = true
+			lastWasRegional = isRegionalIndicator(r)
 			continue
 		}
-		if !isEmojiCombiner(r) && !isEmojiLead(r) {
+		// Check combiner before lead: skin-tone modifiers (U+1F3FB–U+1F3FF) fall
+		// inside the isEmojiLead supplementary range; treating them as combiners
+		// here is the correct semantics.
+		if isEmojiCombiner(r) {
+			afterZWJ = r == 0x200D
+			lastWasRegional = false
+			continue
+		}
+		if isEmojiLead(r) {
+			if afterZWJ {
+				// ZWJ sequence continuation (e.g. 👨‍👩‍👧).
+				afterZWJ = false
+				lastWasRegional = isRegionalIndicator(r)
+				continue
+			}
+			if lastWasRegional && isRegionalIndicator(r) && !consumedFlagPair {
+				// Second regional indicator completes a flag pair (e.g. 🇳🇴).
+				consumedFlagPair = true
+				lastWasRegional = false
+				continue
+			}
 			return ErrInvalidEmoji
 		}
+		return ErrInvalidEmoji
 	}
 	if !gotSymbol {
 		return ErrInvalidEmoji
@@ -174,9 +214,23 @@ func isEmojiCombiner(r rune) bool {
 	return false
 }
 
+// isKeycapBase reports whether r is an ASCII rune that can begin a keycap
+// sequence ([0-9#*] + U+FE0F? + U+20E3).
+func isKeycapBase(r rune) bool {
+	return (r >= '0' && r <= '9') || r == '#' || r == '*'
+}
+
+// isRegionalIndicator reports whether r is a Unicode regional indicator
+// letter (U+1F1E6–U+1F1FF). Two consecutive regional indicators form a
+// flag emoji (e.g. 🇳🇴 = U+1F1F3 U+1F1F4).
+func isRegionalIndicator(r rune) bool {
+	return r >= 0x1F1E6 && r <= 0x1F1FF
+}
+
 // reactionEventPayload is the JSON envelope broadcast over SSE for reaction
-// add/remove events. Recipients compute the `me` flag themselves by comparing
-// UserID to the viewer.
+// add/remove events. It intentionally omits a `me` field: emitting per-viewer
+// data would require per-subscriber payloads. Clients derive `me` by comparing
+// UserID to the authenticated viewer's own ID.
 type reactionEventPayload struct {
 	MessageID      int64  `json:"message_id"`
 	ConversationID int64  `json:"conversation_id"`
@@ -223,7 +277,7 @@ func addReactionHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
 			return
 		}
 
-		count, err := addReaction(db, convID, msgID, user.ID, emoji)
+		count, changed, err := addReaction(db, convID, msgID, user.ID, emoji)
 		if err != nil {
 			if errors.Is(err, ErrForbidden) {
 				notFound(w)
@@ -234,7 +288,7 @@ func addReactionHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
 			return
 		}
 
-		if hub != nil {
+		if hub != nil && changed {
 			hub.Publish(convID, Event{
 				Type: EventReactionAdded,
 				Data: reactionEventPayload{
@@ -276,7 +330,7 @@ func removeReactionHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
 			return
 		}
 
-		count, err := removeReaction(db, convID, msgID, user.ID, emoji)
+		count, changed, err := removeReaction(db, convID, msgID, user.ID, emoji)
 		if err != nil {
 			if errors.Is(err, ErrForbidden) {
 				notFound(w)
@@ -287,7 +341,7 @@ func removeReactionHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
 			return
 		}
 
-		if hub != nil {
+		if hub != nil && changed {
 			hub.Publish(convID, Event{
 				Type: EventReactionRemoved,
 				Data: reactionEventPayload{
@@ -304,40 +358,53 @@ func removeReactionHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
 }
 
 // addReaction validates membership + message ownership of the conversation,
-// inserts the reaction row (ignoring PK conflicts), and returns the new
-// count for that emoji on that message.
-func addReaction(db *sql.DB, convID, msgID, userID int64, emoji string) (int, error) {
+// inserts the reaction row (ignoring PK conflicts), and returns the new count
+// for that emoji on that message plus a boolean indicating whether the row was
+// newly inserted (false means the reaction already existed — a no-op).
+func addReaction(db *sql.DB, convID, msgID, userID int64, emoji string) (int, bool, error) {
 	if err := requireMessageInConversation(db, convID, msgID, userID); err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	now := time.Now().UTC().Format(timeFormat)
-	if _, err := db.Exec(
+	res, err := db.Exec(
 		`INSERT INTO family_chat_message_reactions (message_id, user_id, emoji, reacted_at)
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(message_id, user_id, emoji) DO NOTHING`,
 		msgID, userID, emoji, now,
-	); err != nil {
-		return 0, fmt.Errorf("insert reaction: %w", err)
+	)
+	if err != nil {
+		return 0, false, fmt.Errorf("insert reaction: %w", err)
 	}
-	return reactionCount(db, msgID, emoji)
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, false, err
+	}
+	count, err := reactionCount(db, msgID, emoji)
+	return count, n > 0, err
 }
 
 // removeReaction validates membership + message ownership of the conversation,
-// deletes the (user, emoji) row, and returns the new count for that emoji.
-// Removing a reaction that does not exist is not an error (still returns the
-// current count of 0).
-func removeReaction(db *sql.DB, convID, msgID, userID int64, emoji string) (int, error) {
+// deletes the (user, emoji) row, and returns the new count for that emoji plus
+// a boolean indicating whether a row was actually deleted. Removing a reaction
+// that does not exist is not an error (returns count 0, changed false).
+func removeReaction(db *sql.DB, convID, msgID, userID int64, emoji string) (int, bool, error) {
 	if err := requireMessageInConversation(db, convID, msgID, userID); err != nil {
-		return 0, err
+		return 0, false, err
 	}
-	if _, err := db.Exec(
+	res, err := db.Exec(
 		`DELETE FROM family_chat_message_reactions
 		 WHERE message_id = ? AND user_id = ? AND emoji = ?`,
 		msgID, userID, emoji,
-	); err != nil {
-		return 0, fmt.Errorf("delete reaction: %w", err)
+	)
+	if err != nil {
+		return 0, false, fmt.Errorf("delete reaction: %w", err)
 	}
-	return reactionCount(db, msgID, emoji)
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, false, err
+	}
+	count, err := reactionCount(db, msgID, emoji)
+	return count, n > 0, err
 }
 
 // requireMessageInConversation returns ErrForbidden when userID is not a

--- a/internal/familychat/reactions_test.go
+++ b/internal/familychat/reactions_test.go
@@ -46,6 +46,15 @@ func TestValidateEmoji(t *testing.T) {
 		{"injection attempt", "<script>", true},
 		{"shortcode with bad chars", ":bad chars:", true},
 		{"shortcode missing trailing", ":thumbsup", true},
+		// Keycap sequences (digit/# /* + VS16? + enclosing keycap).
+		{"keycap 1", "1️⃣", false},
+		{"keycap hash", "#️⃣", false},
+		{"keycap star", "*️⃣", false},
+		{"keycap without VS16", "1⃣", false},
+		{"bare digit without keycap", "1", true},
+		// Multi-emoji inputs must be rejected (only a single cluster is allowed).
+		{"two identical emoji", "👍👍", true},
+		{"two different emoji", "👍🎉", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -182,7 +191,7 @@ func TestRemoveReactionHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create message: %v", err)
 	}
-	if _, err := addReaction(db, convID, msg.ID, 2, "👍"); err != nil {
+	if _, _, err := addReaction(db, convID, msg.ID, 2, "👍"); err != nil {
 		t.Fatalf("seed reaction: %v", err)
 	}
 
@@ -217,13 +226,13 @@ func TestListMessagesHandler_EmbedsReactions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create message: %v", err)
 	}
-	if _, err := addReaction(db, convID, msg.ID, 1, "👍"); err != nil {
+	if _, _, err := addReaction(db, convID, msg.ID, 1, "👍"); err != nil {
 		t.Fatalf("react 1: %v", err)
 	}
-	if _, err := addReaction(db, convID, msg.ID, 2, "👍"); err != nil {
+	if _, _, err := addReaction(db, convID, msg.ID, 2, "👍"); err != nil {
 		t.Fatalf("react 2: %v", err)
 	}
-	if _, err := addReaction(db, convID, msg.ID, 3, "🎉"); err != nil {
+	if _, _, err := addReaction(db, convID, msg.ID, 3, "🎉"); err != nil {
 		t.Fatalf("react 3: %v", err)
 	}
 
@@ -285,7 +294,7 @@ func TestListMessagesHandler_ReactionsCappedAt20Users(t *testing.T) {
 		t.Fatalf("create message: %v", err)
 	}
 	for i := int64(1); i <= userCount; i++ {
-		if _, err := addReaction(db, convID, msg.ID, i, "🔥"); err != nil {
+		if _, _, err := addReaction(db, convID, msg.ID, i, "🔥"); err != nil {
 			t.Fatalf("react %d: %v", i, err)
 		}
 	}

--- a/internal/familychat/reactions_test.go
+++ b/internal/familychat/reactions_test.go
@@ -1,0 +1,479 @@
+package familychat
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// withChiReactionParams installs both {id} and {messageID} on the request
+// context so reaction handlers can resolve them.
+func withChiReactionParams(r *http.Request, convID, msgID int64) *http.Request {
+	return withChiParams(r, map[string]string{
+		"id":        strconv.FormatInt(convID, 10),
+		"messageID": strconv.FormatInt(msgID, 10),
+	})
+}
+
+func TestValidateEmoji(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"single emoji", "👍", false},
+		{"heart", "❤", false},
+		{"heart with VS16", "❤️", false},
+		{"tada", "🎉", false},
+		{"skin tone", "👍🏽", false},
+		{"zwj sequence (family)", "👨‍👩‍👧", false},
+		{"flag", "🇳🇴", false},
+		{"shortcode allowed", ":thumbsup:", false},
+		{"shortcode unknown", ":sparkles:", true},
+		{"empty", "", true},
+		{"plain text", "hi", true},
+		{"letters that look like emoji name", "thumbsup", true},
+		{"too long", strings.Repeat("👍", 32), true},
+		{"injection attempt", "<script>", true},
+		{"shortcode with bad chars", ":bad chars:", true},
+		{"shortcode missing trailing", ":thumbsup", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateEmoji(c.input)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("validateEmoji(%q) err=%v, wantErr=%v", c.input, err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestAddReactionHandler_Idempotent(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+	msg, err := CreateMessage(db, convID, 1, "hi", "", "")
+	if err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	hub := NewHub()
+	handler := addReactionHandler(db, hub)
+
+	doAdd := func() int {
+		t.Helper()
+		body := `{"emoji":"👍"}`
+		req := withUser(httptest.NewRequest("POST",
+			fmt.Sprintf("/api/familychat/conversations/%d/messages/%d/reactions", convID, msg.ID),
+			strings.NewReader(body)), 2)
+		req.Header.Set("Content-Type", "application/json")
+		req = withChiReactionParams(req, convID, msg.ID)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if code := doAdd(); code != http.StatusNoContent {
+		t.Fatalf("first add: expected 204, got %d", code)
+	}
+	if code := doAdd(); code != http.StatusNoContent {
+		t.Fatalf("second add: expected 204, got %d", code)
+	}
+
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM family_chat_message_reactions WHERE message_id = ? AND emoji = ?`,
+		msg.ID, "👍",
+	).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 reaction row after duplicate add, got %d", count)
+	}
+}
+
+func TestAddReactionHandler_NonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com") // not a member
+	convID := seedConversation(t, db, 1, "Family", 2)
+	msg, err := CreateMessage(db, convID, 1, "hi", "", "")
+	if err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	body := `{"emoji":"👍"}`
+	req := withUser(httptest.NewRequest("POST",
+		fmt.Sprintf("/api/familychat/conversations/%d/messages/%d/reactions", convID, msg.ID),
+		strings.NewReader(body)), 3)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiReactionParams(req, convID, msg.ID)
+	rec := httptest.NewRecorder()
+	AddReactionHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-member, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAddReactionHandler_InvalidEmoji(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+	msg, err := CreateMessage(db, convID, 1, "hi", "", "")
+	if err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	body := `{"emoji":"<script>"}`
+	req := withUser(httptest.NewRequest("POST",
+		fmt.Sprintf("/api/familychat/conversations/%d/messages/%d/reactions", convID, msg.ID),
+		strings.NewReader(body)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiReactionParams(req, convID, msg.ID)
+	rec := httptest.NewRecorder()
+	AddReactionHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid emoji, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAddReactionHandler_MessageInOtherConversation(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convA := seedConversation(t, db, 1, "A", 2)
+	convB := seedConversation(t, db, 1, "B", 2)
+	msgA, err := CreateMessage(db, convA, 1, "hi", "", "")
+	if err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	// Try to react via convB even though msg belongs to convA.
+	body := `{"emoji":"👍"}`
+	req := withUser(httptest.NewRequest("POST",
+		fmt.Sprintf("/api/familychat/conversations/%d/messages/%d/reactions", convB, msgA.ID),
+		strings.NewReader(body)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiReactionParams(req, convB, msgA.ID)
+	rec := httptest.NewRecorder()
+	AddReactionHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-conversation reaction, got %d", rec.Code)
+	}
+}
+
+func TestRemoveReactionHandler(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+	msg, err := CreateMessage(db, convID, 1, "hi", "", "")
+	if err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+	if _, err := addReaction(db, convID, msg.ID, 2, "👍"); err != nil {
+		t.Fatalf("seed reaction: %v", err)
+	}
+
+	req := withUser(httptest.NewRequest("DELETE",
+		fmt.Sprintf("/api/familychat/conversations/%d/messages/%d/reactions?emoji=%s", convID, msg.ID, "%F0%9F%91%8D"),
+		nil), 2)
+	req = withChiReactionParams(req, convID, msg.ID)
+	rec := httptest.NewRecorder()
+	RemoveReactionHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM family_chat_message_reactions WHERE message_id = ?`, msg.ID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected reaction removed, still have %d", count)
+	}
+}
+
+func TestListMessagesHandler_EmbedsReactions(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2, 3)
+	msg, err := CreateMessage(db, convID, 1, "hi", "", "")
+	if err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+	if _, err := addReaction(db, convID, msg.ID, 1, "👍"); err != nil {
+		t.Fatalf("react 1: %v", err)
+	}
+	if _, err := addReaction(db, convID, msg.ID, 2, "👍"); err != nil {
+		t.Fatalf("react 2: %v", err)
+	}
+	if _, err := addReaction(db, convID, msg.ID, 3, "🎉"); err != nil {
+		t.Fatalf("react 3: %v", err)
+	}
+
+	// Bob (id=2) requests the list. me=true for 👍 (he reacted), false for 🎉.
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages", nil), 2)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Messages []Message `json:"messages"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(body.Messages))
+	}
+	got := body.Messages[0].Reactions
+	if got == nil {
+		t.Fatal("reactions map is nil")
+	}
+	thumb := got["👍"]
+	if thumb == nil {
+		t.Fatal("missing 👍 bucket")
+	}
+	if thumb.Count != 2 {
+		t.Errorf("👍 count = %d, want 2", thumb.Count)
+	}
+	if !thumb.Me {
+		t.Errorf("👍 me should be true for Bob")
+	}
+	if len(thumb.Users) != 2 {
+		t.Errorf("👍 users len = %d, want 2", len(thumb.Users))
+	}
+	tada := got["🎉"]
+	if tada == nil || tada.Count != 1 || tada.Me {
+		t.Errorf("🎉 bucket wrong: %+v", tada)
+	}
+}
+
+func TestListMessagesHandler_ReactionsCappedAt20Users(t *testing.T) {
+	db := setupTestDB(t)
+	const userCount = 25
+	for i := int64(1); i <= userCount; i++ {
+		makeUser(t, db, i, fmt.Sprintf("u%d@example.com", i))
+	}
+	// owner=1, all others added as members.
+	members := make([]int64, 0, userCount-1)
+	for i := int64(2); i <= userCount; i++ {
+		members = append(members, i)
+	}
+	convID := seedConversation(t, db, 1, "Big", members...)
+	msg, err := CreateMessage(db, convID, 1, "react me", "", "")
+	if err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+	for i := int64(1); i <= userCount; i++ {
+		if _, err := addReaction(db, convID, msg.ID, i, "🔥"); err != nil {
+			t.Fatalf("react %d: %v", i, err)
+		}
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages", nil), 1)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Messages []Message `json:"messages"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	fire := body.Messages[0].Reactions["🔥"]
+	if fire == nil {
+		t.Fatal("missing 🔥 bucket")
+	}
+	if fire.Count != userCount {
+		t.Errorf("count = %d, want %d", fire.Count, userCount)
+	}
+	if len(fire.Users) != maxReactionUsers {
+		t.Errorf("users len = %d, want %d", len(fire.Users), maxReactionUsers)
+	}
+	wantExtra := userCount - maxReactionUsers
+	if fire.ExtraCount != wantExtra {
+		t.Errorf("extra = %d, want %d", fire.ExtraCount, wantExtra)
+	}
+	if !fire.Me {
+		t.Errorf("user 1 reacted, expected me=true (even though they're past the cap)")
+	}
+}
+
+func TestReactionHandler_PublishesSSEEvent(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+	msg, err := CreateMessage(db, convID, 1, "hi", "", "")
+	if err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	hub := NewHub()
+	bobSub := hub.Subscribe(2, convID)
+	defer hub.Unsubscribe(convID, bobSub)
+
+	// Alice (user 1) adds a reaction via the handler; Bob's SSE subscription
+	// must receive a reaction_added event.
+	handler := addReactionHandler(db, hub)
+	body := `{"emoji":"👍"}`
+	req := withUser(httptest.NewRequest("POST",
+		fmt.Sprintf("/api/familychat/conversations/%d/messages/%d/reactions", convID, msg.ID),
+		strings.NewReader(body)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiReactionParams(req, convID, msg.ID)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("add reaction: %d %s", rec.Code, rec.Body.String())
+	}
+
+	select {
+	case evt := <-bobSub.Events():
+		if evt.Type != EventReactionAdded {
+			t.Fatalf("event type = %q, want %q", evt.Type, EventReactionAdded)
+		}
+		payload, ok := evt.Data.(reactionEventPayload)
+		if !ok {
+			t.Fatalf("payload type = %T", evt.Data)
+		}
+		if payload.Emoji != "👍" || payload.MessageID != msg.ID || payload.UserID != 1 {
+			t.Errorf("payload mismatch: %+v", payload)
+		}
+		if payload.Count != 1 {
+			t.Errorf("count = %d, want 1", payload.Count)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive SSE event")
+	}
+}
+
+func TestReactionHandler_PublishesSSEEventOverHTTP(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+	msg, err := CreateMessage(db, convID, 1, "hi", "", "")
+	if err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	hub := NewHub()
+	mem := newMembershipSet([2]int64{1, convID}, [2]int64{2, convID})
+
+	r := chi.NewRouter()
+	r.Get("/api/familychat/conversations/{id}/stream",
+		withCtxUser(2, StreamHandler(hub, mem.fn())))
+	r.Post("/api/familychat/conversations/{id}/messages/{messageID}/reactions",
+		withCtxUser(1, addReactionHandler(db, hub)))
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf("%s/api/familychat/conversations/%d/stream", srv.URL, convID), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.subscriberCount(convID) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("subscriber never registered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	postResp, err := http.Post(
+		fmt.Sprintf("%s/api/familychat/conversations/%d/messages/%d/reactions", srv.URL, convID, msg.ID),
+		"application/json", strings.NewReader(`{"emoji":"👍"}`),
+	)
+	if err != nil {
+		t.Fatalf("POST reaction: %v", err)
+	}
+	postResp.Body.Close()
+	if postResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", postResp.StatusCode)
+	}
+
+	// Read SSE frames until we get the event.
+	type result struct {
+		event string
+		data  string
+		err   error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		var event, data string
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				event = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if event != "" {
+					resCh <- result{event: event, data: data}
+					return
+				}
+			}
+		}
+		resCh <- result{err: scanner.Err()}
+	}()
+
+	select {
+	case r := <-resCh:
+		if r.err != nil {
+			t.Fatalf("read body: %v", r.err)
+		}
+		if r.event != EventReactionAdded {
+			t.Fatalf("event = %q, want %q", r.event, EventReactionAdded)
+		}
+		if !strings.Contains(r.data, `"emoji":"👍"`) {
+			t.Fatalf("data missing emoji: %q", r.data)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("did not receive SSE event in time")
+	}
+}
+
+// withCtxUser wraps next so requests are served as if `userID` is logged in.
+func withCtxUser(userID int64, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, withUser(r, userID))
+	}
+}

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -33,15 +33,18 @@ type Conversation struct {
 }
 
 // Message is a single chat message returned to the client. Body and
-// AttachmentPath are returned in plaintext after decryption.
+// AttachmentPath are returned in plaintext after decryption. Reactions is
+// always non-nil so the JSON shape is stable (an empty `{}` instead of null
+// when nobody has reacted yet).
 type Message struct {
-	ID             int64  `json:"id"`
-	ConversationID int64  `json:"conversation_id"`
-	SenderUserID   int64  `json:"sender_user_id"`
-	Body           string `json:"body"`
-	AttachmentPath string `json:"attachment_path,omitempty"`
-	AttachmentMime string `json:"attachment_mime,omitempty"`
-	CreatedAt      string `json:"created_at"`
+	ID             int64                       `json:"id"`
+	ConversationID int64                       `json:"conversation_id"`
+	SenderUserID   int64                       `json:"sender_user_id"`
+	Body           string                      `json:"body"`
+	AttachmentPath string                      `json:"attachment_path,omitempty"`
+	AttachmentMime string                      `json:"attachment_mime,omitempty"`
+	CreatedAt      string                      `json:"created_at"`
+	Reactions      map[string]*ReactionSummary `json:"reactions"`
 }
 
 // IsMember reports whether userID belongs to convID. It delegates to
@@ -328,6 +331,24 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+
+	if len(out) > 0 {
+		ids := make([]int64, len(out))
+		for i := range out {
+			ids[i] = out[i].ID
+		}
+		reactions, err := batchReactions(db, ids, userID)
+		if err != nil {
+			return nil, fmt.Errorf("load reactions: %w", err)
+		}
+		for i := range out {
+			byEmoji := reactions[out[i].ID]
+			if byEmoji == nil {
+				byEmoji = map[string]*ReactionSummary{}
+			}
+			out[i].Reactions = byEmoji
+		}
+	}
 	return out, nil
 }
 
@@ -389,6 +410,7 @@ func CreateMessage(db *sql.DB, convID, senderID int64, body, attachmentPath, att
 		AttachmentPath: attachmentPath,
 		AttachmentMime: attachmentMime,
 		CreatedAt:      now,
+		Reactions:      map[string]*ReactionSummary{},
 	}, nil
 }
 

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -48,6 +48,11 @@
       "unsupportedType": "File type is not supported"
     }
   },
+  "reactions": {
+    "add": "React with {{emoji}}",
+    "remove": "Remove your {{emoji}} reaction",
+    "pickerLabel": "Pick a reaction"
+  },
   "newModal": {
     "title": "New conversation",
     "nameLabel": "Name",

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -48,6 +48,11 @@
       "unsupportedType": "Filtypen støttes ikke"
     }
   },
+  "reactions": {
+    "add": "Reager med {{emoji}}",
+    "remove": "Fjern din {{emoji}}-reaksjon",
+    "pickerLabel": "Velg en reaksjon"
+  },
   "newModal": {
     "title": "Ny samtale",
     "nameLabel": "Navn",

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -48,6 +48,11 @@
       "unsupportedType": "ไม่รองรับประเภทไฟล์นี้"
     }
   },
+  "reactions": {
+    "add": "ตอบกลับด้วย {{emoji}}",
+    "remove": "ลบรีแอ็กชัน {{emoji}} ของคุณ",
+    "pickerLabel": "เลือกรีแอ็กชัน"
+  },
   "newModal": {
     "title": "การสนทนาใหม่",
     "nameLabel": "ชื่อ",

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -34,6 +34,9 @@ const TRANSLATIONS: Record<string, string> = {
   'chat.lightboxClose': 'Close preview',
   'chat.connection.reconnecting': 'Reconnecting…',
   'newModal.parent': 'Parent',
+  'reactions.pickerLabel': 'Add reaction',
+  'reactions.add': 'React with {{emoji}}',
+  'reactions.remove': 'Remove {{emoji}} reaction',
 }
 
 function stableT(key: string, opts?: Record<string, string | number>): string {
@@ -549,4 +552,104 @@ describe('ChatView – reconnect gap-fill', () => {
 
     await waitFor(() => expect(screen.getByText('Arrived during disconnect')).toBeInTheDocument())
   }, 15000)
+})
+
+describe('ChatView – reactions', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('renders reaction chips when a message includes reaction data', async () => {
+    const msg = makeMessage({
+      id: 5,
+      body: 'Hello!',
+      reactions: { '👍': { count: 2, users: [1, 2], me: true } },
+    })
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([msg]))
+      .mockResolvedValueOnce(streamOk()),
+    )
+    renderChatView()
+    const chip = await screen.findByTestId('reaction-chip-👍')
+    expect(chip).toBeInTheDocument()
+    expect(chip.textContent).toContain('2')
+  })
+
+  it('opens the reaction picker when the trigger button is clicked', async () => {
+    const msg = makeMessage({ id: 5, body: 'Hello!' })
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([msg]))
+      .mockResolvedValueOnce(streamOk()),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByTestId(`reaction-trigger-${msg.id}`))
+
+    fireEvent.click(screen.getByTestId(`reaction-trigger-${msg.id}`))
+    expect(screen.getByTestId('reaction-picker')).toBeInTheDocument()
+  })
+
+  it('closes the picker on Escape key', async () => {
+    const msg = makeMessage({ id: 5, body: 'Hello!' })
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([msg]))
+      .mockResolvedValueOnce(streamOk()),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByTestId(`reaction-trigger-${msg.id}`))
+
+    fireEvent.click(screen.getByTestId(`reaction-trigger-${msg.id}`))
+    expect(screen.getByTestId('reaction-picker')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByTestId('reaction-picker')).not.toBeInTheDocument())
+  })
+
+  it('optimistically increments count on chip click and rolls back on network failure', async () => {
+    const msg = makeMessage({
+      id: 5,
+      body: 'Hello!',
+      reactions: { '👍': { count: 1, users: [2], me: false } },
+    })
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([msg]))
+      .mockResolvedValueOnce(streamOk())
+      .mockResolvedValueOnce({ ok: false, status: 500 }),
+    )
+    renderChatView()
+    const chip = await screen.findByTestId('reaction-chip-👍')
+    expect(chip.textContent).toContain('1')
+
+    fireEvent.click(chip)
+    await waitFor(() => expect(screen.getByTestId('reaction-chip-👍').textContent).toContain('2'))
+
+    // Network failed → rollback to original count
+    await waitFor(() => expect(screen.getByTestId('reaction-chip-👍').textContent).toContain('1'))
+  })
+
+  it('applies a reaction_added SSE event to the message chips', async () => {
+    const sse = streamWithController()
+    const msg = makeMessage({ id: 5, body: 'Hello!' })
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([msg]))
+      .mockResolvedValueOnce(sse.response),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByText('Hello!'))
+
+    await act(async () => {
+      sse.push('reaction_added', {
+        message_id: 5,
+        conversation_id: 1,
+        user_id: 2,
+        emoji: '👍',
+        count: 1,
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(screen.getByTestId('reaction-chip-👍')).toBeInTheDocument())
+  })
 })

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronLeft, MessageSquare, Download, X, WifiOff } from 'lucide-react'
+import { ChevronLeft, MessageSquare, Download, X, WifiOff, Smile } from 'lucide-react'
 import { Skeleton } from '../../components/ui/skeleton'
 import { useAuth } from '../../auth'
 import Composer from './Composer'
+import ReactionChips from './ReactionChips'
+import ReactionPicker from './ReactionPicker'
+import { addReaction, removeReaction, applyReactionEvent, type ReactionMap } from './api'
 import { formatRelative } from './utils'
 
 interface ChatViewProps {
@@ -29,6 +32,7 @@ export interface ChatMessage {
   attachment_path?: string
   attachment_mime?: string
   created_at: string
+  reactions?: ReactionMap
 }
 
 interface MemberInfo {
@@ -69,8 +73,16 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // so the initial-load skeleton isn't shadowed by a "Reconnecting" badge.
   const [streamDropped, setStreamDropped] = useState(false)
   const [hasConnected, setHasConnected] = useState(false)
+  // pickerForMsgId is the id of the bubble whose reaction picker is open, or
+  // null when nothing is open. We only show one picker at a time.
+  const [pickerForMsgId, setPickerForMsgId] = useState<number | null>(null)
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  // currentUserIdRef shadows user?.id so the long-lived SSE reader closure
+  // (recreated only when conversationId changes) can read the most recent
+  // value without forcing the effect to re-run on auth changes.
+  const currentUserIdRef = useRef<number | undefined>(user?.id)
+  useEffect(() => { currentUserIdRef.current = user?.id }, [user?.id])
 
   const rtf = useMemo(
     () => new Intl.RelativeTimeFormat(i18n.language, { numeric: 'auto' }),
@@ -178,6 +190,30 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       })
     }
 
+    // applyReactionEventLocal merges an incoming reaction event into the
+    // open message list. We can't compute the recipient's `me` flag from
+    // the wire payload alone (the server broadcasts a single payload to
+    // every subscriber), so the comparison happens here against the
+    // current user's id.
+    const applyReactionEventLocal = (
+      payload: { message_id: number; user_id: number; emoji: string; count: number; conversation_id?: number },
+      removed: boolean,
+    ) => {
+      if (payload.conversation_id !== undefined && payload.conversation_id !== conversationId) return
+      setMessages(prev => {
+        let changed = false
+        const next = prev.map(m => {
+          if (m.id !== payload.message_id) return m
+          changed = true
+          return {
+            ...m,
+            reactions: applyReactionEvent(m.reactions, payload, currentUserIdRef.current, removed),
+          }
+        })
+        return changed ? next : prev
+      })
+    }
+
     const fillGap = async () => {
       if (controller.signal.aborted) return
       try {
@@ -253,6 +289,12 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                   const payload = JSON.parse(dataLines.join('\n'))
                   if (eventName === 'message_new' && payload?.message) {
                     appendIncoming(payload.message as ChatMessage)
+                  } else if (
+                    (eventName === 'reaction_added' || eventName === 'reaction_removed') &&
+                    payload?.message_id !== undefined &&
+                    payload?.emoji !== undefined
+                  ) {
+                    applyReactionEventLocal(payload, eventName === 'reaction_removed')
                   }
                 } catch {
                   // Ignore a malformed payload; the server should never emit
@@ -364,6 +406,46 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       return [...prev, msg]
     })
   }, [conversationId])
+
+  // toggleReaction applies the change optimistically (chips update before the
+  // network round-trip) and rolls back on failure. The eventual SSE
+  // confirmation overwrites the optimistic state with the server-authoritative
+  // count, which keeps two clients in sync even if either one races.
+  const toggleReaction = useCallback(async (msgId: number, emoji: string, currentlyMine: boolean) => {
+    if (conversationId === null || user?.id === undefined) return
+    const meID = user.id
+    const snapshot = messages.find(m => m.id === msgId) ?? null
+    setMessages(prev => prev.map(m => {
+      if (m.id !== msgId) return m
+      const synthetic = currentlyMine
+        ? { user_id: meID, emoji, count: Math.max((m.reactions?.[emoji]?.count ?? 1) - 1, 0) }
+        : { user_id: meID, emoji, count: (m.reactions?.[emoji]?.count ?? 0) + 1 }
+      return {
+        ...m,
+        reactions: applyReactionEvent(m.reactions, synthetic, meID, currentlyMine),
+      }
+    }))
+    try {
+      if (currentlyMine) {
+        await removeReaction(conversationId, msgId, emoji)
+      } else {
+        await addReaction(conversationId, msgId, emoji)
+      }
+    } catch {
+      // Roll back to the pre-toggle snapshot. The eventual SSE event from
+      // any successful interaction is still the source of truth.
+      if (snapshot) {
+        setMessages(prev => prev.map(m => (m.id === msgId ? snapshot : m)))
+      }
+    }
+  }, [conversationId, user?.id, messages])
+
+  const handlePickFromPicker = useCallback((msgId: number, emoji: string) => {
+    setPickerForMsgId(null)
+    const msg = messages.find(m => m.id === msgId)
+    const mine = !!msg?.reactions?.[emoji]?.me
+    void toggleReaction(msgId, emoji, mine)
+  }, [messages, toggleReaction])
 
   const memberChips = useMemo(() => {
     if (!conversation) return []
@@ -488,60 +570,84 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
           const mime = msg.attachment_mime ?? ''
           const isImage = mime.startsWith('image/')
           const isAudio = mime.startsWith('audio/')
+          const pickerOpen = pickerForMsgId === msg.id
           return (
             <div
               key={msg.id}
-              className={`flex flex-col ${isOwn ? 'items-end' : 'items-start'}`}
+              className={`flex flex-col group ${isOwn ? 'items-end' : 'items-start'}`}
+              data-testid={`chat-bubble-${msg.id}`}
             >
               {!isOwn && (
                 <span className="text-xs text-gray-400 mb-0.5 px-1">{senderLabel}</span>
               )}
-              <div
-                className={`max-w-[85%] sm:max-w-[70%] px-3 py-2 rounded-2xl text-sm break-words ${
-                  isOwn
-                    ? 'bg-blue-600 text-white rounded-br-sm'
-                    : 'bg-gray-800 text-gray-100 rounded-bl-sm'
-                }`}
-              >
-                {attachmentUrl && isImage && (
-                  <button
-                    type="button"
-                    onClick={() => setLightbox({ url: attachmentUrl, alt: t('chat.attachmentImageAlt') })}
-                    className="block cursor-zoom-in mb-1"
-                    aria-label={t('chat.attachmentImageAlt')}
-                  >
-                    <img
+              <div className={`relative max-w-[85%] sm:max-w-[70%]`}>
+                <div
+                  className={`px-3 py-2 rounded-2xl text-sm break-words ${
+                    isOwn
+                      ? 'bg-blue-600 text-white rounded-br-sm'
+                      : 'bg-gray-800 text-gray-100 rounded-bl-sm'
+                  }`}
+                  onContextMenu={(e) => { e.preventDefault(); setPickerForMsgId(msg.id) }}
+                >
+                  {attachmentUrl && isImage && (
+                    <button
+                      type="button"
+                      onClick={() => setLightbox({ url: attachmentUrl, alt: t('chat.attachmentImageAlt') })}
+                      className="block cursor-zoom-in mb-1"
+                      aria-label={t('chat.attachmentImageAlt')}
+                    >
+                      <img
+                        src={attachmentUrl}
+                        alt={t('chat.attachmentImageAlt')}
+                        loading="lazy"
+                        className="rounded-lg max-h-60 max-w-full object-contain"
+                      />
+                    </button>
+                  )}
+                  {attachmentUrl && isAudio && (
+                    <audio
+                      controls
                       src={attachmentUrl}
-                      alt={t('chat.attachmentImageAlt')}
-                      loading="lazy"
-                      className="rounded-lg max-h-60 max-w-full object-contain"
+                      className="block max-w-full mb-1"
+                      aria-label={t('chat.attachmentAudioAlt')}
                     />
-                  </button>
-                )}
-                {attachmentUrl && isAudio && (
-                  <audio
-                    controls
-                    src={attachmentUrl}
-                    className="block max-w-full mb-1"
-                    aria-label={t('chat.attachmentAudioAlt')}
+                  )}
+                  {attachmentUrl && !isImage && !isAudio && (
+                    <a
+                      href={attachmentUrl}
+                      download
+                      className={`flex items-center gap-2 rounded-lg px-2 py-1.5 mb-1 text-xs ${
+                        isOwn ? 'bg-blue-700/60 hover:bg-blue-700/80' : 'bg-gray-700/70 hover:bg-gray-700'
+                      }`}
+                    >
+                      <Download size={14} aria-hidden="true" />
+                      <span className="truncate">{t('chat.attachmentFileLabel', { mime })}</span>
+                    </a>
+                  )}
+                  {msg.body && (
+                    <div className="whitespace-pre-wrap">{msg.body}</div>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setPickerForMsgId(pickerOpen ? null : msg.id)}
+                  aria-label={t('reactions.pickerLabel')}
+                  className={`absolute -top-3 ${isOwn ? '-left-2' : '-right-2'} p-1 rounded-full bg-gray-800 border border-gray-700 text-gray-300 hover:text-white opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity cursor-pointer`}
+                  data-testid={`reaction-trigger-${msg.id}`}
+                >
+                  <Smile size={14} aria-hidden="true" />
+                </button>
+                {pickerOpen && (
+                  <ReactionPicker
+                    onPick={(emoji) => handlePickFromPicker(msg.id, emoji)}
+                    onClose={() => setPickerForMsgId(null)}
                   />
                 )}
-                {attachmentUrl && !isImage && !isAudio && (
-                  <a
-                    href={attachmentUrl}
-                    download
-                    className={`flex items-center gap-2 rounded-lg px-2 py-1.5 mb-1 text-xs ${
-                      isOwn ? 'bg-blue-700/60 hover:bg-blue-700/80' : 'bg-gray-700/70 hover:bg-gray-700'
-                    }`}
-                  >
-                    <Download size={14} aria-hidden="true" />
-                    <span className="truncate">{t('chat.attachmentFileLabel', { mime })}</span>
-                  </a>
-                )}
-                {msg.body && (
-                  <div className="whitespace-pre-wrap">{msg.body}</div>
-                )}
               </div>
+              <ReactionChips
+                reactions={msg.reactions}
+                onToggle={(emoji, mine) => { void toggleReaction(msg.id, emoji, mine) }}
+              />
               {relative && (
                 <span className="text-[10px] text-gray-500 mt-0.5 px-1">{relative}</span>
               )}

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -411,9 +411,10 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // network round-trip) and rolls back on failure. The eventual SSE
   // confirmation overwrites the optimistic state with the server-authoritative
   // count, which keeps two clients in sync even if either one races.
+  const userId = user?.id
   const toggleReaction = useCallback(async (msgId: number, emoji: string, currentlyMine: boolean) => {
-    if (conversationId === null || user?.id === undefined) return
-    const meID = user.id
+    if (conversationId === null || userId === undefined) return
+    const meID = userId
     const snapshot = messages.find(m => m.id === msgId) ?? null
     setMessages(prev => prev.map(m => {
       if (m.id !== msgId) return m
@@ -438,7 +439,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         setMessages(prev => prev.map(m => (m.id === msgId ? snapshot : m)))
       }
     }
-  }, [conversationId, user?.id, messages])
+  }, [conversationId, userId, messages])
 
   const handlePickFromPicker = useCallback((msgId: number, emoji: string) => {
     setPickerForMsgId(null)

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -82,6 +82,10 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // (recreated only when conversationId changes) can read the most recent
   // value without forcing the effect to re-run on auth changes.
   const currentUserIdRef = useRef<number | undefined>(user?.id)
+  // lastPointerTypeRef is set by onPointerDown so onContextMenu knows whether
+  // it was triggered by a touch long-press (open picker, suppress native menu)
+  // or a mouse right-click (leave native menu alone; picker is on hover button).
+  const lastPointerTypeRef = useRef<string>('mouse')
   useEffect(() => { currentUserIdRef.current = user?.id }, [user?.id])
 
   const rtf = useMemo(
@@ -433,10 +437,14 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         await addReaction(conversationId, msgId, emoji)
       }
     } catch {
-      // Roll back to the pre-toggle snapshot. The eventual SSE event from
-      // any successful interaction is still the source of truth.
+      // Roll back only the reactions field to the pre-toggle snapshot. Rolling
+      // back the whole message would clobber any concurrent SSE updates (edits,
+      // other reactions) that arrived between the optimistic update and the
+      // network failure.
       if (snapshot) {
-        setMessages(prev => prev.map(m => (m.id === msgId ? snapshot : m)))
+        setMessages(prev => prev.map(m =>
+          m.id === msgId ? { ...m, reactions: snapshot.reactions } : m,
+        ))
       }
     }
   }, [conversationId, userId, messages])
@@ -588,7 +596,17 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                       ? 'bg-blue-600 text-white rounded-br-sm'
                       : 'bg-gray-800 text-gray-100 rounded-bl-sm'
                   }`}
-                  onContextMenu={(e) => { e.preventDefault(); setPickerForMsgId(msg.id) }}
+                  onPointerDown={(e) => { lastPointerTypeRef.current = e.pointerType }}
+                  onContextMenu={(e) => {
+                    // Only intercept touch long-press (suppress native menu, open
+                    // picker). Mouse right-clicks keep the native menu so users
+                    // can copy text/images; the picker is reachable via the hover
+                    // button (Smile icon) on desktop.
+                    if (lastPointerTypeRef.current === 'touch') {
+                      e.preventDefault()
+                      setPickerForMsgId(msg.id)
+                    }
+                  }}
                 >
                   {attachmentUrl && isImage && (
                     <button

--- a/web/src/pages/familychat/ReactionChips.test.tsx
+++ b/web/src/pages/familychat/ReactionChips.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ReactionChips from './ReactionChips'
+import type { ReactionMap } from './api'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, string | number>) => {
+      if (opts) return `${key}:${JSON.stringify(opts)}`
+      return key
+    },
+  }),
+}))
+
+describe('ReactionChips', () => {
+  it('renders nothing when reactions are undefined', () => {
+    const { container } = render(<ReactionChips reactions={undefined} onToggle={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing for an empty reaction map', () => {
+    const { container } = render(<ReactionChips reactions={{}} onToggle={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a chip per emoji with its count', () => {
+    const reactions: ReactionMap = {
+      '👍': { count: 2, users: [1, 2], me: false },
+      '🎉': { count: 1, users: [3], me: false },
+    }
+    render(<ReactionChips reactions={reactions} onToggle={vi.fn()} />)
+    expect(screen.getByTestId('reaction-chip-👍').textContent).toContain('2')
+    expect(screen.getByTestId('reaction-chip-🎉').textContent).toContain('1')
+  })
+
+  it('marks own reactions with aria-pressed=true', () => {
+    const reactions: ReactionMap = {
+      '👍': { count: 1, users: [1], me: true },
+      '😢': { count: 1, users: [2], me: false },
+    }
+    render(<ReactionChips reactions={reactions} onToggle={vi.fn()} />)
+    expect(screen.getByTestId('reaction-chip-👍').getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByTestId('reaction-chip-😢').getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('invokes onToggle with the chip emoji and current me-flag', () => {
+    const onToggle = vi.fn()
+    const reactions: ReactionMap = { '👍': { count: 1, users: [1], me: true } }
+    render(<ReactionChips reactions={reactions} onToggle={onToggle} />)
+    fireEvent.click(screen.getByTestId('reaction-chip-👍'))
+    expect(onToggle).toHaveBeenCalledWith('👍', true)
+  })
+
+  it('skips buckets whose count has dropped to zero', () => {
+    const reactions: ReactionMap = {
+      '👍': { count: 0, users: [], me: false },
+      '🎉': { count: 1, users: [1], me: false },
+    }
+    render(<ReactionChips reactions={reactions} onToggle={vi.fn()} />)
+    expect(screen.queryByTestId('reaction-chip-👍')).not.toBeInTheDocument()
+    expect(screen.getByTestId('reaction-chip-🎉')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/familychat/ReactionChips.tsx
+++ b/web/src/pages/familychat/ReactionChips.tsx
@@ -9,9 +9,9 @@ interface ReactionChipsProps {
 export default function ReactionChips({ reactions, onToggle }: ReactionChipsProps) {
   const { t } = useTranslation('familyChat')
   if (!reactions) return null
-  // Sort emoji keys for stable display order across renders. The backend
-  // returns the map keyed by emoji string; iteration order over a JS Map
-  // mirrors insertion order, which is non-deterministic across reloads.
+  // Sort emoji keys for stable display order across renders. reactions is a
+  // plain JSON object; Go map serialization order is non-deterministic, so
+  // without sorting the chips can shuffle between renders.
   const emojis = Object.keys(reactions).sort()
   if (emojis.length === 0) return null
   return (

--- a/web/src/pages/familychat/ReactionChips.tsx
+++ b/web/src/pages/familychat/ReactionChips.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next'
+import type { ReactionMap } from './api'
+
+interface ReactionChipsProps {
+  reactions: ReactionMap | undefined
+  onToggle: (emoji: string, currentlyMine: boolean) => void
+}
+
+export default function ReactionChips({ reactions, onToggle }: ReactionChipsProps) {
+  const { t } = useTranslation('familyChat')
+  if (!reactions) return null
+  // Sort emoji keys for stable display order across renders. The backend
+  // returns the map keyed by emoji string; iteration order over a JS Map
+  // mirrors insertion order, which is non-deterministic across reloads.
+  const emojis = Object.keys(reactions).sort()
+  if (emojis.length === 0) return null
+  return (
+    <div className="flex flex-wrap gap-1 mt-1" data-testid="reaction-chips">
+      {emojis.map(emoji => {
+        const bucket = reactions[emoji]
+        if (!bucket || bucket.count <= 0) return null
+        const mine = !!bucket.me
+        return (
+          <button
+            key={emoji}
+            type="button"
+            onClick={() => onToggle(emoji, mine)}
+            aria-label={mine ? t('reactions.remove', { emoji }) : t('reactions.add', { emoji })}
+            aria-pressed={mine}
+            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs cursor-pointer border ${
+              mine
+                ? 'bg-blue-500/20 border-blue-400/60 text-blue-100'
+                : 'bg-gray-700/60 border-gray-600 text-gray-200 hover:bg-gray-700'
+            }`}
+            data-testid={`reaction-chip-${emoji}`}
+          >
+            <span aria-hidden="true">{emoji}</span>
+            <span>{bucket.count}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/pages/familychat/ReactionPicker.tsx
+++ b/web/src/pages/familychat/ReactionPicker.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+// PICKER_EMOJIS is the fixed grid shown when the user opens the picker. The
+// list is intentionally short so the popover stays compact on mobile and we
+// don't ship a megabyte emoji search index. Server-side validation accepts
+// any single emoji grapheme so users can still react with anything they can
+// type via their OS keyboard from the textarea path (future work).
+export const PICKER_EMOJIS = [
+  '👍', '❤️', '🎉', '😂',
+  '😮', '😢', '🙏', '🔥',
+  '👏', '👀', '💯', '🚀',
+  '😡', '🤔', '🥳', '😴',
+]
+
+interface ReactionPickerProps {
+  onPick: (emoji: string) => void
+  onClose: () => void
+}
+
+export default function ReactionPicker({ onPick, onClose }: ReactionPickerProps) {
+  const { t } = useTranslation('familyChat')
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      ref={containerRef}
+      role="dialog"
+      aria-label={t('reactions.pickerLabel')}
+      className="absolute z-30 bottom-full mb-2 right-0 bg-gray-800 border border-gray-700 rounded-lg shadow-lg p-2 grid grid-cols-4 gap-1"
+      data-testid="reaction-picker"
+    >
+      {PICKER_EMOJIS.map(emoji => (
+        <button
+          key={emoji}
+          type="button"
+          onClick={() => onPick(emoji)}
+          className="w-9 h-9 flex items-center justify-center text-xl rounded-md hover:bg-gray-700 cursor-pointer"
+          aria-label={emoji}
+        >
+          {emoji}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/web/src/pages/familychat/ReactionPicker.tsx
+++ b/web/src/pages/familychat/ReactionPicker.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 // don't ship a megabyte emoji search index. Server-side validation accepts
 // any single emoji grapheme so users can still react with anything they can
 // type via their OS keyboard from the textarea path (future work).
-export const PICKER_EMOJIS = [
+const PICKER_EMOJIS = [
   '👍', '❤️', '🎉', '😂',
   '😮', '😢', '🙏', '🔥',
   '👏', '👀', '💯', '🚀',

--- a/web/src/pages/familychat/ReactionPicker.tsx
+++ b/web/src/pages/familychat/ReactionPicker.tsx
@@ -23,6 +23,7 @@ export default function ReactionPicker({ onPick, onClose }: ReactionPickerProps)
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
+    containerRef.current?.focus()
     const handleClickOutside = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         onClose()
@@ -43,8 +44,10 @@ export default function ReactionPicker({ onPick, onClose }: ReactionPickerProps)
     <div
       ref={containerRef}
       role="dialog"
+      aria-modal={true}
       aria-label={t('reactions.pickerLabel')}
-      className="absolute z-30 bottom-full mb-2 right-0 bg-gray-800 border border-gray-700 rounded-lg shadow-lg p-2 grid grid-cols-4 gap-1"
+      tabIndex={-1}
+      className="absolute z-30 bottom-full mb-2 right-0 bg-gray-800 border border-gray-700 rounded-lg shadow-lg p-2 grid grid-cols-4 gap-1 outline-none"
       data-testid="reaction-picker"
     >
       {PICKER_EMOJIS.map(emoji => (

--- a/web/src/pages/familychat/api.test.ts
+++ b/web/src/pages/familychat/api.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { addReaction, removeReaction, applyReactionEvent, type ReactionMap } from './api'
+
+describe('addReaction', () => {
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('POSTs to the reactions endpoint with the emoji in the body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    await addReaction(7, 42, '👍')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/familychat/conversations/7/messages/42/reactions')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ emoji: '👍' })
+  })
+
+  it('throws when the response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 400 }))
+    await expect(addReaction(1, 1, '👍')).rejects.toThrow()
+  })
+})
+
+describe('removeReaction', () => {
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('DELETEs with the emoji url-encoded into the query string', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    await removeReaction(3, 9, '👍')
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toContain('/api/familychat/conversations/3/messages/9/reactions?emoji=')
+    expect(url).toContain(encodeURIComponent('👍'))
+    expect(init.method).toBe('DELETE')
+  })
+})
+
+describe('applyReactionEvent', () => {
+  it('adds a brand-new emoji bucket', () => {
+    const out = applyReactionEvent(undefined, { user_id: 5, emoji: '🎉', count: 1 }, 5, false)
+    expect(out).toEqual({ '🎉': { count: 1, users: [5], extra_count: undefined, me: true } })
+  })
+
+  it('increments an existing bucket and sets me when the viewer is the actor', () => {
+    const prev: ReactionMap = { '👍': { count: 1, users: [3], me: false } }
+    const out = applyReactionEvent(prev, { user_id: 7, emoji: '👍', count: 2 }, 7, false)
+    expect(out['👍'].count).toBe(2)
+    expect(out['👍'].users).toEqual([3, 7])
+    expect(out['👍'].me).toBe(true)
+  })
+
+  it('does not flip me when another user adds a reaction', () => {
+    const prev: ReactionMap = { '👍': { count: 1, users: [3], me: false } }
+    const out = applyReactionEvent(prev, { user_id: 8, emoji: '👍', count: 2 }, 7, false)
+    expect(out['👍'].me).toBe(false)
+  })
+
+  it('removes the bucket entirely when the count drops to zero', () => {
+    const prev: ReactionMap = { '👍': { count: 1, users: [3], me: false } }
+    const out = applyReactionEvent(prev, { user_id: 3, emoji: '👍', count: 0 }, 3, true)
+    expect(out['👍']).toBeUndefined()
+  })
+
+  it('clears me when the viewer themselves removes', () => {
+    const prev: ReactionMap = { '👍': { count: 2, users: [3, 7], me: true } }
+    const out = applyReactionEvent(prev, { user_id: 7, emoji: '👍', count: 1 }, 7, true)
+    expect(out['👍'].me).toBe(false)
+    expect(out['👍'].users).toEqual([3])
+  })
+})

--- a/web/src/pages/familychat/api.ts
+++ b/web/src/pages/familychat/api.ts
@@ -39,9 +39,9 @@ export async function removeReaction(convID: number, msgID: number, emoji: strin
   if (!res.ok) throw new Error(`remove reaction failed: ${res.status}`)
 }
 
-// applyReactionEvent mutates a reaction map in place to reflect an
-// add/remove SSE event. Returns a NEW object so React state updates trigger
-// re-renders even when the bucket fields didn't change identity.
+// applyReactionEvent returns a new reaction map reflecting an add/remove SSE
+// event. The input map is never mutated; a shallow clone is always returned so
+// React state updates trigger re-renders even when bucket fields are unchanged.
 export function applyReactionEvent(
   current: ReactionMap | undefined,
   evt: { user_id: number; emoji: string; count: number },

--- a/web/src/pages/familychat/api.ts
+++ b/web/src/pages/familychat/api.ts
@@ -1,0 +1,80 @@
+// Shared types and helpers for Family Chat API calls. Kept narrowly scoped to
+// the reactions feature for now; if other pages start hitting the API
+// directly we can grow this into a fuller wrapper.
+
+export interface ReactionBucket {
+  count: number
+  users: number[]
+  extra_count?: number
+  me: boolean
+}
+
+export type ReactionMap = Record<string, ReactionBucket>
+
+// addReaction POSTs a reaction. Resolves on success (204). Throws on any
+// non-success response so callers can roll back optimistic UI updates.
+export async function addReaction(convID: number, msgID: number, emoji: string): Promise<void> {
+  const res = await fetch(
+    `/api/familychat/conversations/${convID}/messages/${msgID}/reactions`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ emoji }),
+    },
+  )
+  if (!res.ok) throw new Error(`add reaction failed: ${res.status}`)
+}
+
+// removeReaction DELETEs a reaction. Resolves on success (204). Throws on
+// any non-success response.
+export async function removeReaction(convID: number, msgID: number, emoji: string): Promise<void> {
+  const res = await fetch(
+    `/api/familychat/conversations/${convID}/messages/${msgID}/reactions?emoji=${encodeURIComponent(emoji)}`,
+    {
+      method: 'DELETE',
+      credentials: 'include',
+    },
+  )
+  if (!res.ok) throw new Error(`remove reaction failed: ${res.status}`)
+}
+
+// applyReactionEvent mutates a reaction map in place to reflect an
+// add/remove SSE event. Returns a NEW object so React state updates trigger
+// re-renders even when the bucket fields didn't change identity.
+export function applyReactionEvent(
+  current: ReactionMap | undefined,
+  evt: { user_id: number; emoji: string; count: number },
+  meUserID: number | undefined,
+  removed: boolean,
+): ReactionMap {
+  const next: ReactionMap = { ...(current ?? {}) }
+  const existing = next[evt.emoji]
+  const isMe = meUserID !== undefined && evt.user_id === meUserID
+  if (removed) {
+    if (!existing) return next
+    const users = existing.users.filter(u => u !== evt.user_id)
+    const newCount = evt.count
+    if (newCount <= 0) {
+      delete next[evt.emoji]
+      return next
+    }
+    next[evt.emoji] = {
+      ...existing,
+      count: newCount,
+      users,
+      me: isMe ? false : existing.me,
+    }
+    return next
+  }
+  // added
+  const users = existing?.users ?? []
+  const alreadyHasUser = users.includes(evt.user_id)
+  next[evt.emoji] = {
+    count: evt.count,
+    users: alreadyHasUser ? users : [...users, evt.user_id],
+    extra_count: existing?.extra_count,
+    me: isMe ? true : (existing?.me ?? false),
+  }
+  return next
+}


### PR DESCRIPTION
## Changes

- **Family Chat emoji reactions** - Members can now react to messages with emoji. Reactions live in a new `family_chat_message_reactions` table, surface as toggleable chips under each bubble, and stream in real time over the existing SSE hub so other clients update without a refetch. (Hytte-hp9b)

## Original Issue (feature): Family Chat: emoji reactions on messages

Add emoji reactions on messages in Family Chat. Reuses the existing SSE live-event hub so reactions appear in real time on other clients, and the member-gated access pattern from the REST handlers.

## Scope

### Schema (internal/db/db.go createSchema)
- New table `family_chat_message_reactions (message_id INTEGER FK, user_id INTEGER FK, emoji TEXT NOT NULL, reacted_at TIMESTAMP NOT NULL, PRIMARY KEY (message_id, user_id, emoji))`. Single index `idx_family_chat_message_reactions_message ON (message_id)`.
- Idempotent migration block following the existing pattern.

### Backend
- `POST /api/familychat/conversations/{id}/messages/{messageID}/reactions` body `{emoji: "..."}` — adds (idempotent on PK conflict). Member-gated; non-members 404.
- `DELETE /api/familychat/conversations/{id}/messages/{messageID}/reactions?emoji=...` — removes.
- `GET /api/familychat/conversations/{id}/messages?limit=...` extends each message DTO with a `reactions` map: `{emoji → {count, users: [user_id,...], me: bool}}`. Cap each emoji's user list at 20 and add an `extra_count` field once larger so the response payload stays bounded for big convos.
- SSE: emit `reaction_added` and `reaction_removed` events from the existing hub with payload `{message_id, user_id, emoji, count, me}`. Frontend updates the local message in place; no full refetch.
- Emoji validation: allow only single Unicode emoji clusters or short `:shortcode:` (validated against a small allowlist) to prevent reaction-spam with arbitrary text. Reject otherwise with 400.

### Frontend (web/src/pages/familychat/*)
- Add a "react" affordance on each bubble — long-press on mobile, hover-bar on desktop — that opens a small picker (Lucide `Smile` icon, ~16 emoji rows).
- Render reaction chips under each message: `[👍 3] [🎉 1]`. Tapping a chip toggles your reaction. Your own chips have a subtle border highlight.
- i18n: add `familyChat.reactions.{add,remove,pickerLabel}` to en/nb/th.

### Tests
- Backend handler tests: add/remove idempotency, member-gating, emoji validation, list response embeds reactions correctly with `me` flag per user.
- SSE test: a reaction add from user A delivers `reaction_added` to user B's open stream within the existing test harness.
- Frontend: bubble renders chips, toggling a chip fires the right API call, optimistic update + rollback on failure.

### Acceptance
- Two members on the same conversation can tap reactions and see them appear in real time without refreshing.
- Reactions count survives reload (read back via `GET /messages`).
- `make build`, `make test`, `npm run lint`, `npm run build` pass.
- Changelog fragment in `changelog.d/` (category: Added).

## Reference
- internal/familychat/handlers.go — handler pattern + member resolution.
- internal/familychat/sse.go (or wherever the hub lives) — event dispatch.
- web/src/pages/familychat/ChatView.tsx — bubble rendering.


---
Bead: Hytte-hp9b | Branch: forge/Hytte-hp9b
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->