### PR TITLE
Cache tab data so re-entering a tab does not re-fetch and flash skeletons (Hytte-wj73)

### DIFF
--- a/changelog.d/Hytte-wj73.md
+++ b/changelog.d/Hytte-wj73.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Allowance tabs cache data between switches** - Switching between Today, Chores, Payouts, Extras, and Bonuses tabs after a tab has loaded once no longer refetches or flashes a skeleton over cached data. Each tab gains an explicit Refresh control, and mutating actions (approve/reject, record, approve extra) invalidate dependent tabs so their data refetches on next visit. (Hytte-wj73)

--- a/web/public/locales/en/allowance.json
+++ b/web/public/locales/en/allowance.json
@@ -30,7 +30,8 @@
     "markPaid": "Mark as Paid",
     "saveRule": "Save Rule",
     "viewPhoto": "View photo",
-    "close": "Close"
+    "close": "Close",
+    "refresh": "Refresh"
   },
   "form": {
     "newChore": "New Chore",

--- a/web/public/locales/nb/allowance.json
+++ b/web/public/locales/nb/allowance.json
@@ -30,7 +30,8 @@
     "markPaid": "Merk som betalt",
     "saveRule": "Lagre regel",
     "viewPhoto": "Se bilde",
-    "close": "Lukk"
+    "close": "Lukk",
+    "refresh": "Oppdater"
   },
   "form": {
     "newChore": "Ny oppgave",

--- a/web/public/locales/th/allowance.json
+++ b/web/public/locales/th/allowance.json
@@ -30,7 +30,8 @@
     "markPaid": "ทำเครื่องหมายว่าจ่ายแล้ว",
     "saveRule": "บันทึกกฎ",
     "viewPhoto": "ดูรูปภาพ",
-    "close": "ปิด"
+    "close": "ปิด",
+    "refresh": "รีเฟรช"
   },
   "form": {
     "newChore": "งานใหม่",

--- a/web/src/hooks/useTabFetch.ts
+++ b/web/src/hooks/useTabFetch.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface UseTabFetchResult {
+  loading: boolean
+  error: string
+  reload: () => void
+  invalidate: () => void
+}
+
+// Caches per-tab fetched data for the lifetime of the page mount.
+//
+// - First time `active` becomes true, the fetcher runs and result is delivered
+//   to `onSuccess`. Subsequent `active` toggles do not refetch.
+// - `reload()` always re-runs the fetcher (also when inactive, so that data
+//   stays fresh for cross-tab effects like badges).
+// - `invalidate()` marks the data stale so the next time the tab becomes
+//   active the fetcher will run again.
+// - In-flight requests are cancelled on unmount, tab switch, and reload.
+export function useTabFetch<T>(
+  active: boolean,
+  fetcher: (signal: AbortSignal) => Promise<T>,
+  onSuccess: (data: T) => void,
+  errorMessage: string,
+): UseTabFetchResult {
+  const [internalLoading, setInternalLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [loaded, setLoaded] = useState(false)
+  const [forceKey, setForceKey] = useState(0)
+  const handledForceKey = useRef(0)
+
+  const fetcherRef = useRef(fetcher)
+  const onSuccessRef = useRef(onSuccess)
+  const errorMessageRef = useRef(errorMessage)
+  useEffect(() => {
+    fetcherRef.current = fetcher
+    onSuccessRef.current = onSuccess
+    errorMessageRef.current = errorMessage
+  })
+
+  useEffect(() => {
+    const isForced = forceKey > handledForceKey.current
+    if (!isForced && (!active || loaded)) {
+      // Guarded: reset any in-flight loading flag left over by an aborted fetch
+      // so a cached tab doesn't show its skeleton when reopened.
+      setInternalLoading(false)
+      return
+    }
+    if (isForced) handledForceKey.current = forceKey
+    const controller = new AbortController()
+    let cancelled = false
+    setInternalLoading(true)
+    setError('')
+    void (async () => {
+      try {
+        const data = await fetcherRef.current(controller.signal)
+        if (cancelled) return
+        onSuccessRef.current(data)
+        setLoaded(true)
+      } catch (err) {
+        if (cancelled) return
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        setError(errorMessageRef.current)
+      } finally {
+        if (!cancelled) setInternalLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [active, loaded, forceKey])
+
+  const reload = useCallback(() => {
+    setForceKey(k => k + 1)
+  }, [])
+
+  const invalidate = useCallback(() => {
+    setLoaded(false)
+  }, [])
+
+  // Show loading on first-entry into an active tab (before the effect kicks in)
+  // so the skeleton appears immediately, matching the pre-cache behavior.
+  const loading = internalLoading || (active && !loaded && !error)
+
+  return { loading, error, reload, invalidate }
+}

--- a/web/src/hooks/useTabFetch.ts
+++ b/web/src/hooks/useTabFetch.ts
@@ -27,6 +27,10 @@ export function useTabFetch<T>(
   const [loaded, setLoaded] = useState(false)
   const [forceKey, setForceKey] = useState(0)
   const handledForceKey = useRef(0)
+  // Tracks whether the last fetch attempt ended in a non-abort error.
+  // While true the guard skips refetching on tab-switch so the error message
+  // is preserved until the user explicitly calls reload().
+  const failedRef = useRef(false)
 
   const fetcherRef = useRef(fetcher)
   const onSuccessRef = useRef(onSuccess)
@@ -39,13 +43,18 @@ export function useTabFetch<T>(
 
   useEffect(() => {
     const isForced = forceKey > handledForceKey.current
-    if (!isForced && (!active || loaded)) {
+    if (!isForced && (!active || loaded || failedRef.current)) {
       // Guarded: reset any in-flight loading flag left over by an aborted fetch
       // so a cached tab doesn't show its skeleton when reopened.
       setInternalLoading(false)
       return
     }
-    if (isForced) handledForceKey.current = forceKey
+    // Capture forceKey for this invocation. handledForceKey is advanced only
+    // after the fetch resolves (success or real error, not abort) so that an
+    // abort mid-reload (e.g. due to a tab-switch) keeps the forced reload
+    // "pending" and automatically retries on the next active transition.
+    const capturedForceKey = forceKey
+    failedRef.current = false
     const controller = new AbortController()
     let cancelled = false
     setInternalLoading(true)
@@ -54,11 +63,14 @@ export function useTabFetch<T>(
       try {
         const data = await fetcherRef.current(controller.signal)
         if (cancelled) return
+        handledForceKey.current = Math.max(handledForceKey.current, capturedForceKey)
         onSuccessRef.current(data)
         setLoaded(true)
       } catch (err) {
         if (cancelled) return
         if (err instanceof DOMException && err.name === 'AbortError') return
+        handledForceKey.current = Math.max(handledForceKey.current, capturedForceKey)
+        failedRef.current = true
         setError(errorMessageRef.current)
       } finally {
         if (!cancelled) setInternalLoading(false)
@@ -75,6 +87,9 @@ export function useTabFetch<T>(
   }, [])
 
   const invalidate = useCallback(() => {
+    // Also clear failedRef so that a post-mutation invalidate on a previously
+    // failed tab correctly retries on the next activation.
+    failedRef.current = false
     setLoaded(false)
   }, [])
 

--- a/web/src/pages/AllowancePage.tsx
+++ b/web/src/pages/AllowancePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Camera, CheckCircle, XCircle, Plus, Pencil, Trash2, Star, X, ClipboardCheck } from 'lucide-react'
+import { Camera, CheckCircle, XCircle, Plus, Pencil, Trash2, Star, X, ClipboardCheck, RefreshCw } from 'lucide-react'
 import { formatDate, formatNumber } from '../utils/formatDate'
 import { Skeleton } from '../components/ui/skeleton'
 import { ConfirmDialog } from '../components/ui/dialog'
@@ -8,6 +8,7 @@ import { Tabs, TabList, TabTrigger, TabPanel } from '../components/ui/tabs'
 import RecordCompletionModal from '../components/allowance/RecordCompletionModal'
 import ToastList from '../components/ToastList'
 import { useToast } from '../hooks/useToast'
+import { useTabFetch } from '../hooks/useTabFetch'
 
 const formatAmount2dp = (amount: number) =>
   formatNumber(amount, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
@@ -143,8 +144,6 @@ export default function AllowancePage() {
 
   // Today tab state
   const [pending, setPending] = useState<CompletionWithDetails[]>([])
-  const [pendingLoading, setPendingLoading] = useState(true)
-  const [pendingError, setPendingError] = useState('')
   const [photoPreviewId, setPhotoPreviewId] = useState<number | null>(null)
   const [photoEnlarged, setPhotoEnlarged] = useState(false)
   const enlargedCloseRef = useRef<HTMLButtonElement>(null)
@@ -152,8 +151,6 @@ export default function AllowancePage() {
 
   // Chores tab state
   const [chores, setChores] = useState<Chore[]>([])
-  const [choresLoading, setChoresLoading] = useState(false)
-  const [choresError, setChoresError] = useState('')
   const [showChoreForm, setShowChoreForm] = useState(false)
   const [editingChore, setEditingChore] = useState<Chore | null>(null)
   const [choreForm, setChoreForm] = useState<ChoreFormState>(DEFAULT_CHORE_FORM)
@@ -181,13 +178,9 @@ export default function AllowancePage() {
 
   // Payouts tab state
   const [payouts, setPayouts] = useState<Payout[]>([])
-  const [payoutsLoading, setPayoutsLoading] = useState(false)
-  const [payoutsError, setPayoutsError] = useState('')
 
   // Extras tab state
   const [extras, setExtras] = useState<Extra[]>([])
-  const [extrasLoading, setExtrasLoading] = useState(false)
-  const [extrasError, setExtrasError] = useState('')
   const [showExtraForm, setShowExtraForm] = useState(false)
   const [extraForm, setExtraForm] = useState({ name: '', amount: '', expires_at: '' })
   const [extraFormSaving, setExtraFormSaving] = useState(false)
@@ -195,8 +188,6 @@ export default function AllowancePage() {
   const [extraActionError, setExtraActionError] = useState('')
 
   // Bonuses tab state
-  const [bonusesLoading, setBonusesLoading] = useState(false)
-  const [bonusesError, setBonusesError] = useState('')
   const [bonusForms, setBonusForms] = useState<Record<BonusType, BonusRuleFormState>>({
     full_week: { multiplier: '1.2', flat_amount: '0', active: false },
     early_bird: { multiplier: '1.0', flat_amount: '5', active: false },
@@ -220,97 +211,77 @@ export default function AllowancePage() {
   const [deactivateError, setDeactivateError] = useState('')
   const [payoutActionError, setPayoutActionError] = useState('')
 
-  useEffect(() => {
-    if (tab !== 'today') return
-    let cancelled = false
-    fetch('/api/allowance/pending', { credentials: 'include' })
-      .then(res => (res.ok ? res.json() : Promise.reject(res)))
-      .then((data: { pending: CompletionWithDetails[] }) => {
-        if (!cancelled) { setPending(data.pending ?? []); setPendingError('') }
-      })
-      .catch(() => { if (!cancelled) setPendingError(t('errors.loadFailed')) })
-      .finally(() => { if (!cancelled) setPendingLoading(false) })
-    return () => { cancelled = true }
-  }, [tab, t])
+  const loadFailed = t('errors.loadFailed')
 
-  useEffect(() => {
-    if (tab !== 'chores') return
-    let cancelled = false
-    fetch('/api/allowance/chores', { credentials: 'include' })
-      .then(res => (res.ok ? res.json() : Promise.reject(res)))
-      .then((data: { chores: Chore[] }) => {
-        if (!cancelled) { setChores(data.chores ?? []); setChoresError('') }
-      })
-      .catch(() => { if (!cancelled) setChoresError(t('errors.loadFailed')) })
-      .finally(() => { if (!cancelled) setChoresLoading(false) })
-    return () => { cancelled = true }
-  }, [tab, t])
+  const pendingFetch = useTabFetch<{ pending: CompletionWithDetails[] }>(
+    tab === 'today',
+    async signal => {
+      const res = await fetch('/api/allowance/pending', { credentials: 'include', signal })
+      if (!res.ok) throw new Error()
+      return res.json()
+    },
+    data => setPending(data.pending ?? []),
+    loadFailed,
+  )
 
-  useEffect(() => {
-    if (tab !== 'payouts') return
-    let cancelled = false
-    fetch('/api/allowance/payouts?weeks=8', { credentials: 'include' })
-      .then(res => (res.ok ? res.json() : Promise.reject(res)))
-      .then((data: { payouts: Payout[] }) => {
-        if (!cancelled) { setPayouts(data.payouts ?? []); setPayoutsError('') }
-      })
-      .catch(() => { if (!cancelled) setPayoutsError(t('errors.loadFailed')) })
-      .finally(() => { if (!cancelled) setPayoutsLoading(false) })
-    return () => { cancelled = true }
-  }, [tab, t])
+  const choresFetch = useTabFetch<{ chores: Chore[] }>(
+    tab === 'chores',
+    async signal => {
+      const res = await fetch('/api/allowance/chores', { credentials: 'include', signal })
+      if (!res.ok) throw new Error()
+      return res.json()
+    },
+    data => setChores(data.chores ?? []),
+    loadFailed,
+  )
 
-  useEffect(() => {
-    if (tab !== 'extras') return
-    let cancelled = false
-    void (async () => {
-      setExtrasLoading(true)
-      try {
-        const res = await fetch('/api/allowance/extras', { credentials: 'include' })
-        const data: { extras: Extra[] } = await (res.ok ? res.json() : Promise.reject(res))
-        if (!cancelled) { setExtras(data.extras ?? []); setExtrasError('') }
-      } catch {
-        if (!cancelled) setExtrasError(t('errors.loadFailed'))
-      } finally {
-        if (!cancelled) setExtrasLoading(false)
-      }
-    })()
-    return () => { cancelled = true }
-  }, [tab, t])
+  const payoutsFetch = useTabFetch<{ payouts: Payout[] }>(
+    tab === 'payouts',
+    async signal => {
+      const res = await fetch('/api/allowance/payouts?weeks=8', { credentials: 'include', signal })
+      if (!res.ok) throw new Error()
+      return res.json()
+    },
+    data => setPayouts(data.payouts ?? []),
+    loadFailed,
+  )
 
-  useEffect(() => {
-    if (tab !== 'bonuses') return
-    let cancelled = false
-    void (async () => {
-      setBonusesLoading(true)
-      try {
-        const res = await fetch('/api/allowance/bonuses', { credentials: 'include' })
-        const data: { bonus_rules: BonusRule[] } = await (res.ok ? res.json() : Promise.reject(res))
-        if (!cancelled) {
-          setBonusesError('')
-          // Populate form state from loaded rules using functional update to avoid stale closure
-          setBonusForms(prev => {
-            const updatedForms = { ...prev }
-            for (const rule of data.bonus_rules ?? []) {
-              const ruleType = rule.type as BonusType
-              if (BONUS_TYPES.includes(ruleType)) {
-                updatedForms[ruleType] = {
-                  multiplier: String(rule.multiplier ?? 1.0),
-                  flat_amount: String(rule.flat_amount ?? 0),
-                  active: rule.active,
-                }
-              }
+  const extrasFetch = useTabFetch<{ extras: Extra[] }>(
+    tab === 'extras',
+    async signal => {
+      const res = await fetch('/api/allowance/extras', { credentials: 'include', signal })
+      if (!res.ok) throw new Error()
+      return res.json()
+    },
+    data => setExtras(data.extras ?? []),
+    loadFailed,
+  )
+
+  const bonusesFetch = useTabFetch<{ bonus_rules: BonusRule[] }>(
+    tab === 'bonuses',
+    async signal => {
+      const res = await fetch('/api/allowance/bonuses', { credentials: 'include', signal })
+      if (!res.ok) throw new Error()
+      return res.json()
+    },
+    data => {
+      setBonusForms(prev => {
+        const updatedForms = { ...prev }
+        for (const rule of data.bonus_rules ?? []) {
+          const ruleType = rule.type as BonusType
+          if (BONUS_TYPES.includes(ruleType)) {
+            updatedForms[ruleType] = {
+              multiplier: String(rule.multiplier ?? 1.0),
+              flat_amount: String(rule.flat_amount ?? 0),
+              active: rule.active,
             }
-            return updatedForms
-          })
+          }
         }
-      } catch {
-        if (!cancelled) setBonusesError(t('errors.loadFailed'))
-      } finally {
-        if (!cancelled) setBonusesLoading(false)
-      }
-    })()
-    return () => { cancelled = true }
-  }, [tab, t])
+        return updatedForms
+      })
+    },
+    loadFailed,
+  )
 
   useEffect(() => {
     if (!recordChore || familyChildrenLoaded) return
@@ -333,28 +304,8 @@ export default function AllowancePage() {
   }, [recordChore, familyChildrenLoaded, t, showToast])
 
   const handleRecordSuccess = () => {
-    setPendingLoading(true)
-    setPendingError('')
-    fetch('/api/allowance/pending', { credentials: 'include' })
-      .then(res => (res.ok ? res.json() : Promise.reject(res)))
-      .then((data: { pending: CompletionWithDetails[] }) => {
-        if (!mountedRef.current) return
-        setPending(data.pending ?? [])
-        setPendingError('')
-      })
-      .catch(() => { if (mountedRef.current) setPendingError(t('errors.loadFailed')) })
-      .finally(() => { if (mountedRef.current) setPendingLoading(false) })
-
-    setPayoutsLoading(true)
-    fetch('/api/allowance/payouts?weeks=8', { credentials: 'include' })
-      .then(res => (res.ok ? res.json() : Promise.reject(res)))
-      .then((data: { payouts: Payout[] }) => {
-        if (!mountedRef.current) return
-        setPayouts(data.payouts ?? [])
-        setPayoutsError('')
-      })
-      .catch(() => { if (mountedRef.current) setPayoutsError(t('errors.loadFailed')) })
-      .finally(() => { if (mountedRef.current) setPayoutsLoading(false) })
+    pendingFetch.reload()
+    payoutsFetch.reload()
   }
 
   const handleApprove = async (id: number) => {
@@ -363,6 +314,7 @@ export default function AllowancePage() {
       const res = await fetch(`/api/allowance/approve/${id}`, { method: 'POST', credentials: 'include' })
       if (!res.ok) throw new Error()
       setPending(prev => prev.filter(c => c.id !== id))
+      payoutsFetch.invalidate()
     } catch {
       setActionError(t('errors.actionFailed'))
     }
@@ -379,6 +331,7 @@ export default function AllowancePage() {
       })
       if (!res.ok) throw new Error()
       setPending(prev => prev.filter(c => c.id !== id))
+      payoutsFetch.invalidate()
     } catch {
       setActionError(t('errors.actionFailed'))
     }
@@ -529,6 +482,7 @@ export default function AllowancePage() {
       if (!res.ok) throw new Error()
       const updated: Extra = await res.json()
       setExtras(prev => prev.map(e => (e.id === updated.id ? updated : e)))
+      payoutsFetch.invalidate()
     } catch {
       setExtraActionError(t('errors.actionFailed'))
     }
@@ -612,14 +566,21 @@ export default function AllowancePage() {
 
   const handleTabSwitch = (newTab: Tab) => {
     if (newTab === tab) return
-    if (newTab === 'today') { setPendingLoading(true); setPendingError('') }
-    else if (newTab === 'chores') { setChoresLoading(true); setChoresError('') }
-    else if (newTab === 'payouts') { setPayoutsLoading(true); setPayoutsError('') }
-    else if (newTab === 'extras') { setExtrasLoading(true); setExtrasError('') }
-    else if (newTab === 'bonuses') { setBonusesLoading(true); setBonusesError('') }
     setShowEmojiPicker(false)
     setTab(newTab)
   }
+
+  const renderRefresh = (onClick: () => void, loading: boolean) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={loading}
+      aria-label={t('actions.refresh')}
+      className="p-2 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+    </button>
+  )
 
   const tabs: { id: Tab; label: string }[] = [
     { id: 'today', label: t('tabs.today') },
@@ -650,7 +611,7 @@ export default function AllowancePage() {
           {tabs.map(({ id, label }) => (
             <TabTrigger key={id} value={id}>
               {label}
-              {id === 'today' && pending.length > 0 && !pendingLoading && (
+              {id === 'today' && pending.length > 0 && !pendingFetch.loading && (
                 <span className="ml-1.5 inline-flex items-center justify-center min-w-[18px] h-[18px] rounded-full bg-amber-500 text-white text-[10px] font-bold px-1">
                   {pending.length}
                 </span>
@@ -661,16 +622,19 @@ export default function AllowancePage() {
 
       {/* Today — pending approvals */}
       <TabPanel value="today">
+          <div className="flex justify-end mb-3">
+            {renderRefresh(() => pendingFetch.reload(), pendingFetch.loading)}
+          </div>
           {actionError && (
             <p className="text-red-400 text-sm mb-3">{actionError}</p>
           )}
-          {pendingLoading ? (
+          {pendingFetch.loading ? (
             <div role="status" aria-live="polite">
               <span className="sr-only">{t('loading')}</span>
               <Skeleton className="h-5 w-32" />
             </div>
-          ) : pendingError ? (
-            <p className="text-red-400 text-sm">{pendingError}</p>
+          ) : pendingFetch.error ? (
+            <p className="text-red-400 text-sm">{pendingFetch.error}</p>
           ) : pending.length === 0 ? (
             <div className="text-center py-16 text-gray-400">
               <p className="text-5xl mb-4">✅</p>
@@ -807,7 +771,8 @@ export default function AllowancePage() {
 
       {/* Chores — manage definitions */}
       <TabPanel value="chores">
-          <div className="flex justify-end mb-4">
+          <div className="flex justify-end gap-2 mb-4">
+            {renderRefresh(() => choresFetch.reload(), choresFetch.loading)}
             <button
               type="button"
               onClick={() => {
@@ -1041,13 +1006,13 @@ export default function AllowancePage() {
           {deactivateError && (
             <p className="text-red-400 text-sm mb-3">{deactivateError}</p>
           )}
-          {choresLoading ? (
+          {choresFetch.loading ? (
             <div role="status" aria-live="polite">
               <span className="sr-only">{t('loading')}</span>
               <Skeleton className="h-5 w-32" />
             </div>
-          ) : choresError ? (
-            <p className="text-red-400 text-sm">{choresError}</p>
+          ) : choresFetch.error ? (
+            <p className="text-red-400 text-sm">{choresFetch.error}</p>
           ) : chores.length === 0 ? (
             <div className="text-center py-16 text-gray-400">
               <p className="text-5xl mb-4">📋</p>
@@ -1111,7 +1076,8 @@ export default function AllowancePage() {
 
       {/* Extras — one-off tasks */}
       <TabPanel value="extras">
-          <div className="flex justify-end mb-4">
+          <div className="flex justify-end gap-2 mb-4">
+            {renderRefresh(() => extrasFetch.reload(), extrasFetch.loading)}
             <button
               type="button"
               onClick={() => {
@@ -1208,13 +1174,13 @@ export default function AllowancePage() {
           {extraActionError && (
             <p className="text-red-400 text-sm mb-3">{extraActionError}</p>
           )}
-          {extrasLoading ? (
+          {extrasFetch.loading ? (
             <div role="status" aria-live="polite">
               <span className="sr-only">{t('loading')}</span>
               <Skeleton className="h-5 w-32" />
             </div>
-          ) : extrasError ? (
-            <p className="text-red-400 text-sm">{extrasError}</p>
+          ) : extrasFetch.error ? (
+            <p className="text-red-400 text-sm">{extrasFetch.error}</p>
           ) : extras.length === 0 ? (
             <div className="text-center py-16 text-gray-400">
               <p className="text-5xl mb-4">🎯</p>
@@ -1258,16 +1224,19 @@ export default function AllowancePage() {
 
       {/* Bonuses — bonus rules settings */}
       <TabPanel value="bonuses">
+          <div className="flex justify-end mb-3">
+            {renderRefresh(() => bonusesFetch.reload(), bonusesFetch.loading)}
+          </div>
           {bonusActionError && (
             <p className="text-red-400 text-sm mb-3">{bonusActionError}</p>
           )}
-          {bonusesLoading ? (
+          {bonusesFetch.loading ? (
             <div role="status" aria-live="polite">
               <span className="sr-only">{t('loading')}</span>
               <Skeleton className="h-5 w-32" />
             </div>
-          ) : bonusesError ? (
-            <p className="text-red-400 text-sm">{bonusesError}</p>
+          ) : bonusesFetch.error ? (
+            <p className="text-red-400 text-sm">{bonusesFetch.error}</p>
           ) : (
             <div className="space-y-4">
               {ACTIVE_BONUS_TYPES.map(bonusType => {
@@ -1375,16 +1344,19 @@ export default function AllowancePage() {
 
       {/* Payouts — weekly summaries */}
       <TabPanel value="payouts">
+          <div className="flex justify-end mb-3">
+            {renderRefresh(() => payoutsFetch.reload(), payoutsFetch.loading)}
+          </div>
           {payoutActionError && (
             <p className="text-red-400 text-sm mb-3">{payoutActionError}</p>
           )}
-          {payoutsLoading ? (
+          {payoutsFetch.loading ? (
             <div role="status" aria-live="polite">
               <span className="sr-only">{t('loading')}</span>
               <Skeleton className="h-5 w-32" />
             </div>
-          ) : payoutsError ? (
-            <p className="text-red-400 text-sm">{payoutsError}</p>
+          ) : payoutsFetch.error ? (
+            <p className="text-red-400 text-sm">{payoutsFetch.error}</p>
           ) : payouts.length === 0 ? (
             <div className="text-center py-16 text-gray-400">
               <p className="text-5xl mb-4">💰</p>

--- a/web/src/pages/AllowancePage.tsx
+++ b/web/src/pages/AllowancePage.tsx
@@ -201,8 +201,6 @@ export default function AllowancePage() {
   const [recordChore, setRecordChore] = useState<Chore | null>(null)
   const [familyChildren, setFamilyChildren] = useState<{ child_id: number; nickname: string; avatar_emoji: string }[]>([])
   const [familyChildrenLoaded, setFamilyChildrenLoaded] = useState(false)
-  const mountedRef = useRef(true)
-  useEffect(() => () => { mountedRef.current = false }, [])
   const { toasts, showToast } = useToast()
 
   // Action error feedback


### PR DESCRIPTION
## Changes

- **Allowance tabs cache data between switches** - Switching between Today, Chores, Payouts, Extras, and Bonuses tabs after a tab has loaded once no longer refetches or flashes a skeleton over cached data. Each tab gains an explicit Refresh control, and mutating actions (approve/reject, record, approve extra) invalidate dependent tabs so their data refetches on next visit. (Hytte-wj73)

## Original Issue (feature): Cache tab data so re-entering a tab does not re-fetch and flash skeletons

### Scope
Stop the five tab-data effects in `AllowancePage.tsx` from refetching every time a tab is re-entered. Introduce a small per-tab "loaded" tracking helper so cached data stays on screen across tab switches, with an explicit Refresh action and the existing `handleRecordSuccess` path for forced reloads.

### Files to touch
- `web/src/pages/AllowancePage.tsx` — replace the five tab `useEffect` fetch blocks (lines ~223–313) with a `useTabFetch`-style helper or per-tab `loaded` flags; remove the `setPendingLoading(true)`/`setChoresLoading(true)` resets in the tab-switch handler (around line ~615); wire a Refresh button per tab; mark loaded after success and invalidate on `handleRecordSuccess` and other mutating actions.
- `web/src/hooks/useTabFetch.ts` (new, optional) — small helper encapsulating cancellation, loading state, error state, and a `reload()` returned for explicit refresh. Only add if it clearly reduces duplication; otherwise inline per-tab `loaded` flags.
- `web/public/locales/{en,nb,th}/allowance.json` (or the file currently holding allowance strings) — add a `refresh` label key used by the new Refresh button.

### Acceptance criteria
- Switching between Today, Chores, Payouts, Extras, and Bonuses tabs after each has loaded once does NOT trigger a network request and does NOT replace the rendered content with a skeleton.
- First entry into each tab still fetches and shows the existing loading skeleton exactly as today.
- A visible Refresh control on each tab triggers a fresh fetch, shows a loading indicator (skeleton or inline spinner), and updates the cached data on success.
- After approving/recording/editing a chore completion (existing `handleRecordSuccess` path) and after other mutating actions in each tab, the affected tab's data is invalidated and refetched so the UI reflects the change.
- In-flight requests are still cancelled on unmount and on tab switch (no setState-after-unmount warnings).
- Error states from a failed fetch are preserved and clearable by Refresh.
- Net code in `AllowancePage.tsx` decreases (target ~80 lines of duplicated effect/cancellation boilerplate removed); `npm run lint`, `npm run build`, and `go test ./...` all pass.
- A changelog fragment is added under `changelog.d/` in the `Changed` category.

### Non-goals
- No backend changes in `internal/allowance/handlers.go` or new caching layer/endpoints.
- No global client cache library (React Query, SWR, etc.) — keep it local to this page.
- No changes to `MyChoresPage.tsx` or other pages.
- No redesign of tab UI, skeletons, or error styling beyond adding the Refresh control.
- No background revalidation, polling, or TTL-based expiry — caching is for the lifetime of the page mount only.

## Source

Created from Suggestions page (suggestion id 127, page slug "allowance", source=claude).

## Original suggestion

Each of the five tab effects in AllowancePage.tsx:223-313 unconditionally re-runs its fetch every time the user switches to that tab, replacing already-loaded data with a skeleton for a few hundred ms before the same response arrives. For a parent flipping between Today and Chores while approving, this is jittery and wasteful. Track a per-tab `loaded` flag (or move the five fetches behind a tiny `useTabFetch(tab, key, url)` helper) so a tab only fetches when it has no data yet, and expose an explicit `Refresh` action plus the existing `handleRecordSuccess` path for forced reloads. Keeps current data visible across tab switches and removes ~80 lines of duplicated effect/cancellation boilerplate.


---
Bead: Hytte-wj73 | Branch: forge/Hytte-wj73
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->