### PR TITLE
Frontend: RTCPeerConnection wiring + call lifecycle hook (Hytte-go7t)

### DIFF
--- a/changelog.d/Hytte-go7t.md
+++ b/changelog.d/Hytte-go7t.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat voice call hook** - Added the useVoiceCall hook that wires RTCPeerConnection to the Family Chat signalling relay: fetches STUN/TURN config, drives the offer/answer/ICE/end lifecycle, listens to call_* SSE events, and keeps an AudioContext alive so backgrounded tabs do not let the call suspend. (Hytte-go7t)

--- a/web/src/pages/familychat/voice/useVoiceCall.test.tsx
+++ b/web/src/pages/familychat/voice/useVoiceCall.test.tsx
@@ -166,12 +166,22 @@ function installRtcGlobals() {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
+let originalMediaDevicesDescriptor: PropertyDescriptor | undefined
+
 beforeEach(() => {
   FakePeerConnection.instances = []
+  originalMediaDevicesDescriptor = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices')
 })
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  // Restore navigator.mediaDevices to its original state so the stub doesn't
+  // leak into subsequent test files sharing the same worker.
+  if (originalMediaDevicesDescriptor !== undefined) {
+    Object.defineProperty(navigator, 'mediaDevices', originalMediaDevicesDescriptor)
+  } else {
+    delete (navigator as unknown as Record<string, unknown>).mediaDevices
+  }
 })
 
 describe('useVoiceCall — outgoing call', () => {

--- a/web/src/pages/familychat/voice/useVoiceCall.test.tsx
+++ b/web/src/pages/familychat/voice/useVoiceCall.test.tsx
@@ -1,0 +1,508 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useVoiceCall, type CallSignalPayload } from './useVoiceCall'
+
+// ── Fakes ─────────────────────────────────────────────────────────────────────
+
+class FakeMediaStreamTrack {
+  kind = 'audio' as const
+  stop = vi.fn()
+}
+
+function makeFakeMediaStream(): MediaStream {
+  const track = new FakeMediaStreamTrack()
+  const tracks = [track]
+  return {
+    getTracks: () => tracks,
+    getAudioTracks: () => tracks,
+    getVideoTracks: () => [],
+  } as unknown as MediaStream
+}
+
+interface FakeIceCandidate {
+  candidate: string
+  sdpMid: string
+  sdpMLineIndex: number
+}
+
+class FakePeerConnection {
+  static instances: FakePeerConnection[] = []
+  config: RTCConfiguration
+  localDescription: RTCSessionDescriptionInit | null = null
+  remoteDescription: RTCSessionDescriptionInit | null = null
+  tracks: Array<{ track: MediaStreamTrack; stream: MediaStream }> = []
+  addedRemoteCandidates: RTCIceCandidateInit[] = []
+  connectionState: RTCPeerConnectionState = 'new'
+  ontrack: ((event: RTCTrackEvent) => void) | null = null
+  onicecandidate: ((event: RTCPeerConnectionIceEvent) => void) | null = null
+  oniceconnectionstatechange: (() => void) | null = null
+  onconnectionstatechange: (() => void) | null = null
+  closed = false
+
+  constructor(config: RTCConfiguration) {
+    this.config = config
+    FakePeerConnection.instances.push(this)
+  }
+
+  addTrack(track: MediaStreamTrack, stream: MediaStream) {
+    this.tracks.push({ track, stream })
+    return {} as RTCRtpSender
+  }
+
+  async createOffer(): Promise<RTCSessionDescriptionInit> {
+    return { type: 'offer', sdp: 'v=0\r\nfake-offer' }
+  }
+
+  async createAnswer(): Promise<RTCSessionDescriptionInit> {
+    return { type: 'answer', sdp: 'v=0\r\nfake-answer' }
+  }
+
+  async setLocalDescription(desc: RTCSessionDescriptionInit) {
+    this.localDescription = desc
+  }
+
+  async setRemoteDescription(desc: RTCSessionDescriptionInit) {
+    this.remoteDescription = desc
+  }
+
+  async addIceCandidate(cand: RTCIceCandidateInit) {
+    this.addedRemoteCandidates.push(cand)
+  }
+
+  close() {
+    this.closed = true
+    this.connectionState = 'closed'
+  }
+
+  // Test helper — simulate the browser firing an ICE candidate event.
+  fireIce(candidate: FakeIceCandidate | null) {
+    if (!this.onicecandidate) return
+    this.onicecandidate({
+      candidate: candidate
+        ? ({ ...candidate, toJSON: () => ({ ...candidate }) } as unknown as RTCIceCandidate)
+        : null,
+    } as RTCPeerConnectionIceEvent)
+  }
+
+  // Test helper — simulate the browser delivering a remote track.
+  fireTrack(stream: MediaStream) {
+    if (!this.ontrack) return
+    this.ontrack({
+      streams: [stream],
+      track: stream.getTracks()[0],
+    } as unknown as RTCTrackEvent)
+  }
+}
+
+interface FetchCall {
+  url: string
+  method: string
+  body?: string
+}
+
+function installFetchMock() {
+  const calls: FetchCall[] = []
+  const responses = new Map<string, () => Response>()
+
+  const mock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method ?? 'GET').toUpperCase()
+    const body = typeof init?.body === 'string' ? init.body : undefined
+    calls.push({ url, method, body })
+
+    const key = `${method} ${url}`
+    const handler = responses.get(key) ?? responses.get(`* ${url}`)
+    if (handler) return handler()
+
+    // Default success for relay POSTs.
+    if (url.includes('/calls/') && method === 'POST') {
+      return new Response(null, { status: 204 })
+    }
+    if (url.endsWith('/api/familychat/turn') && method === 'GET') {
+      return new Response(JSON.stringify({
+        iceServers: [{ urls: ['stun:stun.example.com:3478'] }],
+        ttl: 3600,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }
+    // Default: empty SSE-like body for the stream endpoint so the reader loop
+    // exits immediately.
+    if (url.includes('/stream')) {
+      return new Response(new ReadableStream({
+        start(controller) { controller.close() },
+      }), { status: 200 })
+    }
+    return new Response('not found', { status: 404 })
+  })
+
+  vi.stubGlobal('fetch', mock)
+  return {
+    calls,
+    setResponse(method: string, url: string, factory: () => Response) {
+      responses.set(`${method} ${url}`, factory)
+    },
+  }
+}
+
+function findCall(calls: FetchCall[], method: string, urlSubstring: string): FetchCall | undefined {
+  return calls.find(c => c.method === method && c.url.includes(urlSubstring))
+}
+
+function installRtcGlobals() {
+  vi.stubGlobal('RTCPeerConnection', FakePeerConnection)
+  // happy-dom doesn't ship a getUserMedia — install one that hands back our fake.
+  const stream = makeFakeMediaStream()
+  const getUserMedia = vi.fn(async () => stream)
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia },
+  })
+  return { getUserMedia, stream }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  FakePeerConnection.instances = []
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useVoiceCall — outgoing call', () => {
+  it('fetches TURN config, creates an offer, and POSTs it to the relay', async () => {
+    const fetchMock = installFetchMock()
+    installRtcGlobals()
+    const factory = vi.fn((cfg: RTCConfiguration) => new FakePeerConnection(cfg))
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: factory,
+      skipSignalSubscription: true,
+      generateCallId: () => 'call-uuid-A',
+    }))
+
+    expect(result.current.state).toBe('idle')
+
+    await act(async () => { await result.current.startCall() })
+
+    expect(result.current.state).toBe('outgoing-ringing')
+    expect(result.current.callId).toBe('call-uuid-A')
+
+    // TURN config fetched first.
+    expect(findCall(fetchMock.calls, 'GET', '/api/familychat/turn')).toBeDefined()
+
+    // Peer connection built with the iceServers from the TURN response.
+    expect(factory).toHaveBeenCalledTimes(1)
+    expect(factory.mock.calls[0][0].iceServers).toEqual([
+      { urls: ['stun:stun.example.com:3478'] },
+    ])
+
+    // Offer POSTed with the SDP wrapped under {data: {type, sdp}}.
+    const offerCall = findCall(fetchMock.calls, 'POST', '/calls/call-uuid-A/offer')
+    expect(offerCall).toBeDefined()
+    expect(JSON.parse(offerCall!.body!)).toEqual({
+      data: { type: 'offer', sdp: 'v=0\r\nfake-offer' },
+    })
+
+    // The peer connection has the local mic track wired up.
+    const pc = FakePeerConnection.instances[0]
+    expect(pc.tracks).toHaveLength(1)
+    expect(pc.localDescription?.type).toBe('offer')
+  })
+
+  it('relays trickled ICE candidates as POSTs to the ice endpoint', async () => {
+    const fetchMock = installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+      generateCallId: () => 'call-uuid-B',
+    }))
+
+    await act(async () => { await result.current.startCall() })
+    const pc = FakePeerConnection.instances[0]
+
+    await act(async () => {
+      pc.fireIce({
+        candidate: 'candidate:1 1 udp 2122260223 192.168.1.1 49152 typ host',
+        sdpMid: '0',
+        sdpMLineIndex: 0,
+      })
+    })
+
+    await waitFor(() => {
+      expect(findCall(fetchMock.calls, 'POST', '/calls/call-uuid-B/ice')).toBeDefined()
+    })
+    const iceCall = findCall(fetchMock.calls, 'POST', '/calls/call-uuid-B/ice')!
+    expect(JSON.parse(iceCall.body!).data.candidate).toContain('192.168.1.1')
+  })
+
+  it('transitions to active when the answer arrives and applies remote SDP', async () => {
+    installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+      generateCallId: () => 'call-uuid-C',
+    }))
+
+    await act(async () => { await result.current.startCall() })
+
+    const payload: CallSignalPayload = {
+      conversation_id: 7,
+      call_id: 'call-uuid-C',
+      from_user_id: 2,
+      data: { type: 'answer', sdp: 'v=0\r\nfake-remote-answer' },
+    }
+    await act(async () => { await result.current.handleSignalEvent('call_answer', payload) })
+
+    expect(result.current.state).toBe('active')
+    expect(result.current.remoteUserId).toBe(2)
+    expect(FakePeerConnection.instances[0].remoteDescription?.sdp).toBe('v=0\r\nfake-remote-answer')
+  })
+
+  it('buffers ICE candidates that arrive before setRemoteDescription resolves', async () => {
+    installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+      generateCallId: () => 'call-uuid-D',
+    }))
+
+    await act(async () => { await result.current.startCall() })
+
+    // ICE first.
+    await act(async () => {
+      await result.current.handleSignalEvent('call_ice', {
+        conversation_id: 7,
+        call_id: 'call-uuid-D',
+        from_user_id: 2,
+        data: { candidate: 'cand:early', sdpMid: '0', sdpMLineIndex: 0 },
+      })
+    })
+    const pc = FakePeerConnection.instances[0]
+    expect(pc.addedRemoteCandidates).toHaveLength(0)
+
+    // Answer arrives, candidate should be flushed.
+    await act(async () => {
+      await result.current.handleSignalEvent('call_answer', {
+        conversation_id: 7,
+        call_id: 'call-uuid-D',
+        from_user_id: 2,
+        data: { type: 'answer', sdp: 'v=0\r\nanswer' },
+      })
+    })
+    expect(pc.addedRemoteCandidates).toHaveLength(1)
+    expect(pc.addedRemoteCandidates[0].candidate).toBe('cand:early')
+  })
+
+  it('endCall POSTs to the end endpoint and tears down the peer connection', async () => {
+    const fetchMock = installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+      generateCallId: () => 'call-uuid-E',
+    }))
+
+    await act(async () => { await result.current.startCall() })
+    const pc = FakePeerConnection.instances[0]
+    await act(async () => { await result.current.endCall() })
+
+    expect(result.current.state).toBe('ended')
+    expect(pc.closed).toBe(true)
+    expect(findCall(fetchMock.calls, 'POST', '/calls/call-uuid-E/end')).toBeDefined()
+  })
+})
+
+describe('useVoiceCall — incoming call', () => {
+  it('transitions to incoming-ringing when a call_offer arrives', async () => {
+    installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+    }))
+
+    await act(async () => {
+      await result.current.handleSignalEvent('call_offer', {
+        conversation_id: 7,
+        call_id: 'inbound-1',
+        from_user_id: 2,
+        data: { type: 'offer', sdp: 'v=0\r\nremote-offer' },
+      })
+    })
+
+    expect(result.current.state).toBe('incoming-ringing')
+    expect(result.current.callId).toBe('inbound-1')
+    expect(result.current.remoteUserId).toBe(2)
+    // No peer connection until the user accepts — the offer is only buffered.
+    expect(FakePeerConnection.instances).toHaveLength(0)
+  })
+
+  it('acceptCall fetches TURN, applies remote SDP, and POSTs an answer', async () => {
+    const fetchMock = installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+    }))
+
+    await act(async () => {
+      await result.current.handleSignalEvent('call_offer', {
+        conversation_id: 7,
+        call_id: 'inbound-2',
+        from_user_id: 3,
+        data: { type: 'offer', sdp: 'v=0\r\nremote-offer-2' },
+      })
+    })
+
+    await act(async () => { await result.current.acceptCall() })
+
+    expect(result.current.state).toBe('active')
+
+    expect(findCall(fetchMock.calls, 'GET', '/api/familychat/turn')).toBeDefined()
+
+    const pc = FakePeerConnection.instances[0]
+    expect(pc.remoteDescription?.sdp).toBe('v=0\r\nremote-offer-2')
+    expect(pc.localDescription?.type).toBe('answer')
+
+    const answerCall = findCall(fetchMock.calls, 'POST', '/calls/inbound-2/answer')
+    expect(answerCall).toBeDefined()
+    expect(JSON.parse(answerCall!.body!)).toEqual({
+      data: { type: 'answer', sdp: 'v=0\r\nfake-answer' },
+    })
+  })
+
+  it('rejectCall POSTs end without ever creating a peer connection', async () => {
+    const fetchMock = installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+    }))
+
+    await act(async () => {
+      await result.current.handleSignalEvent('call_offer', {
+        conversation_id: 7,
+        call_id: 'inbound-3',
+        from_user_id: 2,
+        data: { type: 'offer', sdp: 'v=0\r\nremote-offer-3' },
+      })
+    })
+
+    await act(async () => { await result.current.rejectCall() })
+
+    expect(result.current.state).toBe('idle')
+    expect(FakePeerConnection.instances).toHaveLength(0)
+    expect(findCall(fetchMock.calls, 'POST', '/calls/inbound-3/end')).toBeDefined()
+  })
+
+  it('call_end during active state transitions to ended and closes the peer connection', async () => {
+    installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+    }))
+
+    await act(async () => {
+      await result.current.handleSignalEvent('call_offer', {
+        conversation_id: 7,
+        call_id: 'inbound-4',
+        from_user_id: 2,
+        data: { type: 'offer', sdp: 'v=0\r\nremote-offer-4' },
+      })
+    })
+    await act(async () => { await result.current.acceptCall() })
+    const pc = FakePeerConnection.instances[0]
+
+    await act(async () => {
+      await result.current.handleSignalEvent('call_end', {
+        conversation_id: 7,
+        call_id: 'inbound-4',
+        from_user_id: 2,
+        status: 'ended',
+      })
+    })
+
+    expect(result.current.state).toBe('ended')
+    expect(pc.closed).toBe(true)
+  })
+})
+
+describe('useVoiceCall — event filtering', () => {
+  it('ignores events for a different conversation', async () => {
+    installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+    }))
+
+    await act(async () => {
+      await result.current.handleSignalEvent('call_offer', {
+        conversation_id: 99,
+        call_id: 'other-conv',
+        from_user_id: 2,
+        data: { type: 'offer', sdp: 'v=0\r\nignored' },
+      })
+    })
+
+    expect(result.current.state).toBe('idle')
+  })
+
+  it("ignores echoes of our own POSTs (from_user_id matches the local user)", async () => {
+    installFetchMock()
+    installRtcGlobals()
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      skipSignalSubscription: true,
+    }))
+
+    await act(async () => {
+      await result.current.handleSignalEvent('call_offer', {
+        conversation_id: 7,
+        call_id: 'self-echo',
+        from_user_id: 1,
+        data: { type: 'offer', sdp: 'v=0\r\necho' },
+      })
+    })
+
+    expect(result.current.state).toBe('idle')
+  })
+})

--- a/web/src/pages/familychat/voice/useVoiceCall.test.tsx
+++ b/web/src/pages/familychat/voice/useVoiceCall.test.tsx
@@ -437,6 +437,37 @@ describe('useVoiceCall — incoming call', () => {
     expect(findCall(fetchMock.calls, 'POST', '/calls/inbound-3/end')).toBeDefined()
   })
 
+  it('clears stale error when a new inbound offer arrives', async () => {
+    installRtcGlobals()
+    const fetchMock = installFetchMock()
+    // Force TURN to fail so startCall sets an error.
+    fetchMock.setResponse('GET', '/api/familychat/turn', () => new Response('', { status: 500 }))
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: makeFakePeerConnection,
+      skipSignalSubscription: true,
+      generateCallId: () => 'call-err',
+    }))
+
+    await act(async () => { await result.current.startCall() })
+    expect(result.current.error).not.toBeNull()
+    expect(result.current.state).toBe('idle')
+
+    await act(async () => {
+      await result.current.handleSignalEvent('call_offer', {
+        conversation_id: 7,
+        call_id: 'fresh-inbound',
+        from_user_id: 2,
+        data: { type: 'offer', sdp: 'v=0\r\nfresh-offer' },
+      })
+    })
+
+    expect(result.current.state).toBe('incoming-ringing')
+    expect(result.current.error).toBeNull()
+  })
+
   it('call_end during active state transitions to ended and closes the peer connection', async () => {
     installFetchMock()
     installRtcGlobals()
@@ -470,6 +501,51 @@ describe('useVoiceCall — incoming call', () => {
 
     expect(result.current.state).toBe('ended')
     expect(pc.closed).toBe(true)
+  })
+})
+
+describe('useVoiceCall — epoch guards', () => {
+  it('acceptCall bails out if rejectCall fires while TURN is in-flight', async () => {
+    installRtcGlobals()
+    let resolveTurn!: (r: Response) => void
+    const turnPromise = new Promise<Response>(resolve => { resolveTurn = resolve })
+
+    const fetchMock = installFetchMock()
+    fetchMock.setResponse('GET', '/api/familychat/turn', (() => turnPromise) as unknown as () => Response)
+
+    const { result } = renderHook(() => useVoiceCall({
+      conversationId: 7,
+      userId: 1,
+      rtcPeerConnectionFactory: makeFakePeerConnection,
+      skipSignalSubscription: true,
+    }))
+
+    await act(async () => {
+      await result.current.handleSignalEvent('call_offer', {
+        conversation_id: 7,
+        call_id: 'inbound-ep',
+        from_user_id: 2,
+        data: { type: 'offer', sdp: 'v=0\r\nremote-offer-ep' },
+      })
+    })
+    expect(result.current.state).toBe('incoming-ringing')
+
+    await act(async () => {
+      // acceptCall suspends on the deferred TURN fetch.
+      const accept = result.current.acceptCall()
+      // rejectCall runs tearDown synchronously, bumping the epoch.
+      await result.current.rejectCall()
+      // Unblock TURN — the epoch guard in acceptCall should bail out.
+      resolveTurn(new Response(JSON.stringify({
+        iceServers: [{ urls: ['stun:stun.example.com:3478'] }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      await accept
+    })
+
+    // No peer connection created and no answer posted.
+    expect(FakePeerConnection.instances).toHaveLength(0)
+    expect(findCall(fetchMock.calls, 'POST', '/calls/inbound-ep/answer')).toBeUndefined()
+    expect(result.current.state).toBe('idle')
   })
 })
 

--- a/web/src/pages/familychat/voice/useVoiceCall.test.tsx
+++ b/web/src/pages/familychat/voice/useVoiceCall.test.tsx
@@ -95,6 +95,10 @@ class FakePeerConnection {
   }
 }
 
+function makeFakePeerConnection(cfg: RTCConfiguration): RTCPeerConnection {
+  return new FakePeerConnection(cfg) as unknown as RTCPeerConnection
+}
+
 interface FetchCall {
   url: string
   method: string
@@ -174,7 +178,7 @@ describe('useVoiceCall — outgoing call', () => {
   it('fetches TURN config, creates an offer, and POSTs it to the relay', async () => {
     const fetchMock = installFetchMock()
     installRtcGlobals()
-    const factory = vi.fn((cfg: RTCConfiguration) => new FakePeerConnection(cfg))
+    const factory = vi.fn(makeFakePeerConnection)
 
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
@@ -220,7 +224,7 @@ describe('useVoiceCall — outgoing call', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
       generateCallId: () => 'call-uuid-B',
     }))
@@ -250,7 +254,7 @@ describe('useVoiceCall — outgoing call', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
       generateCallId: () => 'call-uuid-C',
     }))
@@ -277,7 +281,7 @@ describe('useVoiceCall — outgoing call', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
       generateCallId: () => 'call-uuid-D',
     }))
@@ -316,7 +320,7 @@ describe('useVoiceCall — outgoing call', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
       generateCallId: () => 'call-uuid-E',
     }))
@@ -339,7 +343,7 @@ describe('useVoiceCall — incoming call', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
     }))
 
@@ -366,7 +370,7 @@ describe('useVoiceCall — incoming call', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
     }))
 
@@ -403,7 +407,7 @@ describe('useVoiceCall — incoming call', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
     }))
 
@@ -430,7 +434,7 @@ describe('useVoiceCall — incoming call', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
     }))
 
@@ -467,7 +471,7 @@ describe('useVoiceCall — event filtering', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
     }))
 
@@ -490,7 +494,7 @@ describe('useVoiceCall — event filtering', () => {
     const { result } = renderHook(() => useVoiceCall({
       conversationId: 7,
       userId: 1,
-      rtcPeerConnectionFactory: cfg => new FakePeerConnection(cfg),
+      rtcPeerConnectionFactory: makeFakePeerConnection,
       skipSignalSubscription: true,
     }))
 

--- a/web/src/pages/familychat/voice/useVoiceCall.ts
+++ b/web/src/pages/familychat/voice/useVoiceCall.ts
@@ -1,0 +1,679 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// useVoiceCall manages the WebRTC lifecycle of a 1:1 voice call between two
+// members of a Family Chat conversation. It is intentionally UI-agnostic:
+// state transitions and stream handles are exposed so an outer component can
+// render the ringing banner, in-call controls, and end-of-call summary.
+//
+// Responsibilities:
+//   1. Fetch the STUN/TURN ICE config from /api/familychat/turn before each
+//      new call so coturn ephemeral credentials are fresh.
+//   2. Manage RTCPeerConnection — createOffer / createAnswer, set local/remote
+//      descriptions, trickle ICE candidates.
+//   3. POST each signalling artifact (offer, answer, ICE candidate, hang-up)
+//      to the relay endpoints provided by the backend.
+//   4. Consume call_offer / call_answer / call_ice / call_end SSE events
+//      (either via its own subscription or by being fed events through
+//      handleSignalEvent) and drive the state machine accordingly.
+//   5. Keep an AudioContext "kicked" while the call is active so background
+//      tabs do not let the WebRTC pipeline suspend silently.
+//
+// The hook is deliberately framework-thin: tests inject a fake
+// RTCPeerConnection constructor and a stubbed getUserMedia, then call
+// handleSignalEvent directly to drive the state machine without standing up
+// a real SSE source.
+
+export type VoiceCallState =
+  | 'idle'
+  | 'outgoing-ringing'
+  | 'incoming-ringing'
+  | 'active'
+  | 'ended'
+
+export type CallSignalEventName =
+  | 'call_offer'
+  | 'call_answer'
+  | 'call_ice'
+  | 'call_end'
+
+// CallSignalPayload mirrors the JSON shape emitted by the backend SSE relay
+// (see internal/familychat/calls_handlers.go: callRelayPayload). `data` is the
+// opaque artifact — SDP for offer/answer, an ICE candidate object for ice, or
+// a hang-up envelope for end. `status` is only populated on call_end and lets
+// the UI distinguish missed vs ended without an extra query.
+export interface CallSignalPayload {
+  conversation_id: number
+  call_id: string
+  from_user_id: number
+  data?: unknown
+  status?: string
+}
+
+export interface ICEServerConfig {
+  urls: string[]
+  username?: string
+  credential?: string
+}
+
+export interface ICEFetchResult {
+  iceServers: ICEServerConfig[]
+  ttl?: number
+}
+
+export interface UseVoiceCallOptions {
+  conversationId: number | null
+  // userId is the local user's id. Used to filter out our own SSE echoes —
+  // the relay fans every event to all conversation members including the
+  // sender, so without this guard we would react to our own offer/answer.
+  userId: number | null
+  // Inject a custom RTCPeerConnection constructor. Used by tests to swap in
+  // a stub that records method calls. Defaults to globalThis.RTCPeerConnection.
+  rtcPeerConnectionFactory?: (config: RTCConfiguration) => RTCPeerConnection
+  // Override getUserMedia for tests. Defaults to navigator.mediaDevices.getUserMedia.
+  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>
+  // Skip the hook's internal SSE subscription. The consumer must then feed
+  // events via handleSignalEvent. Useful when the surrounding page already
+  // has an SSE stream open and wants to fan call events into the hook.
+  skipSignalSubscription?: boolean
+  // Override the call-id generator. Defaults to crypto.randomUUID with a
+  // random-hex fallback for environments that lack it.
+  generateCallId?: () => string
+}
+
+export interface UseVoiceCallApi {
+  state: VoiceCallState
+  callId: string | null
+  remoteUserId: number | null
+  error: string | null
+  remoteStream: MediaStream | null
+  startCall: () => Promise<void>
+  acceptCall: () => Promise<void>
+  rejectCall: () => Promise<void>
+  endCall: () => Promise<void>
+  // Drive the call state machine from an external signal source. Exposed so
+  // tests can simulate incoming events without a real SSE connection, and so
+  // an outer page that already owns an SSE stream can route call_* frames in.
+  handleSignalEvent: (event: CallSignalEventName, payload: CallSignalPayload) => Promise<void>
+}
+
+function defaultGenerateCallId(): string {
+  const c = typeof crypto !== 'undefined' ? crypto : undefined
+  if (c && typeof c.randomUUID === 'function') return c.randomUUID()
+  // Fallback: 16 random bytes hex-encoded. Not RFC4122 but unique enough for
+  // a call-id; the server only requires opaque text ≤ 128 chars.
+  const bytes = new Uint8Array(16)
+  if (c && typeof c.getRandomValues === 'function') c.getRandomValues(bytes)
+  else for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256)
+  return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+}
+
+async function fetchICEConfig(signal?: AbortSignal): Promise<ICEFetchResult> {
+  const res = await fetch('/api/familychat/turn', { credentials: 'include', signal })
+  if (!res.ok) throw new Error(`turn config failed: ${res.status}`)
+  return res.json()
+}
+
+async function postSignal(
+  convId: number,
+  callId: string,
+  kind: 'offer' | 'answer' | 'ice' | 'end',
+  data: unknown,
+  signal?: AbortSignal,
+): Promise<void> {
+  const res = await fetch(
+    `/api/familychat/conversations/${convId}/calls/${callId}/${kind}`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data }),
+      signal,
+    },
+  )
+  // 204 is the documented success code; any 2xx counts as success in case the
+  // backend gains a body in a future revision.
+  if (!res.ok) throw new Error(`signal ${kind} failed: ${res.status}`)
+}
+
+function defaultPeerConnectionFactory(config: RTCConfiguration): RTCPeerConnection {
+  const Ctor = (globalThis as unknown as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection
+  if (!Ctor) throw new Error('RTCPeerConnection unavailable')
+  return new Ctor(config)
+}
+
+function defaultGetUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream> {
+  if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+    return Promise.reject(new Error('getUserMedia unavailable'))
+  }
+  return navigator.mediaDevices.getUserMedia(constraints)
+}
+
+export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
+  const {
+    conversationId,
+    userId,
+    rtcPeerConnectionFactory = defaultPeerConnectionFactory,
+    getUserMedia = defaultGetUserMedia,
+    skipSignalSubscription = false,
+    generateCallId = defaultGenerateCallId,
+  } = options
+
+  const [state, setState] = useState<VoiceCallState>('idle')
+  const [callId, setCallId] = useState<string | null>(null)
+  const [remoteUserId, setRemoteUserId] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null)
+
+  // Refs hold values the async signalling callbacks must read without
+  // capturing stale closures. React state is used for things the UI needs to
+  // re-render on; everything else is a ref.
+  const pcRef = useRef<RTCPeerConnection | null>(null)
+  const localStreamRef = useRef<MediaStream | null>(null)
+  const callIdRef = useRef<string | null>(null)
+  const remoteUserIdRef = useRef<number | null>(null)
+  const stateRef = useRef<VoiceCallState>('idle')
+  // pendingOfferRef stores an inbound SDP offer waiting for the user to
+  // acceptCall(). The hook does not auto-accept — the UI must trigger it.
+  const pendingOfferRef = useRef<RTCSessionDescriptionInit | null>(null)
+  // pendingRemoteCandidatesRef buffers ICE candidates that arrive before the
+  // remote description is set (common when answer SDP and the first trickled
+  // candidate race over the relay). They are flushed once setRemoteDescription
+  // resolves.
+  const pendingRemoteCandidatesRef = useRef<RTCIceCandidateInit[]>([])
+  const remoteDescriptionSetRef = useRef<boolean>(false)
+  const audioCtxRef = useRef<AudioContext | null>(null)
+  const visibilityHandlerRef = useRef<(() => void) | null>(null)
+  // optionsRef lets the SSE/visibility effects always see the latest factory
+  // overrides without re-running on every render that passes new function
+  // references.
+  const optionsRef = useRef({ rtcPeerConnectionFactory, getUserMedia, generateCallId, userId })
+  useEffect(() => {
+    optionsRef.current = { rtcPeerConnectionFactory, getUserMedia, generateCallId, userId }
+  })
+
+  const updateState = useCallback((next: VoiceCallState) => {
+    stateRef.current = next
+    setState(next)
+  }, [])
+
+  const updateCallId = useCallback((next: string | null) => {
+    callIdRef.current = next
+    setCallId(next)
+  }, [])
+
+  const updateRemoteUserId = useCallback((next: number | null) => {
+    remoteUserIdRef.current = next
+    setRemoteUserId(next)
+  }, [])
+
+  // tearDown closes the peer connection, stops local tracks, releases the
+  // AudioContext, and clears every transient buffer. It is safe to call from
+  // any state — every step guards a missing handle.
+  const tearDown = useCallback((nextState: VoiceCallState = 'idle') => {
+    const pc = pcRef.current
+    if (pc) {
+      // Drop event listeners before close() to avoid a final connectionstate
+      // change racing the "ended" UI transition.
+      pc.ontrack = null
+      pc.onicecandidate = null
+      pc.oniceconnectionstatechange = null
+      pc.onconnectionstatechange = null
+      try { pc.close() } catch { /* already closed */ }
+    }
+    pcRef.current = null
+
+    const localStream = localStreamRef.current
+    localStreamRef.current = null
+    if (localStream) {
+      for (const track of localStream.getTracks()) {
+        try { track.stop() } catch { /* already stopped */ }
+      }
+    }
+
+    setRemoteStream(null)
+    pendingOfferRef.current = null
+    pendingRemoteCandidatesRef.current = []
+    remoteDescriptionSetRef.current = false
+
+    const handler = visibilityHandlerRef.current
+    visibilityHandlerRef.current = null
+    if (handler && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', handler)
+    }
+
+    const ctx = audioCtxRef.current
+    audioCtxRef.current = null
+    if (ctx && typeof ctx.close === 'function') {
+      void ctx.close().catch(() => {})
+    }
+
+    updateRemoteUserId(null)
+    updateCallId(null)
+    updateState(nextState)
+  }, [updateCallId, updateRemoteUserId, updateState])
+
+  // installAudioContextKick keeps a silent AudioContext alive for the
+  // duration of the call. Browsers throttle background tabs aggressively; an
+  // AudioContext in the 'running' state prevents the WebRTC pipeline from
+  // being suspended along with the rest of the tab, which would otherwise
+  // drop frames or stall ICE keepalives. The context plays nothing — it just
+  // anchors the page in the high-priority media path.
+  const installAudioContextKick = useCallback(() => {
+    if (audioCtxRef.current) return
+    if (typeof window === 'undefined') return
+    const Ctor = window.AudioContext
+      ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!Ctor) return
+    let ctx: AudioContext
+    try {
+      ctx = new Ctor()
+    } catch {
+      return
+    }
+    audioCtxRef.current = ctx
+    // Connect a 0-gain oscillator to the destination. It produces no audible
+    // output but it keeps the audio graph "doing something" so the browser
+    // does not park the context.
+    try {
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+      gain.gain.value = 0
+      osc.connect(gain)
+      gain.connect(ctx.destination)
+      osc.start()
+    } catch {
+      // Some test environments (happy-dom) only stub createMediaStreamSource.
+      // Skipping the oscillator is fine — the context itself is the anchor.
+    }
+    const onVisibility = () => {
+      // Resume immediately when the tab regains focus; some browsers auto-
+      // suspend a context that was created while hidden.
+      if (ctx.state !== 'running' && typeof ctx.resume === 'function') {
+        void ctx.resume().catch(() => {})
+      }
+    }
+    visibilityHandlerRef.current = onVisibility
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVisibility)
+    }
+  }, [])
+
+  // wirePeerConnection attaches the standard listeners used by both legs of
+  // the call. Caller-specific behaviour (creating the offer vs the answer) is
+  // handled inline by startCall / acceptCall after this returns.
+  const wirePeerConnection = useCallback((pc: RTCPeerConnection, convId: number, theCallId: string) => {
+    pc.ontrack = (event: RTCTrackEvent) => {
+      // Prefer the stream the remote sent; fall back to a synthetic one
+      // built from the track when the browser does not expose streams[0].
+      const stream = event.streams?.[0]
+        ?? new MediaStream([event.track])
+      setRemoteStream(stream)
+    }
+
+    pc.onicecandidate = (event: RTCPeerConnectionIceEvent) => {
+      if (!event.candidate) return
+      const init = typeof event.candidate.toJSON === 'function'
+        ? event.candidate.toJSON()
+        : ({
+            candidate: event.candidate.candidate,
+            sdpMid: event.candidate.sdpMid,
+            sdpMLineIndex: event.candidate.sdpMLineIndex,
+            usernameFragment: event.candidate.usernameFragment,
+          } as RTCIceCandidateInit)
+      postSignal(convId, theCallId, 'ice', init).catch(err => {
+        // ICE trickling is best-effort; if a single candidate fails to relay
+        // the connection can still succeed via earlier candidates. Surface
+        // the error for debugging but don't tear down.
+        if (typeof console !== 'undefined') {
+          console.warn('voice call: ice relay failed', err)
+        }
+      })
+    }
+
+    pc.onconnectionstatechange = () => {
+      const cs = pc.connectionState
+      if (cs === 'failed' || cs === 'closed') {
+        // Surface a tear-down on transport failure so the UI exits the
+        // "active" state even if the remote never sent a call_end.
+        if (stateRef.current === 'active' || stateRef.current === 'outgoing-ringing') {
+          tearDown('ended')
+        }
+      }
+    }
+  }, [tearDown])
+
+  // applyRemoteCandidates flushes any ICE candidates that arrived before
+  // setRemoteDescription resolved. Called immediately after each successful
+  // setRemoteDescription.
+  const flushBufferedCandidates = useCallback(async () => {
+    const pc = pcRef.current
+    if (!pc) return
+    const buffered = pendingRemoteCandidatesRef.current
+    pendingRemoteCandidatesRef.current = []
+    for (const cand of buffered) {
+      try {
+        await pc.addIceCandidate(cand)
+      } catch (err) {
+        if (typeof console !== 'undefined') {
+          console.warn('voice call: addIceCandidate failed', err)
+        }
+      }
+    }
+  }, [])
+
+  const startCall = useCallback(async () => {
+    if (conversationId === null) {
+      setError('no-conversation')
+      return
+    }
+    if (stateRef.current !== 'idle' && stateRef.current !== 'ended') {
+      // Already in a call or ringing — ignore so a double-click on the call
+      // button doesn't open a second peer connection.
+      return
+    }
+    setError(null)
+    const theCallId = optionsRef.current.generateCallId()
+    updateCallId(theCallId)
+    updateState('outgoing-ringing')
+
+    try {
+      const ice = await fetchICEConfig()
+      const pc = optionsRef.current.rtcPeerConnectionFactory({
+        iceServers: ice.iceServers as RTCIceServer[],
+      })
+      pcRef.current = pc
+      wirePeerConnection(pc, conversationId, theCallId)
+
+      const localStream = await optionsRef.current.getUserMedia({ audio: true })
+      localStreamRef.current = localStream
+      for (const track of localStream.getTracks()) {
+        pc.addTrack(track, localStream)
+      }
+
+      const offer = await pc.createOffer()
+      await pc.setLocalDescription(offer)
+      // Relay the SDP from localDescription (rather than the raw createOffer
+      // result) because some implementations massage the SDP during setLocal.
+      const sdp = pc.localDescription ?? offer
+      await postSignal(conversationId, theCallId, 'offer', {
+        type: sdp.type,
+        sdp: sdp.sdp,
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'start-failed')
+      tearDown('idle')
+    }
+  }, [conversationId, tearDown, updateCallId, updateState, wirePeerConnection])
+
+  const acceptCall = useCallback(async () => {
+    const convId = conversationId
+    const theCallId = callIdRef.current
+    const offer = pendingOfferRef.current
+    if (convId === null || theCallId === null || offer === null) {
+      setError('no-pending-call')
+      return
+    }
+    if (stateRef.current !== 'incoming-ringing') return
+    setError(null)
+
+    try {
+      const ice = await fetchICEConfig()
+      const pc = optionsRef.current.rtcPeerConnectionFactory({
+        iceServers: ice.iceServers as RTCIceServer[],
+      })
+      pcRef.current = pc
+      wirePeerConnection(pc, convId, theCallId)
+
+      await pc.setRemoteDescription(offer)
+      remoteDescriptionSetRef.current = true
+      await flushBufferedCandidates()
+
+      const localStream = await optionsRef.current.getUserMedia({ audio: true })
+      localStreamRef.current = localStream
+      for (const track of localStream.getTracks()) {
+        pc.addTrack(track, localStream)
+      }
+
+      const answer = await pc.createAnswer()
+      await pc.setLocalDescription(answer)
+      const sdp = pc.localDescription ?? answer
+      await postSignal(convId, theCallId, 'answer', {
+        type: sdp.type,
+        sdp: sdp.sdp,
+      })
+
+      pendingOfferRef.current = null
+      updateState('active')
+      installAudioContextKick()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'accept-failed')
+      // Notify the caller that we couldn't pick up so their UI updates.
+      if (convId !== null && theCallId !== null) {
+        postSignal(convId, theCallId, 'end', { reason: 'accept-failed' }).catch(() => {})
+      }
+      tearDown('idle')
+    }
+  }, [
+    conversationId,
+    flushBufferedCandidates,
+    installAudioContextKick,
+    tearDown,
+    updateState,
+    wirePeerConnection,
+  ])
+
+  const rejectCall = useCallback(async () => {
+    const convId = conversationId
+    const theCallId = callIdRef.current
+    if (convId === null || theCallId === null) {
+      tearDown('idle')
+      return
+    }
+    if (stateRef.current !== 'incoming-ringing') return
+    // Fire-and-forget the end relay so the caller's UI exits ringing even if
+    // the network is flaky. The local tear-down happens regardless.
+    postSignal(convId, theCallId, 'end', { reason: 'rejected' }).catch(() => {})
+    tearDown('idle')
+  }, [conversationId, tearDown])
+
+  const endCall = useCallback(async () => {
+    const convId = conversationId
+    const theCallId = callIdRef.current
+    const wasActive = stateRef.current === 'active' || stateRef.current === 'outgoing-ringing'
+    if (convId === null || theCallId === null || !wasActive) {
+      tearDown('idle')
+      return
+    }
+    try {
+      await postSignal(convId, theCallId, 'end', { reason: 'hangup' })
+    } catch {
+      // The local hang-up still proceeds — the remote will eventually see
+      // ICE/connection failure if our end signal never reaches them.
+    }
+    tearDown('ended')
+  }, [conversationId, tearDown])
+
+  const handleSignalEvent = useCallback(async (
+    event: CallSignalEventName,
+    payload: CallSignalPayload,
+  ) => {
+    // Ignore echoes of our own POSTs — the relay fans every event to every
+    // member including the sender.
+    const me = optionsRef.current.userId
+    if (me !== null && me !== undefined && payload.from_user_id === me) return
+    if (conversationId === null || payload.conversation_id !== conversationId) return
+
+    const incomingCallId = payload.call_id
+
+    switch (event) {
+      case 'call_offer': {
+        // Only accept an offer when we are completely idle. An offer that
+        // arrives while we are already in a call is a glare condition; the
+        // simplest resolution is to ignore the second offer rather than
+        // tear down an in-progress call.
+        if (stateRef.current !== 'idle' && stateRef.current !== 'ended') return
+        const data = payload.data as { type?: RTCSdpType; sdp?: string } | undefined
+        if (!data || !data.sdp || !data.type) return
+        pendingOfferRef.current = { type: data.type, sdp: data.sdp }
+        updateCallId(incomingCallId)
+        updateRemoteUserId(payload.from_user_id)
+        updateState('incoming-ringing')
+        return
+      }
+      case 'call_answer': {
+        if (stateRef.current !== 'outgoing-ringing') return
+        if (callIdRef.current !== incomingCallId) return
+        const pc = pcRef.current
+        const data = payload.data as { type?: RTCSdpType; sdp?: string } | undefined
+        if (!pc || !data || !data.sdp || !data.type) return
+        try {
+          await pc.setRemoteDescription({ type: data.type, sdp: data.sdp })
+          remoteDescriptionSetRef.current = true
+          await flushBufferedCandidates()
+          updateRemoteUserId(payload.from_user_id)
+          updateState('active')
+          installAudioContextKick()
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'answer-failed')
+          tearDown('ended')
+        }
+        return
+      }
+      case 'call_ice': {
+        if (callIdRef.current !== incomingCallId) return
+        const pc = pcRef.current
+        const cand = payload.data as RTCIceCandidateInit | undefined
+        if (!cand) return
+        if (!pc || !remoteDescriptionSetRef.current) {
+          pendingRemoteCandidatesRef.current.push(cand)
+          return
+        }
+        try {
+          await pc.addIceCandidate(cand)
+        } catch (err) {
+          if (typeof console !== 'undefined') {
+            console.warn('voice call: addIceCandidate failed', err)
+          }
+        }
+        return
+      }
+      case 'call_end': {
+        if (callIdRef.current !== incomingCallId) return
+        tearDown('ended')
+        return
+      }
+    }
+  }, [
+    conversationId,
+    flushBufferedCandidates,
+    installAudioContextKick,
+    tearDown,
+    updateCallId,
+    updateRemoteUserId,
+    updateState,
+  ])
+
+  // Internal SSE subscription — disabled by passing skipSignalSubscription so
+  // tests (and outer pages that already own a stream) can route events in
+  // manually. The reader mirrors the loop in ChatView so the on-wire framing
+  // stays consistent.
+  useEffect(() => {
+    if (skipSignalSubscription) return
+    if (conversationId === null) return
+    if (typeof window === 'undefined' || typeof fetch === 'undefined') return
+
+    const controller = new AbortController()
+    let cancelled = false
+
+    const dispatch = (eventName: string, data: string) => {
+      if (
+        eventName !== 'call_offer'
+        && eventName !== 'call_answer'
+        && eventName !== 'call_ice'
+        && eventName !== 'call_end'
+      ) return
+      let payload: CallSignalPayload
+      try {
+        payload = JSON.parse(data) as CallSignalPayload
+      } catch {
+        return
+      }
+      void handleSignalEvent(eventName as CallSignalEventName, payload)
+    }
+
+    const run = async () => {
+      try {
+        const res = await fetch(
+          `/api/familychat/conversations/${conversationId}/stream`,
+          { credentials: 'include', signal: controller.signal },
+        )
+        if (!res.ok || !res.body) return
+        const reader = res.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+        let eventName = 'message'
+        let dataLines: string[] = []
+        while (!cancelled) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          let nl = buffer.indexOf('\n')
+          while (nl >= 0) {
+            let line = buffer.slice(0, nl)
+            buffer = buffer.slice(nl + 1)
+            if (line.endsWith('\r')) line = line.slice(0, -1)
+            if (line === '') {
+              if (dataLines.length > 0) {
+                dispatch(eventName, dataLines.join('\n'))
+              }
+              eventName = 'message'
+              dataLines = []
+            } else if (line.startsWith(':')) {
+              // SSE heartbeat comment — ignore.
+            } else if (line.startsWith('event:')) {
+              eventName = line.slice(6).trimStart()
+            } else if (line.startsWith('data:')) {
+              const v = line.slice(5)
+              dataLines.push(v.startsWith(' ') ? v.slice(1) : v)
+            }
+            nl = buffer.indexOf('\n')
+          }
+        }
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        // The hook deliberately does not reconnect — the outer ChatView SSE
+        // stream owns reconnection semantics, and a missed call_offer simply
+        // means the recipient does not ring. The webpush fallback (sibling 1)
+        // still wakes the phone.
+      }
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [conversationId, handleSignalEvent, skipSignalSubscription])
+
+  // Tear down on unmount so a mid-call navigation away releases the mic and
+  // the PeerConnection rather than leaving the call dangling.
+  useEffect(() => {
+    return () => {
+      tearDown('idle')
+    }
+  }, [tearDown])
+
+  return {
+    state,
+    callId,
+    remoteUserId,
+    error,
+    remoteStream,
+    startCall,
+    acceptCall,
+    rejectCall,
+    endCall,
+    handleSignalEvent,
+  }
+}

--- a/web/src/pages/familychat/voice/useVoiceCall.ts
+++ b/web/src/pages/familychat/voice/useVoiceCall.ts
@@ -281,6 +281,12 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
       return
     }
     audioCtxRef.current = ctx
+    // Best-effort immediate resume so the context reliably reaches 'running'
+    // without waiting for the next visibilitychange — some browsers start it
+    // suspended even when created during a user gesture.
+    if (typeof ctx.resume === 'function') {
+      void ctx.resume().catch(() => {})
+    }
     // Connect a 0-gain oscillator to the destination. It produces no audible
     // output but it keeps the audio graph "doing something" so the browser
     // does not park the context.
@@ -438,9 +444,13 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
     }
     if (stateRef.current !== 'incoming-ringing') return
     setError(null)
+    // Capture epoch so continuations can detect if tearDown fired while awaiting.
+    const epoch = callEpochRef.current
 
     try {
       const ice = await fetchICEConfig()
+      if (callEpochRef.current !== epoch) return
+
       const pc = optionsRef.current.rtcPeerConnectionFactory({
         iceServers: ice.iceServers as RTCIceServer[],
       })
@@ -448,27 +458,38 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
       wirePeerConnection(pc, convId, theCallId)
 
       await pc.setRemoteDescription(offer)
+      if (callEpochRef.current !== epoch) return
       remoteDescriptionSetRef.current = true
       await flushBufferedCandidates()
+      if (callEpochRef.current !== epoch) return
 
       const localStream = await optionsRef.current.getUserMedia({ audio: true })
+      if (callEpochRef.current !== epoch) {
+        // tearDown already ran — release the mic without touching state.
+        for (const t of localStream.getTracks()) { try { t.stop() } catch { /* ok */ } }
+        return
+      }
       localStreamRef.current = localStream
       for (const track of localStream.getTracks()) {
         pc.addTrack(track, localStream)
       }
 
       const answer = await pc.createAnswer()
+      if (callEpochRef.current !== epoch) return
       await pc.setLocalDescription(answer)
+      if (callEpochRef.current !== epoch) return
       const sdp = pc.localDescription ?? answer
       await postSignal(convId, theCallId, 'answer', {
         type: sdp.type,
         sdp: sdp.sdp,
       })
+      if (callEpochRef.current !== epoch) return
 
       pendingOfferRef.current = null
       updateState('active')
       installAudioContextKick()
     } catch (err) {
+      if (callEpochRef.current !== epoch) return
       setError(err instanceof Error ? err.message : 'accept-failed')
       // Notify the caller that we couldn't pick up so their UI updates.
       if (convId !== null && theCallId !== null) {
@@ -538,6 +559,7 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
         const data = payload.data as { type?: RTCSdpType; sdp?: string } | undefined
         if (!data || !data.sdp) return
         pendingOfferRef.current = { type: data.type ?? 'offer', sdp: data.sdp }
+        setError(null)
         updateCallId(incomingCallId)
         updateRemoteUserId(payload.from_user_id)
         updateState('incoming-ringing')

--- a/web/src/pages/familychat/voice/useVoiceCall.ts
+++ b/web/src/pages/familychat/voice/useVoiceCall.ts
@@ -1,9 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 // useVoiceCall manages the WebRTC lifecycle of a 1:1 voice call between two
-// members of a Family Chat conversation. It is intentionally UI-agnostic:
-// state transitions and stream handles are exposed so an outer component can
-// render the ringing banner, in-call controls, and end-of-call summary.
+// members of a Family Chat conversation. Voice calling is only supported for
+// 2-member conversations — the signalling endpoints broadcast to all members
+// but this hook tracks a single remoteUserId. Callers should disable the call
+// UI (or reject incoming offers) when the conversation has more than 2 members.
+//
+// It is intentionally UI-agnostic: state transitions and stream handles are
+// exposed so an outer component can render the ringing banner, in-call
+// controls, and end-of-call summary.
 //
 // Responsibilities:
 //   1. Fetch the STUN/TURN ICE config from /api/familychat/turn before each
@@ -168,6 +173,10 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
   // capturing stale closures. React state is used for things the UI needs to
   // re-render on; everything else is a ref.
   const pcRef = useRef<RTCPeerConnection | null>(null)
+  // callEpochRef is incremented by tearDown so that any in-flight startCall
+  // continuation can detect that the call was ended and bail out rather than
+  // re-creating a PeerConnection or POSTing a stale offer.
+  const callEpochRef = useRef<number>(0)
   const localStreamRef = useRef<MediaStream | null>(null)
   const callIdRef = useRef<string | null>(null)
   const remoteUserIdRef = useRef<number | null>(null)
@@ -210,6 +219,7 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
   // AudioContext, and clears every transient buffer. It is safe to call from
   // any state — every step guards a missing handle.
   const tearDown = useCallback((nextState: VoiceCallState = 'idle') => {
+    callEpochRef.current++ // Invalidate any in-flight startCall continuation.
     const pc = pcRef.current
     if (pc) {
       // Drop event listeners before close() to avoid a final connectionstate
@@ -372,12 +382,17 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
       return
     }
     setError(null)
+    // Capture the current epoch so every resumed continuation can detect
+    // whether endCall/tearDown fired while an async step was in-flight.
+    const epoch = callEpochRef.current
     const theCallId = optionsRef.current.generateCallId()
     updateCallId(theCallId)
     updateState('outgoing-ringing')
 
     try {
       const ice = await fetchICEConfig()
+      if (callEpochRef.current !== epoch) return
+
       const pc = optionsRef.current.rtcPeerConnectionFactory({
         iceServers: ice.iceServers as RTCIceServer[],
       })
@@ -385,13 +400,20 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
       wirePeerConnection(pc, conversationId, theCallId)
 
       const localStream = await optionsRef.current.getUserMedia({ audio: true })
+      if (callEpochRef.current !== epoch) {
+        // tearDown already ran — release the mic without touching state.
+        for (const t of localStream.getTracks()) { try { t.stop() } catch { /* ok */ } }
+        return
+      }
       localStreamRef.current = localStream
       for (const track of localStream.getTracks()) {
         pc.addTrack(track, localStream)
       }
 
       const offer = await pc.createOffer()
+      if (callEpochRef.current !== epoch) return
       await pc.setLocalDescription(offer)
+      if (callEpochRef.current !== epoch) return
       // Relay the SDP from localDescription (rather than the raw createOffer
       // result) because some implementations massage the SDP during setLocal.
       const sdp = pc.localDescription ?? offer
@@ -400,6 +422,7 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
         sdp: sdp.sdp,
       })
     } catch (err) {
+      if (callEpochRef.current !== epoch) return
       setError(err instanceof Error ? err.message : 'start-failed')
       tearDown('idle')
     }
@@ -513,8 +536,8 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
         // tear down an in-progress call.
         if (stateRef.current !== 'idle' && stateRef.current !== 'ended') return
         const data = payload.data as { type?: RTCSdpType; sdp?: string } | undefined
-        if (!data || !data.sdp || !data.type) return
-        pendingOfferRef.current = { type: data.type, sdp: data.sdp }
+        if (!data || !data.sdp) return
+        pendingOfferRef.current = { type: data.type ?? 'offer', sdp: data.sdp }
         updateCallId(incomingCallId)
         updateRemoteUserId(payload.from_user_id)
         updateState('incoming-ringing')
@@ -525,9 +548,9 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
         if (callIdRef.current !== incomingCallId) return
         const pc = pcRef.current
         const data = payload.data as { type?: RTCSdpType; sdp?: string } | undefined
-        if (!pc || !data || !data.sdp || !data.type) return
+        if (!pc || !data || !data.sdp) return
         try {
-          await pc.setRemoteDescription({ type: data.type, sdp: data.sdp })
+          await pc.setRemoteDescription({ type: data.type ?? 'answer', sdp: data.sdp })
           remoteDescriptionSetRef.current = true
           await flushBufferedCandidates()
           updateRemoteUserId(payload.from_user_id)
@@ -584,6 +607,7 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
 
     const controller = new AbortController()
     let cancelled = false
+    let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null
 
     const dispatch = (eventName: string, data: string) => {
       if (
@@ -609,6 +633,7 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
         )
         if (!res.ok || !res.body) return
         const reader = res.body.getReader()
+        activeReader = reader
         const decoder = new TextDecoder()
         let buffer = ''
         let eventName = 'message'
@@ -653,6 +678,12 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
     return () => {
       cancelled = true
       controller.abort()
+      // Some environments don't propagate abort to the body reader; cancel
+      // explicitly so the read loop cannot hang and leak after cleanup.
+      if (activeReader) {
+        activeReader.cancel().catch(() => {})
+        activeReader = null
+      }
     }
   }, [conversationId, handleSignalEvent, skipSignalSubscription])
 


### PR DESCRIPTION
## Changes

- **Family Chat voice call hook** - Added the useVoiceCall hook that wires RTCPeerConnection to the Family Chat signalling relay: fetches STUN/TURN config, drives the offer/answer/ICE/end lifecycle, listens to call_* SSE events, and keeps an AudioContext alive so backgrounded tabs do not let the call suspend. (Hytte-go7t)

## Original Issue (task): Frontend: RTCPeerConnection wiring + call lifecycle hook

Create a useVoiceCall hook (or similar) in web/src/pages/familychat/ that: (1) fetches ICE config from /api/familychat/turn, (2) manages RTCPeerConnection lifecycle (offer/answer/ICE candidate generation), (3) POSTs each to the relay endpoints from sibling 1, (4) listens to the SSE stream for incoming call_offer/call_answer/call_ice/call_end events. Handle background-tab survival with an AudioContext kick. Expose state: idle | outgoing-ringing | incoming-ringing | active | ended. Mock PeerConnection in tests; assert correct POSTs fire on accept. This hook is consumed by the UI components in sibling 4.

---
Bead: Hytte-go7t | Branch: forge/Hytte-go7t
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->