### PR TITLE
Virtualise the transaction list and memoise GroupSection totals (Hytte-ah6y)

### DIFF
--- a/changelog.d/Hytte-ah6y.md
+++ b/changelog.d/Hytte-ah6y.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Faster Credit Cards transaction list** - Virtualised the per-group transaction rows with `react-window` and memoised `GroupSection`/`TransactionItem` plus the per-group totals so the page stays smooth with 1000+ transactions. Assigning a single transaction now re-renders only the affected row instead of every sibling. (Hytte-ah6y)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,6 +25,7 @@
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.15.1",
         "react-syntax-highlighter": "^16.1.1",
+        "react-window": "^2.2.7",
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.6.0",
@@ -6491,6 +6492,16 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.2.7.tgz",
+      "integrity": "sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/recharts": {

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.15.1",
     "react-syntax-highlighter": "^16.1.1",
+    "react-window": "^2.2.7",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0",

--- a/web/src/pages/BudgetCreditCards.test.tsx
+++ b/web/src/pages/BudgetCreditCards.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import BudgetCreditCards from './BudgetCreditCards'
+import BudgetCreditCards, { computeGroupTotals } from './BudgetCreditCards'
 import enBudget from '../../public/locales/en/budget.json'
 
 // ── Translation helpers ───────────────────────────────────────────────────────
@@ -626,5 +626,148 @@ describe('BudgetCreditCards – import preview modal', () => {
     await waitFor(() => {
       expect(screen.getByText('No new transactions in this file.')).toBeInTheDocument()
     })
+  })
+})
+
+// ── Group totals semantics ────────────────────────────────────────────────────
+// Verifies that the memoised per-group totals preserve the legacy
+// filter+reduce behaviour: carry-overs (deferred_from_previous_month) are
+// counted, rows deferred forward out of the month are excluded, and
+// innbetalinger are tracked separately.
+
+interface TxFixture {
+  id: number
+  transaksjonsdato: string
+  beskrivelse: string
+  belop: number
+  belop_i_valuta: number
+  is_pending: boolean
+  is_innbetaling: boolean
+  deferred_to_next_month: boolean
+  deferred_from_previous_month: boolean
+  group_id: number | null
+  group_name: string
+}
+
+function makeTx(overrides: Partial<TxFixture> & { id: number; belop: number }): TxFixture {
+  return {
+    transaksjonsdato: '2024-01-15',
+    beskrivelse: `Tx ${overrides.id}`,
+    belop_i_valuta: 0,
+    is_pending: false,
+    is_innbetaling: false,
+    deferred_to_next_month: false,
+    deferred_from_previous_month: false,
+    group_id: 2,
+    group_name: 'Groceries',
+    ...overrides,
+  }
+}
+
+describe('computeGroupTotals', () => {
+  it('sums plain expenses', () => {
+    const totals = computeGroupTotals([
+      makeTx({ id: 1, belop: -100 }),
+      makeTx({ id: 2, belop: -250 }),
+    ])
+    expect(totals.expenseTotal).toBe(350)
+    expect(totals.innbetalingTotal).toBe(0)
+  })
+
+  it('counts carry-overs from the previous month', () => {
+    const totals = computeGroupTotals([
+      makeTx({ id: 1, belop: -100 }),
+      // Carry-over: both flags true while still being displayed in this month.
+      makeTx({ id: 2, belop: -50, deferred_from_previous_month: true, deferred_to_next_month: true }),
+    ])
+    expect(totals.expenseTotal).toBe(150)
+  })
+
+  it('excludes rows deferred forward out of this month', () => {
+    const totals = computeGroupTotals([
+      makeTx({ id: 1, belop: -100 }),
+      // Deferred forward: to_next=true, from_prev=false → excluded.
+      makeTx({ id: 2, belop: -30, deferred_to_next_month: true }),
+    ])
+    expect(totals.expenseTotal).toBe(100)
+  })
+
+  it('keeps innbetalinger out of the expense total', () => {
+    const totals = computeGroupTotals([
+      makeTx({ id: 1, belop: -100 }),
+      makeTx({ id: 2, belop: 200, is_innbetaling: true }),
+    ])
+    expect(totals.expenseTotal).toBe(100)
+    expect(totals.innbetalingTotal).toBe(200)
+  })
+
+  it('returns a payments-only group with zero expenses', () => {
+    const totals = computeGroupTotals([
+      makeTx({ id: 1, belop: 500, is_innbetaling: true }),
+    ])
+    expect(totals.expenseTotal).toBe(0)
+    expect(totals.innbetalingTotal).toBe(500)
+  })
+
+  it('combines all cases the page actually displays', () => {
+    const totals = computeGroupTotals([
+      makeTx({ id: 1, belop: -100 }),
+      makeTx({ id: 2, belop: -50, deferred_from_previous_month: true, deferred_to_next_month: true }),
+      makeTx({ id: 3, belop: -30, deferred_to_next_month: true }),
+      makeTx({ id: 4, belop: 200, is_innbetaling: true }),
+    ])
+    // -100 + carry-over -50 = 150 (deferred-away -30 excluded)
+    expect(totals.expenseTotal).toBe(150)
+    expect(totals.innbetalingTotal).toBe(200)
+  })
+})
+
+// ── 1000-row virtualisation smoke test ────────────────────────────────────────
+// Verifies that rendering ~1000 transactions does not crash and that
+// virtualisation kicks in: the first row mounts but rows far below the
+// visible area do not.
+
+describe('BudgetCreditCards – large transaction list', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('renders the first row of a 1000-transaction group without mounting all rows', async () => {
+    const manyTxns = Array.from({ length: 1000 }, (_, i) => ({
+      id: i + 100,
+      transaksjonsdato: '2024-01-01',
+      beskrivelse: `Test Transaction ${i + 1}`,
+      belop: -(i + 1),
+      belop_i_valuta: 0,
+      is_pending: false,
+      is_innbetaling: false,
+      deferred_to_next_month: false,
+      deferred_from_previous_month: false,
+      group_id: 2,
+      group_name: 'Groceries',
+    }))
+
+    vi.stubGlobal(
+      'fetch',
+      makeFetchMock({
+        transactions: {
+          transactions: manyTxns,
+          variable_bill_name: null,
+          variable_bill_amount: 0,
+          opening_balance: 0,
+        },
+      }),
+    )
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Transaction 1')).toBeInTheDocument()
+    })
+
+    // Virtualisation guarantee: rows far beyond the visible viewport should
+    // not be mounted into the DOM.
+    expect(screen.queryByText('Test Transaction 1000')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -659,10 +659,6 @@ export default function BudgetCreditCards() {
   useEffect(() => { transactionsRef.current = transactions }, [transactions])
   useEffect(() => { groupsRef.current = groups }, [groups])
 
-  // Previous per-group transaction arrays. Used to reuse the same array
-  // reference for groups whose contents haven't changed between renders so
-  // that React.memo on `GroupSection` can short-circuit unaffected groups.
-  const byGroupIdRef = useRef<Map<number | null, Transaction[]>>(new Map())
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- reset result when selection changes
     setReapplyResult(null)
@@ -982,27 +978,14 @@ export default function BudgetCreditCards() {
     [groups],
   )
 
-  // Group transactions by group_id with structural sharing: groups whose
-  // contents haven't changed reuse the previous array reference so that
-  // memoised GroupSection instances can short-circuit.
+  // Group transactions by group_id
   const byGroupId = useMemo(() => {
-    const fresh = new Map<number | null, Transaction[]>()
+    const result = new Map<number | null, Transaction[]>()
     for (const tx of transactions) {
       const key = tx.group_id
-      if (!fresh.has(key)) fresh.set(key, [])
-      fresh.get(key)!.push(tx)
+      if (!result.has(key)) result.set(key, [])
+      result.get(key)!.push(tx)
     }
-    const result = new Map<number | null, Transaction[]>()
-    const prev = byGroupIdRef.current
-    for (const [groupId, txs] of fresh) {
-      const prevTxs = prev.get(groupId)
-      if (prevTxs && prevTxs.length === txs.length && prevTxs.every((p, i) => p === txs[i])) {
-        result.set(groupId, prevTxs)
-      } else {
-        result.set(groupId, txs)
-      }
-    }
-    byGroupIdRef.current = result
     return result
   }, [transactions])
 

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo, memo, type ChangeEvent } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo, useReducer, memo, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { Link } from 'react-router-dom'
@@ -984,32 +984,40 @@ export default function BudgetCreditCards() {
     [groups],
   )
 
-  // Tracks the previous grouping so we can preserve per-group array references
-  // for unchanged groups (see byGroupId below).
-  const prevByGroupIdRef = useRef(new Map<number | null, Transaction[]>())
-
-  // Group transactions by group_id. After building the new map we compare each
-  // group's transactions to the previous run: if every transaction object
-  // reference is identical (setTransactions uses structural updates that keep
-  // unchanged objects stable), we reuse the old array so React.memo(GroupSection)
-  // and the per-group useMemo([transactions]) inside it can short-circuit for
-  // groups that weren't touched by an optimistic update.
-  const byGroupId = useMemo(() => {
-    const next = new Map<number | null, Transaction[]>()
-    for (const tx of transactions) {
-      const key = tx.group_id
-      if (!next.has(key)) next.set(key, [])
-      next.get(key)!.push(tx)
-    }
-    const prev = prevByGroupIdRef.current
-    for (const [key, arr] of next) {
-      const old = prev.get(key)
-      if (old && old.length === arr.length && old.every((t, i) => t === arr[i])) {
-        next.set(key, old)
+  // Group transactions by group_id. The reducer preserves per-group array
+  // references for unchanged groups so React.memo(GroupSection) can
+  // short-circuit for groups not touched by an optimistic update.
+  // useLayoutEffect keeps it in sync synchronously after commit (before paint)
+  // so there is no visible flicker.
+  const [byGroupId, updateByGroupId] = useReducer(
+    (prev: Map<number | null, Transaction[]>, txs: Transaction[]) => {
+      const next = new Map<number | null, Transaction[]>()
+      for (const tx of txs) {
+        const key = tx.group_id
+        if (!next.has(key)) next.set(key, [])
+        next.get(key)!.push(tx)
       }
-    }
-    prevByGroupIdRef.current = next
-    return next
+      for (const [key, arr] of next) {
+        const old = prev.get(key)
+        if (old && old.length === arr.length && old.every((t, i) => t === arr[i])) {
+          next.set(key, old)
+        }
+      }
+      return next
+    },
+    transactions,
+    (txs: Transaction[]) => {
+      const map = new Map<number | null, Transaction[]>()
+      for (const tx of txs) {
+        const key = tx.group_id
+        if (!map.has(key)) map.set(key, [])
+        map.get(key)!.push(tx)
+      }
+      return map
+    },
+  )
+  useLayoutEffect(() => {
+    updateByGroupId(transactions)
   }, [transactions])
 
   // Diverse catch-all: transactions in Diverse group + unassigned.

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -990,6 +990,10 @@ export default function BudgetCreditCards() {
   // A ref tracks the previous map so per-group array references are preserved
   // for unchanged groups, letting React.memo(GroupSection) short-circuit for
   // groups not touched by an optimistic update.
+  //
+  // The useMemo is kept pure (no ref writes during render). The ref is updated
+  // in useLayoutEffect after commit so it is safe under concurrent/StrictMode
+  // rendering where renders may be aborted and re-run.
   const prevByGroupIdRef = useRef<Map<number | null, Transaction[]>>(new Map())
   const byGroupId = useMemo(() => {
     const prev = prevByGroupIdRef.current
@@ -1000,16 +1004,19 @@ export default function BudgetCreditCards() {
       next.get(key)!.push(tx)
     }
     for (const [key, arr] of next) {
-      // eslint-disable-next-line react-hooks/refs -- intentional: stable ref read inside useMemo for referential stability without extra render
       const old = prev.get(key)
       if (old && old.length === arr.length && old.every((t, i) => t === arr[i])) {
         next.set(key, old)
       }
     }
-    // eslint-disable-next-line react-hooks/refs -- intentional: stable ref write inside useMemo; avoids the two-render useLayoutEffect pattern
-    prevByGroupIdRef.current = next
     return next
   }, [transactions])
+  // Keep the ref in sync with the last committed map so the next useMemo run
+  // can do structural sharing against it. This must be useLayoutEffect (not
+  // useMemo) so the write happens after commit, not during render.
+  useLayoutEffect(() => {
+    prevByGroupIdRef.current = byGroupId
+  }, [byGroupId])
 
   // Diverse catch-all: transactions in Diverse group + unassigned.
   // Split into two intermediate memos so the concatenation can be memoised on

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -138,8 +138,8 @@ function formatAmount(amount: number, currency = 'NOK'): string {
 
 // ── Subcomponents ─────────────────────────────────────────────────────────────
 
-// Row height (px) for a single transaction. Slightly taller than typical content
-// to leave room for badge wrap on narrow viewports without clipping.
+// Row height (px) for a single transaction. Badges are prevented from wrapping
+// (overflow-hidden + flex-1 truncation) so this height is truly fixed.
 const TX_ROW_HEIGHT = 60
 // Cap each virtualised list at ~8 rows tall; larger groups scroll internally.
 const TX_LIST_MAX_HEIGHT = 480
@@ -167,8 +167,8 @@ const TransactionItem = memo(function TransactionItem({ tx, groups, currency, t,
   return (
     <div className={`flex items-start gap-2 px-3 py-2 ${isDeferredAway ? 'opacity-60' : ''}`}>
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-1.5 flex-wrap">
-          <span className={`text-sm truncate ${tx.is_innbetaling ? 'text-green-400' : 'text-gray-200'}`}>
+        <div className="flex items-center gap-1.5 overflow-hidden">
+          <span className={`text-sm truncate min-w-0 flex-1 ${tx.is_innbetaling ? 'text-green-400' : 'text-gray-200'}`}>
             {tx.beskrivelse}
           </span>
           {tx.is_pending && (
@@ -655,6 +655,11 @@ export default function BudgetCreditCards() {
   useEffect(() => { currentSelectedIdRef.current = selectedId }, [selectedId])
   useEffect(() => { currentMonthRef.current = month }, [month])
 
+  // Tracks the previous byGroupId map so structural sharing can reuse array
+  // references for groups whose transactions haven't changed. Kept as a ref
+  // so it's available inside useMemo without being a dependency.
+  const prevByGroupIdRef = useRef<Map<number | null, Transaction[]>>(new Map())
+
   // Latest-value refs so that row callbacks stay reference-stable across
   // transaction/group state changes (otherwise memoised TransactionItems
   // re-render on every optimistic update).
@@ -982,14 +987,27 @@ export default function BudgetCreditCards() {
     [groups],
   )
 
-  // Group transactions by group_id
+  // Group transactions by group_id, with structural sharing: if a group's
+  // transactions are referentially identical to the previous render (same
+  // objects in the same order), reuse the previous array reference so that
+  // React.memo(GroupSection) and the [transactions]-keyed useMemo inside it
+  // can short-circuit even when other groups changed.
   const byGroupId = useMemo(() => {
+    const prev = prevByGroupIdRef.current
     const result = new Map<number | null, Transaction[]>()
     for (const tx of transactions) {
       const key = tx.group_id
       if (!result.has(key)) result.set(key, [])
       result.get(key)!.push(tx)
     }
+    // Share array references from the previous map for groups that are unchanged.
+    for (const [key, arr] of result) {
+      const prevArr = prev.get(key)
+      if (prevArr && prevArr.length === arr.length && prevArr.every((t, i) => t === arr[i])) {
+        result.set(key, prevArr)
+      }
+    }
+    prevByGroupIdRef.current = result
     return result
   }, [transactions])
 

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -655,11 +655,6 @@ export default function BudgetCreditCards() {
   useEffect(() => { currentSelectedIdRef.current = selectedId }, [selectedId])
   useEffect(() => { currentMonthRef.current = month }, [month])
 
-  // Tracks the previous byGroupId map so structural sharing can reuse array
-  // references for groups whose transactions haven't changed. Kept as a ref
-  // so it's available inside useMemo without being a dependency.
-  const prevByGroupIdRef = useRef<Map<number | null, Transaction[]>>(new Map())
-
   // Latest-value refs so that row callbacks stay reference-stable across
   // transaction/group state changes (otherwise memoised TransactionItems
   // re-render on every optimistic update).
@@ -987,27 +982,16 @@ export default function BudgetCreditCards() {
     [groups],
   )
 
-  // Group transactions by group_id, with structural sharing: if a group's
-  // transactions are referentially identical to the previous render (same
-  // objects in the same order), reuse the previous array reference so that
-  // React.memo(GroupSection) and the [transactions]-keyed useMemo inside it
-  // can short-circuit even when other groups changed.
+  // Group transactions by group_id. Recomputed only when the `transactions`
+  // array reference changes (i.e. after a fetch), so GroupSection and the
+  // per-group useMemos below only re-run when real data changes.
   const byGroupId = useMemo(() => {
-    const prev = prevByGroupIdRef.current
     const result = new Map<number | null, Transaction[]>()
     for (const tx of transactions) {
       const key = tx.group_id
       if (!result.has(key)) result.set(key, [])
       result.get(key)!.push(tx)
     }
-    // Share array references from the previous map for groups that are unchanged.
-    for (const [key, arr] of result) {
-      const prevArr = prev.get(key)
-      if (prevArr && prevArr.length === arr.length && prevArr.every((t, i) => t === arr[i])) {
-        result.set(key, prevArr)
-      }
-    }
-    prevByGroupIdRef.current = result
     return result
   }, [transactions])
 

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo, useReducer, memo, type ChangeEvent } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo, memo, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { Link } from 'react-router-dom'
@@ -662,8 +662,8 @@ export default function BudgetCreditCards() {
   // paints and can accept user input, so handlers never read stale data.
   const transactionsRef = useRef<Transaction[]>(transactions)
   const groupsRef = useRef<Group[]>(groups)
-  useLayoutEffect(() => { transactionsRef.current = transactions })
-  useLayoutEffect(() => { groupsRef.current = groups })
+  useLayoutEffect(() => { transactionsRef.current = transactions }, [transactions])
+  useLayoutEffect(() => { groupsRef.current = groups }, [groups])
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- reset result when selection changes
@@ -984,40 +984,29 @@ export default function BudgetCreditCards() {
     [groups],
   )
 
-  // Group transactions by group_id. The reducer preserves per-group array
-  // references for unchanged groups so React.memo(GroupSection) can
-  // short-circuit for groups not touched by an optimistic update.
-  // useLayoutEffect keeps it in sync synchronously after commit (before paint)
-  // so there is no visible flicker.
-  const [byGroupId, updateByGroupId] = useReducer(
-    (prev: Map<number | null, Transaction[]>, txs: Transaction[]) => {
-      const next = new Map<number | null, Transaction[]>()
-      for (const tx of txs) {
-        const key = tx.group_id
-        if (!next.has(key)) next.set(key, [])
-        next.get(key)!.push(tx)
+  // Group transactions by group_id. Derived directly from transactions via
+  // useMemo so no extra render is needed (vs. the useReducer + useLayoutEffect
+  // pattern which always caused two renders on every transaction update).
+  // A ref tracks the previous map so per-group array references are preserved
+  // for unchanged groups, letting React.memo(GroupSection) short-circuit for
+  // groups not touched by an optimistic update.
+  const prevByGroupIdRef = useRef<Map<number | null, Transaction[]>>(new Map())
+  const byGroupId = useMemo(() => {
+    const prev = prevByGroupIdRef.current
+    const next = new Map<number | null, Transaction[]>()
+    for (const tx of transactions) {
+      const key = tx.group_id
+      if (!next.has(key)) next.set(key, [])
+      next.get(key)!.push(tx)
+    }
+    for (const [key, arr] of next) {
+      const old = prev.get(key)
+      if (old && old.length === arr.length && old.every((t, i) => t === arr[i])) {
+        next.set(key, old)
       }
-      for (const [key, arr] of next) {
-        const old = prev.get(key)
-        if (old && old.length === arr.length && old.every((t, i) => t === arr[i])) {
-          next.set(key, old)
-        }
-      }
-      return next
-    },
-    transactions,
-    (txs: Transaction[]) => {
-      const map = new Map<number | null, Transaction[]>()
-      for (const tx of txs) {
-        const key = tx.group_id
-        if (!map.has(key)) map.set(key, [])
-        map.get(key)!.push(tx)
-      }
-      return map
-    },
-  )
-  useLayoutEffect(() => {
-    updateByGroupId(transactions)
+    }
+    prevByGroupIdRef.current = next
+    return next
   }, [transactions])
 
   // Diverse catch-all: transactions in Diverse group + unassigned.

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback, useRef, type ChangeEvent } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo, memo, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { Link } from 'react-router-dom'
 import { ChevronLeft, ChevronRight, Upload, X, Link2, CreditCard, Plus, Trash2, Settings, History } from 'lucide-react'
+import { List, type RowComponentProps } from 'react-window'
 import { formatDate as fmtDate, formatNumber } from '../utils/formatDate'
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -133,60 +134,11 @@ function formatAmount(amount: number, currency = 'NOK'): string {
 
 // ── Subcomponents ─────────────────────────────────────────────────────────────
 
-interface GroupSectionProps {
-  title: string
-  transactions: Transaction[]
-  groups: Group[]
-  currency: string
-  t: TFunction<'budget'>
-  onAssign: (txId: number, groupId: number | null) => void
-  onDelete: (txId: number) => void
-  onDefer: (txId: number) => void
-}
-
-function GroupSection({ title, transactions, groups, currency, t, onAssign, onDelete, onDefer }: GroupSectionProps) {
-  // A carry-over (deferred_from_previous_month) is active in the viewed month and
-  // counts toward its total; a row deferred forward out of this month does not.
-  const expenseTotal = transactions
-    .filter(tx => !tx.is_innbetaling && (tx.deferred_from_previous_month || !tx.deferred_to_next_month))
-    .reduce((sum, tx) => sum + Math.abs(tx.belop), 0)
-  const innbetalingTotal = transactions
-    .filter(tx => tx.is_innbetaling)
-    .reduce((sum, tx) => sum + Math.abs(tx.belop), 0)
-
-  if (transactions.length === 0) return null
-
-  return (
-    <div className="bg-gray-800 rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between px-3 py-2 bg-gray-700 border-b border-gray-600">
-        <span className="text-sm font-semibold text-gray-200">{title}</span>
-        {innbetalingTotal > 0 && expenseTotal === 0 ? (
-          <span className="text-sm font-semibold text-green-400">
-            {formatCurrency(innbetalingTotal, currency)}
-          </span>
-        ) : (
-          <span className="text-sm font-semibold text-red-400">
-            {formatCurrency(expenseTotal, currency)}
-          </span>
-        )}
-      </div>
-      <div className="divide-y divide-gray-700/50">
-        {transactions.map(tx => (
-          <TransactionItem
-            key={tx.id}
-            tx={tx}
-            groups={groups}
-            currency={currency}
-            t={t}
-            onAssign={onAssign}
-            onDelete={onDelete}
-            onDefer={onDefer}
-          />
-        ))}
-      </div>
-    </div>
-  )
-}
+// Row height (px) for a single transaction. Slightly taller than typical content
+// to leave room for badge wrap on narrow viewports without clipping.
+const TX_ROW_HEIGHT = 60
+// Cap each virtualised list at ~8 rows tall; larger groups scroll internally.
+const TX_LIST_MAX_HEIGHT = 480
 
 interface TransactionItemProps {
   tx: Transaction
@@ -198,7 +150,7 @@ interface TransactionItemProps {
   onDefer: (txId: number) => void
 }
 
-function TransactionItem({ tx, groups, currency, t, onAssign, onDelete, onDefer }: TransactionItemProps) {
+const TransactionItem = memo(function TransactionItem({ tx, groups, currency, t, onAssign, onDelete, onDefer }: TransactionItemProps) {
   const showForeignAmount =
     tx.belop_i_valuta !== 0 &&
     Math.abs(Math.abs(tx.belop_i_valuta) - Math.abs(tx.belop)) > 0.01
@@ -281,7 +233,101 @@ function TransactionItem({ tx, groups, currency, t, onAssign, onDelete, onDefer 
       </div>
     </div>
   )
+})
+
+// Sum a group's transactions using the same semantics as the legacy
+// filter+reduce: include carry-overs from the previous month, exclude rows
+// deferred forward out of this month, and split innbetalinger separately.
+// eslint-disable-next-line react-refresh/only-export-components
+export function computeGroupTotals(transactions: Transaction[]): { expenseTotal: number; innbetalingTotal: number } {
+  let expenseTotal = 0
+  let innbetalingTotal = 0
+  for (const tx of transactions) {
+    if (tx.is_innbetaling) {
+      innbetalingTotal += Math.abs(tx.belop)
+    } else if (tx.deferred_from_previous_month || !tx.deferred_to_next_month) {
+      expenseTotal += Math.abs(tx.belop)
+    }
+  }
+  return { expenseTotal, innbetalingTotal }
 }
+
+interface TransactionRowExtraProps {
+  transactions: Transaction[]
+  groups: Group[]
+  currency: string
+  t: TFunction<'budget'>
+  onAssign: (txId: number, groupId: number | null) => void
+  onDelete: (txId: number) => void
+  onDefer: (txId: number) => void
+}
+
+// Thin wrapper rendered by react-window for each visible row. The wrapper
+// re-renders whenever `rowProps` changes (e.g. after an optimistic update),
+// but `TransactionItem` is memoised on the individual `tx` reference, so
+// unaffected rows skip their actual render.
+function TransactionRow({ index, style, transactions, groups, currency, t, onAssign, onDelete, onDefer }: RowComponentProps<TransactionRowExtraProps>) {
+  const tx = transactions[index]
+  if (!tx) return null
+  return (
+    <div style={style} className="border-b border-gray-700/50">
+      <TransactionItem
+        tx={tx}
+        groups={groups}
+        currency={currency}
+        t={t}
+        onAssign={onAssign}
+        onDelete={onDelete}
+        onDefer={onDefer}
+      />
+    </div>
+  )
+}
+
+interface GroupSectionProps {
+  title: string
+  transactions: Transaction[]
+  groups: Group[]
+  currency: string
+  t: TFunction<'budget'>
+  onAssign: (txId: number, groupId: number | null) => void
+  onDelete: (txId: number) => void
+  onDefer: (txId: number) => void
+}
+
+const GroupSection = memo(function GroupSection({ title, transactions, groups, currency, t, onAssign, onDelete, onDefer }: GroupSectionProps) {
+  const { expenseTotal, innbetalingTotal } = useMemo(() => computeGroupTotals(transactions), [transactions])
+
+  if (transactions.length === 0) return null
+
+  const listHeight = Math.min(transactions.length * TX_ROW_HEIGHT, TX_LIST_MAX_HEIGHT)
+
+  return (
+    <div className="bg-gray-800 rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2 bg-gray-700 border-b border-gray-600">
+        <span className="text-sm font-semibold text-gray-200">{title}</span>
+        {innbetalingTotal > 0 && expenseTotal === 0 ? (
+          <span className="text-sm font-semibold text-green-400">
+            {formatCurrency(innbetalingTotal, currency)}
+          </span>
+        ) : (
+          <span className="text-sm font-semibold text-red-400">
+            {formatCurrency(expenseTotal, currency)}
+          </span>
+        )}
+      </div>
+      <List<TransactionRowExtraProps>
+        rowComponent={TransactionRow}
+        rowCount={transactions.length}
+        rowHeight={TX_ROW_HEIGHT}
+        rowProps={{ transactions, groups, currency, t, onAssign, onDelete, onDefer }}
+        style={{ height: listHeight }}
+        defaultHeight={listHeight}
+        overscanCount={3}
+      />
+    </div>
+  )
+})
 
 // ── Import Preview Modal ───────────────────────────────────────────────────────
 
@@ -604,6 +650,19 @@ export default function BudgetCreditCards() {
   const currentMonthRef = useRef(month)
   useEffect(() => { currentSelectedIdRef.current = selectedId }, [selectedId])
   useEffect(() => { currentMonthRef.current = month }, [month])
+
+  // Latest-value refs so that row callbacks stay reference-stable across
+  // transaction/group state changes (otherwise memoised TransactionItems
+  // re-render on every optimistic update).
+  const transactionsRef = useRef<Transaction[]>(transactions)
+  const groupsRef = useRef<Group[]>(groups)
+  useEffect(() => { transactionsRef.current = transactions }, [transactions])
+  useEffect(() => { groupsRef.current = groups }, [groups])
+
+  // Previous per-group transaction arrays. Used to reuse the same array
+  // reference for groups whose contents haven't changed between renders so
+  // that React.memo on `GroupSection` can short-circuit unaffected groups.
+  const byGroupIdRef = useRef<Map<number | null, Transaction[]>>(new Map())
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- reset result when selection changes
     setReapplyResult(null)
@@ -801,12 +860,14 @@ export default function BudgetCreditCards() {
 
   const handleAssignGroup = useCallback(async (txId: number, groupId: number | null) => {
     // Find the transaction to get its description for the merchant rule.
-    const tx = transactions.find(t => t.id === txId)
+    // Reads through refs so this callback stays reference-stable when
+    // transactions/groups update (keeps memoised TransactionItems quiet).
+    const tx = transactionsRef.current.find(t => t.id === txId)
 
     // Optimistic update
     setTransactions(prev => prev.map(t => {
       if (t.id !== txId) return t
-      const group = groups.find(g => g.id === groupId)
+      const group = groupsRef.current.find(g => g.id === groupId)
       return { ...t, group_id: groupId, group_name: group?.name ?? '' }
     }))
 
@@ -846,7 +907,7 @@ export default function BudgetCreditCards() {
       setTxnsError(t('creditCards.errors.assignFailed'))
       if (selectedId !== null) loadTransactions(selectedId, month)
     }
-  }, [groups, transactions, t, selectedId, month, loadTransactions])
+  }, [t, selectedId, month, loadTransactions])
 
   const handleSaveOpeningBalance = useCallback(async () => {
     if (selectedId === null) return
@@ -905,6 +966,64 @@ export default function BudgetCreditCards() {
       setTxnsError(t('creditCards.errors.deferFailed'))
     }
   }, [t, selectedId, month, loadTransactions])
+
+  // ── Derived data (memoised) ───────────────────────────────────────────────
+
+  // Groups to show in dropdown for reassignment (include Diverse so any
+  // persisted group_id always has a matching option in the controlled select).
+  const allGroupOptions = useMemo(
+    () => [...groups].sort((a, b) => a.sort_order - b.sort_order),
+    [groups],
+  )
+
+  const diverseGroup = useMemo(() => groups.find(g => g.name === 'Diverse'), [groups])
+  const namedGroups = useMemo(
+    () => groups.filter(g => g.name !== 'Diverse').sort((a, b) => a.sort_order - b.sort_order),
+    [groups],
+  )
+
+  // Group transactions by group_id with structural sharing: groups whose
+  // contents haven't changed reuse the previous array reference so that
+  // memoised GroupSection instances can short-circuit.
+  const byGroupId = useMemo(() => {
+    const fresh = new Map<number | null, Transaction[]>()
+    for (const tx of transactions) {
+      const key = tx.group_id
+      if (!fresh.has(key)) fresh.set(key, [])
+      fresh.get(key)!.push(tx)
+    }
+    const result = new Map<number | null, Transaction[]>()
+    const prev = byGroupIdRef.current
+    for (const [groupId, txs] of fresh) {
+      const prevTxs = prev.get(groupId)
+      if (prevTxs && prevTxs.length === txs.length && prevTxs.every((p, i) => p === txs[i])) {
+        result.set(groupId, prevTxs)
+      } else {
+        result.set(groupId, txs)
+      }
+    }
+    byGroupIdRef.current = result
+    return result
+  }, [transactions])
+
+  // Diverse catch-all: transactions in Diverse group + unassigned
+  const diverseTxns = useMemo<Transaction[]>(() => [
+    ...(diverseGroup ? (byGroupId.get(diverseGroup.id) ?? []) : []),
+    ...(byGroupId.get(null) ?? []),
+  ], [byGroupId, diverseGroup])
+
+  // When a variable bill is linked, derive the monthly total from the backend-computed
+  // closing balance so it stays consistent with SyncCreditCardExpense. Otherwise sum
+  // the visible rows: include carry-overs from the previous month, exclude rows
+  // deferred forward out of this month.
+  const expenseTotal = useMemo(
+    () => variableBillName !== null
+      ? variableBillAmount - openingBalance
+      : transactions
+          .filter(tx => !tx.is_innbetaling && (tx.deferred_from_previous_month || !tx.deferred_to_next_month))
+          .reduce((sum, tx) => sum + Math.abs(tx.belop), 0),
+    [transactions, variableBillName, variableBillAmount, openingBalance],
+  )
 
   // ── Render ─────────────────────────────────────────────────────────────────
 
@@ -1007,36 +1126,7 @@ export default function BudgetCreditCards() {
     }
   }
 
-  // Build grouped transactions
-  const diverseGroup = groups.find(g => g.name === 'Diverse')
-  const namedGroups = groups.filter(g => g.name !== 'Diverse').sort((a, b) => a.sort_order - b.sort_order)
-
-  const byGroupId = new Map<number | null, Transaction[]>()
-  for (const tx of transactions) {
-    const key = tx.group_id
-    if (!byGroupId.has(key)) byGroupId.set(key, [])
-    byGroupId.get(key)!.push(tx)
-  }
-
-  // Diverse catch-all: transactions in Diverse group + unassigned
-  const diverseTxns: Transaction[] = [
-    ...(diverseGroup ? (byGroupId.get(diverseGroup.id) ?? []) : []),
-    ...(byGroupId.get(null) ?? []),
-  ]
-
-  // When a variable bill is linked, derive the monthly total from the backend-computed
-  // closing balance so it stays consistent with SyncCreditCardExpense. Otherwise sum
-  // the visible rows: include carry-overs from the previous month, exclude rows
-  // deferred forward out of this month.
-  const expenseTotal = variableBillName !== null
-    ? variableBillAmount - openingBalance
-    : transactions
-        .filter(tx => !tx.is_innbetaling && (tx.deferred_from_previous_month || !tx.deferred_to_next_month))
-        .reduce((sum, tx) => sum + Math.abs(tx.belop), 0)
-
-  // Groups to show in dropdown for reassignment (include Diverse so any
-  // persisted group_id always has a matching option in the controlled select)
-  const allGroupOptions = [...groups].sort((a, b) => a.sort_order - b.sort_order)
+  // Grouping, totals, and dropdown options are computed in useMemo hooks above.
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -90,6 +90,10 @@ interface MonthlyHistory {
   net_totals: Record<string, number>         // net outstanding = expenses + innbetaling_totals
 }
 
+// Stable empty array for groups with no transactions — avoids allocating a new
+// [] on every render when byGroupId.get(key) returns undefined.
+const EMPTY_TX_ARRAY: Transaction[] = []
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function currentMonth(): string {
@@ -989,11 +993,24 @@ export default function BudgetCreditCards() {
     return result
   }, [transactions])
 
-  // Diverse catch-all: transactions in Diverse group + unassigned
-  const diverseTxns = useMemo<Transaction[]>(() => [
-    ...(diverseGroup ? (byGroupId.get(diverseGroup.id) ?? []) : []),
-    ...(byGroupId.get(null) ?? []),
-  ], [byGroupId, diverseGroup])
+  // Diverse catch-all: transactions in Diverse group + unassigned.
+  // Split into two intermediate memos so the concatenation can be memoised on
+  // those references independently: if only a named-group transaction changes,
+  // only diverseGroupTxns/unassignedTxns need updating — and if they haven't
+  // changed, diverseTxns itself stays referentially stable and the Diverse
+  // GroupSection skips re-rendering.
+  const diverseGroupTxns = useMemo(
+    () => diverseGroup ? (byGroupId.get(diverseGroup.id) ?? EMPTY_TX_ARRAY) : EMPTY_TX_ARRAY,
+    [byGroupId, diverseGroup],
+  )
+  const unassignedTxns = useMemo(
+    () => byGroupId.get(null) ?? EMPTY_TX_ARRAY,
+    [byGroupId],
+  )
+  const diverseTxns = useMemo<Transaction[]>(
+    () => [...diverseGroupTxns, ...unassignedTxns],
+    [diverseGroupTxns, unassignedTxns],
+  )
 
   // When a variable bill is linked, derive the monthly total from the backend-computed
   // closing balance so it stays consistent with SyncCreditCardExpense. Otherwise sum

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo, memo, type ChangeEvent } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo, memo, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { Link } from 'react-router-dom'
@@ -657,11 +657,13 @@ export default function BudgetCreditCards() {
 
   // Latest-value refs so that row callbacks stay reference-stable across
   // transaction/group state changes (otherwise memoised TransactionItems
-  // re-render on every optimistic update).
+  // re-render on every optimistic update). useLayoutEffect (rather than
+  // useEffect) ensures the refs are flushed synchronously before the browser
+  // paints and can accept user input, so handlers never read stale data.
   const transactionsRef = useRef<Transaction[]>(transactions)
   const groupsRef = useRef<Group[]>(groups)
-  useEffect(() => { transactionsRef.current = transactions }, [transactions])
-  useEffect(() => { groupsRef.current = groups }, [groups])
+  useLayoutEffect(() => { transactionsRef.current = transactions })
+  useLayoutEffect(() => { groupsRef.current = groups })
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- reset result when selection changes
@@ -982,17 +984,32 @@ export default function BudgetCreditCards() {
     [groups],
   )
 
-  // Group transactions by group_id. Recomputed only when the `transactions`
-  // array reference changes (i.e. after a fetch), so GroupSection and the
-  // per-group useMemos below only re-run when real data changes.
+  // Tracks the previous grouping so we can preserve per-group array references
+  // for unchanged groups (see byGroupId below).
+  const prevByGroupIdRef = useRef(new Map<number | null, Transaction[]>())
+
+  // Group transactions by group_id. After building the new map we compare each
+  // group's transactions to the previous run: if every transaction object
+  // reference is identical (setTransactions uses structural updates that keep
+  // unchanged objects stable), we reuse the old array so React.memo(GroupSection)
+  // and the per-group useMemo([transactions]) inside it can short-circuit for
+  // groups that weren't touched by an optimistic update.
   const byGroupId = useMemo(() => {
-    const result = new Map<number | null, Transaction[]>()
+    const next = new Map<number | null, Transaction[]>()
     for (const tx of transactions) {
       const key = tx.group_id
-      if (!result.has(key)) result.set(key, [])
-      result.get(key)!.push(tx)
+      if (!next.has(key)) next.set(key, [])
+      next.get(key)!.push(tx)
     }
-    return result
+    const prev = prevByGroupIdRef.current
+    for (const [key, arr] of next) {
+      const old = prev.get(key)
+      if (old && old.length === arr.length && old.every((t, i) => t === arr[i])) {
+        next.set(key, old)
+      }
+    }
+    prevByGroupIdRef.current = next
+    return next
   }, [transactions])
 
   // Diverse catch-all: transactions in Diverse group + unassigned.

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -1000,11 +1000,13 @@ export default function BudgetCreditCards() {
       next.get(key)!.push(tx)
     }
     for (const [key, arr] of next) {
+      // eslint-disable-next-line react-hooks/refs -- intentional: stable ref read inside useMemo for referential stability without extra render
       const old = prev.get(key)
       if (old && old.length === arr.length && old.every((t, i) => t === arr[i])) {
         next.set(key, old)
       }
     }
+    // eslint-disable-next-line react-hooks/refs -- intentional: stable ref write inside useMemo; avoids the two-render useLayoutEffect pattern
     prevByGroupIdRef.current = next
     return next
   }, [transactions])


### PR DESCRIPTION
## Changes

- **Faster Credit Cards transaction list** - Virtualised the per-group transaction rows with `react-window` and memoised `GroupSection`/`TransactionItem` plus the per-group totals so the page stays smooth with 1000+ transactions. Assigning a single transaction now re-renders only the affected row instead of every sibling. (Hytte-ah6y)

## Original Issue (feature): Virtualise the transaction list and memoise GroupSection totals

### Scope
Reduce render cost on the Credit Cards page so it stays smooth with 1000+ transactions: memoise `GroupSection` and `TransactionItem`, compute per-group totals via `useMemo`, and virtualise the rendered transaction rows with `react-window`. Backend (`internal/creditcard/*`) is not touched.

### Files to touch
- `web/src/pages/BudgetCreditCards.tsx` — wrap `GroupSection` and `TransactionItem` in `React.memo`, replace the inline `filter+reduce` totals with `useMemo` keyed on `transactions`, swap the `transactions.map(...)` body for a `react-window` `FixedSizeList` (or `VariableSizeList` if heights vary), stabilise `onAssign`/`onDelete`/`onDefer` callbacks with `useCallback` so memoisation actually short-circuits.
- `web/src/pages/BudgetCreditCards.test.tsx` — add/extend tests covering: totals match the previous filter+reduce semantics (carryover counted, deferred-away excluded), and a smoke test that renders ~1000 transactions without crashing and lists the first row.
- `web/package.json` and `web/package-lock.json` — add `react-window` (and `@types/react-window` if not bundled) as runtime deps.

### Acceptance criteria
- Opening the group dropdown on a real Credit Cards month (after several months of data) feels smooth on mobile; no visible jank scrolling within a group.
- A profiling pass with React DevTools shows that assigning a single transaction re-renders only the affected `TransactionItem` (plus its `GroupSection` header), not every sibling row.
- Per-group `expenseTotal` / `innbetalingTotal` displayed in the header match current behaviour exactly: carry-overs (`deferred_from_previous_month`) are included, rows deferred forward out of the month are excluded; innbetaling-only groups still show the green total.
- The `transactions.map` rendering is replaced by a virtualised list — only DOM nodes for visible rows are mounted (verifiable via DevTools elements panel with 1000 rows).
- Existing E2E / unit tests for Budget Credit Cards still pass; new tests cover the totals semantics and a 1000-row render smoke test.
- `npm run lint`, `npm run build`, `go build`, `go test` all pass.
- A changelog fragment is added under `changelog.d/` (category `Changed`).

### Non-goals
- No changes to the backend (`internal/creditcard/*`), DB schema, or API shape.
- No redesign of the group/transaction visual layout, sorting, or filtering behaviour.
- Not virtualising the list of groups themselves — only the rows inside the flat transaction list.
- No general perf sweep of other Budget pages (Recurring, Variables, Loan, Accounts) — they can follow up separately if needed.
- Not introducing a global state library or refactoring the page's data-fetching model.

## Source

Created from Suggestions page (suggestion id 135, page slug "budget-credit-cards", source=claude).

## Original suggestion

GroupSection recomputes expenseTotal and innbetalingTotal on every parent re-render via two filter+reduce passes, and the entire list of TransactionItems is re-rendered when a single assignment changes. After a few months of data this is noticeably janky on mobile when opening the group dropdown. Memoise GroupSection/TransactionItem with React.memo, derive the per-group totals once via useMemo keyed on transactions, and render the flat list with react-window so only visible rows mount. The page should stay smooth at 1000+ transactions.


---
Bead: Hytte-ah6y | Branch: forge/Hytte-ah6y
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->