### PR TITLE
Backend: extend MIME allowlist + optional meta_json column (Hytte-bgvt)

### DIFF
--- a/changelog.d/Hytte-bgvt.md
+++ b/changelog.d/Hytte-bgvt.md
@@ -1,2 +1,3 @@
 category: Added
 - **Family Chat voice-note plumbing** - Added audio/webm and audio/ogg (plus application/ogg, the type http.DetectContentType returns for OggS-prefixed bodies) to the attachment MIME allowlist so MediaRecorder voice notes upload across browsers. Added a nullable meta_json column to family_chat_messages — encrypted at rest like the body — and exposed it on the POST /messages request and GET /messages response so clients can persist the precomputed waveform and duration server-side. (Hytte-bgvt)
+

--- a/changelog.d/Hytte-bgvt.md
+++ b/changelog.d/Hytte-bgvt.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat voice-note plumbing** - Added audio/webm and audio/ogg (plus application/ogg, the type http.DetectContentType returns for OggS-prefixed bodies) to the attachment MIME allowlist so MediaRecorder voice notes upload across browsers. Added a nullable meta_json column to family_chat_messages — encrypted at rest like the body — and exposed it on the POST /messages request and GET /messages response so clients can persist the precomputed waveform and duration server-side. (Hytte-bgvt)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1823,7 +1823,8 @@ func createSchema(db *sql.DB) error {
 		created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
 		edited_at         TEXT,
 		deleted_at        TEXT,
-		deleted_by        INTEGER REFERENCES users(id) ON DELETE SET NULL
+		deleted_by        INTEGER REFERENCES users(id) ON DELETE SET NULL,
+		meta_json         TEXT
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_family_chat_messages_conversation_id ON family_chat_messages(conversation_id, id DESC);
@@ -2602,6 +2603,9 @@ func createSchema(db *sql.DB) error {
 
 	// Add edit/soft-delete tombstone columns to family_chat_messages (Hytte-f0tw).
 	// Each is nullable so legacy rows continue to behave as non-edited / non-deleted.
+	// meta_json (Hytte-bgvt) carries the client-supplied opaque JSON blob used to
+	// persist the precomputed waveform + duration of voice notes; encrypted at
+	// rest like body via internal/encryption.
 	familyChatMsgCols := []struct {
 		name string
 		ddl  string
@@ -2609,6 +2613,7 @@ func createSchema(db *sql.DB) error {
 		{"edited_at", `ALTER TABLE family_chat_messages ADD COLUMN edited_at TEXT`},
 		{"deleted_at", `ALTER TABLE family_chat_messages ADD COLUMN deleted_at TEXT`},
 		{"deleted_by", `ALTER TABLE family_chat_messages ADD COLUMN deleted_by INTEGER REFERENCES users(id) ON DELETE SET NULL`},
+		{"meta_json", `ALTER TABLE family_chat_messages ADD COLUMN meta_json TEXT`},
 	}
 	for _, col := range familyChatMsgCols {
 		var present int

--- a/internal/familychat/attachments.go
+++ b/internal/familychat/attachments.go
@@ -183,13 +183,24 @@ func UploadAttachmentHandler(db *sql.DB) http.HandlerFunc {
 		if idx := strings.Index(mimeType, ";"); idx >= 0 {
 			mimeType = strings.TrimSpace(mimeType[:idx])
 		}
+		// Normalise the client-declared Content-Type so we can use it both for
+		// the octet-stream fallback below and for disambiguating sniffed types
+		// whose container is shared between audio and video.
+		clientCT := strings.TrimSpace(header.Header.Get("Content-Type"))
+		if idx := strings.Index(clientCT, ";"); idx >= 0 {
+			clientCT = strings.TrimSpace(clientCT[:idx])
+		}
+		clientCT = strings.ToLower(clientCT)
 		if mimeType == "application/octet-stream" {
-			if ct := strings.TrimSpace(header.Header.Get("Content-Type")); ct != "" {
-				if idx := strings.Index(ct, ";"); idx >= 0 {
-					ct = strings.TrimSpace(ct[:idx])
-				}
-				mimeType = strings.ToLower(ct)
+			if clientCT != "" {
+				mimeType = clientCT
 			}
+		} else if mimeType == "video/webm" && clientCT == "audio/webm" {
+			// WebM uses the same EBML/Matroska container for audio and video,
+			// and Go's sniff table only recognises it as "video/webm". Trust
+			// the client header when it declares an audio-only stream — that
+			// is what Chromium MediaRecorder emits for voice notes.
+			mimeType = "audio/webm"
 		}
 		if _, allowed := allowedAttachmentMimes[mimeType]; !allowed {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unsupported file type"})

--- a/internal/familychat/attachments.go
+++ b/internal/familychat/attachments.go
@@ -30,6 +30,12 @@ const (
 
 // allowedAttachmentMimes is the strict allowlist of accepted upload types.
 // Anything else is rejected with 400 before the file ever hits disk.
+//
+// audio/webm and audio/ogg cover MediaRecorder voice-note output across
+// browsers: Chromium emits audio/webm;codecs=opus, Firefox emits
+// audio/ogg;codecs=opus. application/ogg is included as an alias because
+// http.DetectContentType returns it for OggS-prefixed bodies — without it,
+// real OGG audio uploads would be rejected by the sniff path.
 var allowedAttachmentMimes = map[string]struct{}{
 	"image/jpeg":      {},
 	"image/png":       {},
@@ -39,6 +45,9 @@ var allowedAttachmentMimes = map[string]struct{}{
 	"application/pdf": {},
 	"audio/mpeg":      {},
 	"audio/mp4":       {},
+	"audio/webm":      {},
+	"audio/ogg":       {},
+	"application/ogg": {},
 }
 
 // attachmentRoot returns the base directory under which Family Chat

--- a/internal/familychat/attachments_test.go
+++ b/internal/familychat/attachments_test.go
@@ -118,6 +118,102 @@ func TestUploadAttachmentHandler_RejectsTooLarge(t *testing.T) {
 	}
 }
 
+func TestUploadAttachmentHandler_AcceptsAudioWebm(t *testing.T) {
+	// MediaRecorder voice-note uploads from Chromium arrive as audio/webm.
+	// http.DetectContentType has no WebM signature, so the sniff returns
+	// application/octet-stream and the handler must fall through to the
+	// client-supplied Content-Type. The recorder sub-task depends on this.
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+
+	// EBML / Matroska magic 1A 45 DF A3 followed by padding. Go's sniff
+	// table does not include WebM, so DetectContentType returns
+	// application/octet-stream and the handler uses the request header.
+	payload := []byte{0x1A, 0x45, 0xDF, 0xA3}
+	payload = append(payload, bytes.Repeat([]byte{0x00}, 512)...)
+	req := withUser(buildUploadRequest(t, convID, "voice.webm", "audio/webm", payload), 1)
+	rec := httptest.NewRecorder()
+	UploadAttachmentHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for audio/webm, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		UploadID string `json:"upload_id"`
+		Mime     string `json:"mime"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Mime != "audio/webm" {
+		t.Errorf("mime = %q, want audio/webm", body.Mime)
+	}
+}
+
+func TestUploadAttachmentHandler_AcceptsAudioOgg(t *testing.T) {
+	// MediaRecorder voice-note uploads from Firefox arrive as audio/ogg.
+	// Go's sniff table recognises the OggS magic and returns application/ogg,
+	// so the allowlist must accept that variant — adding only "audio/ogg"
+	// would silently reject real OGG bodies. Use OggS-prefixed payload to
+	// exercise the sniff-then-allowlist path end to end.
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+
+	payload := append([]byte("OggS"), bytes.Repeat([]byte{0x00}, 512)...)
+	req := withUser(buildUploadRequest(t, convID, "voice.ogg", "audio/ogg", payload), 1)
+	rec := httptest.NewRecorder()
+	UploadAttachmentHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for audio/ogg, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		UploadID string `json:"upload_id"`
+		Mime     string `json:"mime"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Server uses the sniffed type. http.DetectContentType returns
+	// application/ogg for OggS-prefixed bodies; the allowlist accepts both
+	// application/ogg and audio/ogg so this is the value clients receive.
+	if body.Mime != "application/ogg" && body.Mime != "audio/ogg" {
+		t.Errorf("mime = %q, want application/ogg or audio/ogg", body.Mime)
+	}
+}
+
+func TestUploadAttachmentHandler_RejectsUnknownAudio(t *testing.T) {
+	// audio/x-aiff is deliberately outside the allowlist — only the
+	// MediaRecorder-friendly audio types are accepted. Body bytes are
+	// arbitrary so the sniff returns application/octet-stream and the
+	// handler falls back to the client header before checking the allowlist.
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+	root := t.TempDir()
+	t.Setenv("UPLOAD_ROOT", root)
+
+	payload := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+	req := withUser(buildUploadRequest(t, convID, "voice.aiff", "audio/x-aiff", payload), 1)
+	rec := httptest.NewRecorder()
+	UploadAttachmentHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for audio/x-aiff, got %d: %s", rec.Code, rec.Body.String())
+	}
+	dir := filepath.Join(root, "familychat", strconv.FormatInt(convID, 10))
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("expected no files persisted, found %d", len(entries))
+	}
+}
+
 func TestUploadAttachmentHandler_RejectsBadMime(t *testing.T) {
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com")

--- a/internal/familychat/attachments_test.go
+++ b/internal/familychat/attachments_test.go
@@ -120,18 +120,20 @@ func TestUploadAttachmentHandler_RejectsTooLarge(t *testing.T) {
 
 func TestUploadAttachmentHandler_AcceptsAudioWebm(t *testing.T) {
 	// MediaRecorder voice-note uploads from Chromium arrive as audio/webm.
-	// http.DetectContentType has no WebM signature, so the sniff returns
-	// application/octet-stream and the handler must fall through to the
-	// client-supplied Content-Type. The recorder sub-task depends on this.
+	// Go's http.DetectContentType only knows the EBML/Matroska container
+	// signature and returns "video/webm" — it cannot tell the audio-only
+	// stream apart from a video. The handler disambiguates by trusting the
+	// client's Content-Type when it declares audio/webm, which is what the
+	// recorder sub-task depends on.
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com")
 	convID := seedConversation(t, db, 1, "Family")
 	root := t.TempDir()
 	t.Setenv("UPLOAD_ROOT", root)
 
-	// EBML / Matroska magic 1A 45 DF A3 followed by padding. Go's sniff
-	// table does not include WebM, so DetectContentType returns
-	// application/octet-stream and the handler uses the request header.
+	// EBML / Matroska magic 1A 45 DF A3 followed by padding. This triggers
+	// Go's "video/webm" sniff signature; the handler then overrides it to
+	// "audio/webm" based on the client-supplied Content-Type.
 	payload := []byte{0x1A, 0x45, 0xDF, 0xA3}
 	payload = append(payload, bytes.Repeat([]byte{0x00}, 512)...)
 	req := withUser(buildUploadRequest(t, convID, "voice.webm", "audio/webm", payload), 1)

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -273,6 +273,11 @@ func postMessageHandler(db *sql.DB, hub *Hub, sender PushSenderFunc, notifySync 
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "meta_json is too long"})
 			return
 		}
+		// Normalize empty meta_json to nil so the API contract holds:
+		// a non-nil pointer always means "the sender attached metadata".
+		if body.MetaJSON != nil && strings.TrimSpace(*body.MetaJSON) == "" {
+			body.MetaJSON = nil
+		}
 		// If the client references an attachment, the upload_id must point at
 		// a real file under this conversation's storage dir. Anything else
 		// (path traversal, fabricated id, mismatched conv) is rejected so a

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -29,6 +29,12 @@ const (
 	defaultMsgLimit   = 50
 	maxMsgLimit       = 500
 	maxRequestBytes   = 1 << 20 // 1 MiB
+	// maxMetaJSONLen caps the opaque client-supplied meta_json blob. Voice-note
+	// waveforms (the only current user) sit comfortably under 8 KiB even at
+	// 200 sample bars, so 16 KiB leaves room for forward-compatible additions
+	// without giving a single message room to fill a chat row with megabytes
+	// of pseudo-metadata.
+	maxMetaJSONLen = 16 * 1024
 
 	// pushWorkerLimit caps the number of concurrently running webpush fan-out
 	// goroutines so slow or unreachable push endpoints cannot grow the goroutine
@@ -232,9 +238,14 @@ func postMessageHandler(db *sql.DB, hub *Hub, sender PushSenderFunc, notifySync 
 		}
 
 		var body struct {
-			Body           string `json:"body"`
-			AttachmentPath string `json:"attachment_path"`
-			AttachmentMime string `json:"attachment_mime"`
+			Body           string  `json:"body"`
+			AttachmentPath string  `json:"attachment_path"`
+			AttachmentMime string  `json:"attachment_mime"`
+			// MetaJSON is opaque client-supplied JSON the server stores and
+			// returns verbatim. Pointer so the client can distinguish "omit
+			// the field" from "store an empty object"; the server never parses
+			// the inner string.
+			MetaJSON *string `json:"meta_json"`
 		}
 		if !decodeJSON(w, r, &body) {
 			return
@@ -256,6 +267,10 @@ func postMessageHandler(db *sql.DB, hub *Hub, sender PushSenderFunc, notifySync 
 		}
 		if len(body.AttachmentMime) > maxAttachmentMime {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "attachment_mime is too long"})
+			return
+		}
+		if body.MetaJSON != nil && len(*body.MetaJSON) > maxMetaJSONLen {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "meta_json is too long"})
 			return
 		}
 		// If the client references an attachment, the upload_id must point at
@@ -287,7 +302,7 @@ func postMessageHandler(db *sql.DB, hub *Hub, sender PushSenderFunc, notifySync 
 			}
 		}
 
-		msg, err := CreateMessage(db, convID, user.ID, body.Body, body.AttachmentPath, attachmentMime)
+		msg, err := CreateMessageWithMeta(db, convID, user.ID, body.Body, body.AttachmentPath, attachmentMime, body.MetaJSON)
 		if err != nil {
 			if errors.Is(err, ErrForbidden) {
 				notFound(w)

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -74,7 +74,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 			created_at      TEXT NOT NULL DEFAULT '',
 			edited_at       TEXT,
 			deleted_at      TEXT,
-			deleted_by      INTEGER REFERENCES users(id) ON DELETE SET NULL
+			deleted_by      INTEGER REFERENCES users(id) ON DELETE SET NULL,
+			meta_json       TEXT
 		);
 		CREATE TABLE IF NOT EXISTS vapid_keys (
 			id          INTEGER PRIMARY KEY,
@@ -411,6 +412,149 @@ func TestPostMessageHandler_AttachmentEncryption(t *testing.T) {
 	}
 	if storedMime != "image/jpeg" {
 		t.Errorf("attachment_mime should be server-determined image/jpeg, got %q", storedMime)
+	}
+}
+
+func TestPostMessageHandler_MetaJSONRoundTrip(t *testing.T) {
+	// meta_json is the opaque client-supplied JSON blob used by voice notes to
+	// persist the precomputed waveform + duration. It must:
+	//   - encrypt at rest (the body convention),
+	//   - survive a list round-trip with byte-for-byte equality,
+	//   - default to nil (JSON null) when the client omits it.
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	// Send a representative voice-note metadata blob. The server stores and
+	// returns the string verbatim; we never parse the inner JSON.
+	const metaJSON = `{"waveform":[0.1,0.5,0.9,0.4],"duration_ms":3200,"codec":"opus"}`
+	payload := fmt.Sprintf(`{"body":"audio","meta_json":%q}`, metaJSON)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created struct {
+		Message Message `json:"message"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.Message.MetaJSON == nil || *created.Message.MetaJSON != metaJSON {
+		t.Errorf("create response meta_json = %v, want %q", created.Message.MetaJSON, metaJSON)
+	}
+
+	// Stored value must be encrypted (enc: prefix) so a DB dump can't expose
+	// the waveform without the encryption key.
+	var stored sql.NullString
+	if err := db.QueryRow(`SELECT meta_json FROM family_chat_messages WHERE id = ?`, created.Message.ID).Scan(&stored); err != nil {
+		t.Fatalf("read stored meta_json: %v", err)
+	}
+	if !stored.Valid {
+		t.Fatal("meta_json stored as NULL when client supplied a value")
+	}
+	if !strings.HasPrefix(stored.String, "enc:") {
+		t.Errorf("meta_json not encrypted at rest: %q", stored.String)
+	}
+
+	// Read back via the list handler — the decrypted plaintext must equal the
+	// originally posted bytes.
+	listReq := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages", nil), 1)
+	listReq = withChiParam(listReq, "id", idStr)
+	listRec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 list, got %d: %s", listRec.Code, listRec.Body.String())
+	}
+	var list struct {
+		Messages []Message `json:"messages"`
+	}
+	if err := json.NewDecoder(listRec.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(list.Messages))
+	}
+	if list.Messages[0].MetaJSON == nil || *list.Messages[0].MetaJSON != metaJSON {
+		t.Errorf("list meta_json = %v, want %q", list.Messages[0].MetaJSON, metaJSON)
+	}
+}
+
+func TestPostMessageHandler_MetaJSONOmittedReturnsNull(t *testing.T) {
+	// When the client omits meta_json the column must stay NULL and the API
+	// response must marshal it as JSON null (so the frontend's localStorage
+	// fallback for legacy voice notes still works).
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	payload := `{"body":"plain text"}`
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created struct {
+		Message Message `json:"message"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if created.Message.MetaJSON != nil {
+		t.Errorf("expected nil meta_json when omitted, got %q", *created.Message.MetaJSON)
+	}
+
+	// JSON envelope must explicitly include `"meta_json":null` so clients can
+	// distinguish "field present, value null" from "field missing".
+	bodyBytes, _ := json.Marshal(created)
+	if !strings.Contains(string(bodyBytes), `"meta_json":null`) {
+		t.Errorf("envelope missing explicit null meta_json: %s", bodyBytes)
+	}
+
+	var stored sql.NullString
+	if err := db.QueryRow(`SELECT meta_json FROM family_chat_messages WHERE id = ?`, created.Message.ID).Scan(&stored); err != nil {
+		t.Fatalf("read stored: %v", err)
+	}
+	if stored.Valid {
+		t.Errorf("meta_json should be NULL when omitted, got %q", stored.String)
+	}
+}
+
+func TestPostMessageHandler_MetaJSONTooLong(t *testing.T) {
+	// A 32 KiB blob exceeds the 16 KiB cap. The handler must reject before
+	// touching the DB so an oversized waveform cannot bloat the conversation.
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+
+	idStr := strconv.FormatInt(convID, 10)
+	huge := strings.Repeat("a", maxMetaJSONLen+1)
+	payload := fmt.Sprintf(`{"body":"audio","meta_json":%q}`, huge)
+	req := withUser(httptest.NewRequest("POST", "/api/familychat/conversations/"+idStr+"/messages", strings.NewReader(payload)), 1)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	PostMessageHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized meta_json, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_messages WHERE conversation_id = ?`, convID).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("rejected message persisted (%d rows)", n)
 	}
 }
 

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -504,21 +504,25 @@ func TestPostMessageHandler_MetaJSONOmittedReturnsNull(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
 	}
+
+	// Capture the raw HTTP body BEFORE decoding — once json.NewDecoder reads
+	// from rec.Body the bytes.Buffer position advances and String() returns "".
+	rawBody := rec.Body.String()
+
+	// JSON envelope must explicitly include `"meta_json":null` so clients can
+	// distinguish "field present, value null" from "field missing".
+	if !strings.Contains(rawBody, `"meta_json":null`) {
+		t.Errorf("HTTP response missing explicit null meta_json: %s", rawBody)
+	}
+
 	var created struct {
 		Message Message `json:"message"`
 	}
-	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+	if err := json.NewDecoder(strings.NewReader(rawBody)).Decode(&created); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if created.Message.MetaJSON != nil {
 		t.Errorf("expected nil meta_json when omitted, got %q", *created.Message.MetaJSON)
-	}
-
-	// JSON envelope must explicitly include `"meta_json":null` so clients can
-	// distinguish "field present, value null" from "field missing".
-	bodyBytes, _ := json.Marshal(created)
-	if !strings.Contains(string(bodyBytes), `"meta_json":null`) {
-		t.Errorf("envelope missing explicit null meta_json: %s", bodyBytes)
 	}
 
 	var stored sql.NullString

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -42,6 +42,12 @@ type Conversation struct {
 // null (not the zero value) for messages that have not been edited or deleted.
 // A soft-deleted message returns body, attachment_path, attachment_mime cleared
 // and edited_at forced to null so the renderer treats it as a tombstone.
+//
+// MetaJSON is an opaque client-controlled JSON string (currently used by voice
+// notes to persist the precomputed waveform + duration). It is encrypted at
+// rest like the body and treated as nullable end-to-end: nil when the column
+// is NULL, *"" never appears in the API so clients can rely on a non-nil
+// pointer meaning "the sender attached metadata".
 type Message struct {
 	ID             int64                       `json:"id"`
 	ConversationID int64                       `json:"conversation_id"`
@@ -53,6 +59,7 @@ type Message struct {
 	EditedAt       *string                     `json:"edited_at"`
 	DeletedAt      *string                     `json:"deleted_at"`
 	DeletedBy      *int64                      `json:"deleted_by"`
+	MetaJSON       *string                     `json:"meta_json"`
 	Reactions      map[string]*ReactionSummary `json:"reactions"`
 }
 
@@ -301,7 +308,7 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 	)
 	if since > 0 {
 		rows, queryErr = db.Query(
-			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at, edited_at, deleted_at, deleted_by
+			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at, edited_at, deleted_at, deleted_by, meta_json
 			 FROM family_chat_messages
 			 WHERE conversation_id = ? AND id > ?
 			 ORDER BY id DESC
@@ -310,7 +317,7 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 		)
 	} else {
 		rows, queryErr = db.Query(
-			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at, edited_at, deleted_at, deleted_by
+			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at, edited_at, deleted_at, deleted_by, meta_json
 			 FROM family_chat_messages
 			 WHERE conversation_id = ?
 			 ORDER BY id DESC
@@ -326,9 +333,9 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 	out := []Message{}
 	for rows.Next() {
 		var m Message
-		var editedAt, deletedAt sql.NullString
+		var editedAt, deletedAt, metaJSON sql.NullString
 		var deletedBy sql.NullInt64
-		if err := rows.Scan(&m.ID, &m.ConversationID, &m.SenderUserID, &m.Body, &m.AttachmentPath, &m.AttachmentMime, &m.CreatedAt, &editedAt, &deletedAt, &deletedBy); err != nil {
+		if err := rows.Scan(&m.ID, &m.ConversationID, &m.SenderUserID, &m.Body, &m.AttachmentPath, &m.AttachmentMime, &m.CreatedAt, &editedAt, &deletedAt, &deletedBy, &metaJSON); err != nil {
 			return nil, err
 		}
 		if m.Body, err = encryption.DecryptField(m.Body); err != nil {
@@ -341,6 +348,13 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 			s := editedAt.String
 			m.EditedAt = &s
 		}
+		if metaJSON.Valid {
+			plain, decErr := encryption.DecryptField(metaJSON.String)
+			if decErr != nil {
+				return nil, fmt.Errorf("decrypt meta_json: %w", decErr)
+			}
+			m.MetaJSON = &plain
+		}
 		if deletedAt.Valid {
 			s := deletedAt.String
 			m.DeletedAt = &s
@@ -351,6 +365,7 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 			m.AttachmentPath = ""
 			m.AttachmentMime = ""
 			m.EditedAt = nil
+			m.MetaJSON = nil
 		}
 		if deletedBy.Valid {
 			id := deletedBy.Int64
@@ -385,7 +400,16 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 // CreateMessage inserts a new message authored by senderID into convID,
 // touches the conversation's last_message_at, and returns the inserted row
 // in plaintext form. Returns ErrForbidden if the sender is not a member.
+// Equivalent to CreateMessageWithMeta(..., nil) — kept as a thin wrapper so
+// older call sites (and tests) that never persist meta_json stay compact.
 func CreateMessage(db *sql.DB, convID, senderID int64, body, attachmentPath, attachmentMime string) (*Message, error) {
+	return CreateMessageWithMeta(db, convID, senderID, body, attachmentPath, attachmentMime, nil)
+}
+
+// CreateMessageWithMeta is the full-fat constructor: metaJSON is nullable so
+// callers can persist client-supplied opaque metadata (e.g. voice-note waveform
+// + duration) encrypted at rest. Pass nil to leave the meta_json column NULL.
+func CreateMessageWithMeta(db *sql.DB, convID, senderID int64, body, attachmentPath, attachmentMime string, metaJSON *string) (*Message, error) {
 	ok, err := IsMember(db, convID, senderID)
 	if err != nil {
 		return nil, err
@@ -402,6 +426,14 @@ func CreateMessage(db *sql.DB, convID, senderID int64, body, attachmentPath, att
 	if err != nil {
 		return nil, fmt.Errorf("encrypt attachment path: %w", err)
 	}
+	var encMeta any // nil → NULL column; otherwise the ciphertext string.
+	if metaJSON != nil {
+		ct, mErr := encryption.EncryptField(*metaJSON)
+		if mErr != nil {
+			return nil, fmt.Errorf("encrypt meta_json: %w", mErr)
+		}
+		encMeta = ct
+	}
 	now := time.Now().UTC().Format(timeFormat)
 
 	tx, err := db.Begin()
@@ -411,9 +443,9 @@ func CreateMessage(db *sql.DB, convID, senderID int64, body, attachmentPath, att
 	defer func() { _ = tx.Rollback() }()
 
 	res, err := tx.Exec(
-		`INSERT INTO family_chat_messages (conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
-		convID, senderID, encBody, encPath, attachmentMime, now,
+		`INSERT INTO family_chat_messages (conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at, meta_json)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		convID, senderID, encBody, encPath, attachmentMime, now, encMeta,
 	)
 	if err != nil {
 		return nil, err
@@ -440,6 +472,7 @@ func CreateMessage(db *sql.DB, convID, senderID int64, body, attachmentPath, att
 		AttachmentPath: attachmentPath,
 		AttachmentMime: attachmentMime,
 		CreatedAt:      now,
+		MetaJSON:       metaJSON,
 		Reactions:      map[string]*ReactionSummary{},
 	}, nil
 }
@@ -600,7 +633,7 @@ func SoftDeleteMessage(db *sql.DB, convID, msgID, userID int64) (attachmentPath 
 
 	now := time.Now().UTC().Format(timeFormat)
 	if _, err := db.Exec(
-		`UPDATE family_chat_messages SET deleted_at = ?, deleted_by = ?, body = '', attachment_path = '', attachment_mime = '' WHERE id = ?`,
+		`UPDATE family_chat_messages SET deleted_at = ?, deleted_by = ?, body = '', attachment_path = '', attachment_mime = '', meta_json = NULL WHERE id = ?`,
 		now, userID, msgID,
 	); err != nil {
 		return "", err

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -46,8 +46,9 @@ type Conversation struct {
 // MetaJSON is an opaque client-controlled JSON string (currently used by voice
 // notes to persist the precomputed waveform + duration). It is encrypted at
 // rest like the body and treated as nullable end-to-end: nil when the column
-// is NULL, *"" never appears in the API so clients can rely on a non-nil
-// pointer meaning "the sender attached metadata".
+// is NULL. The handler normalizes empty/whitespace-only strings to nil before
+// storage so clients can rely on a non-nil pointer meaning "the sender
+// attached metadata".
 type Message struct {
 	ID             int64                       `json:"id"`
 	ConversationID int64                       `json:"conversation_id"`
@@ -552,16 +553,25 @@ func EditMessage(db *sql.DB, convID, msgID, userID int64, body string) (*Message
 	var (
 		createdAt    string
 		editedAtNull sql.NullString
+		metaJSONNull sql.NullString
 	)
 	if err := db.QueryRow(
-		`SELECT created_at, edited_at FROM family_chat_messages WHERE id = ?`,
+		`SELECT created_at, edited_at, meta_json FROM family_chat_messages WHERE id = ?`,
 		msgID,
-	).Scan(&createdAt, &editedAtNull); err != nil {
+	).Scan(&createdAt, &editedAtNull, &metaJSONNull); err != nil {
 		return nil, err
 	}
 	editedAt := now
 	if editedAtNull.Valid {
 		editedAt = editedAtNull.String
+	}
+	var metaJSON *string
+	if metaJSONNull.Valid {
+		plain, decErr := encryption.DecryptField(metaJSONNull.String)
+		if decErr != nil {
+			return nil, fmt.Errorf("decrypt meta_json: %w", decErr)
+		}
+		metaJSON = &plain
 	}
 	reactions, err := batchReactions(db, []int64{msgID}, userID)
 	if err != nil {
@@ -578,6 +588,7 @@ func EditMessage(db *sql.DB, convID, msgID, userID int64, body string) (*Message
 		Body:           body,
 		CreatedAt:      createdAt,
 		EditedAt:       &editedAt,
+		MetaJSON:       metaJSON,
 		Reactions:      byEmoji,
 	}, nil
 }


### PR DESCRIPTION
## Changes

- **Family Chat voice-note plumbing** - Added audio/webm and audio/ogg (plus application/ogg, the type http.DetectContentType returns for OggS-prefixed bodies) to the attachment MIME allowlist so MediaRecorder voice notes upload across browsers. Added a nullable meta_json column to family_chat_messages — encrypted at rest like the body — and exposed it on the POST /messages request and GET /messages response so clients can persist the precomputed waveform and duration server-side. (Hytte-bgvt)

## Original Issue (task): Backend: extend MIME allowlist + optional meta_json column

Modify internal/familychat/upload_handlers.go (per Hytte-zwjg) to add 'audio/webm' and 'audio/ogg' to the attachment MIME allowlist. Add a Go test that the upload handler accepts audio/webm and rejects an unknown audio MIME (e.g. audio/x-aiff). Optionally add a nullable `meta_json TEXT` column to `family_chat_messages` via a new migration, encrypted at rest like the body field — expose it on the message read/write structs and the JSON API so the frontend can persist the precomputed waveform + duration. If meta_json is skipped, document that decision in the PR so the playback sub-task knows to fall back to localStorage. This is the foundation other sub-tasks depend on; finish first so the recorder upload and playback caching have a working contract.

---
Bead: Hytte-bgvt | Branch: forge/Hytte-bgvt
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->