### PR TITLE
Debounce the search input instead of requiring Enter to apply (Hytte-9aly)

### DIFF
--- a/changelog.d/Hytte-9aly.md
+++ b/changelog.d/Hytte-9aly.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Debounce Ingots search input** - Typing in the search box on the Ingots page now applies filters automatically after a 300 ms pause, instead of requiring Enter or blur. Pagination still resets to page 1 on each debounced apply. (Hytte-9aly)

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -1004,7 +1004,7 @@ export default function BudgetCreditCards() {
       next.get(key)!.push(tx)
     }
     for (const [key, arr] of next) {
-      // eslint-disable-next-line react-hooks/refs
+      // eslint-disable-next-line react-hooks/refs -- intentional: prev is the last-committed map (updated via useLayoutEffect, not during render); reading it here is safe for structural sharing
       const old = prev.get(key)
       if (old && old.length === arr.length && old.every((t, i) => t === arr[i])) {
         next.set(key, old)

--- a/web/src/pages/IngotsPage.tsx
+++ b/web/src/pages/IngotsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
@@ -67,17 +67,13 @@ export default function IngotsPage() {
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
 
-  const handleSearch = useCallback(() => {
-    setSearch(searchInput)
-    setPage(1)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearch(searchInput)
+      setPage(1)
+    }, 300)
+    return () => clearTimeout(timer)
   }, [searchInput])
-
-  const handleSearchKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') handleSearch()
-    },
-    [handleSearch],
-  )
 
   const handleClearFilters = useCallback(() => {
     setSearch('')
@@ -170,8 +166,6 @@ export default function IngotsPage() {
             type="text"
             value={searchInput}
             onChange={e => setSearchInput(e.target.value)}
-            onKeyDown={handleSearchKeyDown}
-            onBlur={handleSearch}
             placeholder={t('ingotsPage.searchPlaceholder')}
             className="w-full pl-8 pr-3 py-2 text-sm rounded-lg bg-gray-800 border border-gray-700 text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             aria-label={t('ingotsPage.searchLabel')}


### PR DESCRIPTION
## Changes

- **Debounce Ingots search input** - Typing in the search box on the Ingots page now applies filters automatically after a 300 ms pause, instead of requiring Enter or blur. Pagination still resets to page 1 on each debounced apply. (Hytte-9aly)

## Original Issue (feature): Debounce the search input instead of requiring Enter to apply

### Scope
Replace the manual Enter/blur-triggered search apply on the Ingots page with a 300 ms debounced effect, so typing in the search box updates results automatically. The search icon stays as a visual affordance, but no manual trigger remains. Behavior of other filters (status, date range) is unchanged.

### Files to touch
- `web/src/pages/IngotsPage.tsx` — drop `handleSearch`/`handleSearchKeyDown`, add a `useEffect` that debounces `searchInput` into `search` and resets `page` to 1, remove `onKeyDown` and `onBlur` wiring from the input.

### Acceptance criteria
- Typing into the search input on `/forge/mezzanine/ingots` updates the results without pressing Enter or blurring the field.
- After the user stops typing, results refresh roughly 300 ms later (a single debounced apply, not one request per keystroke).
- Each debounced apply also resets pagination to page 1 (matches today's `handleSearch` behavior).
- Clearing the input via the keyboard or via the "clear filters" control empties results to the unfiltered state, with no stale pending update firing afterwards.
- Rapid typing while on page 3+ does not fire multiple intermediate requests for partial queries; only the final value is applied.
- The search icon remains visible inside/next to the input; there is no Enter-required hint or click-to-search button.
- `npm run lint` and `npm run build` pass; existing tests still pass.

### Non-goals
- No changes to the backend search endpoint, query semantics, or `internal/forge/handlers.go`.
- No change to debounce behavior of the status filter or date range inputs.
- No new shared `useDebounce` hook extraction unless it falls out naturally; a local effect is acceptable.
- No visual redesign of the filter bar, no new translation keys, no changes to `PAGE_SIZE` or pagination UI.
- No debounce tuning knob exposed to users; 300 ms is fixed.

## Source

Created from Suggestions page (suggestion id 59, page slug "ingots", source=claude).

## Original suggestion

Today the user types in `searchInput`, but nothing happens until they press Enter, at which point `setSearch(searchInput)` fires. There is no visible hint that Enter is required, so it's easy to type a query, see no results update, and assume the page is broken. Replace the Enter-only handler with a 300 ms debounced effect that copies `searchInput` into `search` and resets `page` to 1. Keep the search icon but drop the manual trigger; the result is faster, more discoverable filtering that matches how the rest of the app behaves.


---
Bead: Hytte-9aly | Branch: forge/Hytte-9aly
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->