### PR TITLE
Family Chat: reaction picker positioning + sizing (clips off-screen, cells too cramped) (Hytte-i6e8)

### DIFF
--- a/changelog.d/Hytte-i6e8.md
+++ b/changelog.d/Hytte-i6e8.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Family Chat reaction picker positioning + sizing** - The emoji picker now portals to the document body and flips above or below the message bubble based on available space, so it no longer clips off-screen for messages near the top of the chat. The grid was widened to 6 columns with larger 44px tap targets, more padding, and a clearer drop shadow for comfortable mobile use. (Hytte-i6e8)

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -112,11 +112,15 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // it was triggered by a touch long-press (open picker, suppress native menu)
   // or a mouse right-click (leave native menu alone; picker is on hover button).
   const lastPointerTypeRef = useRef<string>('mouse')
-  // pickerTriggerRef anchors the open reaction picker to whichever trigger
-  // (hover button or bubble long-press target) opened it. The picker portals
-  // out to document.body so it needs an explicit anchor rect rather than
-  // relying on its position in the DOM.
-  const pickerTriggerRef = useRef<HTMLElement | null>(null)
+  // pickerAnchorRef: element used by ReactionPicker for placement/positioning.
+  // Set to the hover button or the message bubble (long-press), whichever opened the picker.
+  const pickerAnchorRef = useRef<HTMLElement | null>(null)
+  // pickerGuardRef: the actual toggle button (hover Smile button only). The
+  // picker's outside-click handler ignores clicks on this element so the button
+  // can toggle the picker closed without the picker immediately re-closing on
+  // the same click. NOT set on long-press (no toggle button exists there), so
+  // tapping the bubble correctly closes the picker.
+  const pickerGuardRef = useRef<HTMLElement | null>(null)
   useEffect(() => { currentUserIdRef.current = user?.id }, [user?.id])
 
   // Focus management + Escape handling for the delete confirmation modal,
@@ -862,7 +866,11 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                       // MoreVertical button for own messages.
                       if (lastPointerTypeRef.current === 'touch') {
                         e.preventDefault()
-                        pickerTriggerRef.current = e.currentTarget
+                        // Use the bubble as the positioning anchor only.
+                        // pickerGuardRef is NOT set here — there is no toggle
+                        // button for long-press, so clicks on the bubble should
+                        // correctly dismiss the picker.
+                        pickerAnchorRef.current = e.currentTarget
                         setPickerForMsgId(msg.id)
                       }
                     }}
@@ -911,11 +919,17 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                   <button
                     type="button"
                     ref={(el) => {
-                      if (pickerOpen) pickerTriggerRef.current = el
+                      if (pickerOpen) {
+                        pickerAnchorRef.current = el
+                        pickerGuardRef.current = el
+                      }
                     }}
                     onClick={(e) => {
                       const willOpen = !pickerOpen
-                      if (willOpen) pickerTriggerRef.current = e.currentTarget
+                      if (willOpen) {
+                        pickerAnchorRef.current = e.currentTarget
+                        pickerGuardRef.current = e.currentTarget
+                      }
                       setPickerForMsgId(willOpen ? msg.id : null)
                     }}
                     aria-label={t('reactions.pickerLabel')}
@@ -985,7 +999,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                   <ReactionPicker
                     onPick={(emoji) => handlePickFromPicker(msg.id, emoji)}
                     onClose={() => setPickerForMsgId(null)}
-                    triggerRef={pickerTriggerRef}
+                    anchorRef={pickerAnchorRef}
+                    triggerRef={pickerGuardRef}
                   />
                 )}
               </div>

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -112,6 +112,11 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // it was triggered by a touch long-press (open picker, suppress native menu)
   // or a mouse right-click (leave native menu alone; picker is on hover button).
   const lastPointerTypeRef = useRef<string>('mouse')
+  // pickerTriggerRef anchors the open reaction picker to whichever trigger
+  // (hover button or bubble long-press target) opened it. The picker portals
+  // out to document.body so it needs an explicit anchor rect rather than
+  // relying on its position in the DOM.
+  const pickerTriggerRef = useRef<HTMLElement | null>(null)
   useEffect(() => { currentUserIdRef.current = user?.id }, [user?.id])
 
   // Focus management + Escape handling for the delete confirmation modal,
@@ -857,6 +862,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                       // MoreVertical button for own messages.
                       if (lastPointerTypeRef.current === 'touch') {
                         e.preventDefault()
+                        pickerTriggerRef.current = e.currentTarget
                         setPickerForMsgId(msg.id)
                       }
                     }}
@@ -904,7 +910,14 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                 {!isDeleted && !isEditing && (
                   <button
                     type="button"
-                    onClick={() => setPickerForMsgId(pickerOpen ? null : msg.id)}
+                    ref={(el) => {
+                      if (pickerOpen) pickerTriggerRef.current = el
+                    }}
+                    onClick={(e) => {
+                      const willOpen = !pickerOpen
+                      if (willOpen) pickerTriggerRef.current = e.currentTarget
+                      setPickerForMsgId(willOpen ? msg.id : null)
+                    }}
                     aria-label={t('reactions.pickerLabel')}
                     className={`absolute -top-3 ${isOwn ? '-left-2' : '-right-2'} p-1 rounded-full bg-gray-800 border border-gray-700 text-gray-300 hover:text-white opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity cursor-pointer`}
                     data-testid={`reaction-trigger-${msg.id}`}
@@ -972,6 +985,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                   <ReactionPicker
                     onPick={(emoji) => handlePickFromPicker(msg.id, emoji)}
                     onClose={() => setPickerForMsgId(null)}
+                    triggerRef={pickerTriggerRef}
                   />
                 )}
               </div>

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -867,10 +867,13 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                       if (lastPointerTypeRef.current === 'touch') {
                         e.preventDefault()
                         // Use the bubble as the positioning anchor only.
-                        // pickerGuardRef is NOT set here — there is no toggle
-                        // button for long-press, so clicks on the bubble should
-                        // correctly dismiss the picker.
+                        // pickerGuardRef is explicitly cleared here — there is
+                        // no toggle button for long-press, so clicks on the
+                        // bubble should correctly dismiss the picker. Clearing
+                        // prevents a stale guard ref from a prior hover-button
+                        // open from suppressing the outside-click close.
                         pickerAnchorRef.current = e.currentTarget
+                        pickerGuardRef.current = null
                         setPickerForMsgId(msg.id)
                       }
                     }}
@@ -918,12 +921,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                 {!isDeleted && !isEditing && (
                   <button
                     type="button"
-                    ref={(el) => {
-                      if (pickerOpen) {
-                        pickerAnchorRef.current = el
-                        pickerGuardRef.current = el
-                      }
-                    }}
                     onClick={(e) => {
                       const willOpen = !pickerOpen
                       if (willOpen) {

--- a/web/src/pages/familychat/ReactionPicker.test.tsx
+++ b/web/src/pages/familychat/ReactionPicker.test.tsx
@@ -102,7 +102,7 @@ describe('ReactionPicker', () => {
     ;(ref as { current: HTMLElement | null }).current = trigger
 
     const { container } = render(
-      <ReactionPicker onPick={() => {}} onClose={() => {}} triggerRef={ref} />,
+      <ReactionPicker onPick={() => {}} onClose={() => {}} anchorRef={ref} />,
     )
 
     // The portal target is document.body, NOT the React render container.
@@ -124,16 +124,16 @@ describe('ReactionPicker', () => {
     })
   })
 
-  it('positions itself via fixed coordinates derived from the trigger rect', () => {
+  it('positions itself via fixed coordinates derived from the anchor rect', () => {
     const ref = createRef<HTMLElement | null>()
     ;(ref as { current: HTMLElement | null }).current = trigger
 
-    render(<ReactionPicker onPick={() => {}} onClose={() => {}} triggerRef={ref} />)
+    render(<ReactionPicker onPick={() => {}} onClose={() => {}} anchorRef={ref} />)
 
     const picker = screen.getByTestId('reaction-picker')
     expect(picker.style.position).toBe('fixed')
-    // Trigger sits at top=400 with plenty of room above (>= 180 + 16), so the
-    // picker should flip above.
+    // Trigger sits at top=400 with plenty of room above (>= 180 + TRIGGER_GAP + VIEWPORT_MARGIN),
+    // so the picker should flip above.
     expect(picker.style.top).not.toBe('')
     expect(picker.style.left).not.toBe('')
   })
@@ -143,7 +143,7 @@ describe('ReactionPicker', () => {
     const ref = createRef<HTMLElement | null>()
     ;(ref as { current: HTMLElement | null }).current = trigger
 
-    render(<ReactionPicker onPick={onPick} onClose={() => {}} triggerRef={ref} />)
+    render(<ReactionPicker onPick={onPick} onClose={() => {}} anchorRef={ref} />)
 
     const picker = screen.getByTestId('reaction-picker')
     const firstCell = picker.querySelector('button')!
@@ -157,7 +157,7 @@ describe('ReactionPicker', () => {
     const ref = createRef<HTMLElement | null>()
     ;(ref as { current: HTMLElement | null }).current = trigger
 
-    render(<ReactionPicker onPick={() => {}} onClose={onClose} triggerRef={ref} />)
+    render(<ReactionPicker onPick={() => {}} onClose={onClose} anchorRef={ref} />)
 
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(onClose).toHaveBeenCalledTimes(1)
@@ -168,7 +168,7 @@ describe('ReactionPicker', () => {
     const ref = createRef<HTMLElement | null>()
     ;(ref as { current: HTMLElement | null }).current = trigger
 
-    render(<ReactionPicker onPick={() => {}} onClose={onClose} triggerRef={ref} />)
+    render(<ReactionPicker onPick={() => {}} onClose={onClose} anchorRef={ref} />)
 
     const outside = document.createElement('div')
     document.body.appendChild(outside)
@@ -177,15 +177,31 @@ describe('ReactionPicker', () => {
     outside.remove()
   })
 
-  it('does NOT close when clicking the trigger element (toggling is the trigger\'s job)', () => {
+  it('does NOT close when clicking the trigger button (triggerRef guard, toggling is the button\'s job)', () => {
     const onClose = vi.fn()
-    const ref = createRef<HTMLElement | null>()
-    ;(ref as { current: HTMLElement | null }).current = trigger
+    const anchorRef = createRef<HTMLElement | null>()
+    ;(anchorRef as { current: HTMLElement | null }).current = trigger
+    // triggerRef is the actual toggle button — pass same element here to verify guard.
+    const triggerRef = createRef<HTMLElement | null>()
+    ;(triggerRef as { current: HTMLElement | null }).current = trigger
 
-    render(<ReactionPicker onPick={() => {}} onClose={onClose} triggerRef={ref} />)
+    render(<ReactionPicker onPick={() => {}} onClose={onClose} anchorRef={anchorRef} triggerRef={triggerRef} />)
 
     fireEvent.mouseDown(trigger)
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes when clicking the anchor element when no triggerRef is set (long-press case)', () => {
+    const onClose = vi.fn()
+    const anchorRef = createRef<HTMLElement | null>()
+    ;(anchorRef as { current: HTMLElement | null }).current = trigger
+
+    // No triggerRef — simulates the long-press / touch path where there is no
+    // toggle button and clicking the bubble should close the picker.
+    render(<ReactionPicker onPick={() => {}} onClose={onClose} anchorRef={anchorRef} />)
+
+    fireEvent.mouseDown(trigger)
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('does not close when clicking inside the picker itself', () => {
@@ -193,7 +209,7 @@ describe('ReactionPicker', () => {
     const ref = createRef<HTMLElement | null>()
     ;(ref as { current: HTMLElement | null }).current = trigger
 
-    render(<ReactionPicker onPick={() => {}} onClose={onClose} triggerRef={ref} />)
+    render(<ReactionPicker onPick={() => {}} onClose={onClose} anchorRef={ref} />)
 
     const picker = screen.getByTestId('reaction-picker')
     fireEvent.mouseDown(picker)

--- a/web/src/pages/familychat/ReactionPicker.test.tsx
+++ b/web/src/pages/familychat/ReactionPicker.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createRef } from 'react'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import ReactionPicker, { computePickerPosition } from './ReactionPicker'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+function rect(left: number, top: number, width = 24, height = 24): DOMRect {
+  return {
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+describe('computePickerPosition', () => {
+  const viewport = { w: 800, h: 600 }
+  const pickerSize = { w: 320, h: 180 }
+
+  it('places below + left-aligned when trigger is near the top-left', () => {
+    const pos = computePickerPosition(rect(20, 20), viewport, pickerSize)
+    expect(pos.placement).toBe('below')
+    expect(pos.align).toBe('left')
+    expect(pos.top).toBe(20 + 24 + 8)
+    expect(pos.left).toBe(20)
+  })
+
+  it('places below + right-aligned when trigger is near the top-right', () => {
+    const pos = computePickerPosition(rect(760, 20), viewport, pickerSize)
+    expect(pos.placement).toBe('below')
+    expect(pos.align).toBe('right')
+    expect(pos.top).toBe(20 + 24 + 8)
+    // right-aligned: left = triggerRect.right - pickerW, clamped to maxLeft.
+    const expectedLeft = Math.min(760 + 24 - 320, viewport.w - pickerSize.w - 8)
+    expect(pos.left).toBe(expectedLeft)
+  })
+
+  it('places above + left-aligned when trigger is near the bottom-left', () => {
+    const pos = computePickerPosition(rect(20, 560), viewport, pickerSize)
+    expect(pos.placement).toBe('above')
+    expect(pos.align).toBe('left')
+    expect(pos.top).toBe(560 - 180 - 8)
+    expect(pos.left).toBe(20)
+  })
+
+  it('places above + right-aligned when trigger is near the bottom-right', () => {
+    const pos = computePickerPosition(rect(760, 560), viewport, pickerSize)
+    expect(pos.placement).toBe('above')
+    expect(pos.align).toBe('right')
+    expect(pos.top).toBe(560 - 180 - 8)
+    const expectedLeft = Math.min(760 + 24 - 320, viewport.w - pickerSize.w - 8)
+    expect(pos.left).toBe(expectedLeft)
+  })
+
+  it('falls back to below + clamps when the picker fits nowhere', () => {
+    const tinyViewport = { w: 200, h: 200 }
+    const bigPicker = { w: 320, h: 180 }
+    // Trigger near the top with no room above; picker is also wider than
+    // viewport so left clamps to the left margin.
+    const pos = computePickerPosition(rect(10, 10), tinyViewport, bigPicker)
+    expect(pos.placement).toBe('below')
+    // Top clamped to the maxTop = max(8, h - pickerH - 8) = max(8, 200-180-8)=12.
+    // raw top is 10+24+8 = 42, clamped down to 12.
+    expect(pos.top).toBe(12)
+    // Left clamped to the left margin (8) because picker is wider than viewport.
+    expect(pos.left).toBe(8)
+  })
+})
+
+describe('ReactionPicker', () => {
+  let trigger: HTMLButtonElement
+
+  beforeEach(() => {
+    trigger = document.createElement('button')
+    trigger.getBoundingClientRect = () => rect(100, 400, 24, 24)
+    document.body.appendChild(trigger)
+    // happy-dom doesn't always set window dimensions for layout — pin them
+    // explicitly so computePickerPosition reads stable values.
+    Object.defineProperty(window, 'innerWidth', { value: 800, configurable: true })
+    Object.defineProperty(window, 'innerHeight', { value: 600, configurable: true })
+  })
+
+  afterEach(() => {
+    cleanup()
+    trigger.remove()
+  })
+
+  it('renders the picker into document.body via a portal with the new grid classes', () => {
+    const ref = createRef<HTMLElement | null>()
+    ;(ref as { current: HTMLElement | null }).current = trigger
+
+    const { container } = render(
+      <ReactionPicker onPick={() => {}} onClose={() => {}} triggerRef={ref} />,
+    )
+
+    // The portal target is document.body, NOT the React render container.
+    const inContainer = container.querySelector('[data-testid="reaction-picker"]')
+    expect(inContainer).toBeNull()
+
+    const picker = screen.getByTestId('reaction-picker')
+    expect(picker).toBeInTheDocument()
+    expect(picker.className).toContain('grid-cols-6')
+    expect(picker.className).toContain('gap-2')
+    expect(picker.className).toContain('p-3')
+
+    const cells = picker.querySelectorAll('button')
+    expect(cells.length).toBe(16)
+    cells.forEach(cell => {
+      expect(cell.className).toContain('w-11')
+      expect(cell.className).toContain('h-11')
+      expect(cell.className).toContain('text-2xl')
+    })
+  })
+
+  it('positions itself via fixed coordinates derived from the trigger rect', () => {
+    const ref = createRef<HTMLElement | null>()
+    ;(ref as { current: HTMLElement | null }).current = trigger
+
+    render(<ReactionPicker onPick={() => {}} onClose={() => {}} triggerRef={ref} />)
+
+    const picker = screen.getByTestId('reaction-picker')
+    expect(picker.style.position).toBe('fixed')
+    // Trigger sits at top=400 with plenty of room above (>= 180 + 16), so the
+    // picker should flip above.
+    expect(picker.style.top).not.toBe('')
+    expect(picker.style.left).not.toBe('')
+  })
+
+  it('invokes onPick with the chosen emoji', () => {
+    const onPick = vi.fn()
+    const ref = createRef<HTMLElement | null>()
+    ;(ref as { current: HTMLElement | null }).current = trigger
+
+    render(<ReactionPicker onPick={onPick} onClose={() => {}} triggerRef={ref} />)
+
+    const picker = screen.getByTestId('reaction-picker')
+    const firstCell = picker.querySelector('button')!
+    fireEvent.click(firstCell)
+    expect(onPick).toHaveBeenCalledTimes(1)
+    expect(typeof onPick.mock.calls[0][0]).toBe('string')
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    const ref = createRef<HTMLElement | null>()
+    ;(ref as { current: HTMLElement | null }).current = trigger
+
+    render(<ReactionPicker onPick={() => {}} onClose={onClose} triggerRef={ref} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes when clicking outside the picker and outside the trigger', () => {
+    const onClose = vi.fn()
+    const ref = createRef<HTMLElement | null>()
+    ;(ref as { current: HTMLElement | null }).current = trigger
+
+    render(<ReactionPicker onPick={() => {}} onClose={onClose} triggerRef={ref} />)
+
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    fireEvent.mouseDown(outside)
+    expect(onClose).toHaveBeenCalledTimes(1)
+    outside.remove()
+  })
+
+  it('does NOT close when clicking the trigger element (toggling is the trigger\'s job)', () => {
+    const onClose = vi.fn()
+    const ref = createRef<HTMLElement | null>()
+    ;(ref as { current: HTMLElement | null }).current = trigger
+
+    render(<ReactionPicker onPick={() => {}} onClose={onClose} triggerRef={ref} />)
+
+    fireEvent.mouseDown(trigger)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not close when clicking inside the picker itself', () => {
+    const onClose = vi.fn()
+    const ref = createRef<HTMLElement | null>()
+    ;(ref as { current: HTMLElement | null }).current = trigger
+
+    render(<ReactionPicker onPick={() => {}} onClose={onClose} triggerRef={ref} />)
+
+    const picker = screen.getByTestId('reaction-picker')
+    fireEvent.mouseDown(picker)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/pages/familychat/ReactionPicker.test.tsx
+++ b/web/src/pages/familychat/ReactionPicker.test.tsx
@@ -2,7 +2,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createRef } from 'react'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
-import ReactionPicker, { computePickerPosition } from './ReactionPicker'
+import ReactionPicker from './ReactionPicker'
+import { computePickerPosition } from './pickerPosition'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({

--- a/web/src/pages/familychat/ReactionPicker.tsx
+++ b/web/src/pages/familychat/ReactionPicker.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
 // PICKER_EMOJIS is the fixed grid shown when the user opens the picker. The
@@ -7,27 +8,127 @@ import { useTranslation } from 'react-i18next'
 // any single emoji grapheme so users can still react with anything they can
 // type via their OS keyboard from the textarea path (future work).
 const PICKER_EMOJIS = [
-  '👍', '❤️', '🎉', '😂',
-  '😮', '😢', '🙏', '🔥',
-  '👏', '👀', '💯', '🚀',
+  '👍', '❤️', '🎉', '😂', '😮', '😢',
+  '🙏', '🔥', '👏', '👀', '💯', '🚀',
   '😡', '🤔', '🥳', '😴',
 ]
+
+// Sensible first-paint defaults until the portal node has been measured. The
+// real size is read back via getBoundingClientRect in a second layout effect.
+const DEFAULT_PICKER_W = 320
+const DEFAULT_PICKER_H = 180
+
+// Gap between trigger and popup, and minimum margin from viewport edges.
+const TRIGGER_GAP = 8
+const VIEWPORT_MARGIN = 8
+
+export type PickerPlacement = 'above' | 'below'
+export type PickerAlign = 'left' | 'right'
+
+export interface PickerPosition {
+  top: number
+  left: number
+  placement: PickerPlacement
+  align: PickerAlign
+}
+
+export interface Viewport {
+  w: number
+  h: number
+}
+
+export interface PickerSize {
+  w: number
+  h: number
+}
+
+// computePickerPosition picks the popover placement around a trigger rect.
+// Vertical: prefer above if there's room (>= pickerH + TRIGGER_GAP), else
+// below. Horizontal: right-align when the trigger center is in the right half
+// of the viewport, else left-align. Final top/left are clamped so the popup
+// stays within the viewport (with a small margin), which matters on tiny
+// viewports where the picker doesn't really fit either side.
+export function computePickerPosition(
+  triggerRect: DOMRect,
+  viewport: Viewport,
+  pickerSize: PickerSize,
+): PickerPosition {
+  const fitsAbove = triggerRect.top >= pickerSize.h + TRIGGER_GAP
+  const placement: PickerPlacement = fitsAbove ? 'above' : 'below'
+
+  const rawTop = placement === 'above'
+    ? triggerRect.top - pickerSize.h - TRIGGER_GAP
+    : triggerRect.bottom + TRIGGER_GAP
+
+  const triggerCenterX = triggerRect.left + triggerRect.width / 2
+  const align: PickerAlign = triggerCenterX >= viewport.w / 2 ? 'right' : 'left'
+
+  const rawLeft = align === 'right'
+    ? triggerRect.right - pickerSize.w
+    : triggerRect.left
+
+  const maxLeft = Math.max(VIEWPORT_MARGIN, viewport.w - pickerSize.w - VIEWPORT_MARGIN)
+  const maxTop = Math.max(VIEWPORT_MARGIN, viewport.h - pickerSize.h - VIEWPORT_MARGIN)
+  const left = Math.min(Math.max(rawLeft, VIEWPORT_MARGIN), maxLeft)
+  const top = Math.min(Math.max(rawTop, VIEWPORT_MARGIN), maxTop)
+
+  return { top, left, placement, align }
+}
 
 interface ReactionPickerProps {
   onPick: (emoji: string) => void
   onClose: () => void
+  triggerRef: RefObject<HTMLElement | null>
 }
 
-export default function ReactionPicker({ onPick, onClose }: ReactionPickerProps) {
+export default function ReactionPicker({ onPick, onClose, triggerRef }: ReactionPickerProps) {
   const { t } = useTranslation('familyChat')
   const containerRef = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState<PickerPosition | null>(null)
+
+  // First layout pass: compute a position using default picker dimensions so
+  // the popup paints in roughly the right place on the first frame and we
+  // don't flash at (0,0). Read the trigger via the parent-supplied ref.
+  useLayoutEffect(() => {
+    const trigger = triggerRef.current
+    if (!trigger) return
+    const viewport = { w: window.innerWidth, h: window.innerHeight }
+    const pickerSize = { w: DEFAULT_PICKER_W, h: DEFAULT_PICKER_H }
+    setPosition(computePickerPosition(trigger.getBoundingClientRect(), viewport, pickerSize))
+  }, [triggerRef])
+
+  // Second layout pass: measure the actual rendered popup and recompute the
+  // position so the clamping uses real dimensions. This is what catches the
+  // case where the popup is shorter/taller than the default and would
+  // otherwise have a stale top/left.
+  useLayoutEffect(() => {
+    const trigger = triggerRef.current
+    const popup = containerRef.current
+    if (!trigger || !popup) return
+    const rect = popup.getBoundingClientRect()
+    const viewport = { w: window.innerWidth, h: window.innerHeight }
+    const pickerSize = { w: rect.width, h: rect.height }
+    const next = computePickerPosition(trigger.getBoundingClientRect(), viewport, pickerSize)
+    setPosition(prev => {
+      if (prev && prev.top === next.top && prev.left === next.left
+        && prev.placement === next.placement && prev.align === next.align) {
+        return prev
+      }
+      return next
+    })
+  }, [triggerRef])
 
   useEffect(() => {
     containerRef.current?.focus()
     const handleClickOutside = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        onClose()
-      }
+      const target = e.target as Node
+      if (containerRef.current && containerRef.current.contains(target)) return
+      // Clicks on the trigger itself shouldn't fall through onClose, because
+      // the trigger's own click handler is responsible for toggling the
+      // picker. Without this guard the picker would close, then immediately
+      // re-open on the same click.
+      if (triggerRef.current && triggerRef.current.contains(target)) return
+      onClose()
     }
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -38,16 +139,27 @@ export default function ReactionPicker({ onPick, onClose }: ReactionPickerProps)
       document.removeEventListener('mousedown', handleClickOutside)
       document.removeEventListener('keydown', handleKey)
     }
-  }, [onClose])
+  }, [onClose, triggerRef])
 
-  return (
+  if (typeof document === 'undefined') return null
+
+  const style: React.CSSProperties = position
+    ? { position: 'fixed', top: position.top, left: position.left }
+    // First paint before the layout effect runs — keep the popup off-screen
+    // so it can't flash in the wrong place. The layout effect runs
+    // synchronously before the browser paints, so this style is almost never
+    // observable.
+    : { position: 'fixed', top: -9999, left: -9999 }
+
+  const popup = (
     <div
       ref={containerRef}
       role="dialog"
       aria-modal={true}
       aria-label={t('reactions.pickerLabel')}
       tabIndex={-1}
-      className="absolute z-30 bottom-full mb-2 right-0 bg-gray-800 border border-gray-700 rounded-lg shadow-lg p-2 grid grid-cols-4 gap-1 outline-none"
+      style={style}
+      className="z-[60] bg-gray-800 border border-gray-700 rounded-lg shadow-xl p-3 grid grid-cols-6 gap-2 outline-none"
       data-testid="reaction-picker"
     >
       {PICKER_EMOJIS.map(emoji => (
@@ -55,7 +167,7 @@ export default function ReactionPicker({ onPick, onClose }: ReactionPickerProps)
           key={emoji}
           type="button"
           onClick={() => onPick(emoji)}
-          className="w-9 h-9 flex items-center justify-center text-xl rounded-md hover:bg-gray-700 cursor-pointer"
+          className="w-11 h-11 flex items-center justify-center text-2xl rounded-md hover:bg-gray-700 cursor-pointer"
           aria-label={emoji}
         >
           {emoji}
@@ -63,4 +175,6 @@ export default function ReactionPicker({ onPick, onClose }: ReactionPickerProps)
       ))}
     </div>
   )
+
+  return createPortal(popup, document.body)
 }

--- a/web/src/pages/familychat/ReactionPicker.tsx
+++ b/web/src/pages/familychat/ReactionPicker.tsx
@@ -1,79 +1,16 @@
 import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
+import { computePickerPosition, type PickerPosition } from './pickerPosition'
 
-// PICKER_EMOJIS is the fixed grid shown when the user opens the picker. The
-// list is intentionally short so the popover stays compact on mobile and we
-// don't ship a megabyte emoji search index. Server-side validation accepts
-// any single emoji grapheme so users can still react with anything they can
-// type via their OS keyboard from the textarea path (future work).
 const PICKER_EMOJIS = [
   '👍', '❤️', '🎉', '😂', '😮', '😢',
   '🙏', '🔥', '👏', '👀', '💯', '🚀',
   '😡', '🤔', '🥳', '😴',
 ]
 
-// Sensible first-paint defaults until the portal node has been measured. The
-// real size is read back via getBoundingClientRect in a second layout effect.
 const DEFAULT_PICKER_W = 320
 const DEFAULT_PICKER_H = 180
-
-// Gap between trigger and popup, and minimum margin from viewport edges.
-const TRIGGER_GAP = 8
-const VIEWPORT_MARGIN = 8
-
-export type PickerPlacement = 'above' | 'below'
-export type PickerAlign = 'left' | 'right'
-
-export interface PickerPosition {
-  top: number
-  left: number
-  placement: PickerPlacement
-  align: PickerAlign
-}
-
-export interface Viewport {
-  w: number
-  h: number
-}
-
-export interface PickerSize {
-  w: number
-  h: number
-}
-
-// computePickerPosition picks the popover placement around a trigger rect.
-// Vertical: prefer above if there's room (>= pickerH + TRIGGER_GAP), else
-// below. Horizontal: right-align when the trigger center is in the right half
-// of the viewport, else left-align. Final top/left are clamped so the popup
-// stays within the viewport (with a small margin), which matters on tiny
-// viewports where the picker doesn't really fit either side.
-export function computePickerPosition(
-  triggerRect: DOMRect,
-  viewport: Viewport,
-  pickerSize: PickerSize,
-): PickerPosition {
-  const fitsAbove = triggerRect.top >= pickerSize.h + TRIGGER_GAP
-  const placement: PickerPlacement = fitsAbove ? 'above' : 'below'
-
-  const rawTop = placement === 'above'
-    ? triggerRect.top - pickerSize.h - TRIGGER_GAP
-    : triggerRect.bottom + TRIGGER_GAP
-
-  const triggerCenterX = triggerRect.left + triggerRect.width / 2
-  const align: PickerAlign = triggerCenterX >= viewport.w / 2 ? 'right' : 'left'
-
-  const rawLeft = align === 'right'
-    ? triggerRect.right - pickerSize.w
-    : triggerRect.left
-
-  const maxLeft = Math.max(VIEWPORT_MARGIN, viewport.w - pickerSize.w - VIEWPORT_MARGIN)
-  const maxTop = Math.max(VIEWPORT_MARGIN, viewport.h - pickerSize.h - VIEWPORT_MARGIN)
-  const left = Math.min(Math.max(rawLeft, VIEWPORT_MARGIN), maxLeft)
-  const top = Math.min(Math.max(rawTop, VIEWPORT_MARGIN), maxTop)
-
-  return { top, left, placement, align }
-}
 
 interface ReactionPickerProps {
   onPick: (emoji: string) => void

--- a/web/src/pages/familychat/ReactionPicker.tsx
+++ b/web/src/pages/familychat/ReactionPicker.tsx
@@ -84,11 +84,20 @@ export default function ReactionPicker({ onPick, onClose, anchorRef, triggerRef 
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
+    // Close the picker on scroll or resize so the fixed-position popup never
+    // becomes visually detached from its anchor. The capture-phase scroll
+    // listener catches scrolling inside the chat log container (overflow-y-auto)
+    // which doesn't bubble to window.
+    const handleScrollOrResize = () => onClose()
     document.addEventListener('mousedown', handleClickOutside)
     document.addEventListener('keydown', handleKey)
+    window.addEventListener('scroll', handleScrollOrResize, true)
+    window.addEventListener('resize', handleScrollOrResize)
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
       document.removeEventListener('keydown', handleKey)
+      window.removeEventListener('scroll', handleScrollOrResize, true)
+      window.removeEventListener('resize', handleScrollOrResize)
     }
   }, [onClose, triggerRef])
 

--- a/web/src/pages/familychat/ReactionPicker.tsx
+++ b/web/src/pages/familychat/ReactionPicker.tsx
@@ -15,37 +15,48 @@ const DEFAULT_PICKER_H = 180
 interface ReactionPickerProps {
   onPick: (emoji: string) => void
   onClose: () => void
-  triggerRef: RefObject<HTMLElement | null>
+  /** Element used to compute placement (getBoundingClientRect). Always required. */
+  anchorRef: RefObject<HTMLElement | null>
+  /**
+   * Optional toggle-button element. Clicks inside this element are ignored by
+   * the outside-click handler so the button's own click handler can toggle the
+   * picker without the picker immediately closing first.
+   *
+   * Omit (or leave as null) for long-press / touch-triggered pickers where
+   * there is no toggle button — clicks on the anchor will then correctly close
+   * the picker.
+   */
+  triggerRef?: RefObject<HTMLElement | null>
 }
 
-export default function ReactionPicker({ onPick, onClose, triggerRef }: ReactionPickerProps) {
+export default function ReactionPicker({ onPick, onClose, anchorRef, triggerRef }: ReactionPickerProps) {
   const { t } = useTranslation('familyChat')
   const containerRef = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState<PickerPosition | null>(null)
 
   // First layout pass: compute a position using default picker dimensions so
   // the popup paints in roughly the right place on the first frame and we
-  // don't flash at (0,0). Read the trigger via the parent-supplied ref.
+  // don't flash at (0,0). Read the anchor via the parent-supplied ref.
   useLayoutEffect(() => {
-    const trigger = triggerRef.current
-    if (!trigger) return
+    const anchor = anchorRef.current
+    if (!anchor) return
     const viewport = { w: window.innerWidth, h: window.innerHeight }
     const pickerSize = { w: DEFAULT_PICKER_W, h: DEFAULT_PICKER_H }
-    setPosition(computePickerPosition(trigger.getBoundingClientRect(), viewport, pickerSize))
-  }, [triggerRef])
+    setPosition(computePickerPosition(anchor.getBoundingClientRect(), viewport, pickerSize))
+  }, [anchorRef])
 
   // Second layout pass: measure the actual rendered popup and recompute the
   // position so the clamping uses real dimensions. This is what catches the
   // case where the popup is shorter/taller than the default and would
   // otherwise have a stale top/left.
   useLayoutEffect(() => {
-    const trigger = triggerRef.current
+    const anchor = anchorRef.current
     const popup = containerRef.current
-    if (!trigger || !popup) return
+    if (!anchor || !popup) return
     const rect = popup.getBoundingClientRect()
     const viewport = { w: window.innerWidth, h: window.innerHeight }
     const pickerSize = { w: rect.width, h: rect.height }
-    const next = computePickerPosition(trigger.getBoundingClientRect(), viewport, pickerSize)
+    const next = computePickerPosition(anchor.getBoundingClientRect(), viewport, pickerSize)
     setPosition(prev => {
       if (prev && prev.top === next.top && prev.left === next.left
         && prev.placement === next.placement && prev.align === next.align) {
@@ -53,18 +64,21 @@ export default function ReactionPicker({ onPick, onClose, triggerRef }: Reaction
       }
       return next
     })
-  }, [triggerRef])
+  }, [anchorRef])
 
   useEffect(() => {
     containerRef.current?.focus()
     const handleClickOutside = (e: MouseEvent) => {
       const target = e.target as Node
       if (containerRef.current && containerRef.current.contains(target)) return
-      // Clicks on the trigger itself shouldn't fall through onClose, because
-      // the trigger's own click handler is responsible for toggling the
+      // Clicks on the trigger button itself shouldn't fall through onClose,
+      // because the button's own click handler is responsible for toggling the
       // picker. Without this guard the picker would close, then immediately
       // re-open on the same click.
-      if (triggerRef.current && triggerRef.current.contains(target)) return
+      // triggerRef is intentionally absent for long-press / touch-triggered
+      // pickers (no toggle button exists), so clicks on the anchor bubble will
+      // correctly dismiss the picker.
+      if (triggerRef?.current && triggerRef.current.contains(target)) return
       onClose()
     }
     const handleKey = (e: KeyboardEvent) => {

--- a/web/src/pages/familychat/pickerPosition.ts
+++ b/web/src/pages/familychat/pickerPosition.ts
@@ -1,0 +1,55 @@
+export type PickerPlacement = 'above' | 'below'
+export type PickerAlign = 'left' | 'right'
+
+export interface PickerPosition {
+  top: number
+  left: number
+  placement: PickerPlacement
+  align: PickerAlign
+}
+
+export interface Viewport {
+  w: number
+  h: number
+}
+
+export interface PickerSize {
+  w: number
+  h: number
+}
+
+const TRIGGER_GAP = 8
+const VIEWPORT_MARGIN = 8
+
+// computePickerPosition picks the popover placement around a trigger rect.
+// Vertical: prefer above if there's room (>= pickerH + TRIGGER_GAP), else
+// below. Horizontal: right-align when the trigger center is in the right half
+// of the viewport, else left-align. Final top/left are clamped so the popup
+// stays within the viewport (with a small margin), which matters on tiny
+// viewports where the picker doesn't really fit either side.
+export function computePickerPosition(
+  triggerRect: DOMRect,
+  viewport: Viewport,
+  pickerSize: PickerSize,
+): PickerPosition {
+  const fitsAbove = triggerRect.top >= pickerSize.h + TRIGGER_GAP
+  const placement: PickerPlacement = fitsAbove ? 'above' : 'below'
+
+  const rawTop = placement === 'above'
+    ? triggerRect.top - pickerSize.h - TRIGGER_GAP
+    : triggerRect.bottom + TRIGGER_GAP
+
+  const triggerCenterX = triggerRect.left + triggerRect.width / 2
+  const align: PickerAlign = triggerCenterX >= viewport.w / 2 ? 'right' : 'left'
+
+  const rawLeft = align === 'right'
+    ? triggerRect.right - pickerSize.w
+    : triggerRect.left
+
+  const maxLeft = Math.max(VIEWPORT_MARGIN, viewport.w - pickerSize.w - VIEWPORT_MARGIN)
+  const maxTop = Math.max(VIEWPORT_MARGIN, viewport.h - pickerSize.h - VIEWPORT_MARGIN)
+  const left = Math.min(Math.max(rawLeft, VIEWPORT_MARGIN), maxLeft)
+  const top = Math.min(Math.max(rawTop, VIEWPORT_MARGIN), maxTop)
+
+  return { top, left, placement, align }
+}

--- a/web/src/pages/familychat/pickerPosition.ts
+++ b/web/src/pages/familychat/pickerPosition.ts
@@ -22,17 +22,19 @@ const TRIGGER_GAP = 8
 const VIEWPORT_MARGIN = 8
 
 // computePickerPosition picks the popover placement around a trigger rect.
-// Vertical: prefer above if there's room (>= pickerH + TRIGGER_GAP), else
-// below. Horizontal: right-align when the trigger center is in the right half
-// of the viewport, else left-align. Final top/left are clamped so the popup
-// stays within the viewport (with a small margin), which matters on tiny
-// viewports where the picker doesn't really fit either side.
+// Vertical: prefer above if there's room (>= pickerH + TRIGGER_GAP + VIEWPORT_MARGIN),
+// else below. Including the margin ensures there's real space above and we don't
+// choose 'above' only to have the clamping eat into the gap. Horizontal:
+// right-align when the trigger center is in the right half of the viewport,
+// else left-align. Final top/left are clamped so the popup stays within the
+// viewport (with a small margin), which matters on tiny viewports where the
+// picker doesn't really fit either side.
 export function computePickerPosition(
   triggerRect: DOMRect,
   viewport: Viewport,
   pickerSize: PickerSize,
 ): PickerPosition {
-  const fitsAbove = triggerRect.top >= pickerSize.h + TRIGGER_GAP
+  const fitsAbove = triggerRect.top >= pickerSize.h + TRIGGER_GAP + VIEWPORT_MARGIN
   const placement: PickerPlacement = fitsAbove ? 'above' : 'below'
 
   const rawTop = placement === 'above'


### PR DESCRIPTION
## Changes

- **Family Chat reaction picker positioning + sizing** - The emoji picker now portals to the document body and flips above or below the message bubble based on available space, so it no longer clips off-screen for messages near the top of the chat. The grid was widened to 6 columns with larger 44px tap targets, more padding, and a clearer drop shadow for comfortable mobile use. (Hytte-i6e8)

## Original Issue (bug): Family Chat: reaction picker positioning + sizing (clips off-screen, cells too cramped)

The emoji reaction picker shipped with Hytte-hp9b has two UI bugs that make it hard to use on the production Android Chrome target:

1. The popup is positioned with `absolute bottom-full mb-2 right-0` against the bubble's `relative` container. For a message near the top of the visible scroll area, the picker overflows the chat clip rectangle and visually "lands outside the page" above the message text. There is no flip-direction logic and the picker is not portaled, so any ancestor `overflow:hidden` clips it.
2. The grid is too dense to be readable: `grid-cols-4` with `w-9 h-9` cells (~144px wide overall), `text-xl` emoji, `gap-1` (4px). 16 emojis squeezed into 4×4 makes them visually jumbled — touching each other with no room to tap accurately on mobile.

## Scope

### 1. Smart positioning — measure then flip

In `web/src/pages/familychat/ReactionPicker.tsx`:
- On mount, in `useLayoutEffect`, measure the trigger button's `getBoundingClientRect()` (the parent passes a `triggerRef` or we accept an `anchor: DOMRect` prop) and the viewport. Decide:
    - If the trigger has at least `pickerH + 16px` of room above → place above.
    - Else → place below.
- Similarly choose horizontal alignment: prefer right-aligned (matching the current behaviour for own messages) when the trigger is in the right half of the viewport; left-aligned when in the left half. Clamp so the picker never exceeds either viewport edge.
- Render the picker via `createPortal(<>, document.body)` with `position: fixed; left/top/right/bottom: <computed>`. The portal lifts the picker out of every ancestor's overflow/transform stacking context, which is what causes the current clipping.
- The existing click-outside + Escape handlers must keep working through the portal (they already use `document.addEventListener`, no change needed there).

### 2. Comfortable grid

Same component:
- `grid-cols-6` (was 4) so 16 emojis become 3 rows of 6 — wider, easier to scan.
- Cells `w-11 h-11` (was 9, ~44px target which matches WCAG/Android comfortable hit targets).
- `text-2xl` emoji.
- `gap-2` between cells, `p-3` outer padding so the grid breathes.
- Add a subtle drop shadow / border so the picker reads as a popover regardless of where it lands.

### 3. ChatView integration

`web/src/pages/familychat/ChatView.tsx` line ~650 mounts the trigger as an absolute button on the bubble and renders the picker as a sibling. After this fix the picker mounts via portal, so its location in the JSX no longer matters — but the trigger button itself stays where it is. Pass the trigger's `ref` (or its bounding rect via a callback) into the new picker so the picker has an anchor.

### 4. Tests

`ReactionPicker.test.tsx`:
- Position helper unit-tested in isolation: feed in synthetic viewport + trigger rects → assert the chosen `{above|below, alignLeft|alignRight}` for the four corner cases (trigger near top-left, top-right, bottom-left, bottom-right) plus the "small viewport, picker doesn't fit anywhere — fall back to below" case.
- Render test: pass a trigger ref; assert the picker renders inside a portal (look for the picker via `document.body`) and has the expected grid class names.
- Existing tests (click-outside, Escape, onPick) keep passing.

### 5. Acceptance

- Tapping the reaction trigger on the very first message in a long conversation opens the picker BELOW the bubble (the "flip when no space above" path) and the picker is fully visible.
- Tapping the trigger on the latest message at the bottom of the chat opens the picker ABOVE the bubble as today.
- Picker is comfortably sized: 6 wide, 3 tall, ~44px tap targets, emojis no longer touching.
- `npm run lint`, `npm run build`, `npm run test` pass.
- Changelog fragment in `changelog.d/` (category: Fixed).

## Reference

- web/src/pages/familychat/ReactionPicker.tsx — the component to rewrite.
- web/src/pages/familychat/ChatView.tsx ~line 650 — mount site; pass an anchor ref into the picker.
- A useful pattern: see `web/src/components/pokemon/CardLightbox.tsx` (or similar modal/portal component already in the codebase) for the `createPortal` shape and z-index conventions.


---
Bead: Hytte-i6e8 | Branch: forge/Hytte-i6e8
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->