### PR TITLE
Stop stripping sign and hardcoding NOK in formatAmount (Hytte-bzsw)

### DIFF
--- a/changelog.d/Hytte-bzsw.md
+++ b/changelog.d/Hytte-bzsw.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Budget page now preserves negative signs and renders each account's own currency** - `formatAmount` no longer strips the sign with `Math.abs()` or hardcodes `NOK`. Transaction rows and the running balance now use the owning account's currency (USD, EUR, NOK, etc.), and negative amounts render with the locale's negative convention so an outgoing transaction is visually distinguishable from a refund. Red/green tinting stays on the row wrapping the amount. (Hytte-bzsw)

--- a/web/src/pages/BudgetPage.tsx
+++ b/web/src/pages/BudgetPage.tsx
@@ -102,10 +102,10 @@ function todayDate(): string {
 // Callers without a per-account context fall back to 'NOK'; the negative sign
 // (or parentheses, depending on locale) is rendered by Intl.NumberFormat —
 // red/green tinting belongs on the surrounding cell, not in here.
-function formatAmount(amount: number, currency: string = 'NOK'): string {
+function formatAmount(amount: number, currency?: string): string {
   return formatNumber(amount, {
     style: 'currency',
-    currency,
+    currency: currency ?? 'NOK',
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   })

--- a/web/src/pages/BudgetPage.tsx
+++ b/web/src/pages/BudgetPage.tsx
@@ -98,10 +98,14 @@ function todayDate(): string {
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
 }
 
-function formatAmount(amount: number): string {
-  return formatNumber(Math.abs(amount), {
+// Formats a signed amount in the given currency using the active locale.
+// Callers without a per-account context fall back to 'NOK'; the negative sign
+// (or parentheses, depending on locale) is rendered by Intl.NumberFormat —
+// red/green tinting belongs on the surrounding cell, not in here.
+function formatAmount(amount: number, currency: string = 'NOK'): string {
+  return formatNumber(amount, {
     style: 'currency',
-    currency: 'NOK',
+    currency,
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   })
@@ -367,7 +371,7 @@ function CategoryRow({ cs, month, onLimitSaved }: CategoryRowProps) {
           <span
             className={`tabular-nums font-medium ${cs.is_income ? 'text-green-400' : cs.total < 0 ? 'text-red-400' : 'text-gray-300'}`}
           >
-            {cs.total >= 0 ? '+' : '-'}{formatAmount(cs.total)}
+            {formatAmount(cs.total)}
           </span>
           {hasBudget && (
             <span className="text-gray-500 text-xs ml-1">
@@ -675,7 +679,7 @@ export default function BudgetPage() {
             <div className="text-center">
               <p className="text-xs text-gray-400 uppercase tracking-wide">{t('summary.net')}</p>
               <p className={`text-lg font-semibold ${summary.net >= 0 ? 'text-green-400' : 'text-red-400'}`}>
-                {summary.net < 0 ? '-' : ''}{formatAmount(summary.net)}
+                {formatAmount(summary.net)}
               </p>
             </div>
             <div className="text-center">
@@ -874,10 +878,10 @@ export default function BudgetPage() {
                     <p
                       className={`text-sm font-medium tabular-nums ${isIncome ? 'text-green-400' : 'text-red-400'}`}
                     >
-                      {isIncome ? '+' : '-'}{formatAmount(txn.amount)}
+                      {formatAmount(txn.amount, acct?.currency)}
                     </p>
                     <p className="text-xs text-gray-500 tabular-nums">
-                      {t('summary.remaining')}: {balance < 0 ? '-' : ''}{formatAmount(balance)}
+                      {t('summary.remaining')}: {formatAmount(balance, acct?.currency)}
                     </p>
                   </div>
 
@@ -947,7 +951,7 @@ export default function BudgetPage() {
                     <p
                       className={`text-sm font-medium tabular-nums ${isIncome ? 'text-green-400/70' : 'text-red-400/70'}`}
                     >
-                      {isIncome ? '+' : '-'}{formatAmount(item.amount)}
+                      {formatAmount(item.amount)}
                     </p>
                     {hasSplit && Math.abs(item.your_share) !== Math.abs(item.amount) && (
                       <p className="text-xs text-gray-500 tabular-nums">


### PR DESCRIPTION
## Changes

- **Budget page now preserves negative signs and renders each account's own currency** - `formatAmount` no longer strips the sign with `Math.abs()` or hardcodes `NOK`. Transaction rows and the running balance now use the owning account's currency (USD, EUR, NOK, etc.), and negative amounts render with the locale's negative convention so an outgoing transaction is visually distinguishable from a refund. Red/green tinting stays on the row wrapping the amount. (Hytte-bzsw)

## Original Issue (feature): Stop stripping sign and hardcoding NOK in formatAmount

### Scope
Fix `formatAmount` on the Budget page so it preserves the sign of negative transactions and renders each account's own currency instead of always using NOK. Move red/green tinting up to the row/cell so the formatter no longer hides cash-flow direction.

### Files to touch
- `web/src/pages/BudgetPage.tsx` — change `formatAmount` signature/implementation; update every call site to pass the correct currency and to apply tinting at the row level.
- `web/src/pages/BudgetCharts.tsx`, `web/src/pages/BudgetAccounts.tsx`, `web/src/pages/BudgetImport.tsx` — only if they import or duplicate the same helper; update them to the new signature for consistency. Skip files that don't use it.

### Acceptance criteria
- `formatAmount` no longer calls `Math.abs()`; negative amounts render with the locale's negative convention (leading minus or parentheses, per `Intl.NumberFormat`).
- `formatAmount` accepts a `currency` argument and uses it; the hardcoded `'NOK'` literal is gone. A sensible fallback (e.g. `'NOK'` only when caller passes nothing) is documented in the call.
- Transaction list rows for a USD account display amounts as `$…`, EUR as `€…`, NOK as `kr …`, matching `account.currency`.
- Account balance summaries use the account's own currency rather than NOK across the page.
- An outgoing transaction and an equal-magnitude refund are visually distinguishable: one shows a negative-formatted amount, the other positive; row-level red/green tinting still applies.
- Red/green colour classes are applied on the row/cell wrapping the amount, not inside `formatAmount`.
- The locale passed to `Intl.NumberFormat` continues to follow `i18n.language` (consistent with other pages).
- `npm run lint` and `npm run build` pass in `web/`; `go test ./...` and `go build ./...` still pass.
- A changelog fragment is added under `changelog.d/` in the `Fixed` category referencing the bead ID.

### Non-goals
- No backend changes to `internal/budget/handlers.go` or the transactions/accounts schema; `currency` is assumed to already exist on `Account`.
- No new currency-conversion logic, FX rates, or multi-currency aggregation across accounts.
- No redesign of the transactions table, filters, or charts beyond the colour/format adjustment described.
- No changes to CSV import parsing or category management.
- No new translation keys unless an existing string is reworded; otherwise leave i18n alone.

## Source

Created from Suggestions page (suggestion id 131, page slug "budget", source=claude).

## Original suggestion

BudgetPage's formatAmount uses Math.abs() and a hardcoded 'NOK' currency, which strips the negative sign from outgoing transactions and ignores each Account's own currency field. A user with a USD or EUR account sees their balance rendered as kroner, and an expense and a refund of equal magnitude become visually indistinguishable in the transactions list. Drop the Math.abs(), let Intl.NumberFormat render the sign in the locale's convention (e.g. parentheses or a leading minus), and accept a currency argument so callers can pass account.currency. Apply red/green tinting at the row level instead of inside the formatter so cash-flow direction stays unambiguous.


---
Bead: Hytte-bzsw | Branch: forge/Hytte-bzsw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->