### PR TITLE
Visually flag anvils whose last activity is stale (Hytte-vt37)

### DIFF
--- a/changelog.d/Hytte-vt37.md
+++ b/changelog.d/Hytte-vt37.md
@@ -1,0 +1,2 @@
+category: Added
+- **Anvil staleness signal** - Anvil cards on the Mezzanine anvils page now tint their border and timestamp amber when `last_activity` is older than 30 minutes, red when older than 24 hours, and use a dashed gray treatment when an anvil has never reported activity. The timestamp block exposes an `aria-label` (e.g. "stale: last active 2h ago") and `role="status"` so screen readers receive the same signal. (Hytte-vt37)

--- a/web/public/locales/en/forge.json
+++ b/web/public/locales/en/forge.json
@@ -562,7 +562,13 @@
     "activeWorkers": "Workers",
     "openPRs": "Open PRs",
     "queueDepth": "Queue",
-    "lastActivity": "Last activity"
+    "lastActivity": "Last activity",
+    "staleness": {
+      "fresh": "active: last active {{relative}}",
+      "stale": "stale: last active {{relative}}",
+      "dead": "inactive: last active {{relative}}",
+      "never": "never active"
+    }
   },
   "prModal": {
     "title": "PR Management",

--- a/web/public/locales/nb/forge.json
+++ b/web/public/locales/nb/forge.json
@@ -562,7 +562,13 @@
     "activeWorkers": "Arbeidere",
     "openPRs": "Åpne PRer",
     "queueDepth": "Kø",
-    "lastActivity": "Siste aktivitet"
+    "lastActivity": "Siste aktivitet",
+    "staleness": {
+      "fresh": "aktiv: sist aktiv {{relative}}",
+      "stale": "foreldet: sist aktiv {{relative}}",
+      "dead": "inaktiv: sist aktiv {{relative}}",
+      "never": "aldri aktiv"
+    }
   },
   "prModal": {
     "title": "PR-håndtering",

--- a/web/public/locales/th/forge.json
+++ b/web/public/locales/th/forge.json
@@ -562,7 +562,13 @@
     "activeWorkers": "คนงาน",
     "openPRs": "PR เปิด",
     "queueDepth": "คิว",
-    "lastActivity": "กิจกรรมล่าสุด"
+    "lastActivity": "กิจกรรมล่าสุด",
+    "staleness": {
+      "fresh": "ใช้งานอยู่: ทำงานล่าสุด {{relative}}",
+      "stale": "ค้างนาน: ทำงานล่าสุด {{relative}}",
+      "dead": "ไม่ทำงาน: ทำงานล่าสุด {{relative}}",
+      "never": "ไม่เคยทำงาน"
+    }
   },
   "prModal": {
     "title": "การจัดการ PR",

--- a/web/src/pages/AnvilsPage.tsx
+++ b/web/src/pages/AnvilsPage.tsx
@@ -11,9 +11,26 @@ import {
 } from 'lucide-react'
 import { useAnvilHealth } from '../hooks/useAnvilHealth'
 import { formatDateTime } from '../utils/formatDate'
+import { getAnvilFreshness, type FreshnessBucket } from '../utils/anvilFreshness'
+import { timeAgo } from '../utils/timeAgo'
+
+const BORDER_CLASS: Record<FreshnessBucket, string> = {
+  fresh: 'border border-gray-700/50',
+  stale: 'border border-amber-500',
+  dead: 'border border-red-500',
+  never: 'border border-dashed border-gray-500',
+}
+
+const TIMESTAMP_TEXT_CLASS: Record<FreshnessBucket, string> = {
+  fresh: 'text-gray-400',
+  stale: 'text-amber-400',
+  dead: 'text-red-400',
+  never: 'text-gray-400',
+}
 
 export default function AnvilsPage() {
   const { t } = useTranslation('forge')
+  const { t: tCommon } = useTranslation('common')
   const { anvils, loading, error, refresh } = useAnvilHealth()
 
   return (
@@ -58,71 +75,84 @@ export default function AnvilsPage() {
       {/* Card grid */}
       {anvils.length > 0 && (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {anvils.map(anvil => (
-            <div
-              key={anvil.anvil}
-              className="bg-gray-800 rounded-lg border border-gray-700/50 p-4"
-            >
-              <div className="flex items-center gap-2 mb-3">
-                <Hammer size={16} className="text-gray-400 shrink-0" />
-                <h2 className="text-sm font-semibold text-white truncate">
-                  {anvil.anvil}
-                </h2>
-              </div>
+          {anvils.map(anvil => {
+            const bucket = getAnvilFreshness(anvil.last_activity)
+            const ariaLabel =
+              bucket === 'never'
+                ? t('anvilsPage.staleness.never')
+                : t(`anvilsPage.staleness.${bucket}`, {
+                    relative: timeAgo(anvil.last_activity as string, tCommon),
+                  })
+            return (
+              <div
+                key={anvil.anvil}
+                className={`bg-gray-800 rounded-lg ${BORDER_CLASS[bucket]} p-4`}
+              >
+                <div className="flex items-center gap-2 mb-3">
+                  <Hammer size={16} className="text-gray-400 shrink-0" />
+                  <h2 className="text-sm font-semibold text-white truncate">
+                    {anvil.anvil}
+                  </h2>
+                </div>
 
-              <div className="grid grid-cols-3 gap-3 mb-3">
-                <div>
-                  <div className="flex items-center gap-1 mb-0.5">
-                    <Activity size={12} className="text-blue-400" />
-                    <span className="text-xs text-gray-500">
-                      {t('anvilsPage.activeWorkers')}
-                    </span>
+                <div className="grid grid-cols-3 gap-3 mb-3">
+                  <div>
+                    <div className="flex items-center gap-1 mb-0.5">
+                      <Activity size={12} className="text-blue-400" />
+                      <span className="text-xs text-gray-500">
+                        {t('anvilsPage.activeWorkers')}
+                      </span>
+                    </div>
+                    <p className="text-lg font-semibold text-white tabular-nums">
+                      {anvil.active_workers}
+                    </p>
                   </div>
-                  <p className="text-lg font-semibold text-white tabular-nums">
-                    {anvil.active_workers}
-                  </p>
-                </div>
-                <div>
-                  <div className="flex items-center gap-1 mb-0.5">
-                    <GitPullRequest size={12} className="text-green-400" />
-                    <span className="text-xs text-gray-500">
-                      {t('anvilsPage.openPRs')}
-                    </span>
+                  <div>
+                    <div className="flex items-center gap-1 mb-0.5">
+                      <GitPullRequest size={12} className="text-green-400" />
+                      <span className="text-xs text-gray-500">
+                        {t('anvilsPage.openPRs')}
+                      </span>
+                    </div>
+                    <p className="text-lg font-semibold text-white tabular-nums">
+                      {anvil.open_prs}
+                    </p>
                   </div>
-                  <p className="text-lg font-semibold text-white tabular-nums">
-                    {anvil.open_prs}
-                  </p>
-                </div>
-                <div>
-                  <div className="flex items-center gap-1 mb-0.5">
-                    <ListOrdered size={12} className="text-yellow-400" />
-                    <span className="text-xs text-gray-500">
-                      {t('anvilsPage.queueDepth')}
-                    </span>
+                  <div>
+                    <div className="flex items-center gap-1 mb-0.5">
+                      <ListOrdered size={12} className="text-yellow-400" />
+                      <span className="text-xs text-gray-500">
+                        {t('anvilsPage.queueDepth')}
+                      </span>
+                    </div>
+                    <p className="text-lg font-semibold text-white tabular-nums">
+                      {anvil.queue_depth}
+                    </p>
                   </div>
-                  <p className="text-lg font-semibold text-white tabular-nums">
-                    {anvil.queue_depth}
-                  </p>
                 </div>
-              </div>
 
-              <div className="border-t border-gray-700/50 pt-2">
-                <span className="text-xs text-gray-500">
-                  {t('anvilsPage.lastActivity')}:{' '}
-                  <span className="text-gray-400 tabular-nums">
-                    {anvil.last_activity
-                      ? formatDateTime(anvil.last_activity, {
-                          month: 'short',
-                          day: 'numeric',
-                          hour: '2-digit',
-                          minute: '2-digit',
-                        })
-                      : '\u2014'}
+                <div
+                  className="border-t border-gray-700/50 pt-2"
+                  role="status"
+                  aria-label={ariaLabel}
+                >
+                  <span className="text-xs text-gray-500">
+                    {t('anvilsPage.lastActivity')}:{' '}
+                    <span className={`${TIMESTAMP_TEXT_CLASS[bucket]} tabular-nums`}>
+                      {anvil.last_activity
+                        ? formatDateTime(anvil.last_activity, {
+                            month: 'short',
+                            day: 'numeric',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })
+                        : '—'}
+                    </span>
                   </span>
-                </span>
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/web/src/pages/AnvilsPage.tsx
+++ b/web/src/pages/AnvilsPage.tsx
@@ -139,8 +139,8 @@ export default function AnvilsPage() {
                   <span className="text-xs text-gray-500">
                     {t('anvilsPage.lastActivity')}:{' '}
                     <span className={`${TIMESTAMP_TEXT_CLASS[bucket]} tabular-nums`}>
-                      {anvil.last_activity
-                        ? formatDateTime(anvil.last_activity, {
+                      {bucket !== 'never'
+                        ? formatDateTime(anvil.last_activity as string, {
                             month: 'short',
                             day: 'numeric',
                             hour: '2-digit',

--- a/web/src/utils/anvilFreshness.test.ts
+++ b/web/src/utils/anvilFreshness.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getAnvilFreshness,
+  FRESH_THRESHOLD_MS,
+  STALE_THRESHOLD_MS,
+} from './anvilFreshness'
+
+const NOW = new Date('2026-05-27T12:00:00Z')
+
+function isoAgo(ms: number): string {
+  return new Date(NOW.getTime() - ms).toISOString()
+}
+
+describe('getAnvilFreshness', () => {
+  it('returns "never" for null', () => {
+    expect(getAnvilFreshness(null, NOW)).toBe('never')
+  })
+
+  it('returns "never" for undefined', () => {
+    expect(getAnvilFreshness(undefined, NOW)).toBe('never')
+  })
+
+  it('returns "never" for an invalid ISO string', () => {
+    expect(getAnvilFreshness('not-a-date', NOW)).toBe('never')
+  })
+
+  it('returns "fresh" for a timestamp 29 minutes old', () => {
+    expect(getAnvilFreshness(isoAgo(29 * 60 * 1000), NOW)).toBe('fresh')
+  })
+
+  it('returns "stale" exactly at the 30-minute boundary', () => {
+    expect(getAnvilFreshness(isoAgo(FRESH_THRESHOLD_MS), NOW)).toBe('stale')
+  })
+
+  it('returns "stale" for a timestamp 23h59m old', () => {
+    const ms = 23 * 60 * 60 * 1000 + 59 * 60 * 1000
+    expect(getAnvilFreshness(isoAgo(ms), NOW)).toBe('stale')
+  })
+
+  it('returns "dead" exactly at the 24-hour boundary', () => {
+    expect(getAnvilFreshness(isoAgo(STALE_THRESHOLD_MS), NOW)).toBe('dead')
+  })
+
+  it('returns "dead" for a timestamp 3 days old', () => {
+    expect(getAnvilFreshness(isoAgo(3 * 24 * 60 * 60 * 1000), NOW)).toBe('dead')
+  })
+
+  it('returns "fresh" for a future timestamp (clock skew)', () => {
+    const future = new Date(NOW.getTime() + 5 * 60 * 1000).toISOString()
+    expect(getAnvilFreshness(future, NOW)).toBe('fresh')
+  })
+
+  it('defaults `now` to the current time when omitted', () => {
+    const oneMinuteAgo = new Date(Date.now() - 60 * 1000).toISOString()
+    expect(getAnvilFreshness(oneMinuteAgo)).toBe('fresh')
+  })
+})

--- a/web/src/utils/anvilFreshness.ts
+++ b/web/src/utils/anvilFreshness.ts
@@ -1,0 +1,17 @@
+export const FRESH_THRESHOLD_MS = 30 * 60 * 1000
+export const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000
+
+export type FreshnessBucket = 'fresh' | 'stale' | 'dead' | 'never'
+
+export function getAnvilFreshness(
+  lastActivity: string | null | undefined,
+  now: Date = new Date(),
+): FreshnessBucket {
+  if (lastActivity == null) return 'never'
+  const parsed = new Date(lastActivity)
+  if (isNaN(parsed.getTime())) return 'never'
+  const ageMs = now.getTime() - parsed.getTime()
+  if (ageMs < FRESH_THRESHOLD_MS) return 'fresh'
+  if (ageMs < STALE_THRESHOLD_MS) return 'stale'
+  return 'dead'
+}


### PR DESCRIPTION
## Changes

- **Anvil staleness signal** - Anvil cards on the Mezzanine anvils page now tint their border and timestamp amber when `last_activity` is older than 30 minutes, red when older than 24 hours, and use a dashed gray treatment when an anvil has never reported activity. The timestamp block exposes an `aria-label` (e.g. "stale: last active 2h ago") and `role="status"` so screen readers receive the same signal. (Hytte-vt37)

## Original Issue (feature): Visually flag anvils whose last activity is stale

### Scope
Add a visual + accessible staleness signal to each anvil card on `/forge/mezzanine/anvils`. Derive a freshness bucket (`fresh` / `stale` / `dead` / `never`) from `last_activity` on the client and use it to tint the card border and the timestamp text, while attaching an `aria-label` that conveys the same information to screen readers. Backend payload stays unchanged.

### Files to touch
- `web/src/pages/AnvilsPage.tsx` — derive freshness from `anvil.last_activity`, apply border + text color, set `aria-label` and `role="status"` on the timestamp block.
- `web/src/utils/anvilFreshness.ts` (new) — pure helper that maps a `last_activity` ISO string + `now` to a bucket (`fresh|stale|dead|never`) using the configured thresholds (30 min, 24 h).
- `web/src/utils/anvilFreshness.test.ts` (new) — unit tests covering each threshold boundary and the `never` case.
- `web/public/locales/en/forge.json` — add `anvilsPage.staleness.{fresh,stale,dead,never}` strings (template like `"stale: last active {{relative}}"`, plus `neverActive`).
- `web/public/locales/nb/forge.json` — Norwegian translations of the same keys.
- `web/public/locales/th/forge.json` — Thai translations of the same keys.

### Acceptance criteria
- An anvil with `last_activity` within the last 30 minutes renders with the existing neutral `border-gray-700/50` and unchanged timestamp color.
- An anvil with `last_activity` between 30 minutes and 24 hours old renders with an amber border and amber timestamp text.
- An anvil with `last_activity` older than 24 hours renders with a red border and red timestamp text.
- An anvil with a null/missing `last_activity` renders with a muted/gray treatment distinct from `fresh` (e.g. dashed or gray-500 border) and the timestamp shows the existing em-dash.
- The timestamp block exposes an `aria-label` such as "stale: last active 2 hours ago" / "inactive: last active 3 days ago" / "never active" — verifiable with the accessibility tree in DevTools.
- All new strings are present in `en`, `nb`, and `th` forge locale files; no hardcoded English appears in the JSX changes.
- `npm run lint`, `npm run build`, and `go test ./...` pass; the new `anvilFreshness.test.ts` passes via `npm test` (or `vitest`).
- Manual check at 375 px width: the colored border does not break the existing `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` layout.

### Non-goals
- No backend changes to `internal/forge/handlers.go` or the anvil health payload shape.
- No configurable thresholds via user preferences or env vars — constants in the helper are fine.
- No auto-refresh / polling cadence changes; the existing `useAnvilHealth` behavior is untouched.
- No filtering, sorting, or grouping of cards by freshness.
- No icon or animation additions beyond the border + text color tint.

## Source

Created from Suggestions page (suggestion id 130, page slug "anvils", source=claude).

## Original suggestion

Right now every card looks identical regardless of whether the anvil last did something 30 seconds ago or three days ago — admins have to read each timestamp and do the math. Tint the card border or the timestamp text amber/red when `last_activity` is older than a threshold (e.g. >30m amber, >24h red, never-active gray) so dead or stuck anvils pop out. Pair the color with an accessible `aria-label` like "stale: last active 2 days ago" so screen readers convey the same signal. This makes the grid scannable at a glance, which is the whole point of a health view.


---
Bead: Hytte-vt37 | Branch: forge/Hytte-vt37
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->