### PR TITLE
Frontend: Call UI (phone icon, overlays, missed-call rows) (Hytte-dfjw)

### DIFF
--- a/changelog.d/Hytte-dfjw.md
+++ b/changelog.d/Hytte-dfjw.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat call UI** - Phone-icon trigger in 1:1 conversation headers, full-screen incoming-call overlay (Accept/Decline), active-call overlay with mute, speakerphone, and hang-up controls plus an elapsed-time counter, a brief "Call ended — m:ss" status banner, and missed-call tombstone rows in the bubble area with a call-back action. Operators deploying the matching coturn relay should follow the steps in `docs/familychat-turn.md` (see the "coturn deploy" section). (Hytte-dfjw)

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -85,6 +85,22 @@
       "seek": "Voice note position"
     }
   },
+  "call": {
+    "start": "Start voice call",
+    "incomingLabel": "Incoming call",
+    "ringing": "Ringing…",
+    "accept": "Accept",
+    "decline": "Decline",
+    "hangup": "Hang up",
+    "mute": "Mute",
+    "unmute": "Unmute",
+    "speakerOn": "Speaker on",
+    "speakerOff": "Speaker off",
+    "ended": "Call ended — {{duration}}",
+    "missedFrom": "Missed call from {{name}}",
+    "callBack": "Call back",
+    "dismiss": "Dismiss"
+  },
   "newModal": {
     "title": "New conversation",
     "nameLabel": "Name",

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -85,6 +85,22 @@
       "seek": "Posisjon i talemeldingen"
     }
   },
+  "call": {
+    "start": "Start talesamtale",
+    "incomingLabel": "Innkommende samtale",
+    "ringing": "Ringer…",
+    "accept": "Svar",
+    "decline": "Avvis",
+    "hangup": "Legg på",
+    "mute": "Demp",
+    "unmute": "Slå på lyd",
+    "speakerOn": "Høyttaler på",
+    "speakerOff": "Høyttaler av",
+    "ended": "Samtale avsluttet — {{duration}}",
+    "missedFrom": "Tapt anrop fra {{name}}",
+    "callBack": "Ring tilbake",
+    "dismiss": "Lukk"
+  },
   "newModal": {
     "title": "Ny samtale",
     "nameLabel": "Navn",

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -85,6 +85,22 @@
       "seek": "ตำแหน่งในข้อความเสียง"
     }
   },
+  "call": {
+    "start": "เริ่มการโทรด้วยเสียง",
+    "incomingLabel": "สายเรียกเข้า",
+    "ringing": "กำลังโทร…",
+    "accept": "รับสาย",
+    "decline": "ปฏิเสธ",
+    "hangup": "วางสาย",
+    "mute": "ปิดเสียง",
+    "unmute": "เปิดเสียง",
+    "speakerOn": "เปิดลำโพง",
+    "speakerOff": "ปิดลำโพง",
+    "ended": "สิ้นสุดการโทร — {{duration}}",
+    "missedFrom": "สายที่ไม่ได้รับจาก {{name}}",
+    "callBack": "โทรกลับ",
+    "dismiss": "ปิด"
+  },
   "newModal": {
     "title": "การสนทนาใหม่",
     "nameLabel": "ชื่อ",

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -69,6 +69,20 @@ const TRANSLATIONS: Record<string, string> = {
   'voice.bubble.play': 'Play voice note',
   'voice.bubble.pause': 'Pause voice note',
   'voice.bubble.seek': 'Voice note position',
+  'call.start': 'Start voice call',
+  'call.incomingLabel': 'Incoming call',
+  'call.ringing': 'Ringing…',
+  'call.accept': 'Accept',
+  'call.decline': 'Decline',
+  'call.hangup': 'Hang up',
+  'call.mute': 'Mute',
+  'call.unmute': 'Unmute',
+  'call.speakerOn': 'Speaker on',
+  'call.speakerOff': 'Speaker off',
+  'call.ended': 'Call ended — {{duration}}',
+  'call.missedFrom': 'Missed call from {{name}}',
+  'call.callBack': 'Call back',
+  'call.dismiss': 'Dismiss',
 }
 
 function stableT(key: string, opts?: Record<string, string | number>): string {
@@ -891,5 +905,241 @@ describe('ChatView – voice note rendering', () => {
       expect(container.querySelector('audio[controls]')).not.toBeNull()
     })
     expect(screen.queryByTestId('voice-bubble-23')).toBeNull()
+  })
+})
+
+// ── Voice call helpers / fakes ────────────────────────────────────────────────
+
+// Fake media + RTC fakes mirror the shapes used by useVoiceCall's own tests so
+// the hook's real signalling code runs against a deterministic peer
+// connection. The ChatView tests only need a couple of behavioural checks:
+//   • An incoming SSE call_offer drives the hook into 'incoming-ringing' so
+//     the overlay appears.
+//   • Clicking Accept fires the TURN fetch + the /answer POST.
+// Anything beyond that is exhaustively covered in useVoiceCall.test.tsx.
+
+interface CallFetchEntry { url: string; method: string; body?: string }
+
+class FakeAudioTrack {
+  kind = 'audio' as const
+  enabled = true
+  stop = vi.fn()
+}
+
+function makeFakeAudioStream(): MediaStream {
+  const track = new FakeAudioTrack()
+  const tracks = [track]
+  return {
+    getTracks: () => tracks,
+    getAudioTracks: () => tracks,
+    getVideoTracks: () => [],
+  } as unknown as MediaStream
+}
+
+class FakeRtcPeerConnection {
+  static instances: FakeRtcPeerConnection[] = []
+  localDescription: RTCSessionDescriptionInit | null = null
+  remoteDescription: RTCSessionDescriptionInit | null = null
+  ontrack: ((event: RTCTrackEvent) => void) | null = null
+  onicecandidate: ((event: RTCPeerConnectionIceEvent) => void) | null = null
+  oniceconnectionstatechange: (() => void) | null = null
+  onconnectionstatechange: (() => void) | null = null
+  closed = false
+  constructor() { FakeRtcPeerConnection.instances.push(this) }
+  addTrack() { return {} as RTCRtpSender }
+  async createOffer(): Promise<RTCSessionDescriptionInit> {
+    return { type: 'offer', sdp: 'v=0\r\nfake-offer' }
+  }
+  async createAnswer(): Promise<RTCSessionDescriptionInit> {
+    return { type: 'answer', sdp: 'v=0\r\nfake-answer' }
+  }
+  async setLocalDescription(d: RTCSessionDescriptionInit) { this.localDescription = d }
+  async setRemoteDescription(d: RTCSessionDescriptionInit) { this.remoteDescription = d }
+  async addIceCandidate() { /* no-op */ }
+  close() { this.closed = true }
+}
+
+// installCallEnv stubs the browser APIs the voice-call hook touches so the
+// regular ChatView SSE fetch paths can drive the call state machine without
+// poking at a real audio device.
+function installCallEnv() {
+  vi.stubGlobal('RTCPeerConnection', FakeRtcPeerConnection as unknown as typeof RTCPeerConnection)
+  const sharedStream = makeFakeAudioStream()
+  const getUserMedia = vi.fn(async () => sharedStream)
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia },
+  })
+  return { getUserMedia }
+}
+
+function uninstallCallEnv() {
+  delete (navigator as unknown as Record<string, unknown>).mediaDevices
+}
+
+describe('ChatView – call UI', () => {
+  beforeEach(() => { FakeRtcPeerConnection.instances = [] })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    uninstallCallEnv()
+  })
+
+  it('renders the phone button only for two-member conversations', async () => {
+    const conv2 = makeConversation({ id: 1, name: 'One on One', member_ids: [1, 2] })
+    installCallEnv()
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk(conv2))
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(streamOk()),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+    expect(screen.getByTestId('family-chat-call-button')).toBeInTheDocument()
+  })
+
+  it('hides the phone button for group conversations (>2 members)', async () => {
+    const group = makeConversation({ id: 1, name: 'Group', member_ids: [1, 2, 3] })
+    installCallEnv()
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk(group))
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(streamOk()),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+    expect(screen.queryByTestId('family-chat-call-button')).not.toBeInTheDocument()
+  })
+
+  it('opens the incoming-call overlay when a call_offer SSE event arrives', async () => {
+    const conv2 = makeConversation({ id: 1, name: 'One on One', member_ids: [1, 2] })
+    const sse = streamWithController()
+    installCallEnv()
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk(conv2))
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(sse.response),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    await act(async () => {
+      sse.push('call_offer', {
+        conversation_id: 1,
+        call_id: 'inbound-A',
+        from_user_id: 2,
+        data: { type: 'offer', sdp: 'v=0\r\nremote-offer' },
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('family-chat-incoming-overlay')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('family-chat-call-accept')).toBeInTheDocument()
+    expect(screen.getByTestId('family-chat-call-decline')).toBeInTheDocument()
+  })
+
+  it('accepting an incoming call fetches TURN config and POSTs an answer to the relay', async () => {
+    const conv2 = makeConversation({ id: 1, name: 'One on One', member_ids: [1, 2] })
+    const sse = streamWithController()
+    installCallEnv()
+    const callFetches: CallFetchEntry[] = []
+
+    // Single fetch handler covers every URL the test cares about: the initial
+    // conv/messages/stream triple plus the TURN + signalling POSTs that
+    // useVoiceCall fires after Accept. Using a router rather than a chain of
+    // mockResolvedValueOnce keeps the test resilient to small ordering
+    // changes in the hook's implementation.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const method = (init?.method ?? 'GET').toUpperCase()
+      const body = typeof init?.body === 'string' ? init.body : undefined
+      if (url.includes('/calls/') || url.includes('/api/familychat/turn')) {
+        callFetches.push({ url, method, body })
+      }
+      if (url.endsWith('/api/familychat/conversations/1') && method === 'GET') {
+        return new Response(JSON.stringify({ conversation: conv2 }), { status: 200 })
+      }
+      if (url.endsWith('/api/familychat/conversations/1/messages') && method === 'GET') {
+        return new Response(JSON.stringify({ messages: [] }), { status: 200 })
+      }
+      if (url.includes('/conversations/1/stream')) {
+        return sse.response as Response
+      }
+      if (url.endsWith('/api/familychat/turn')) {
+        return new Response(JSON.stringify({
+          iceServers: [{ urls: ['stun:stun.example.com:3478'] }],
+          ttl: 3600,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.includes('/calls/')) {
+        return new Response(null, { status: 204 })
+      }
+      throw new Error(`unexpected fetch ${method} ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    await act(async () => {
+      sse.push('call_offer', {
+        conversation_id: 1,
+        call_id: 'inbound-accept',
+        from_user_id: 2,
+        data: { type: 'offer', sdp: 'v=0\r\nremote-offer' },
+      })
+      await Promise.resolve()
+    })
+    await waitFor(() => screen.getByTestId('family-chat-call-accept'))
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('family-chat-call-accept'))
+    })
+
+    await waitFor(() => {
+      const turnCall = callFetches.find(c =>
+        c.method === 'GET' && c.url.endsWith('/api/familychat/turn'))
+      expect(turnCall).toBeDefined()
+    })
+    await waitFor(() => {
+      const answerCall = callFetches.find(c =>
+        c.method === 'POST' && c.url.includes('/calls/inbound-accept/answer'))
+      expect(answerCall).toBeDefined()
+    })
+
+    // After accept the UI transitions to the active overlay.
+    await waitFor(() => {
+      expect(screen.getByTestId('family-chat-active-overlay')).toBeInTheDocument()
+    })
+  })
+
+  it('renders a missed-call tombstone row when a call_end with status=missed arrives', async () => {
+    const conv2 = makeConversation({ id: 1, name: 'One on One', member_ids: [1, 2] })
+    const sse = streamWithController()
+    installCallEnv()
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(convOk(conv2))
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(sse.response),
+    )
+    renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    await act(async () => {
+      sse.push('call_end', {
+        conversation_id: 1,
+        call_id: 'missed-1',
+        from_user_id: 2,
+        status: 'missed',
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missed-call-missed-1')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('missed-call-back-missed-1')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -962,8 +962,11 @@ class FakeRtcPeerConnection {
 // installCallEnv stubs the browser APIs the voice-call hook touches so the
 // regular ChatView SSE fetch paths can drive the call state machine without
 // poking at a real audio device.
+let _originalMediaDevicesDescriptor: PropertyDescriptor | undefined
+
 function installCallEnv() {
   vi.stubGlobal('RTCPeerConnection', FakeRtcPeerConnection as unknown as typeof RTCPeerConnection)
+  _originalMediaDevicesDescriptor = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices')
   const sharedStream = makeFakeAudioStream()
   const getUserMedia = vi.fn(async () => sharedStream)
   Object.defineProperty(navigator, 'mediaDevices', {
@@ -974,7 +977,12 @@ function installCallEnv() {
 }
 
 function uninstallCallEnv() {
-  delete (navigator as unknown as Record<string, unknown>).mediaDevices
+  if (_originalMediaDevicesDescriptor !== undefined) {
+    Object.defineProperty(navigator, 'mediaDevices', _originalMediaDevicesDescriptor)
+  } else {
+    delete (navigator as unknown as Record<string, unknown>).mediaDevices
+  }
+  _originalMediaDevicesDescriptor = undefined
 }
 
 describe('ChatView – call UI', () => {

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -1,6 +1,22 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronLeft, MessageSquare, Download, X, WifiOff, Smile, MoreVertical } from 'lucide-react'
+import {
+  ChevronLeft,
+  MessageSquare,
+  Download,
+  X,
+  WifiOff,
+  Smile,
+  MoreVertical,
+  Phone,
+  PhoneOff,
+  PhoneIncoming,
+  PhoneMissed,
+  Mic,
+  MicOff,
+  Volume2,
+  VolumeX,
+} from 'lucide-react'
 import { Skeleton } from '../../components/ui/skeleton'
 import { useAuth } from '../../auth'
 import Composer from './Composer'
@@ -18,6 +34,7 @@ import { formatRelative } from './utils'
 import VoiceBubble from './voice/VoiceBubble'
 import { readCachedWaveform, parseWaveformJSON, DEFAULT_BAR_COUNT, type Waveform } from './voice/waveform'
 import * as voicePlayer from './voice/voicePlayer'
+import { useVoiceCall, type CallSignalEventName, type CallSignalPayload } from './voice/useVoiceCall'
 
 interface ChatViewProps {
   conversationId: number | null
@@ -63,6 +80,12 @@ function parseVoiceMeta(meta: string | null | undefined): Waveform | null {
 interface MemberInfo {
   label: string
   emoji: string
+}
+
+interface MissedCallEntry {
+  callId: string
+  fromUserId: number
+  receivedAt: string
 }
 
 interface FamilyChild {
@@ -117,8 +140,41 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const [deleteError, setDeleteError] = useState('')
   const deleteConfirmBtnRef = useRef<HTMLButtonElement>(null)
   const deletePrevFocusRef = useRef<Element | null>(null)
+  // missedCalls collects inbound calls the recipient never answered — surfaced
+  // as a tombstone row in the message list with a call-back button. Only
+  // populated for missed calls where the local user was the callee (we ignore
+  // missed calls that we initiated, since those aren't useful history for us).
+  const [missedCalls, setMissedCalls] = useState<MissedCallEntry[]>([])
+  // endedCallSummary is shown briefly after a call wraps up. Tracks the final
+  // duration in seconds so the banner can render "Call ended — m:ss".
+  const [endedCallSummary, setEndedCallSummary] = useState<{ durationSec: number } | null>(null)
+  // callElapsedSec is the running second-counter used by the active-call
+  // overlay. It rounds to whole seconds so the UI updates once per tick.
+  const [callElapsedSec, setCallElapsedSec] = useState(0)
+  const callStartedAtRef = useRef<number | null>(null)
+  const remoteAudioRef = useRef<HTMLAudioElement | null>(null)
+  // speakerOn: UI toggle for the speakerphone hint. The browser controls
+  // routing; this flag just drives the icon state + tries to bump volume to
+  // max so the remote stream is audible without a headset.
+  const [speakerOn, setSpeakerOn] = useState(true)
+
+  // Voice-call state machine. skipSignalSubscription is set so the hook
+  // doesn't open its own SSE stream — ChatView already owns one for messages
+  // and reactions, and routes call_* frames through handleSignalEvent below.
+  const voiceCall = useVoiceCall({
+    conversationId,
+    userId: user?.id ?? null,
+    skipSignalSubscription: true,
+  })
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  // voiceCallSignalRef shadows handleSignalEvent so the long-lived SSE reader
+  // can dispatch into the latest hook state without re-running on every
+  // re-render the hook returns a new function reference for.
+  const voiceCallSignalRef = useRef(voiceCall.handleSignalEvent)
+  useEffect(() => {
+    voiceCallSignalRef.current = voiceCall.handleSignalEvent
+  })
   // currentUserIdRef shadows user?.id so the long-lived SSE reader closure
   // (recreated only when conversationId changes) can read the most recent
   // value without forcing the effect to re-run on auth changes.
@@ -234,6 +290,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       setMessages([])
       setError('')
       setLoading(false)
+      setMissedCalls([])
+      setEndedCallSummary(null)
       return
     }
     const controller = new AbortController()
@@ -251,6 +309,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     setConversation(null)
     setStreamDropped(false)
     setHasConnected(false)
+    setMissedCalls([])
+    setEndedCallSummary(null)
 
     // appendIncoming deduplicates by id so a message that arrives via both
     // SSE and the POST response (the sender path) or via SSE and gap-fill
@@ -419,6 +479,40 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                     payload?.deleted_by !== undefined
                   ) {
                     applyMessageDeleted(payload)
+                  } else if (
+                    eventName === 'call_offer'
+                    || eventName === 'call_answer'
+                    || eventName === 'call_ice'
+                    || eventName === 'call_end'
+                  ) {
+                    // Route call signalling into the voice-call hook. We also
+                    // track missed calls locally so the bubble area can render
+                    // a tombstone-style row with a call-back button: a
+                    // call_end with status=missed from someone other than us
+                    // means we never picked up.
+                    const callPayload = payload as CallSignalPayload
+                    if (
+                      eventName === 'call_end'
+                      && callPayload?.status === 'missed'
+                      && callPayload?.from_user_id !== undefined
+                      && callPayload.from_user_id !== currentUserIdRef.current
+                    ) {
+                      setMissedCalls(prev => {
+                        if (prev.some(m => m.callId === callPayload.call_id)) return prev
+                        return [
+                          ...prev,
+                          {
+                            callId: callPayload.call_id,
+                            fromUserId: callPayload.from_user_id,
+                            receivedAt: new Date().toISOString(),
+                          },
+                        ]
+                      })
+                    }
+                    void voiceCallSignalRef.current(
+                      eventName as CallSignalEventName,
+                      callPayload,
+                    )
                   }
                 } catch {
                   // Ignore a malformed payload; the server should never emit
@@ -522,6 +616,60 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       document.body.style.overflow = prev
     }
   }, [lightbox])
+
+  // Wire the remote audio stream into the hidden <audio> element so the
+  // browser actually plays the peer's voice. The peer connection only opens
+  // the data path; the page is responsible for piping it into an audio sink.
+  useEffect(() => {
+    const el = remoteAudioRef.current
+    if (!el) return
+    if (voiceCall.remoteStream) {
+      el.srcObject = voiceCall.remoteStream
+      el.volume = speakerOn ? 1 : 0.4
+      void el.play().catch(() => {
+        // Autoplay rejection — the accept-button click already counts as a
+        // user gesture in every supported browser, but a stricter policy
+        // would surface here. Nothing actionable from this layer.
+      })
+    } else {
+      el.srcObject = null
+    }
+  }, [voiceCall.remoteStream, speakerOn])
+
+  // Drive the elapsed-time counter while a call is active. Reset on every
+  // state transition so the timer always reads from the moment we entered
+  // 'active', not from the moment startCall was first invoked.
+  useEffect(() => {
+    if (voiceCall.state !== 'active') {
+      // Capture the final elapsed seconds when the call leaves the active
+      // state so the "Call ended — m:ss" banner can show the right total.
+      if (callStartedAtRef.current !== null) {
+        const total = Math.floor((Date.now() - callStartedAtRef.current) / 1000)
+        callStartedAtRef.current = null
+        if (voiceCall.state === 'ended') {
+          setEndedCallSummary({ durationSec: total })
+        }
+      }
+      setCallElapsedSec(0)
+      return
+    }
+    callStartedAtRef.current = Date.now()
+    setCallElapsedSec(0)
+    const interval = setInterval(() => {
+      if (callStartedAtRef.current === null) return
+      setCallElapsedSec(Math.floor((Date.now() - callStartedAtRef.current) / 1000))
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [voiceCall.state])
+
+  // Auto-dismiss the "Call ended" banner after a short hold so it doesn't sit
+  // on screen indefinitely. Five seconds is long enough to read the duration
+  // and short enough not to feel sticky.
+  useEffect(() => {
+    if (!endedCallSummary) return
+    const timer = setTimeout(() => setEndedCallSummary(null), 5000)
+    return () => clearTimeout(timer)
+  }, [endedCallSummary])
 
   const handleMessageCreated = useCallback((msg: ChatMessage) => {
     // Defensive: if the user switched conversations while a send was in
@@ -690,6 +838,51 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     })
   }, [conversation, memberLookup, t, user?.id])
 
+  // Voice calls are 1:1 only — see useVoiceCall.ts. The phone button is
+  // hidden for group conversations rather than disabled so users don't see
+  // an interactive control they can't use.
+  const callPeerId = useMemo<number | null>(() => {
+    if (!conversation || user?.id === undefined) return null
+    if (conversation.member_ids.length !== 2) return null
+    return conversation.member_ids.find(id => id !== user.id) ?? null
+  }, [conversation, user?.id])
+  const canCall = callPeerId !== null
+
+  const peerLabel = useCallback((peerId: number | null) => {
+    if (peerId === null) return t('chat.memberFallback', { id: 0 })
+    return memberLookup.get(peerId)?.label ?? t('chat.memberFallback', { id: peerId })
+  }, [memberLookup, t])
+
+  const incomingCallerLabel = peerLabel(voiceCall.remoteUserId)
+  const activeCallPeerLabel = peerLabel(voiceCall.remoteUserId ?? callPeerId)
+
+  const formatCallDuration = useCallback((totalSec: number): string => {
+    const safe = Math.max(0, Math.floor(totalSec))
+    const minutes = Math.floor(safe / 60)
+    const seconds = safe % 60
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`
+  }, [])
+
+  // startOrIgnoreCall fires the outgoing-call flow only when we're idle. A
+  // second press while already ringing is a no-op so a double-tap can't kick
+  // off two parallel sessions.
+  const handleStartCall = useCallback(() => {
+    if (!canCall) return
+    if (voiceCall.state !== 'idle' && voiceCall.state !== 'ended') return
+    void voiceCall.startCall()
+  }, [canCall, voiceCall])
+
+  const handleCallBack = useCallback((entry: MissedCallEntry) => {
+    // Dismiss the row first so a successful call doesn't leave an obsolete
+    // missed-call entry behind in the message list.
+    setMissedCalls(prev => prev.filter(m => m.callId !== entry.callId))
+    handleStartCall()
+  }, [handleStartCall])
+
+  const dismissMissedCall = useCallback((callId: string) => {
+    setMissedCalls(prev => prev.filter(m => m.callId !== callId))
+  }, [])
+
   if (conversationId === null) {
     return (
       <div
@@ -755,6 +948,19 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
             <WifiOff size={12} aria-hidden="true" />
             <span className="truncate max-w-[8rem] sm:max-w-none">{t('chat.connection.reconnecting')}</span>
           </span>
+        )}
+        {canCall && (
+          <button
+            type="button"
+            onClick={handleStartCall}
+            disabled={voiceCall.state !== 'idle' && voiceCall.state !== 'ended'}
+            aria-label={t('call.start')}
+            title={t('call.start')}
+            className="shrink-0 p-2 rounded-full text-green-300 hover:text-green-200 hover:bg-green-500/15 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+            data-testid="family-chat-call-button"
+          >
+            <Phone size={20} aria-hidden="true" />
+          </button>
         )}
       </header>
 
@@ -1063,6 +1269,40 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
             </div>
           )
         })}
+
+        {!loading && !error && missedCalls.map(entry => (
+          <div
+            key={`missed-call-${entry.callId}`}
+            className="flex justify-center"
+            data-testid={`missed-call-${entry.callId}`}
+          >
+            <div className="inline-flex items-center gap-2 px-3 py-2 rounded-2xl bg-red-900/30 border border-red-700/50 text-red-200 text-xs">
+              <PhoneMissed size={14} aria-hidden="true" />
+              <span>{t('call.missedFrom', { name: peerLabel(entry.fromUserId) })}</span>
+              {canCall && (
+                <button
+                  type="button"
+                  onClick={() => handleCallBack(entry)}
+                  className="px-2 py-0.5 rounded-md bg-red-800/50 hover:bg-red-700/60 text-red-100 text-[11px] font-medium cursor-pointer"
+                  data-testid={`missed-call-back-${entry.callId}`}
+                >
+                  {t('call.callBack')}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => dismissMissedCall(entry.callId)}
+                aria-label={t('call.dismiss')}
+                title={t('call.dismiss')}
+                className="p-0.5 text-red-300 hover:text-red-100 cursor-pointer"
+                data-testid={`missed-call-dismiss-${entry.callId}`}
+              >
+                <X size={12} aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        ))}
+
         <div ref={messagesEndRef} />
       </div>
 
@@ -1130,6 +1370,164 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
               </button>
             </div>
           </div>
+        </div>
+      )}
+
+      {/* Hidden audio sink for the remote peer's stream. Kept outside the
+          conditional overlays so the element survives state transitions and
+          srcObject assignment isn't fighting React re-renders. */}
+      <audio ref={remoteAudioRef} autoPlay playsInline className="hidden" />
+
+      {voiceCall.state === 'incoming-ringing' && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="family-chat-incoming-call-title"
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/85 text-white p-6"
+          data-testid="family-chat-incoming-overlay"
+        >
+          <div className="flex flex-col items-center text-center max-w-sm">
+            <div className="mb-6 p-5 rounded-full bg-green-500/20 animate-pulse">
+              <PhoneIncoming size={48} aria-hidden="true" className="text-green-300" />
+            </div>
+            <p className="text-sm uppercase tracking-wide text-gray-400">
+              {t('call.incomingLabel')}
+            </p>
+            <h2
+              id="family-chat-incoming-call-title"
+              className="mt-2 text-2xl font-semibold"
+            >
+              {incomingCallerLabel}
+            </h2>
+            <div className="mt-8 flex items-center justify-center gap-6">
+              <button
+                type="button"
+                onClick={() => { void voiceCall.rejectCall() }}
+                aria-label={t('call.decline')}
+                className="flex flex-col items-center gap-1 text-red-300 hover:text-red-200 cursor-pointer"
+                data-testid="family-chat-call-decline"
+              >
+                <span className="p-4 rounded-full bg-red-600 text-white hover:bg-red-500">
+                  <PhoneOff size={28} aria-hidden="true" />
+                </span>
+                <span className="text-xs">{t('call.decline')}</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => { void voiceCall.acceptCall() }}
+                aria-label={t('call.accept')}
+                className="flex flex-col items-center gap-1 text-green-300 hover:text-green-200 cursor-pointer"
+                data-testid="family-chat-call-accept"
+              >
+                <span className="p-4 rounded-full bg-green-600 text-white hover:bg-green-500">
+                  <Phone size={28} aria-hidden="true" />
+                </span>
+                <span className="text-xs">{t('call.accept')}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {(voiceCall.state === 'outgoing-ringing' || voiceCall.state === 'active') && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="family-chat-active-call-title"
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/85 text-white p-6"
+          data-testid="family-chat-active-overlay"
+        >
+          <div className="flex flex-col items-center text-center max-w-sm w-full">
+            <div className="mb-6 p-5 rounded-full bg-green-500/20">
+              <Phone size={48} aria-hidden="true" className="text-green-300" />
+            </div>
+            <h2
+              id="family-chat-active-call-title"
+              className="text-2xl font-semibold"
+            >
+              {activeCallPeerLabel}
+            </h2>
+            <p
+              className="mt-2 text-sm text-gray-300"
+              data-testid="family-chat-call-status"
+            >
+              {voiceCall.state === 'outgoing-ringing'
+                ? t('call.ringing')
+                : formatCallDuration(callElapsedSec)}
+            </p>
+            {voiceCall.error && (
+              <p className="mt-2 text-xs text-red-400">{voiceCall.error}</p>
+            )}
+            <div className="mt-8 flex items-center justify-center gap-4">
+              <button
+                type="button"
+                onClick={() => voiceCall.setMuted(!voiceCall.muted)}
+                aria-label={voiceCall.muted ? t('call.unmute') : t('call.mute')}
+                aria-pressed={voiceCall.muted}
+                disabled={voiceCall.state !== 'active'}
+                className={`flex flex-col items-center gap-1 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed ${
+                  voiceCall.muted ? 'text-amber-300' : 'text-gray-200'
+                }`}
+                data-testid="family-chat-call-mute"
+              >
+                <span className={`p-3 rounded-full ${
+                  voiceCall.muted ? 'bg-amber-500/20' : 'bg-gray-700'
+                }`}>
+                  {voiceCall.muted
+                    ? <MicOff size={24} aria-hidden="true" />
+                    : <Mic size={24} aria-hidden="true" />}
+                </span>
+                <span className="text-xs">
+                  {voiceCall.muted ? t('call.unmute') : t('call.mute')}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => { void voiceCall.endCall() }}
+                aria-label={t('call.hangup')}
+                className="flex flex-col items-center gap-1 text-white cursor-pointer"
+                data-testid="family-chat-call-hangup"
+              >
+                <span className="p-4 rounded-full bg-red-600 hover:bg-red-500">
+                  <PhoneOff size={28} aria-hidden="true" />
+                </span>
+                <span className="text-xs">{t('call.hangup')}</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setSpeakerOn(prev => !prev)}
+                aria-label={speakerOn ? t('call.speakerOff') : t('call.speakerOn')}
+                aria-pressed={speakerOn}
+                disabled={voiceCall.state !== 'active'}
+                className={`flex flex-col items-center gap-1 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed ${
+                  speakerOn ? 'text-blue-300' : 'text-gray-200'
+                }`}
+                data-testid="family-chat-call-speaker"
+              >
+                <span className={`p-3 rounded-full ${
+                  speakerOn ? 'bg-blue-500/20' : 'bg-gray-700'
+                }`}>
+                  {speakerOn
+                    ? <Volume2 size={24} aria-hidden="true" />
+                    : <VolumeX size={24} aria-hidden="true" />}
+                </span>
+                <span className="text-xs">
+                  {speakerOn ? t('call.speakerOff') : t('call.speakerOn')}
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {endedCallSummary && voiceCall.state !== 'active' && voiceCall.state !== 'outgoing-ringing' && voiceCall.state !== 'incoming-ringing' && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed top-4 left-1/2 -translate-x-1/2 z-50 px-3 py-1.5 rounded-full bg-gray-800/95 border border-gray-700 text-gray-100 text-xs shadow-lg"
+          data-testid="family-chat-call-ended"
+        >
+          {t('call.ended', { duration: formatCallDuration(endedCallSummary.durationSec) })}
         </div>
       )}
     </div>

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -845,7 +845,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     if (!conversation || user?.id === undefined) return null
     if (conversation.member_ids.length !== 2) return null
     return conversation.member_ids.find(id => id !== user.id) ?? null
-  }, [conversation, user?.id])
+  }, [conversation, user])
   const canCall = callPeerId !== null
 
   const peerLabel = useCallback((peerId: number | null) => {

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -153,9 +153,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const [callElapsedSec, setCallElapsedSec] = useState(0)
   const callStartedAtRef = useRef<number | null>(null)
   const remoteAudioRef = useRef<HTMLAudioElement | null>(null)
-  // speakerOn: UI toggle for the speakerphone hint. The browser controls
-  // routing; this flag just drives the icon state + tries to bump volume to
-  // max so the remote stream is audible without a headset.
+  // speakerOn controls the remote audio volume: true = full volume (1.0),
+  // false = muted (0) so "Speaker off" means no audio is heard.
   const [speakerOn, setSpeakerOn] = useState(true)
 
   // Voice-call state machine. skipSignalSubscription is set so the hook
@@ -175,6 +174,17 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   useEffect(() => {
     voiceCallSignalRef.current = voiceCall.handleSignalEvent
   })
+  // voiceCallEndRef lets the conversationId-change cleanup end any active call
+  // on the old conversation without re-subscribing on every voice-call state change.
+  const voiceCallEndRef = useRef(voiceCall.endCall)
+  useEffect(() => {
+    voiceCallEndRef.current = voiceCall.endCall
+  })
+  // Tear down any active call when switching conversations so the mic and
+  // RTCPeerConnection don't remain active against the old conversation.
+  useEffect(() => {
+    return () => { void voiceCallEndRef.current() }
+  }, [conversationId])
   // currentUserIdRef shadows user?.id so the long-lived SSE reader closure
   // (recreated only when conversationId changes) can read the most recent
   // value without forcing the effect to re-run on auth changes.
@@ -192,7 +202,11 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // the same click. NOT set on long-press (no toggle button exists there), so
   // tapping the bubble correctly closes the picker.
   const pickerGuardRef = useRef<HTMLElement | null>(null)
+  // conversationRef mirrors the conversation state for the long-lived SSE
+  // closure so call-event gating can check member count without re-running.
+  const conversationRef = useRef<Conversation | null>(null)
   useEffect(() => { currentUserIdRef.current = user?.id }, [user?.id])
+  useEffect(() => { conversationRef.current = conversation }, [conversation])
 
   // Focus management + Escape handling for the delete confirmation modal,
   // matching the pattern used by ConfirmDialog.
@@ -485,34 +499,38 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                     || eventName === 'call_ice'
                     || eventName === 'call_end'
                   ) {
-                    // Route call signalling into the voice-call hook. We also
-                    // track missed calls locally so the bubble area can render
-                    // a tombstone-style row with a call-back button: a
-                    // call_end with status=missed from someone other than us
-                    // means we never picked up.
-                    const callPayload = payload as CallSignalPayload
-                    if (
-                      eventName === 'call_end'
-                      && callPayload?.status === 'missed'
-                      && callPayload?.from_user_id !== undefined
-                      && callPayload.from_user_id !== currentUserIdRef.current
-                    ) {
-                      setMissedCalls(prev => {
-                        if (prev.some(m => m.callId === callPayload.call_id)) return prev
-                        return [
-                          ...prev,
-                          {
-                            callId: callPayload.call_id,
-                            fromUserId: callPayload.from_user_id,
-                            receivedAt: new Date().toISOString(),
-                          },
-                        ]
-                      })
+                    // Only process call events for 1:1 conversations — group
+                    // calls are not supported; ignore call_* events from them.
+                    if (conversationRef.current?.member_ids.length === 2) {
+                      // Route call signalling into the voice-call hook. We also
+                      // track missed calls locally so the bubble area can render
+                      // a tombstone-style row with a call-back button: a
+                      // call_end with status=missed from someone other than us
+                      // means we never picked up.
+                      const callPayload = payload as CallSignalPayload
+                      if (
+                        eventName === 'call_end'
+                        && callPayload?.status === 'missed'
+                        && callPayload?.from_user_id !== undefined
+                        && callPayload.from_user_id !== currentUserIdRef.current
+                      ) {
+                        setMissedCalls(prev => {
+                          if (prev.some(m => m.callId === callPayload.call_id)) return prev
+                          return [
+                            ...prev,
+                            {
+                              callId: callPayload.call_id,
+                              fromUserId: callPayload.from_user_id,
+                              receivedAt: new Date().toISOString(),
+                            },
+                          ]
+                        })
+                      }
+                      void voiceCallSignalRef.current(
+                        eventName as CallSignalEventName,
+                        callPayload,
+                      )
                     }
-                    void voiceCallSignalRef.current(
-                      eventName as CallSignalEventName,
-                      callPayload,
-                    )
                   }
                 } catch {
                   // Ignore a malformed payload; the server should never emit
@@ -625,7 +643,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     if (!el) return
     if (voiceCall.remoteStream) {
       el.srcObject = voiceCall.remoteStream
-      el.volume = speakerOn ? 1 : 0.4
+      el.volume = speakerOn ? 1 : 0
       void el.play().catch(() => {
         // Autoplay rejection — the accept-button click already counts as a
         // user gesture in every supported browser, but a stricter policy

--- a/web/src/pages/familychat/voice/useVoiceCall.ts
+++ b/web/src/pages/familychat/voice/useVoiceCall.ts
@@ -91,10 +91,15 @@ export interface UseVoiceCallApi {
   remoteUserId: number | null
   error: string | null
   remoteStream: MediaStream | null
+  muted: boolean
   startCall: () => Promise<void>
   acceptCall: () => Promise<void>
   rejectCall: () => Promise<void>
   endCall: () => Promise<void>
+  // setMuted flips the local audio track's enabled flag so the peer stops
+  // receiving frames without dropping the WebRTC connection. Safe to call in
+  // any state — a no-op when no local track exists.
+  setMuted: (muted: boolean) => void
   // Drive the call state machine from an external signal source. Exposed so
   // tests can simulate incoming events without a real SSE connection, and so
   // an outer page that already owns an SSE stream can route call_* frames in.
@@ -168,6 +173,7 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
   const [remoteUserId, setRemoteUserId] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null)
+  const [muted, setMutedState] = useState(false)
 
   // Refs hold values the async signalling callbacks must read without
   // capturing stale closures. React state is used for things the UI needs to
@@ -241,6 +247,7 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
     }
 
     setRemoteStream(null)
+    setMutedState(false)
     pendingOfferRef.current = null
     pendingRemoteCandidatesRef.current = []
     remoteDescriptionSetRef.current = false
@@ -717,16 +724,27 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
     }
   }, [tearDown])
 
+  const setMuted = useCallback((next: boolean) => {
+    setMutedState(next)
+    const stream = localStreamRef.current
+    if (!stream) return
+    for (const track of stream.getAudioTracks()) {
+      track.enabled = !next
+    }
+  }, [])
+
   return {
     state,
     callId,
     remoteUserId,
     error,
     remoteStream,
+    muted,
     startCall,
     acceptCall,
     rejectCall,
     endCall,
+    setMuted,
     handleSignalEvent,
   }
 }

--- a/web/src/pages/familychat/voice/useVoiceCall.ts
+++ b/web/src/pages/familychat/voice/useVoiceCall.ts
@@ -725,9 +725,9 @@ export function useVoiceCall(options: UseVoiceCallOptions): UseVoiceCallApi {
   }, [tearDown])
 
   const setMuted = useCallback((next: boolean) => {
-    setMutedState(next)
     const stream = localStreamRef.current
     if (!stream) return
+    setMutedState(next)
     for (const track of stream.getAudioTracks()) {
       track.enabled = !next
     }


### PR DESCRIPTION
## Changes

- **Family Chat call UI** - Phone-icon trigger in 1:1 conversation headers, full-screen incoming-call overlay (Accept/Decline), active-call overlay with mute, speakerphone, and hang-up controls plus an elapsed-time counter, a brief "Call ended — m:ss" status banner, and missed-call tombstone rows in the bubble area with a call-back action. Operators deploying the matching coturn relay should follow the steps in `docs/familychat-turn.md` (see the "coturn deploy" section). (Hytte-dfjw)

## Original Issue (task): Frontend: Call UI (phone icon, overlays, missed-call rows)

Modify web/src/pages/familychat/ChatView.tsx to add: (1) phone icon in the conversation header that triggers the outgoing-call flow from sibling 3's hook, (2) full-screen incoming-call overlay (caller name, Accept/Decline), (3) active-call overlay with mute/speaker/hangup buttons and elapsed timer, (4) brief 'Call ended — m:ss' status, (5) tombstone-style 'missed call' system row in the bubble area with a call-back button (rendered when a call_end with reason=missed arrives). Tests: incoming call_offer opens the accept overlay; accepting fires the right POSTs. Add Changelog fragment (category: Added) noting the coturn-deploy doc location. Ensure make build, make test, npm run lint, npm run build pass.

---
Bead: Hytte-dfjw | Branch: forge/Hytte-dfjw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->