### PR TITLE
Update conversation list locally after send instead of refetching (Hytte-r41a)

### DIFF
--- a/changelog.d/Hytte-r41a.md
+++ b/changelog.d/Hytte-r41a.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Chat: update sidebar locally after send instead of refetching** - The send-message endpoint now returns the refreshed conversation (with auto-title applied synchronously) and the client merges it into local state, removing the follow-up `GET /api/chat/conversations` round-trip and the race with mid-flight conversation switches. (Hytte-r41a)

--- a/internal/chat/handlers.go
+++ b/internal/chat/handlers.go
@@ -247,9 +247,11 @@ func SendMessageHandler(db *sql.DB) http.HandlerFunc {
 		// final title on the first turn — the client merges this into local state instead of
 		// firing a follow-up GET /api/chat/conversations.
 		if convo.Title == "" {
-			titleCtx, titleCancel := context.WithTimeout(r.Context(), 15*time.Second)
+			// Derive from the already-deadlined ctx so the total request time stays
+			// bounded by the original 120s budget plus at most 15s (not 120s + 15s).
+			titleCtx, titleCancel := context.WithTimeout(ctx, 15*time.Second)
+			defer titleCancel()
 			autoTitle(titleCtx, db, cfg, convo.ID, user.ID, content)
-			titleCancel()
 		}
 
 		// Re-load the conversation row so title and updated_at reflect the final state

--- a/internal/chat/handlers.go
+++ b/internal/chat/handlers.go
@@ -247,8 +247,9 @@ func SendMessageHandler(db *sql.DB) http.HandlerFunc {
 		// final title on the first turn — the client merges this into local state instead of
 		// firing a follow-up GET /api/chat/conversations.
 		if convo.Title == "" {
-			// Derive from the already-deadlined ctx so the total request time stays
-			// bounded by the original 120s budget plus at most 15s (not 120s + 15s).
+			// Derive a child context from the already-deadlined ctx with an additional
+			// 15s cap. Because WithTimeout takes the minimum of the parent deadline and
+			// the new deadline, auto-titling is bounded by min(remaining parent budget, 15s).
 			titleCtx, titleCancel := context.WithTimeout(ctx, 15*time.Second)
 			defer titleCancel()
 			autoTitle(titleCtx, db, cfg, convo.ID, user.ID, content)

--- a/internal/chat/handlers.go
+++ b/internal/chat/handlers.go
@@ -243,33 +243,28 @@ func SendMessageHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		// Auto-title: generate a title after the first exchange if the conversation has no title.
-		// Re-check the title inside the goroutine to avoid overwriting a user-set title.
+		// Runs synchronously with a bounded timeout so the returned conversation reflects the
+		// final title on the first turn — the client merges this into local state instead of
+		// firing a follow-up GET /api/chat/conversations.
 		if convo.Title == "" {
-			convoID := convo.ID
-			userID := user.ID
-			go func() {
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
+			titleCtx, titleCancel := context.WithTimeout(r.Context(), 15*time.Second)
+			autoTitle(titleCtx, db, cfg, convo.ID, user.ID, content)
+			titleCancel()
+		}
 
-				var currentTitle string
-				err := db.QueryRowContext(ctx,
-					"SELECT title FROM chat_conversations WHERE id = ? AND user_id = ?",
-					convoID, userID,
-				).Scan(&currentTitle)
-				if err != nil {
-					return
-				}
-				if currentTitle != "" {
-					// User has already set a title; skip auto-title.
-					return
-				}
-				autoTitle(db, cfg, convoID, userID, content)
-			}()
+		// Re-load the conversation row so title and updated_at reflect the final state
+		// (after the message insert and any auto-title update).
+		updatedConvo, err := GetConversation(db, convo.ID, user.ID)
+		if err != nil {
+			log.Printf("Failed to reload conversation after send: %v", err)
+			// Fall back to the pre-send snapshot; the client can still display the message pair.
+			updatedConvo = convo
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{
 			"user_message":      userMsg,
 			"assistant_message": assistantMsg,
+			"conversation":      updatedConvo,
 		})
 	}
 }
@@ -325,18 +320,27 @@ func truncateRunes(s string, max int) string {
 	return s
 }
 
-// autoTitle generates a short title for the conversation based on the first user message.
-// It runs in the background and silently updates the title.
-func autoTitle(db *sql.DB, cfg *training.ClaudeConfig, convoID, userID int64, firstMessage string) {
+// autoTitle generates a short title for the conversation based on the first user message
+// and updates the row in place. The caller controls the deadline via ctx.
+func autoTitle(ctx context.Context, db *sql.DB, cfg *training.ClaudeConfig, convoID, userID int64, firstMessage string) {
+	// Re-check the title under the caller's context to avoid overwriting a user-set title.
+	var currentTitle string
+	if err := db.QueryRowContext(ctx,
+		"SELECT title FROM chat_conversations WHERE id = ? AND user_id = ?",
+		convoID, userID,
+	).Scan(&currentTitle); err != nil {
+		return
+	}
+	if currentTitle != "" {
+		return
+	}
+
 	// Truncate long messages for title generation (rune-safe to avoid splitting UTF-8).
 	msg := truncateRunes(firstMessage, 500)
 
 	prompt := fmt.Sprintf(
 		"Generate a very short title (max 6 words) for a conversation that starts with this message. "+
 			"Reply with ONLY the title, no quotes, no punctuation at the end.\n\nMessage: %s", msg)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 
 	title, err := runPromptFn(ctx, cfg, prompt)
 	if err != nil {

--- a/internal/chat/handlers_test.go
+++ b/internal/chat/handlers_test.go
@@ -232,6 +232,7 @@ func TestSendMessageHandler_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
+	preSendUpdatedAt := convo.UpdatedAt
 
 	// Replace runPromptWithSessionFn with a stub that returns a known response.
 	orig := runPromptWithSessionFn
@@ -239,6 +240,14 @@ func TestSendMessageHandler_Success(t *testing.T) {
 		return &training.SessionResult{Response: "Hello from Claude!", SessionID: "test-session-123"}, nil
 	}
 	t.Cleanup(func() { runPromptWithSessionFn = orig })
+
+	// Stub the auto-title prompt so we don't shell out to a real CLI and so we
+	// can assert that the returned conversation reflects the generated title.
+	origPrompt := runPromptFn
+	runPromptFn = func(_ context.Context, _ *training.ClaudeConfig, _ string) (string, error) {
+		return "  Generated Title  ", nil
+	}
+	t.Cleanup(func() { runPromptFn = origPrompt })
 
 	body := `{"content": "Hello!"}`
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
@@ -253,8 +262,9 @@ func TestSendMessageHandler_Success(t *testing.T) {
 	}
 
 	var resp struct {
-		UserMsg      *Message `json:"user_message"`
-		AssistantMsg *Message `json:"assistant_message"`
+		UserMsg      *Message      `json:"user_message"`
+		AssistantMsg *Message      `json:"assistant_message"`
+		Conversation *Conversation `json:"conversation"`
 	}
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -265,6 +275,24 @@ func TestSendMessageHandler_Success(t *testing.T) {
 	if resp.AssistantMsg == nil || resp.AssistantMsg.Content != "Hello from Claude!" {
 		t.Fatalf("unexpected assistant message: %+v", resp.AssistantMsg)
 	}
+	if resp.Conversation == nil {
+		t.Fatal("expected conversation in response, got nil")
+	}
+	if resp.Conversation.ID != convo.ID {
+		t.Fatalf("expected conversation ID %d, got %d", convo.ID, resp.Conversation.ID)
+	}
+	if resp.Conversation.Title == "" {
+		t.Fatal("expected non-empty auto-generated title on first send, got empty")
+	}
+	if resp.Conversation.Title != "Generated Title" {
+		t.Fatalf("expected sanitised title 'Generated Title', got %q", resp.Conversation.Title)
+	}
+	if resp.Conversation.UpdatedAt == "" {
+		t.Fatal("expected non-empty updated_at on returned conversation")
+	}
+	if resp.Conversation.UpdatedAt < preSendUpdatedAt {
+		t.Fatalf("expected updated_at to advance, pre=%q post=%q", preSendUpdatedAt, resp.Conversation.UpdatedAt)
+	}
 
 	// Verify session ID was stored on the conversation.
 	convoAfter, err := GetConversation(d, convo.ID, 1)
@@ -273,6 +301,9 @@ func TestSendMessageHandler_Success(t *testing.T) {
 	}
 	if convoAfter.SessionID != "test-session-123" {
 		t.Fatalf("expected session_id 'test-session-123', got %q", convoAfter.SessionID)
+	}
+	if convoAfter.Title != "Generated Title" {
+		t.Fatalf("expected stored title to be auto-generated, got %q", convoAfter.Title)
 	}
 }
 

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -55,6 +55,12 @@ export default function Chat() {
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const renameInputRef = useRef<HTMLInputElement>(null)
+  // Track locally deleted conversation IDs so we don't resurrect them if a
+  // send response arrives after the user deleted the conversation mid-flight.
+  const deletedConversationIds = useRef<Set<number>>(new Set())
+  // Monotonically decreasing counter for optimistic message IDs (negative to avoid
+  // collisions with server-assigned IDs). Avoids calling Date.now() during render.
+  const tempIdCounter = useRef(0)
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -168,6 +174,7 @@ export default function Chat() {
         credentials: 'include',
       })
       if (!res.ok) throw new Error(t('errors.failedToDelete'))
+      deletedConversationIds.current.add(id)
       setConversations(prev => prev.filter(c => c.id !== id))
       if (activeConversation?.id === id) {
         setActiveConversation(null)
@@ -218,7 +225,7 @@ export default function Chat() {
 
     // Optimistic: add user message immediately
     const tempUserMsg: Message = {
-      id: -Date.now(),
+      id: -(++tempIdCounter.current),
       conversation_id: sentConversationId,
       role: 'user',
       content,
@@ -256,10 +263,19 @@ export default function Chat() {
       // Merge the refreshed conversation into local state (replaces auto-title refetch).
       if (updatedConv) {
         setConversations(prev => {
-          // If the user has already deleted the conversation locally, do not resurrect it.
-          if (!prev.some(c => c.id === updatedConv.id)) return prev
-          const next = prev.map(c => (c.id === updatedConv.id ? updatedConv : c))
-          next.sort((a, b) => (a.updated_at < b.updated_at ? 1 : a.updated_at > b.updated_at ? -1 : 0))
+          // Do not resurrect a conversation the user explicitly deleted locally.
+          if (deletedConversationIds.current.has(updatedConv.id)) return prev
+          const exists = prev.some(c => c.id === updatedConv.id)
+          // Insert when missing (e.g. initial list load finished after createConversation
+          // and overwrote state before the send response arrived).
+          const next = exists
+            ? prev.map(c => (c.id === updatedConv.id ? updatedConv : c))
+            : [updatedConv, ...prev]
+          // Sort by updated_at DESC, then id DESC (matches server ORDER BY) for stable ordering.
+          next.sort((a, b) => {
+            if (a.updated_at !== b.updated_at) return a.updated_at < b.updated_at ? 1 : -1
+            return b.id - a.id
+          })
           return next
         })
         // Only update the active conversation if the user hasn't switched to another one.

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -240,6 +240,7 @@ export default function Chat() {
       const data = await res.json()
       const userMsg = data.user_message as Message
       const assistantMsg = data.assistant_message as Message
+      const updatedConv = data.conversation as Conversation | undefined
 
       // Only update messages if the user hasn't switched conversations
       setActiveConversation(current => {
@@ -252,24 +253,19 @@ export default function Chat() {
         return current
       })
 
-      // Refresh conversation list to pick up auto-title updates (non-fatal)
-      try {
-        const convRes = await fetch('/api/chat/conversations', { credentials: 'include' })
-        if (convRes.ok) {
-          const convData = await convRes.json()
-          setConversations(convData.conversations ?? [])
-          const updated = (convData.conversations ?? []).find(
-            (c: Conversation) => c.id === sentConversationId
-          )
-          if (updated) {
-            setActiveConversation(current =>
-              current?.id === sentConversationId ? updated : current
-            )
-          }
-        }
-      } catch (refreshErr) {
-        // Non-fatal: log but don't roll back successful send
-        console.error('Failed to refresh conversations after sending message', refreshErr)
+      // Merge the refreshed conversation into local state (replaces auto-title refetch).
+      if (updatedConv) {
+        setConversations(prev => {
+          // If the user has already deleted the conversation locally, do not resurrect it.
+          if (!prev.some(c => c.id === updatedConv.id)) return prev
+          const next = prev.map(c => (c.id === updatedConv.id ? updatedConv : c))
+          next.sort((a, b) => (a.updated_at < b.updated_at ? 1 : a.updated_at > b.updated_at ? -1 : 0))
+          return next
+        })
+        // Only update the active conversation if the user hasn't switched to another one.
+        setActiveConversation(current =>
+          current?.id === sentConversationId ? updatedConv : current
+        )
       }
     } catch (err) {
       // Remove optimistic message on error and restore draft

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -59,7 +59,9 @@ export default function Chat() {
   // send response arrives after the user deleted the conversation mid-flight.
   const deletedConversationIds = useRef<Set<number>>(new Set())
   // Monotonically decreasing counter for optimistic message IDs (negative to avoid
-  // collisions with server-assigned IDs). Avoids calling Date.now() during render.
+  // collisions with server-assigned IDs). Using a ref gives stable IDs across
+  // re-renders without depending on wall-clock time (Date.now() could collide if
+  // two messages are sent within the same millisecond).
   const tempIdCounter = useRef(0)
 
   const scrollToBottom = useCallback(() => {


### PR DESCRIPTION
## Changes

- **Chat: update sidebar locally after send instead of refetching** - The send-message endpoint now returns the refreshed conversation (with auto-title applied synchronously) and the client merges it into local state, removing the follow-up `GET /api/chat/conversations` round-trip and the race with mid-flight conversation switches. (Hytte-r41a)

## Original Issue (feature): Update conversation list locally after send instead of refetching

### Scope
Eliminate the second `GET /api/chat/conversations` that `Chat.tsx` issues after every successful send. Make `POST /api/chat/conversations/{id}/messages` return the current conversation row alongside the message pair, and merge that into local state on the client (updating `updated_at` and any auto-generated title, then re-sorting the sidebar). Removes a round-trip and the race between the refetch and a user who has already switched conversations.

### Files to touch
- `internal/chat/handlers.go` — extend `SendMessageHandler` response to include `conversation`. Make `autoTitle` run synchronously with a bounded timeout (e.g. 10–15s) so the returned conversation reflects the final title on the first turn; after message insert + (optional) auto-title, re-load the conversation row so `updated_at` and `title` are fresh.
- `internal/chat/handlers_test.go` (if it exists; otherwise add coverage in the nearest existing test file) — assert that the send-message response includes a `conversation` object with the updated `updated_at`, and that auto-title produces a non-empty title on the first send.
- `web/src/pages/Chat.tsx` — in `sendMessage`, drop the follow-up `fetch('/api/chat/conversations')` block. Read `data.conversation`, then: replace it in the `conversations` array (or insert if missing), re-sort by `updated_at` descending, and update `activeConversation` only if it still matches `sentConversationId`.

### Acceptance criteria
- Network panel shows exactly one request per send (`POST .../messages`); no follow-up `GET /api/chat/conversations` fires.
- After the first message in a fresh conversation, the sidebar entry's title updates from the placeholder to the auto-generated title without any manual refresh.
- After any send, the conversation jumps to the top of the sidebar (re-sorted by `updated_at`) and its timestamp updates.
- Switching to a different conversation mid-flight does not cause the previous conversation's metadata update to overwrite the new active conversation in the header.
- If the user has already deleted the conversation locally before the response arrives, the response does not resurrect it.
- Existing chat tests pass; new test confirms `conversation` is present in the response payload with a non-empty title on first send.

### Non-goals
- Streaming assistant responses or any change to message delivery semantics.
- Reworking the auto-title prompt, model selection, or title length cap.
- Pagination, infinite scroll, or other broader sidebar changes.
- Optimistic title prediction on the client.
- Changes to `GET`, `PUT`, `DELETE`, or `POST /conversations` handlers beyond the send-message response shape.

## Source

Created from Suggestions page (suggestion id 39, page slug "chat", source=claude).

## Original suggestion

After every successful `sendMessage`, the page issues a second GET to `/api/chat/conversations` purely to pick up auto-title and `updated_at` changes, doubling the network round-trips per turn. Have the `POST /messages` response include the (possibly retitled) conversation, then merge it into local state and re-sort by `updated_at`. The result is faster perceived send completion, less server load, and no risk of the refetch racing with optimistic updates after a user has already switched to another conversation.


---
Bead: Hytte-r41a | Branch: forge/Hytte-r41a
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->