### PR TITLE
Add visibility-aware polling and exponential backoff on errors (Hytte-iaql)

### DIFF
--- a/changelog.d/Hytte-iaql.md
+++ b/changelog.d/Hytte-iaql.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Kiosk polling pauses when hidden and backs off on errors** - The kiosk now pauses its 30 s `/api/kiosk/data` poll while the tab is hidden and resumes with an immediate fetch when it returns. Failed fetches (network errors or non-OK responses) escalate the next delay through 30 s → 60 s → 2 min → 5 min, resetting to 30 s on the next success. Reduces battery use on idle tablets and avoids hammering Netatmo/Entur quotas during upstream outages. (Hytte-iaql)

--- a/web/src/pages/KioskPage.test.tsx
+++ b/web/src/pages/KioskPage.test.tsx
@@ -393,6 +393,50 @@ describe('KioskPage – visibility-aware polling and backoff', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('polls unconditionally and skips visibility listener when Page Visibility API is unavailable', async () => {
+    // Simulate browsers (e.g. Android 5) that do not implement the Page
+    // Visibility API. The beforeEach resets visibilityState to 'visible', so we
+    // override it to undefined here so that typeof document.visibilityState ===
+    // 'undefined' — matching the feature-detection branch in KioskPage.
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => undefined,
+    })
+
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(apiPayload) } as Response),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const addSpy = vi.spyOn(document, 'addEventListener')
+
+    renderKiosk('/kiosk?token=test-token')
+
+    // Initial fetch fires immediately.
+    await act(async () => { await flushMicrotasks() })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // No visibilitychange listener should have been attached.
+    const attachedVisibility = addSpy.mock.calls.some(
+      (call) => call[0] === 'visibilitychange',
+    )
+    expect(attachedVisibility).toBe(false)
+
+    // Polling continues unconditionally at the 30s baseline interval.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    addSpy.mockRestore()
+  })
+
   it('does not schedule fetches or attach visibility listeners in mock mode', async () => {
     const fetchMock = vi.fn(() => Promise.reject(new Error('should not be called')))
     vi.stubGlobal('fetch', fetchMock)

--- a/web/src/pages/KioskPage.test.tsx
+++ b/web/src/pages/KioskPage.test.tsx
@@ -192,3 +192,225 @@ describe('KioskPage – stale data badge', () => {
     expect(screen.queryByTestId('kiosk-stale-badge')).not.toBeInTheDocument()
   })
 })
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('KioskPage – visibility-aware polling and backoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'setTimeout', 'clearTimeout', 'Date'] })
+    vi.setSystemTime(new Date('2026-05-27T12:00:00Z'))
+    try { localStorage.removeItem('hytte_kiosk_token') } catch { /* ignore */ }
+    // Reset to visible at the start of each test.
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('pauses fetches while the tab is hidden and resumes immediately on visible', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(apiPayload) } as Response),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderKiosk('/kiosk?token=test-token')
+
+    await act(async () => { await flushMicrotasks() })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // Tab hidden: no further fetches even after several poll intervals.
+    await act(async () => {
+      setVisibility('hidden')
+      await flushMicrotasks()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // Visibility returns: should fire immediately (not after a 30s wait).
+    await act(async () => {
+      setVisibility('visible')
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    // Regular interval resumes from there.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('escalates failure delays through 30 → 60 → 120 → 300 → 300 then resets on success', async () => {
+    let succeed = false
+    const fetchMock = vi.fn(() => {
+      if (succeed) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(apiPayload) } as Response)
+      }
+      return Promise.reject(new Error('network down'))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderKiosk('/kiosk?token=test-token')
+
+    // Initial fetch fails. The 1st failure delay is 30s.
+    await act(async () => { await flushMicrotasks() })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // 29s later: still no new fetch.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(29_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    // 2nd failure → 60s delay.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(59_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    // 3rd failure → 120s delay.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(119_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+
+    // 4th failure → 300s delay (cap).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(299_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(5)
+
+    // 5th failure also caps at 300s.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(6)
+
+    // Success resets to the 30s baseline.
+    succeed = true
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(7)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(8)
+  })
+
+  it('treats !res.ok responses as failures and backs off', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) } as Response),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderKiosk('/kiosk?token=test-token')
+
+    await act(async () => { await flushMicrotasks() })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // 1st failure → 30s, 2nd → 60s.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    // 30s after the 2nd failure: no fetch yet (delay is 60s).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('cancels in-flight fetches and pending timers on unmount', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(apiPayload) } as Response),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { unmount } = renderKiosk('/kiosk?token=test-token')
+
+    await act(async () => { await flushMicrotasks() })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300_000)
+      await flushMicrotasks()
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not schedule fetches or attach visibility listeners in mock mode', async () => {
+    const fetchMock = vi.fn(() => Promise.reject(new Error('should not be called')))
+    vi.stubGlobal('fetch', fetchMock)
+    const addSpy = vi.spyOn(document, 'addEventListener')
+
+    renderKiosk('/kiosk')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000)
+      await flushMicrotasks()
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    const attachedVisibility = addSpy.mock.calls.some(
+      (call) => call[0] === 'visibilitychange',
+    )
+    expect(attachedVisibility).toBe(false)
+
+    addSpy.mockRestore()
+  })
+})

--- a/web/src/pages/KioskPage.tsx
+++ b/web/src/pages/KioskPage.tsx
@@ -194,6 +194,12 @@ function KioskPageInner() {
     let failureCount = 0
     let timerId: ReturnType<typeof setTimeout> | null = null
     let activeController: AbortController | null = null
+    // Monotonically increasing request ID. Guards against a stale response
+    // winning a race and calling setApiData after a newer fetch has started,
+    // independently of whether AbortController is available (when it is not,
+    // both myController and activeController would both be null and the
+    // controller-identity check would never fire).
+    let requestId = 0
 
     // Older browsers (Android 5 / Firefox ESR) may not implement the Page
     // Visibility API. Feature-detect and skip the listener if absent — polling
@@ -237,20 +243,27 @@ function KioskPageInner() {
         typeof AbortController !== 'undefined' ? new AbortController() : null
       activeController = myController
 
+      // Claim a unique ID for this invocation. This is the primary guard
+      // against a stale response winning a race — it works even when
+      // AbortController is unavailable (where both myController and
+      // activeController would be null, making the identity check useless).
+      requestId += 1
+      const myRequestId = requestId
+
       try {
         const res = await fetch('/api/kiosk/data?token=' + encodeURIComponent(token!), {
           credentials: 'include',
           signal: myController?.signal,
         })
         // Bail if unmounted or superseded by a newer fetch.
-        if (cancelled || myController !== activeController) return
+        if (cancelled || myRequestId !== requestId) return
         if (!res.ok) {
           failureCount += 1
           scheduleNext(backoffDelay())
           return
         }
         const json: KioskData = await res.json()
-        if (cancelled || myController !== activeController) return
+        if (cancelled || myRequestId !== requestId) return
         setApiData(json)
         setLastSuccessAt(Date.now())
         failureCount = 0
@@ -258,7 +271,7 @@ function KioskPageInner() {
       } catch {
         // Network failure or abort. If the abort came from unmount/supersede,
         // skip; otherwise treat as a failure and back off.
-        if (cancelled || myController !== activeController) return
+        if (cancelled || myRequestId !== requestId) return
         failureCount += 1
         scheduleNext(backoffDelay())
       }

--- a/web/src/pages/KioskPage.tsx
+++ b/web/src/pages/KioskPage.tsx
@@ -116,6 +116,12 @@ const POLL_INTERVAL_MS = 30_000
 const STALE_THRESHOLD_MS = 2 * POLL_INTERVAL_MS
 const STALE_TICK_INTERVAL_MS = 5_000
 
+// Backoff schedule applied to consecutive fetch failures. Index 0 is the delay
+// after the first failure, index 1 after the second, etc. The final entry is
+// used for any further consecutive failures (cap). A successful fetch resets
+// the failure count, so the next poll fires at POLL_INTERVAL_MS again.
+const BACKOFF_SCHEDULE_MS = [30_000, 60_000, 120_000, 300_000]
+
 // Offset mock departure times so they appear relative to the current time,
 // preventing all departures from showing as "now/0 min" once the static
 // fixture timestamps are in the past.
@@ -181,31 +187,108 @@ function KioskPageInner() {
       return
     }
 
-    // AbortController may be absent on very old browsers (Android 5); guard
-    // so the kiosk doesn't throw before the fetch try/catch can catch it.
-    const controller = typeof AbortController !== 'undefined' ? new AbortController() : null
+    // Visibility-aware polling with exponential backoff on failure. We avoid
+    // setInterval so each scheduling decision can react to the current state
+    // (visibility, failure count) instead of firing on a fixed cadence.
+    let cancelled = false
+    let failureCount = 0
+    let timerId: ReturnType<typeof setTimeout> | null = null
+    let activeController: AbortController | null = null
 
-    async function fetchData() {
-      try {
-        const res = await fetch('/api/kiosk/data?token=' + encodeURIComponent(token!), {
-          credentials: 'include',
-          signal: controller?.signal,
-        })
-        if (!res.ok) return
-        const json: KioskData = await res.json()
-        setApiData(json)
-        setLastSuccessAt(Date.now())
-      } catch {
-        // Keep displaying last known data on error
+    // Older browsers (Android 5 / Firefox ESR) may not implement the Page
+    // Visibility API. Feature-detect and skip the listener if absent — polling
+    // then runs unconditionally, as before.
+    const supportsVisibility =
+      typeof document !== 'undefined' && typeof document.visibilityState !== 'undefined'
+
+    function clearTimer() {
+      if (timerId !== null) {
+        clearTimeout(timerId)
+        timerId = null
       }
     }
 
+    function scheduleNext(delay: number) {
+      if (cancelled) return
+      // Don't schedule new fetches while the tab is hidden; the visibility
+      // listener will trigger an immediate fetch when the tab returns.
+      if (supportsVisibility && document.visibilityState === 'hidden') return
+      clearTimer()
+      timerId = setTimeout(() => {
+        timerId = null
+        fetchData()
+      }, delay)
+    }
+
+    function backoffDelay() {
+      const idx = Math.min(failureCount - 1, BACKOFF_SCHEDULE_MS.length - 1)
+      return BACKOFF_SCHEDULE_MS[idx]
+    }
+
+    async function fetchData() {
+      if (cancelled) return
+
+      // Abort any prior in-flight fetch (e.g. when visibility returns mid-poll
+      // we don't want two requests racing).
+      if (activeController) {
+        try { activeController.abort() } catch { /* ignore */ }
+      }
+      const myController =
+        typeof AbortController !== 'undefined' ? new AbortController() : null
+      activeController = myController
+
+      try {
+        const res = await fetch('/api/kiosk/data?token=' + encodeURIComponent(token!), {
+          credentials: 'include',
+          signal: myController?.signal,
+        })
+        // Bail if unmounted or superseded by a newer fetch.
+        if (cancelled || myController !== activeController) return
+        if (!res.ok) {
+          failureCount += 1
+          scheduleNext(backoffDelay())
+          return
+        }
+        const json: KioskData = await res.json()
+        if (cancelled || myController !== activeController) return
+        setApiData(json)
+        setLastSuccessAt(Date.now())
+        failureCount = 0
+        scheduleNext(POLL_INTERVAL_MS)
+      } catch {
+        // Network failure or abort. If the abort came from unmount/supersede,
+        // skip; otherwise treat as a failure and back off.
+        if (cancelled || myController !== activeController) return
+        failureCount += 1
+        scheduleNext(backoffDelay())
+      }
+    }
+
+    function handleVisibilityChange() {
+      if (cancelled) return
+      if (document.visibilityState === 'hidden') {
+        clearTimer()
+      } else if (document.visibilityState === 'visible') {
+        clearTimer()
+        fetchData()
+      }
+    }
+
+    if (supportsVisibility) {
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+    }
+
     fetchData()
-    const intervalId = setInterval(fetchData, POLL_INTERVAL_MS)
 
     return () => {
-      controller?.abort()
-      clearInterval(intervalId)
+      cancelled = true
+      clearTimer()
+      if (activeController) {
+        try { activeController.abort() } catch { /* ignore */ }
+      }
+      if (supportsVisibility) {
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
+      }
     }
   }, [token])
 


### PR DESCRIPTION
## Changes

- **Kiosk polling pauses when hidden and backs off on errors** - The kiosk now pauses its 30 s `/api/kiosk/data` poll while the tab is hidden and resumes with an immediate fetch when it returns. Failed fetches (network errors or non-OK responses) escalate the next delay through 30 s → 60 s → 2 min → 5 min, resetting to 30 s on the next success. Reduces battery use on idle tablets and avoids hammering Netatmo/Entur quotas during upstream outages. (Hytte-iaql)

## Original Issue (feature): Add visibility-aware polling and exponential backoff on errors

### Scope
Make the kiosk polling loop pause while the tab is hidden and back off on errors so the kiosk stops hammering `/api/kiosk/data` (and the upstream Netatmo/Entur calls behind it) when the screen is off or an upstream is failing. Resume immediately on visibility change and reset the interval on the next successful fetch. Backend behaviour is unchanged.

### Files to touch
- `web/src/pages/KioskPage.tsx` — replace the simple `setInterval` polling effect with a visibility-aware scheduler that uses exponential backoff on failure and resets on success. Distinguish HTTP errors (`!res.ok`) from network/abort errors so transient 4xx/5xx also trigger backoff.
- `web/src/pages/KioskPage.test.tsx` (new) — unit tests using fake timers and a mocked `fetch` to cover: visibility-hidden pauses the interval, visibility-visible triggers an immediate fetch, failures escalate the delay through the 30 s → 60 s → 2 min → 5 min schedule, a success resets the delay back to 30 s, and abort on unmount does not schedule further fetches.

### Acceptance criteria
- When `document.visibilityState` becomes `'hidden'`, no further `/api/kiosk/data` requests are issued until visibility returns (verified in tests with fake timers + `visibilitychange` event).
- When visibility returns to `'visible'`, a fetch fires immediately (not after a 30 s wait), and the regular interval resumes from that point.
- On a failed fetch (network error, abort other than unmount, or `!res.ok`), the next attempt is delayed using the schedule 30 s → 60 s → 120 s → 300 s, capped at 300 s, with each consecutive failure escalating one step.
- A successful fetch resets the delay so the very next scheduled poll is 30 s away again.
- Unmounting the component (or token change) cancels both the in-flight fetch and any pending timer; no callbacks fire afterwards.
- The mock-data path (no token present) is unaffected — no fetches scheduled, no visibility listeners leaked.
- `npm run lint`, `npm run test`, and `npm run build` all pass.

### Non-goals
- No changes to `internal/kiosk/handlers.go` or any backend caching/quotas — server-side mitigation is out of scope.
- No retries within a single fetch attempt and no jitter on the backoff schedule; the four fixed steps above are sufficient.
- No user-visible "offline" / "retrying" indicator; the existing behaviour of continuing to show the last-known data stands.
- No changes to the 30 s baseline cadence, to other kiosk sub-components, or to the error boundary.
- No `Page Visibility API` polyfill for the very old Android 5 / Firefox ESR browsers called out in the file — feature-detect `document.visibilityState` and fall back to the current unconditional interval if absent.

## Source

Created from Suggestions page (suggestion id 63, page slug "kiosk", source=claude).

## Original suggestion

The kiosk hits `/api/kiosk/data` every 30 s forever, even when the tablet screen is off or the network is flapping, which wastes battery and hammers Netatmo/Entur quotas during outages. Pause the interval when `document.visibilityState === 'hidden'` and resume with an immediate fetch on visibility change, and on fetch failure apply exponential backoff (e.g. 30 s → 60 s → 2 min, capped at 5 min) that resets on the next success. The user-visible win is faster recovery when the kiosk wakes up and far less log noise when an upstream is down.


---
Bead: Hytte-iaql | Branch: forge/Hytte-iaql
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->