### PR TITLE
Fix shadowed defer rows.Close in recentActivity to avoid leaks (Hytte-ajhn)

### DIFF
--- a/changelog.d/Hytte-ajhn.md
+++ b/changelog.d/Hytte-ajhn.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Scope sql.Rows lifetimes in dashboard recent activity** - Refactor `recentActivity` to query each source (workouts, lactate, notes, short links) in its own helper with a locally scoped `defer rows.Close()`, preventing a `sql.Rows` handle from staying open if a later source query fails. (Hytte-ajhn)

--- a/internal/dashboard/activity.go
+++ b/internal/dashboard/activity.go
@@ -45,11 +45,36 @@ func ActivityHandler(db *sql.DB) http.HandlerFunc {
 
 // recentActivity queries the most recent items across multiple tables and
 // merges them into a single chronological list, limited to 10 items.
+//
+// Each source is queried via its own helper so the sql.Rows handle is scoped
+// to that helper (defer rows.Close runs on helper return), guaranteeing no
+// rows are left open if a later source fails.
 func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 	cutoff := time.Now().UTC().AddDate(0, 0, -30).Format(time.RFC3339)
-	var items []ActivityItem
 
-	// Recent workouts.
+	var items []ActivityItem
+	for _, query := range []func(*sql.DB, int64, string) ([]ActivityItem, error){
+		queryWorkouts,
+		queryLactate,
+		queryNotes,
+		queryLinks,
+	} {
+		got, err := query(db, userID, cutoff)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, got...)
+	}
+
+	sortByTimestamp(items)
+	if len(items) > 10 {
+		items = items[:10]
+	}
+	return items, nil
+}
+
+// queryWorkouts returns up to 10 recent workout activity items for the user.
+func queryWorkouts(db *sql.DB, userID int64, cutoff string) ([]ActivityItem, error) {
 	rows, err := db.Query(
 		`SELECT sport, title, started_at FROM workouts
 		 WHERE user_id = ? AND started_at >= ?
@@ -60,6 +85,8 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 		return nil, err
 	}
 	defer rows.Close()
+
+	var items []ActivityItem
 	for rows.Next() {
 		var sport, title, startedAt string
 		if err := rows.Scan(&sport, &title, &startedAt); err != nil {
@@ -77,21 +104,28 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	return items, nil
+}
 
-	// Recent lactate tests.
-	rows2, err := db.Query(
+// queryLactate returns up to 10 recent lactate-test activity items for the user.
+// The lactate_tests.date column stores YYYY-MM-DD, so the RFC3339 cutoff is
+// truncated to its date prefix.
+func queryLactate(db *sql.DB, userID int64, cutoff string) ([]ActivityItem, error) {
+	rows, err := db.Query(
 		`SELECT date, comment FROM lactate_tests
 		 WHERE user_id = ? AND date >= ?
 		 ORDER BY date DESC LIMIT 10`,
-		userID, cutoff[:10], // date column is YYYY-MM-DD
+		userID, cutoff[:10],
 	)
 	if err != nil {
 		return nil, err
 	}
-	defer rows2.Close()
-	for rows2.Next() {
+	defer rows.Close()
+
+	var items []ActivityItem
+	for rows.Next() {
 		var date, comment string
-		if err := rows2.Scan(&date, &comment); err != nil {
+		if err := rows.Scan(&date, &comment); err != nil {
 			return nil, err
 		}
 		comment = encryption.DecryptLenient(comment)
@@ -102,12 +136,15 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 			Link:      "/lactate",
 		})
 	}
-	if err := rows2.Err(); err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	return items, nil
+}
 
-	// Recent notes.
-	rows3, err := db.Query(
+// queryNotes returns up to 10 recent note activity items for the user.
+func queryNotes(db *sql.DB, userID int64, cutoff string) ([]ActivityItem, error) {
+	rows, err := db.Query(
 		`SELECT title, created_at FROM notes
 		 WHERE user_id = ? AND created_at >= ?
 		 ORDER BY created_at DESC LIMIT 10`,
@@ -116,10 +153,12 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows3.Close()
-	for rows3.Next() {
+	defer rows.Close()
+
+	var items []ActivityItem
+	for rows.Next() {
 		var title, createdAt string
-		if err := rows3.Scan(&title, &createdAt); err != nil {
+		if err := rows.Scan(&title, &createdAt); err != nil {
 			return nil, err
 		}
 		title = encryption.DecryptLenient(title)
@@ -130,12 +169,15 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 			Link:      "/notes",
 		})
 	}
-	if err := rows3.Err(); err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	return items, nil
+}
 
-	// Recent short links.
-	rows4, err := db.Query(
+// queryLinks returns up to 10 recent short-link activity items for the user.
+func queryLinks(db *sql.DB, userID int64, cutoff string) ([]ActivityItem, error) {
+	rows, err := db.Query(
 		`SELECT title, code, strftime('%Y-%m-%dT%H:%M:%SZ', created_at) FROM short_links
 		 WHERE user_id = ? AND datetime(created_at) >= datetime(?)
 		 ORDER BY created_at DESC LIMIT 10`,
@@ -144,10 +186,12 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows4.Close()
-	for rows4.Next() {
+	defer rows.Close()
+
+	var items []ActivityItem
+	for rows.Next() {
 		var title, code, createdAt string
-		if err := rows4.Scan(&title, &code, &createdAt); err != nil {
+		if err := rows.Scan(&title, &code, &createdAt); err != nil {
 			return nil, err
 		}
 		items = append(items, ActivityItem{
@@ -158,16 +202,9 @@ func recentActivity(db *sql.DB, userID int64) ([]ActivityItem, error) {
 			Link:      "/links",
 		})
 	}
-	if err := rows4.Err(); err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-
-	// Sort by timestamp descending and limit to 10.
-	sortByTimestamp(items)
-	if len(items) > 10 {
-		items = items[:10]
-	}
-
 	return items, nil
 }
 

--- a/internal/dashboard/activity_test.go
+++ b/internal/dashboard/activity_test.go
@@ -536,6 +536,112 @@ func TestActivityHandler_NoEnglishLabelsAcrossAllTypes(t *testing.T) {
 	}
 }
 
+// TestQueryHelpers_Individually exercises each per-source helper directly so
+// that the helper-level contract (own scoped defer rows.Close, returns its own
+// slice) is covered independently of the merge in recentActivity.
+func TestQueryHelpers_Individually(t *testing.T) {
+	d := setupTestDB(t)
+	user := createTestUser(t, d)
+	now := time.Now().UTC()
+	cutoff := now.AddDate(0, 0, -30).Format(time.RFC3339)
+
+	encWorkoutTitle, err := encryption.EncryptField("Solo Run")
+	if err != nil {
+		t.Fatalf("encrypt workout title: %v", err)
+	}
+	if _, err := d.Exec(
+		`INSERT INTO workouts (user_id, sport, title, started_at, duration_seconds, distance_meters,
+		 avg_heart_rate, max_heart_rate, avg_pace_sec_per_km, avg_cadence, calories,
+		 ascent_meters, descent_meters, fit_file_hash, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		user.ID, "running", encWorkoutTitle, now.Add(-2*time.Hour).Format(time.RFC3339),
+		1800, 5000, 150, 170, 360, 180, 300, 50, 30, "hash-helper", now.Add(-2*time.Hour).Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("insert workout: %v", err)
+	}
+
+	encComment, err := encryption.EncryptField("Stage notes")
+	if err != nil {
+		t.Fatalf("encrypt lactate comment: %v", err)
+	}
+	if _, err := d.Exec(
+		`INSERT INTO lactate_tests (user_id, date, comment, created_at) VALUES (?, ?, ?, ?)`,
+		user.ID, now.Add(-3*time.Hour).Format("2006-01-02"), encComment,
+		now.Add(-3*time.Hour).Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("insert lactate: %v", err)
+	}
+
+	encNoteTitle, err := encryption.EncryptField("Helper Note")
+	if err != nil {
+		t.Fatalf("encrypt note title: %v", err)
+	}
+	if _, err := d.Exec(
+		`INSERT INTO notes (user_id, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		user.ID, encNoteTitle, "body",
+		now.Add(-4*time.Hour).Format(time.RFC3339), now.Add(-4*time.Hour).Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("insert note: %v", err)
+	}
+
+	if _, err := d.Exec(
+		`INSERT INTO short_links (user_id, code, target_url, title, created_at) VALUES (?, ?, ?, ?, ?)`,
+		user.ID, "lnk", "https://example.com", "Helper Link",
+		now.Add(-5*time.Hour).Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("insert short link: %v", err)
+	}
+
+	workouts, err := queryWorkouts(d, user.ID, cutoff)
+	if err != nil {
+		t.Fatalf("queryWorkouts: %v", err)
+	}
+	if len(workouts) != 1 || workouts[0].Type != "workout" || workouts[0].Title != "Solo Run" {
+		t.Errorf("unexpected queryWorkouts result: %+v", workouts)
+	}
+
+	lactates, err := queryLactate(d, user.ID, cutoff)
+	if err != nil {
+		t.Fatalf("queryLactate: %v", err)
+	}
+	if len(lactates) != 1 || lactates[0].Type != "lactate" || lactates[0].Comment != "Stage notes" {
+		t.Errorf("unexpected queryLactate result: %+v", lactates)
+	}
+
+	notes, err := queryNotes(d, user.ID, cutoff)
+	if err != nil {
+		t.Fatalf("queryNotes: %v", err)
+	}
+	if len(notes) != 1 || notes[0].Type != "note" || notes[0].Title != "Helper Note" {
+		t.Errorf("unexpected queryNotes result: %+v", notes)
+	}
+
+	links, err := queryLinks(d, user.ID, cutoff)
+	if err != nil {
+		t.Fatalf("queryLinks: %v", err)
+	}
+	if len(links) != 1 || links[0].Type != "link" || links[0].Code != "lnk" || links[0].Title != "Helper Link" {
+		t.Errorf("unexpected queryLinks result: %+v", links)
+	}
+}
+
+// TestRecentActivity_ErrorPropagation verifies that when one source query
+// fails (here, by closing the DB so all queries fail), recentActivity returns
+// the underlying error rather than silently swallowing it. The helpers' scoped
+// defer rows.Close ensures no Rows leak across the failure path.
+func TestRecentActivity_ErrorPropagation(t *testing.T) {
+	d := setupTestDB(t)
+	user := createTestUser(t, d)
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	if _, err := recentActivity(d, user.ID); err == nil {
+		t.Fatal("expected recentActivity to return an error when the DB is closed")
+	}
+}
+
 func TestActivityHandler_LimitTen(t *testing.T) {
 	d := setupTestDB(t)
 	user := createTestUser(t, d)


### PR DESCRIPTION
## Changes

- **Scope sql.Rows lifetimes in dashboard recent activity** - Refactor `recentActivity` to query each source (workouts, lactate, notes, short links) in its own helper with a locally scoped `defer rows.Close()`, preventing a `sql.Rows` handle from staying open if a later source query fails. (Hytte-ajhn)

## Original Issue (feature): Fix shadowed defer rows.Close in recentActivity to avoid leaks

### Scope
Refactor `recentActivity` in `internal/dashboard/activity.go` so each of the four data sources (workouts, lactate tests, notes, short links) is queried in its own helper function with locally-scoped `defer rows.Close()`. This guarantees each `sql.Rows` is closed at its helper's return — including in early-error orderings — and removes the risk of a subsequent `db.Query` racing an unclosed Rows handle on the SQLite connection. Behavior of the `/api/dashboard/activity` endpoint is unchanged.

### Files to touch
- `internal/dashboard/activity.go` — extract `queryWorkouts`, `queryLactate`, `queryNotes`, `queryLinks` helpers; rewrite `recentActivity` to call them and merge results.
- `internal/dashboard/activity_test.go` — extend existing tests if needed to cover the helpers; ensure failure path on one source still surfaces an error and does not leak.

### Acceptance criteria
- Each of the four queries lives in its own helper function with signature `func(db *sql.DB, userID int64, cutoff string) ([]ActivityItem, error)` (or equivalent), each with its own `defer rows.Close()` immediately after a successful `db.Query`.
- `recentActivity` no longer holds multiple `sql.Rows` open concurrently; it calls helpers sequentially and appends their results before sorting and trimming to 10 items.
- If any single source query or scan returns an error, `recentActivity` returns that error and no `sql.Rows` from any source remains open (verified by code review — Close is scoped to the helper).
- Existing JSON response shape (`{"items": [...]}`), ordering (timestamp DESC), and 10-item cap are preserved.
- `go vet ./...` and `go test ./internal/dashboard/...` pass.
- A changelog fragment is added under `changelog.d/` in the `Fixed` category referencing the bead ID.

### Non-goals
- Adding new activity sources or fields to `ActivityItem`.
- Changing the SQL queries themselves (columns, filters, ordering, 30-day cutoff, per-source LIMIT 10).
- Switching to `errgroup`/parallel queries — keep sequential execution to preserve current SQLite behavior and error semantics.
- Touching the React/dashboard frontend or any other handler.
- Reworking encryption handling or moving decrypt logic out of these helpers.

## Source

Created from Suggestions page (suggestion id 3, page slug "dashboard", source=claude).

## Original suggestion

recentActivity opens four sql.Rows (rows, rows2, rows3, rows4) and uses defer for each, but if any later query returns an error the function returns without ever calling Close on the earlier rows variables in some failure orderings, and more importantly the deferred Close calls all stack on the same function exit which is fine but the pattern hides that an early scan error inside one loop leaves the next rows.Query running against a connection that may still be busy on SQLite. Refactor to extract each source into its own helper (queryWorkouts, queryLactate, queryNotes, queryLinks) that scopes its own defer rows.Close() and returns []ActivityItem, then merge in the parent. The dashboard activity endpoint becomes leak-safe under partial failures and the file gets dramatically easier to extend with new sources.


---
Bead: Hytte-ajhn | Branch: forge/Hytte-ajhn
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->