### PR TITLE
Use server-supplied LTV ceiling on the loan card instead of hardcoded 0.85 / "85%" (Hytte-2m05)

### DIFF
--- a/changelog.d/Hytte-2m05.md
+++ b/changelog.d/Hytte-2m05.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Loan LTV ceiling sourced from backend** - The loan list card now reads the LTV ceiling and locale-aware percentage label from the server's `ltv_max` field (via `GET /api/budget/loans`) instead of hardcoding `0.85` and the literal `"85%"`, matching the expanded amortization view. (Hytte-2m05)

--- a/internal/budget/loans.go
+++ b/internal/budget/loans.go
@@ -16,8 +16,8 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// DefaultLTVMax is the regulatory LTV ceiling used to colour the loan UI
-// (Norwegian mortgages cap residential LTV at 85%).
+// DefaultLTVMax is the default regulatory LTV ceiling used to colour the loan UI.
+// This is the standard cap for Norwegian residential mortgages.
 const DefaultLTVMax = 0.85
 
 // -- Loan store --

--- a/internal/budget/loans.go
+++ b/internal/budget/loans.go
@@ -16,6 +16,10 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// DefaultLTVMax is the regulatory LTV ceiling used to colour the loan UI
+// (Norwegian mortgages cap residential LTV at 85%).
+const DefaultLTVMax = 0.85
+
 // -- Loan store --
 
 // CreateLoan inserts a new loan for the given user and sets l.ID.
@@ -464,14 +468,15 @@ func LoansListHandler(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list loans"})
 			return
 		}
-		// Annotate each loan with its LTV ratio.
+		// Annotate each loan with its LTV ratio and the regulatory ceiling.
 		type loanWithLTV struct {
 			Loan
 			LTVRatio float64 `json:"ltv_ratio"`
+			LTVMax   float64 `json:"ltv_max"`
 		}
 		out := make([]loanWithLTV, len(loans))
 		for i, l := range loans {
-			out[i] = loanWithLTV{Loan: l, LTVRatio: LTV(&loans[i])}
+			out[i] = loanWithLTV{Loan: l, LTVRatio: LTV(&loans[i]), LTVMax: DefaultLTVMax}
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"loans": out})
 	}
@@ -672,11 +677,11 @@ func LoansAmortizationHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"loan":          loan,
-			"amortization":  rows,
-			"rate_changes":  rateChanges,
-			"ltv_ratio":     LTV(loan),
-			"ltv_max":       0.85,
+			"loan":         loan,
+			"amortization": rows,
+			"rate_changes": rateChanges,
+			"ltv_ratio":    LTV(loan),
+			"ltv_max":      DefaultLTVMax,
 		})
 	}
 }

--- a/internal/budget/loans_test.go
+++ b/internal/budget/loans_test.go
@@ -300,6 +300,48 @@ func TestLoansListHandler_Empty(t *testing.T) {
 	}
 }
 
+func TestLoansListHandler_ExposesLTVMax(t *testing.T) {
+	db := setupTestDB(t)
+
+	l := &Loan{
+		Name:           "Mortgage",
+		StartDate:      "2020-01-01",
+		Principal:      3000000,
+		CurrentBalance: 2800000,
+		AnnualRate:     0.048,
+		MonthlyPayment: 15000,
+		TermMonths:     240,
+		PropertyValue:  4000000,
+	}
+	if err := CreateLoan(db, 1, l); err != nil {
+		t.Fatalf("CreateLoan: %v", err)
+	}
+
+	req := withUser(httptest.NewRequest("GET", "/api/budget/loans", nil), 1)
+	rec := httptest.NewRecorder()
+	LoansListHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Loans []struct {
+			Loan
+			LTVRatio float64 `json:"ltv_ratio"`
+			LTVMax   float64 `json:"ltv_max"`
+		} `json:"loans"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Loans) != 1 {
+		t.Fatalf("expected 1 loan, got %d", len(body.Loans))
+	}
+	if body.Loans[0].LTVMax != DefaultLTVMax {
+		t.Errorf("ltv_max = %v, want %v", body.Loans[0].LTVMax, DefaultLTVMax)
+	}
+}
+
 func TestLoansCreateHandler_Success(t *testing.T) {
 	db := setupTestDB(t)
 
@@ -496,8 +538,8 @@ func TestLoansAmortizationHandler_Success(t *testing.T) {
 	if len(body.Amortization) != 12 {
 		t.Errorf("expected 12 rows, got %d", len(body.Amortization))
 	}
-	if body.LTVMax != 0.85 {
-		t.Errorf("ltv_max = %v, want 0.85", body.LTVMax)
+	if body.LTVMax != DefaultLTVMax {
+		t.Errorf("ltv_max = %v, want %v", body.LTVMax, DefaultLTVMax)
 	}
 }
 

--- a/web/src/pages/BudgetLoan.tsx
+++ b/web/src/pages/BudgetLoan.tsx
@@ -3,14 +3,12 @@ import { Link } from 'react-router-dom'
 import { ArrowLeft, Home, Plus, Pencil, Trash2, ChevronDown, ChevronUp } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { Loan } from './budget/loan/types'
+import { DEFAULT_LTV_MAX } from './budget/loan/types'
 import { fmt, fmtPct, effectiveRate, localDateString } from './budget/loan/format'
 import { LoanForm } from './budget/loan/LoanForm'
 import { AmortizationTable } from './budget/loan/AmortizationTable'
 import { useLoans } from './budget/loan/useLoans'
 
-// Fallback if the server hasn't started returning ltv_max yet (e.g. during rollout).
-// Kept in one place so the list card still renders sensibly without it.
-const FALLBACK_LTV_MAX = 0.85
 
 const EMPTY_LOAN: Omit<Loan, 'id'> = {
   name: '',
@@ -113,7 +111,7 @@ export default function BudgetLoan() {
           const isEditing = editingLoan?.id === loan.id
           const isAmortOpen = expandedAmortization === loan.id
           const ltvPct = loan.ltv_ratio ?? 0
-          const ltvMax = loan.ltv_max ?? FALLBACK_LTV_MAX
+          const ltvMax = loan.ltv_max ?? DEFAULT_LTV_MAX
           const ltvOk = ltvPct <= ltvMax
 
           return (

--- a/web/src/pages/BudgetLoan.tsx
+++ b/web/src/pages/BudgetLoan.tsx
@@ -8,6 +8,10 @@ import { LoanForm } from './budget/loan/LoanForm'
 import { AmortizationTable } from './budget/loan/AmortizationTable'
 import { useLoans } from './budget/loan/useLoans'
 
+// Fallback if the server hasn't started returning ltv_max yet (e.g. during rollout).
+// Kept in one place so the list card still renders sensibly without it.
+const FALLBACK_LTV_MAX = 0.85
+
 const EMPTY_LOAN: Omit<Loan, 'id'> = {
   name: '',
   principal: 0,
@@ -109,7 +113,8 @@ export default function BudgetLoan() {
           const isEditing = editingLoan?.id === loan.id
           const isAmortOpen = expandedAmortization === loan.id
           const ltvPct = loan.ltv_ratio ?? 0
-          const ltvOk = ltvPct <= 0.85
+          const ltvMax = loan.ltv_max ?? FALLBACK_LTV_MAX
+          const ltvOk = ltvPct <= ltvMax
 
           return (
             <div key={loan.id} className="bg-gray-800 rounded-xl overflow-hidden">
@@ -173,12 +178,12 @@ export default function BudgetLoan() {
                   <div className="mt-3">
                     <div className="flex justify-between text-xs text-gray-500 mb-1">
                       <span>{t('loan.ltv')}</span>
-                      <span>{t('loan.ltvMax', { pct: '85%' })}</span>
+                      <span>{t('loan.ltvMax', { pct: fmtPct(ltvMax) })}</span>
                     </div>
                     <div className="bg-gray-700 rounded-full h-1.5">
                       <div
                         className={`h-1.5 rounded-full transition-all ${ltvOk ? 'bg-green-500' : 'bg-red-500'}`}
-                        style={{ width: `${Math.min(ltvPct / 0.85, 1) * 100}%` }}
+                        style={{ width: `${Math.min(ltvMax > 0 ? ltvPct / ltvMax : 0, 1) * 100}%` }}
                       />
                     </div>
                   </div>

--- a/web/src/pages/budget/loan/types.ts
+++ b/web/src/pages/budget/loan/types.ts
@@ -13,6 +13,7 @@ export interface Loan {
   property_name: string
   notes: string
   ltv_ratio?: number
+  ltv_max?: number
 }
 
 export interface AmortizationRow {

--- a/web/src/pages/budget/loan/types.ts
+++ b/web/src/pages/budget/loan/types.ts
@@ -1,3 +1,6 @@
+/** Default regulatory LTV ceiling – mirrors backend DefaultLTVMax in internal/budget/loans.go. */
+export const DEFAULT_LTV_MAX = 0.85
+
 export interface Loan {
   id: number
   name: string


### PR DESCRIPTION
## Changes

- **Loan LTV ceiling sourced from backend** - The loan list card now reads the LTV ceiling and locale-aware percentage label from the server's `ltv_max` field (via `GET /api/budget/loans`) instead of hardcoding `0.85` and the literal `"85%"`, matching the expanded amortization view. (Hytte-2m05)

## Original Issue (feature): Use server-supplied LTV ceiling on the loan card instead of hardcoded 0.85 / "85%"

### Scope
Eliminate the hardcoded `0.85` / `"85%"` LTV ceiling from the loan list card by extracting the value to a shared backend constant, returning it from `GET /api/budget/loans`, and routing the frontend display through `fmtPct(ltvMax)`. The amortization endpoint and `AmortizationTable` already do this correctly and will reuse the same constant.

### Files to touch
- `internal/budget/loans.go` — define an exported constant (e.g. `DefaultLTVMax = 0.85`), use it in both `LoansAmortizationHandler` (replace the inline `0.85`) and add an `LTVMax` field to the `loanWithLTV` struct in `LoansListHandler`.
- `internal/budget/loans_test.go` — add/extend a test asserting `GET /api/budget/loans` items carry `ltv_max`; update existing amortization test to reference the constant instead of the literal `0.85` if desired.
- `web/src/pages/budget/loan/types.ts` — add `ltv_max?: number` to the `Loan` interface (optional for backwards safety during rollout).
- `web/src/pages/BudgetLoan.tsx` — read `loan.ltv_max` for the threshold comparison, bar-fill calculation, and the `t('loan.ltvMax', { pct: fmtPct(...) })` label. Fall back to a single shared default only if the field is missing.
- `changelog.d/` — new fragment under `Fixed` referencing the bead ID.

### Acceptance criteria
- `GET /api/budget/loans` response includes `ltv_max` on every loan (currently `0.85`) and `GET /api/budget/loans/{id}/amortization` continues to return the same value, sourced from a single backend constant.
- In `BudgetLoan.tsx`, no occurrence of the literal `0.85` or the string `'85%'` remains; the red/green colour, bar width, and cap label are all derived from the response.
- The displayed cap goes through `fmtPct`, so it shows a locale-aware percent (e.g. matches what `AmortizationTable` already renders for the same loan).
- Changing the backend constant to a different value (e.g. `0.80`) produces a consistent threshold, bar fill, and label across both the list card and the expanded amortization view without any frontend code changes.
- Backend `go test ./internal/budget/...` passes, including a check that the list endpoint exposes `ltv_max`.
- `npm run lint` and `npm run build` pass; the page still renders for loans with and without a `property_value`.

### Non-goals
- Making `ltv_max` user- or property-specific, or persisting it in the database.
- Refactoring `AmortizationTable.tsx` (already correct) or the shared `format.ts` helpers.
- Touching unrelated hardcoded constants elsewhere (e.g. `MyChoresPage.tsx` line 347).
- Adding a settings UI to configure the ceiling.
- Translating the bead-card body or expanding i18n coverage beyond the `loan.ltvMax` interpolation already in place.

## Source

Created from Suggestions page (suggestion id 137, page slug "budget-loans", source=claude).

## Original suggestion

The loan card hardcodes the LTV threshold in three places — `ltvOk = ltvPct <= 0.85`, the bar fill `Math.min(ltvPct / 0.85, 1)`, and the literal string `pct: '85%'` passed to `t('loan.ltvMax')` — while the amortization endpoint already returns `ltv_max` (currently 0.85) and the expanded view uses it correctly. If the regulatory ceiling changes (or becomes user/property-specific), the list view will color the wrong loans red and display the wrong cap; the literal `'85%'` also bypasses `fmtPct` so the percent sign isn't locale-aware. Plumb `ltv_max` through `GET /api/budget/loans` (or hoist it into a constant shared with the AmortizationTable) and route the displayed cap through `fmtPct(ltvMax)`. The user sees a single source of truth and correctly localised percentages.


---
Bead: Hytte-2m05 | Branch: forge/Hytte-2m05
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->