### PR TITLE
Show stale-data indicator when kiosk polling fails (Hytte-53ro)

### DIFF
--- a/changelog.d/Hytte-53ro.md
+++ b/changelog.d/Hytte-53ro.md
@@ -1,0 +1,2 @@
+category: Added
+- **Kiosk stale-data indicator** - The kiosk now shows a small unobtrusive "Updated X ago" badge in the top-right corner once the polling fetch has been failing for longer than two poll intervals (60s), so a wall-mounted screen visibly signals when its content is no longer live. The badge clears automatically when fetches recover. (Hytte-53ro)

--- a/web/src/components/kiosk/KioskStaleBadge.tsx
+++ b/web/src/components/kiosk/KioskStaleBadge.tsx
@@ -1,0 +1,30 @@
+interface KioskStaleBadgeProps {
+  isStale: boolean
+  lastSuccessAt: number | null
+  now: number
+}
+
+function formatAge(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000))
+  if (seconds < 60) return `${seconds} sec ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} min ago`
+  const hours = Math.floor(minutes / 60)
+  return `${hours} hr ago`
+}
+
+export default function KioskStaleBadge({ isStale, lastSuccessAt, now }: KioskStaleBadgeProps) {
+  if (!isStale || lastSuccessAt === null) return null
+
+  const ageMs = now - lastSuccessAt
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="kiosk-stale-badge"
+      className="fixed top-2 right-2 px-2 py-1 rounded bg-gray-900/80 text-gray-400 text-xs font-mono opacity-70"
+    >
+      Updated {formatAge(ageMs)}
+    </div>
+  )
+}

--- a/web/src/pages/KioskPage.test.tsx
+++ b/web/src/pages/KioskPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import KioskPage from './KioskPage'
 
@@ -94,13 +94,17 @@ describe('KioskPage – stale data badge', () => {
     expect(screen.queryByTestId('kiosk-stale-badge')).not.toBeInTheDocument()
 
     // From here on, fetches fail. Advance well past 2 * POLL_INTERVAL_MS (60s).
+    // Use the synchronous advanceTimersByTime so all setInterval callbacks fire
+    // within the same JS tick — React batches the setNow updates and flushes
+    // them when act() exits, ensuring the badge is in the DOM before the
+    // synchronous getByTestId call below.
     succeed = false
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(90_000)
+      vi.advanceTimersByTime(90_000)
       await flushMicrotasks()
     })
 
-    const badge = await screen.findByTestId('kiosk-stale-badge')
+    const badge = screen.getByTestId('kiosk-stale-badge')
     expect(badge).toBeInTheDocument()
     expect(badge.textContent).toMatch(/Updated .* (sec|min|hr) ago/)
   })
@@ -120,21 +124,23 @@ describe('KioskPage – stale data badge', () => {
     await act(async () => { await flushMicrotasks() })
 
     succeed = false
-    // Cross the threshold so the badge becomes visible.
+    // Cross the threshold so the badge becomes visible. Use synchronous timer
+    // advancement so React can batch and flush the setNow updates before act()
+    // exits, making getByTestId reliable without fake-timer polling.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(65_000)
+      vi.advanceTimersByTime(65_000)
       await flushMicrotasks()
     })
-    const badge = await screen.findByTestId('kiosk-stale-badge')
+    const badge = screen.getByTestId('kiosk-stale-badge')
     const firstText = badge.textContent
 
     // Now advance a further chunk of time — the staleness clock should tick
     // even though no fetch succeeds.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(120_000)
+      vi.advanceTimersByTime(120_000)
       await flushMicrotasks()
     })
-    const updated = await screen.findByTestId('kiosk-stale-badge')
+    const updated = screen.getByTestId('kiosk-stale-badge')
     expect(updated.textContent).not.toEqual(firstText)
   })
 
@@ -154,21 +160,21 @@ describe('KioskPage – stale data badge', () => {
 
     succeed = false
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(90_000)
+      vi.advanceTimersByTime(90_000)
       await flushMicrotasks()
     })
-    expect(await screen.findByTestId('kiosk-stale-badge')).toBeInTheDocument()
+    expect(screen.getByTestId('kiosk-stale-badge')).toBeInTheDocument()
 
     // Recovery: the next poll succeeds, so the badge should clear.
     succeed = true
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(30_000)
+      vi.advanceTimersByTime(30_000)
       await flushMicrotasks()
     })
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('kiosk-stale-badge')).not.toBeInTheDocument()
-    })
+    // After synchronous timer advancement and act() flushing, the badge should
+    // be gone — no need for waitFor which uses the now-faked setTimeout.
+    expect(screen.queryByTestId('kiosk-stale-badge')).not.toBeInTheDocument()
   })
 
   it('does not show the badge in mock mode (no token)', async () => {

--- a/web/src/pages/KioskPage.test.tsx
+++ b/web/src/pages/KioskPage.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import KioskPage from './KioskPage'
+
+vi.mock('../components/kiosk/KioskClock', () => ({
+  default: () => <div data-testid="mock-clock" />,
+}))
+vi.mock('../components/kiosk/KioskBusDepartures', () => ({
+  default: () => <div data-testid="mock-buses" />,
+}))
+vi.mock('../components/kiosk/KioskWeather', () => ({
+  default: () => <div data-testid="mock-weather" />,
+}))
+vi.mock('../components/kiosk/KioskSunrise', () => ({
+  default: () => <div data-testid="mock-sunrise" />,
+}))
+
+const apiPayload = {
+  transit: [],
+  outdoor: null,
+  indoor: null,
+  wind: null,
+  forecast: null,
+  sun: null,
+  fetched_at: '2026-05-27T12:00:00Z',
+}
+
+function renderKiosk(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/kiosk" element={<KioskPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+  }
+}
+
+describe('KioskPage – stale data badge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'setTimeout', 'clearTimeout', 'Date'] })
+    vi.setSystemTime(new Date('2026-05-27T12:00:00Z'))
+    try { localStorage.removeItem('hytte_kiosk_token') } catch { /* ignore */ }
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('does not show the stale badge after a successful fetch', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(apiPayload) } as Response),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderKiosk('/kiosk?token=test-token')
+
+    await act(async () => { await flushMicrotasks() })
+
+    expect(fetchMock).toHaveBeenCalled()
+    expect(screen.queryByTestId('kiosk-stale-badge')).not.toBeInTheDocument()
+
+    // Advance by a single poll cycle — fetches keep succeeding so still fresh.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushMicrotasks()
+    })
+    expect(screen.queryByTestId('kiosk-stale-badge')).not.toBeInTheDocument()
+  })
+
+  it('shows the stale badge after repeated failures past the threshold', async () => {
+    let succeed = true
+    const fetchMock = vi.fn(() => {
+      if (succeed) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(apiPayload) } as Response)
+      }
+      return Promise.reject(new Error('network down'))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderKiosk('/kiosk?token=test-token')
+
+    // Let the initial successful fetch resolve and record last-success time.
+    await act(async () => { await flushMicrotasks() })
+    expect(screen.queryByTestId('kiosk-stale-badge')).not.toBeInTheDocument()
+
+    // From here on, fetches fail. Advance well past 2 * POLL_INTERVAL_MS (60s).
+    succeed = false
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(90_000)
+      await flushMicrotasks()
+    })
+
+    const badge = await screen.findByTestId('kiosk-stale-badge')
+    expect(badge).toBeInTheDocument()
+    expect(badge.textContent).toMatch(/Updated .* (sec|min|hr) ago/)
+  })
+
+  it('updates the stale badge age via the clock tick without new fetches', async () => {
+    let succeed = true
+    const fetchMock = vi.fn(() => {
+      if (succeed) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(apiPayload) } as Response)
+      }
+      return Promise.reject(new Error('network down'))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderKiosk('/kiosk?token=test-token')
+
+    await act(async () => { await flushMicrotasks() })
+
+    succeed = false
+    // Cross the threshold so the badge becomes visible.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(65_000)
+      await flushMicrotasks()
+    })
+    const badge = await screen.findByTestId('kiosk-stale-badge')
+    const firstText = badge.textContent
+
+    // Now advance a further chunk of time — the staleness clock should tick
+    // even though no fetch succeeds.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000)
+      await flushMicrotasks()
+    })
+    const updated = await screen.findByTestId('kiosk-stale-badge')
+    expect(updated.textContent).not.toEqual(firstText)
+  })
+
+  it('clears the stale badge once a fetch succeeds again', async () => {
+    let succeed = true
+    const fetchMock = vi.fn(() => {
+      if (succeed) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(apiPayload) } as Response)
+      }
+      return Promise.reject(new Error('network down'))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderKiosk('/kiosk?token=test-token')
+
+    await act(async () => { await flushMicrotasks() })
+
+    succeed = false
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(90_000)
+      await flushMicrotasks()
+    })
+    expect(await screen.findByTestId('kiosk-stale-badge')).toBeInTheDocument()
+
+    // Recovery: the next poll succeeds, so the badge should clear.
+    succeed = true
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushMicrotasks()
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('kiosk-stale-badge')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not show the badge in mock mode (no token)', async () => {
+    const fetchMock = vi.fn(() => Promise.reject(new Error('should not be called')))
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderKiosk('/kiosk')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000)
+      await flushMicrotasks()
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('kiosk-stale-badge')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/KioskPage.tsx
+++ b/web/src/pages/KioskPage.tsx
@@ -6,6 +6,7 @@ import KioskBusDepartures from '../components/kiosk/KioskBusDepartures'
 import KioskWeather from '../components/kiosk/KioskWeather'
 import type { ForecastData } from '../components/kiosk/KioskWeather'
 import KioskSunrise from '../components/kiosk/KioskSunrise'
+import KioskStaleBadge from '../components/kiosk/KioskStaleBadge'
 import mockData from '../mocks/kioskData.json'
 
 // Error boundary so that JS errors show a visible message instead of a blank
@@ -112,6 +113,8 @@ interface KioskData {
 }
 
 const POLL_INTERVAL_MS = 30_000
+const STALE_THRESHOLD_MS = 2 * POLL_INTERVAL_MS
+const STALE_TICK_INTERVAL_MS = 5_000
 
 // Offset mock departure times so they appear relative to the current time,
 // preventing all departures from showing as "now/0 min" once the static
@@ -156,6 +159,8 @@ function KioskPageInner() {
   })()
 
   const [apiData, setApiData] = useState<KioskData | null>(null)
+  const [lastSuccessAt, setLastSuccessAt] = useState<number | null>(null)
+  const [now, setNow] = useState<number>(() => Date.now())
 
   // When no token is present, display relativized mock data; otherwise show API data (or mock while loading)
   const data = useMemo<KioskData>(() => {
@@ -181,6 +186,7 @@ function KioskPageInner() {
         if (!res.ok) return
         const json: KioskData = await res.json()
         setApiData(json)
+        setLastSuccessAt(Date.now())
       } catch {
         // Keep displaying last known data on error
       }
@@ -194,6 +200,19 @@ function KioskPageInner() {
       clearInterval(intervalId)
     }
   }, [token])
+
+  // Tick a clock so the stale indicator transitions from fresh to stale even
+  // when no new fetches are succeeding (e.g. kiosk left unattended on a wall).
+  useEffect(() => {
+    if (!token) return
+    const id = setInterval(() => setNow(Date.now()), STALE_TICK_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [token])
+
+  const isStale =
+    !!token &&
+    lastSuccessAt !== null &&
+    now - lastSuccessAt > STALE_THRESHOLD_MS
 
   return (
     <div className="min-h-screen bg-gray-950 text-white flex flex-col overflow-hidden pb-16">
@@ -224,6 +243,8 @@ function KioskPageInner() {
 
       {/* Sunrise / Sunset */}
       <KioskSunrise sun={data.sun ?? null} />
+
+      <KioskStaleBadge isStale={isStale} lastSuccessAt={lastSuccessAt} now={now} />
     </div>
   )
 }

--- a/web/src/pages/KioskPage.tsx
+++ b/web/src/pages/KioskPage.tsx
@@ -147,16 +147,24 @@ function KioskPageInner() {
     return () => { if (link) link.setAttribute('href', '/manifest.json') }
   }, [])
 
-  // Token from URL takes precedence; persist to localStorage so the kiosk
-  // works after "Add to Home Screen" (which strips query params).
-  const token = (() => {
-    const urlToken = searchParams.get('token')
+  const urlToken = searchParams.get('token')
+
+  // Persist URL token to localStorage in an effect so the kiosk works after
+  // "Add to Home Screen" (which strips query params). Doing this in a render
+  // body would write to storage on every re-render; an effect only runs when
+  // the URL token actually changes.
+  useEffect(() => {
     if (urlToken) {
       try { localStorage.setItem(KIOSK_TOKEN_KEY, urlToken) } catch { /* ignore */ }
-      return urlToken
     }
+  }, [urlToken])
+
+  // Read the stored token once at mount via the state initializer. URL param
+  // takes precedence so a fresh ?token=... URL always wins over the stored one.
+  const [storedToken] = useState<string | null>(() => {
     try { return localStorage.getItem(KIOSK_TOKEN_KEY) } catch { return null }
-  })()
+  })
+  const token = urlToken ?? storedToken
 
   const [apiData, setApiData] = useState<KioskData | null>(null)
   const [lastSuccessAt, setLastSuccessAt] = useState<number | null>(null)
@@ -201,13 +209,35 @@ function KioskPageInner() {
     }
   }, [token])
 
-  // Tick a clock so the stale indicator transitions from fresh to stale even
-  // when no new fetches are succeeding (e.g. kiosk left unattended on a wall).
+  // Drive the "Updated X ago" clock.
+  //
+  // The effect is gated on lastSuccessAt being non-null so the interval
+  // never starts before we have received a first data payload — a healthy
+  // kiosk that has never fetched successfully produces zero ticks.
+  //
+  // While data *is* fresh the interval fires every 5 s but skips the
+  // setNow call (and therefore skips the re-render) when we are still well
+  // below the stale threshold.  Only as we approach or cross the threshold
+  // does the state update fire, keeping the badge age display accurate
+  // without wasting renders on low-power wall-mounted devices during normal
+  // operation.
+  //
+  // The effect re-runs on each successful fetch (lastSuccessAt changes), so
+  // the timer is always anchored to the most recent success and a recovery
+  // fetch automatically resets the clock.
   useEffect(() => {
-    if (!token) return
-    const id = setInterval(() => setNow(Date.now()), STALE_TICK_INTERVAL_MS)
+    if (!token || lastSuccessAt === null) return
+    const id = setInterval(() => {
+      const t = Date.now()
+      // Only trigger a re-render when we are within one tick of the stale
+      // threshold or already past it; during the clearly-fresh window the
+      // DOM does not need updating.
+      if (t - lastSuccessAt >= STALE_THRESHOLD_MS - STALE_TICK_INTERVAL_MS) {
+        setNow(t)
+      }
+    }, STALE_TICK_INTERVAL_MS)
     return () => clearInterval(id)
-  }, [token])
+  }, [token, lastSuccessAt])
 
   const isStale =
     !!token &&


### PR DESCRIPTION
## Changes

- **Kiosk stale-data indicator** - The kiosk now shows a small unobtrusive "Updated X ago" badge in the top-right corner once the polling fetch has been failing for longer than two poll intervals (60s), so a wall-mounted screen visibly signals when its content is no longer live. The badge clears automatically when fetches recover. (Hytte-53ro)

## Original Issue (feature): Show stale-data indicator when kiosk polling fails

### Scope
Surface a low-key "stale data" indicator on the kiosk when the polling fetch loop in `KioskPage.tsx` has stopped succeeding, so a wall-mounted screen visibly signals when its content is no longer live. The change is frontend-only: track success/failure state alongside the existing poll, and render a small badge (or dim the existing timestamp) once the last successful fetch is older than two poll intervals (60s).

### Files to touch
- `web/src/pages/KioskPage.tsx` — extend the fetch effect to record last-success time and consecutive failure count; pass staleness down to the layout; render a small badge / dimmed `fetched_at` label in a corner that does not shift other elements.
- `web/src/components/kiosk/KioskStaleBadge.tsx` (new) — small presentational component that renders the badge / timestamp; keeps `KioskPage.tsx` lean and isolates styling.
- `web/src/pages/KioskPage.test.tsx` (new, if no existing test file) — unit test covering: fresh data shows no badge; after simulated failures past the threshold the badge appears; recovery clears it.

### Acceptance criteria
- When fetches succeed normally, no stale indicator is visible and the existing layout is unchanged (no reflow, no new rows).
- When fetches fail (network error, non-OK response, abort during refresh) for longer than 2 × `POLL_INTERVAL_MS` (60s), a small badge or dimmed `fetched_at` label appears in a fixed corner indicating the data is stale, including the age of the last successful payload (e.g. "Updated 3 min ago").
- The indicator updates as time passes even while no new fetch succeeds (i.e. it relies on a clock tick, not only on fetch events), so a kiosk left alone after a failure transitions from "fresh" to "stale" without manual reload.
- As soon as a fetch succeeds again, the indicator disappears and `apiData` is replaced as before.
- Mock-mode (no token) behavior is unchanged — no badge is shown for relativized mock data.
- The error boundary, manifest swap, and existing 30s polling cadence remain untouched.
- Tests for `KioskPage` cover at least: success → no badge, repeated failures past threshold → badge, recovery → badge cleared. `npm run lint` and `npm run build` pass.

### Non-goals
- No backend changes to `internal/kiosk/handlers.go` or the `/api/kiosk/data` response shape.
- No retry/backoff strategy, exponential or otherwise — the existing 30s interval continues to drive recovery.
- No full-screen takeover, modal, or audible alert when stale; the indicator stays unobtrusive by design.
- No telemetry, error reporting, or server-side logging of kiosk failures.
- No changes to non-kiosk pages or to the shared mock fixture beyond what's strictly required.
- No i18n wiring (the kiosk page does not currently use `react-i18next`); keep the badge text inline and consistent with surrounding kiosk strings.

## Source

Created from Suggestions page (suggestion id 61, page slug "kiosk", source=claude).

## Original suggestion

The fetch loop silently swallows errors and keeps rendering the last successful payload, so a kiosk on the wall can show data that is hours out of date with no visual cue. Track the timestamp of the last successful fetch (and consecutive failure count) in state and render a small badge or dimmed `fetched_at` label when the data is older than, say, two poll intervals. This makes it obvious at a glance when the screen is no longer live, without disrupting the layout when things are healthy.


---
Bead: Hytte-53ro | Branch: forge/Hytte-53ro
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->