### PR TITLE
Fix weekday navigation skipping over Norwegian public holidays (Hytte-vxrw)

### DIFF
--- a/changelog.d/Hytte-vxrw.md
+++ b/changelog.d/Hytte-vxrw.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Workhours daily nav skips Norwegian public holidays** - `prevWeekday`, `nextWeekday`, `getInitialDate`, and the date picker on the daily Workhours view now skip Norwegian public holidays as well as weekends, so opening the page on a holiday or stepping back from the day after a holiday lands on the prior actual working day. (Hytte-vxrw)

--- a/web/src/pages/WorkHoursPage.tsx
+++ b/web/src/pages/WorkHoursPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Building2, Calendar, ChevronLeft, ChevronRight, Clock, Copy, Plus, Settings, Trash2 } from 'lucide-react'
 import { formatDate } from '../utils/formatDate'
@@ -109,27 +109,27 @@ function localDateStr(d: Date): string {
   return `${y}-${m}-${day}`
 }
 
-function getInitialDate(): string {
+function getInitialDate(holidays: Set<string>): string {
   const d = new Date()
-  while (d.getDay() === 0 || d.getDay() === 6) {
+  while (d.getDay() === 0 || d.getDay() === 6 || holidays.has(localDateStr(d))) {
     d.setDate(d.getDate() - 1)
   }
   return localDateStr(d)
 }
 
-function prevWeekday(date: string): string {
+function prevWeekday(date: string, holidays: Set<string>): string {
   const d = new Date(date + 'T12:00:00')
   d.setDate(d.getDate() - 1)
-  while (d.getDay() === 0 || d.getDay() === 6) {
+  while (d.getDay() === 0 || d.getDay() === 6 || holidays.has(localDateStr(d))) {
     d.setDate(d.getDate() - 1)
   }
   return localDateStr(d)
 }
 
-function nextWeekday(date: string): string {
+function nextWeekday(date: string, holidays: Set<string>): string {
   const d = new Date(date + 'T12:00:00')
   d.setDate(d.getDate() + 1)
-  while (d.getDay() === 0 || d.getDay() === 6) {
+  while (d.getDay() === 0 || d.getDay() === 6 || holidays.has(localDateStr(d))) {
     d.setDate(d.getDate() + 1)
   }
   return localDateStr(d)
@@ -294,6 +294,16 @@ function getNorwegianHolidays(year: number): Map<string, string> {
   return m
 }
 
+// Build a holiday set covering the given year and its adjacent years so that
+// day-by-day navigation across year boundaries (Dec↔Jan) never loses holidays.
+function buildNavHolidaySet(year: number): Set<string> {
+  return new Set<string>([
+    ...getNorwegianHolidays(year - 1).keys(),
+    ...getNorwegianHolidays(year).keys(),
+    ...getNorwegianHolidays(year + 1).keys(),
+  ])
+}
+
 function currentTimeHHMM(): string {
   const now = new Date()
   return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
@@ -305,7 +315,9 @@ function currentTimeHHMM(): string {
 export default function WorkHoursPage() {
   const { t } = useTranslation(['workhours', 'common'])
   const [activeTab, setActiveTab] = useState<ViewMode>('day')
-  const [currentDate, setCurrentDate] = useState(getInitialDate)
+  const [currentDate, setCurrentDate] = useState<string>(() =>
+    getInitialDate(buildNavHolidaySet(new Date().getFullYear()))
+  )
 
   function handleSelectDay(date: string) {
     setCurrentDate(date)
@@ -385,6 +397,9 @@ function DayView({
   onNavigateToSettings: () => void
 }) {
   const { t } = useTranslation(['workhours', 'common'])
+
+  const navYear = parseInt(currentDate.split('-')[0])
+  const navHolidaySet = useMemo(() => buildNavHolidaySet(navYear), [navYear])
 
   const currentDateRef = useRef(currentDate)
   const leaveDaysCacheRef = useRef<Map<string, LeaveDay[]>>(new Map())
@@ -882,7 +897,7 @@ function DayView({
 
   const handleCopyYesterday = async () => {
     if (sessions.length > 0) return
-    const yesterday = prevWeekday(currentDate)
+    const yesterday = prevWeekday(currentDate, navHolidaySet)
     setSaving(true)
     try {
       const r = await fetch(`/api/workhours/day?date=${encodeURIComponent(yesterday)}`, {
@@ -990,7 +1005,7 @@ function DayView({
       <div className="flex items-center justify-between bg-gray-800 rounded-lg p-3">
         <button
           type="button"
-          onClick={() => setCurrentDate(prev => prevWeekday(prev))}
+          onClick={() => setCurrentDate(prev => prevWeekday(prev, navHolidaySet))}
           className="p-1 text-gray-400 hover:text-white transition-colors cursor-pointer"
           aria-label={t('workhours:prevDay')}
         >
@@ -1023,7 +1038,7 @@ function DayView({
             onChange={e => {
               if (!e.target.value) return
               const d = new Date(e.target.value + 'T12:00:00')
-              while (d.getDay() === 0 || d.getDay() === 6) {
+              while (d.getDay() === 0 || d.getDay() === 6 || navHolidaySet.has(localDateStr(d))) {
                 d.setDate(d.getDate() - 1)
               }
               setCurrentDate(localDateStr(d))
@@ -1035,7 +1050,7 @@ function DayView({
         </div>
         <button
           type="button"
-          onClick={() => setCurrentDate(prev => nextWeekday(prev))}
+          onClick={() => setCurrentDate(prev => nextWeekday(prev, navHolidaySet))}
           className="p-1 text-gray-400 hover:text-white transition-colors cursor-pointer"
           aria-label={t('workhours:nextDay')}
         >

--- a/web/src/pages/WorkHoursPage.tsx
+++ b/web/src/pages/WorkHoursPage.tsx
@@ -1038,7 +1038,9 @@ function DayView({
             onChange={e => {
               if (!e.target.value) return
               const d = new Date(e.target.value + 'T12:00:00')
-              while (d.getDay() === 0 || d.getDay() === 6 || navHolidaySet.has(localDateStr(d))) {
+              const pickedYear = d.getFullYear()
+              const pickedHolidaySet = buildNavHolidaySet(pickedYear)
+              while (d.getDay() === 0 || d.getDay() === 6 || pickedHolidaySet.has(localDateStr(d))) {
                 d.setDate(d.getDate() - 1)
               }
               setCurrentDate(localDateStr(d))


### PR DESCRIPTION
## Changes

- **Workhours daily nav skips Norwegian public holidays** - `prevWeekday`, `nextWeekday`, `getInitialDate`, and the date picker on the daily Workhours view now skip Norwegian public holidays as well as weekends, so opening the page on a holiday or stepping back from the day after a holiday lands on the prior actual working day. (Hytte-vxrw)

## Original Issue (feature): Fix weekday navigation skipping over Norwegian public holidays

### Scope
Update the weekday navigation helpers in `WorkHoursPage.tsx` so `prevWeekday`, `nextWeekday`, and `getInitialDate` skip Norwegian public holidays in addition to weekends, by reusing the existing `getNorwegianHolidays()` map. Also ensure the daily-page caller passes its holiday set into `countWorkdaysUpToNow` (the function already accepts one, but the daily page may not pass it). Visible impact: opening the page on 17. mai (or other holidays) lands on the previous actual workday, and stepping back from the day after a holiday correctly skips over it.

### Files to touch
- `web/src/pages/WorkHoursPage.tsx` — update `getInitialDate`, `prevWeekday`, `nextWeekday` signatures to accept a holiday `Set<string>`; update all call sites (initial state, nav buttons, `yesterday` lookup on ~line 885) to pass a holiday set covering the relevant year(s); ensure the daily-page progress bar uses `countWorkdaysUpToNow(monthStr, holidaySet)` so it matches the month grid.

### Acceptance criteria
- `prevWeekday(date, holidays)` and `nextWeekday(date, holidays)` skip any date in `holidays` as well as Sat/Sun, and never return a holiday or weekend.
- `getInitialDate(holidays)` returns the most recent non-weekend, non-holiday date ≤ today.
- Loading `/workhours` on a Norwegian public holiday (e.g. 17. mai 2026, a Sunday — pick a weekday holiday like 1. mai 2026 / Kristi himmelfartsdag) lands on the prior working weekday, not the holiday itself.
- From a Tuesday immediately after a Monday public holiday, clicking "previous day" lands on the prior Friday, skipping Monday.
- The daily page's "workdays so far this month" progress matches the count of non-dimmed weekday cells in the month grid for the same month (i.e. both exclude holidays consistently).
- Holiday set passed to nav helpers covers both the current year and the adjacent year so December↔January transitions don't lose holidays (mirrors the pattern already used in the week/month views).
- All existing `WorkHoursPage` rendering (holiday notice banner, holiday cell labels in week/month grids, leave balance section) continues to work unchanged.
- `npm run lint`, `npm run build`, and `go build ./...` all pass.

### Non-goals
- No backend changes to `internal/workhours/` — holidays are already computed client-side via `getNorwegianHolidays()`.
- No change to the holiday list / algorithm itself (Easter computation, etc.).
- No change to week navigation (`addWeeks`) or month navigation — only daily nav is affected.
- No new i18n strings, no new API endpoint, no schema change.
- Not touching `countWorkdaysInMonth` semantics — only verifying the daily page passes the same `holidaySet` it already builds.

## Source

Created from Suggestions page (suggestion id 106, page slug "workhours", source=claude).

## Original suggestion

`prevWeekday`/`nextWeekday` and `getInitialDate` only skip Saturday and Sunday, but the backend already tracks Norwegian public holidays (commit 41e0f22) and the leave system records them per-user. On a holiday like 17. mai the page lands on a non-working day with empty summaries, which is confusing on Monday morning when the user expects to land on the previous actual workday. Pass the known holiday set into the navigation helpers so they skip both weekends and holidays, and reuse it in `countWorkdaysUpToNow` so the month progress bar matches reality. Visible impact: opening the page on a holiday or stepping back from Tuesday after Monday's holiday lands on the right day.


---
Bead: Hytte-vxrw | Branch: forge/Hytte-vxrw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->