### PR TITLE
Surface per-calendar sync failures instead of silently swallowing them (Hytte-u8rd)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Hytte/
 - **New pages**: create in `web/src/pages/`, follow Settings.tsx as pattern for complex pages
 - **Mobile-first**: All pages must work on mobile screens (~375px). Use responsive Tailwind breakpoints (`sm:`, `md:`) to add desktop-only columns/features. For data tables: show essential columns on mobile, hide secondary columns with `hidden sm:block`. Use `overflow-x-auto` as a fallback for wide content. Avoid fixed pixel widths that exceed mobile viewport. Test layouts at 375px width.
 - **i18n**: All user-facing strings MUST use `react-i18next`. Import `useTranslation` and use `t('namespace:key')` — never hardcode English text in JSX. Translation files are in `web/public/locales/{en,nb,th}/`. Add new keys to all three languages. Use `i18n.language` as the locale parameter for `Intl.DateTimeFormat`, `Intl.NumberFormat`, etc. See existing pages for patterns.
+  - There is **no** `calendar.json` locale file. `CalendarPage` uses the `common` namespace (`common.json`) under the `calendar.*` key prefix. All calendar i18n keys (including sync-error chip strings) live in `common.json`.
 
 ### Data Security & Encryption
 

--- a/changelog.d/Hytte-u8rd.md
+++ b/changelog.d/Hytte-u8rd.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Surface per-calendar sync failures** - The Calendar page now shows a warning chip beside the sync button when one or more calendars fail to sync, so partial staleness is visible instead of silently swallowed. The chip's tooltip lists the affected calendars. (Hytte-u8rd)

--- a/internal/calendar/handlers.go
+++ b/internal/calendar/handlers.go
@@ -1,6 +1,7 @@
 package calendar
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -20,12 +21,30 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	}
 }
 
+// EventFetcher fetches and caches Google Calendar events for a single calendar.
+// *Client satisfies this interface; tests inject stubs that simulate sync failures.
+type EventFetcher interface {
+	FetchAndCacheEvents(ctx context.Context, userID int64, calendarID string, timeMin, timeMax time.Time) error
+}
+
+// SyncError describes a per-calendar sync failure surfaced to the client so the
+// UI can warn the user that some calendars are showing stale data.
+type SyncError struct {
+	CalendarID string `json:"calendar_id"`
+	Message    string `json:"message"`
+}
+
+type eventsResponse struct {
+	Events     []Event     `json:"events"`
+	SyncErrors []SyncError `json:"sync_errors,omitempty"`
+}
+
 // EventsHandler returns cached calendar events for the authenticated user.
 // Query params:
 //   - start: RFC3339 or YYYY-MM-DD (required)
 //   - end:   RFC3339 or YYYY-MM-DD (required)
 //   - sync:  if "true", performs a sync inline before querying and returning events
-func EventsHandler(db *sql.DB, client *Client) http.HandlerFunc {
+func EventsHandler(db *sql.DB, client EventFetcher) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
 
@@ -59,6 +78,7 @@ func EventsHandler(db *sql.DB, client *Client) http.HandlerFunc {
 			queryCalendars = []string{"primary"}
 		}
 
+		var syncErrors []SyncError
 		if doSync {
 			hasToken, err := auth.HasGoogleToken(db, user.ID)
 			if err != nil {
@@ -70,6 +90,7 @@ func EventsHandler(db *sql.DB, client *Client) http.HandlerFunc {
 				for _, calID := range queryCalendars {
 					if err := client.FetchAndCacheEvents(r.Context(), user.ID, calID, startTime, endTime); err != nil {
 						log.Printf("calendar: sync failed for user %d calendar %s: %v", user.ID, calID, err)
+						syncErrors = append(syncErrors, SyncError{CalendarID: calID, Message: err.Error()})
 					}
 				}
 			}
@@ -85,7 +106,7 @@ func EventsHandler(db *sql.DB, client *Client) http.HandlerFunc {
 			events = []Event{}
 		}
 
-		writeJSON(w, http.StatusOK, map[string]any{"events": events})
+		writeJSON(w, http.StatusOK, eventsResponse{Events: events, SyncErrors: syncErrors})
 	}
 }
 

--- a/internal/calendar/handlers_test.go
+++ b/internal/calendar/handlers_test.go
@@ -1,12 +1,15 @@
 package calendar
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/db"
@@ -111,6 +114,129 @@ func TestEventsHandler_EmptyCache(t *testing.T) {
 	}
 	if len(events) != 0 {
 		t.Errorf("expected 0 events, got %d", len(events))
+	}
+}
+
+// stubFetcher lets a test simulate per-calendar sync results.
+type stubFetcher struct {
+	// errs maps calendarID → error to return for that calendar. nil means success.
+	errs map[string]error
+	// called records the calendar IDs that FetchAndCacheEvents was invoked with.
+	called []string
+}
+
+func (s *stubFetcher) FetchAndCacheEvents(_ context.Context, _ int64, calendarID string, _, _ time.Time) error {
+	s.called = append(s.called, calendarID)
+	if err, ok := s.errs[calendarID]; ok {
+		return err
+	}
+	return nil
+}
+
+func TestEventsHandler_SyncErrorsReported(t *testing.T) {
+	d := setupTestDB(t)
+	user := createTestUser(t, d)
+
+	// Two visible calendars; one fails to sync, the other succeeds.
+	if err := auth.SetPreference(d, user.ID, "calendar_visible_ids", "good@g.com,bad@g.com"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+
+	// Sync only runs when a Google token exists; insert one directly so we
+	// hit the loop without exercising real OAuth.
+	if err := auth.SaveGoogleToken(d, user.ID, &auth.GoogleToken{
+		AccessToken:  "stub-access",
+		RefreshToken: "stub-refresh",
+		TokenType:    "Bearer",
+	}); err != nil {
+		t.Fatalf("save google token: %v", err)
+	}
+
+	// Pre-seed one cached event per calendar so we can confirm the cached
+	// data is still returned alongside any sync errors.
+	if err := UpsertEvents(d, user.ID, []Event{
+		{ID: "good-1", CalendarID: "good@g.com", Title: "Good event", StartTime: "2026-04-08T07:00:00Z", EndTime: "2026-04-08T08:00:00Z", Status: "confirmed"},
+		{ID: "bad-1", CalendarID: "bad@g.com", Title: "Stale event", StartTime: "2026-04-08T09:00:00Z", EndTime: "2026-04-08T10:00:00Z", Status: "confirmed"},
+	}); err != nil {
+		t.Fatalf("seed events: %v", err)
+	}
+
+	fetcher := &stubFetcher{errs: map[string]error{"bad@g.com": errors.New("upstream 500")}}
+	handler := EventsHandler(d, fetcher)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/calendar/events?start=2026-04-01&end=2026-04-30&sync=true", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Events     []Event     `json:"events"`
+		SyncErrors []SyncError `json:"sync_errors"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Both calendars should have been attempted.
+	if len(fetcher.called) != 2 {
+		t.Errorf("expected fetcher to be called twice, got %d: %v", len(fetcher.called), fetcher.called)
+	}
+
+	if len(resp.SyncErrors) != 1 {
+		t.Fatalf("expected exactly 1 sync error, got %d: %+v", len(resp.SyncErrors), resp.SyncErrors)
+	}
+	if resp.SyncErrors[0].CalendarID != "bad@g.com" {
+		t.Errorf("expected sync error for bad@g.com, got %q", resp.SyncErrors[0].CalendarID)
+	}
+	if resp.SyncErrors[0].Message == "" {
+		t.Error("expected non-empty sync error message")
+	}
+	for _, se := range resp.SyncErrors {
+		if se.CalendarID == "good@g.com" {
+			t.Errorf("successful calendar should not appear in sync_errors: %+v", se)
+		}
+	}
+
+	// Cached events for both calendars are still returned.
+	if len(resp.Events) != 2 {
+		t.Errorf("expected 2 cached events, got %d", len(resp.Events))
+	}
+}
+
+func TestEventsHandler_SyncErrorsOmittedOnSuccess(t *testing.T) {
+	d := setupTestDB(t)
+	user := createTestUser(t, d)
+
+	if err := auth.SetPreference(d, user.ID, "calendar_visible_ids", "ok@g.com"); err != nil {
+		t.Fatalf("set preference: %v", err)
+	}
+	if err := auth.SaveGoogleToken(d, user.ID, &auth.GoogleToken{
+		AccessToken:  "stub-access",
+		RefreshToken: "stub-refresh",
+		TokenType:    "Bearer",
+	}); err != nil {
+		t.Fatalf("save google token: %v", err)
+	}
+
+	fetcher := &stubFetcher{}
+	handler := EventsHandler(d, fetcher)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/calendar/events?start=2026-04-01&end=2026-04-30&sync=true", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), user))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rr.Code, rr.Body.String())
+	}
+
+	// The raw payload should omit sync_errors entirely on success.
+	if strings.Contains(rr.Body.String(), "sync_errors") {
+		t.Errorf("expected sync_errors to be omitted when all syncs succeed; body: %s", rr.Body.String())
 	}
 }
 

--- a/internal/calendar/handlers_test.go
+++ b/internal/calendar/handlers_test.go
@@ -234,9 +234,14 @@ func TestEventsHandler_SyncErrorsOmittedOnSuccess(t *testing.T) {
 		t.Fatalf("expected 200, got %d; body: %s", rr.Code, rr.Body.String())
 	}
 
-	// The raw payload should omit sync_errors entirely on success.
-	if strings.Contains(rr.Body.String(), "sync_errors") {
-		t.Errorf("expected sync_errors to be omitted when all syncs succeed; body: %s", rr.Body.String())
+	// Decode the response and assert that the sync_errors key is entirely absent
+	// (omitempty drops the field when nil, so its presence would be a regression).
+	var decoded map[string]json.RawMessage
+	if err := json.NewDecoder(rr.Body).Decode(&decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if rawErrs, present := decoded["sync_errors"]; present {
+		t.Errorf("expected sync_errors to be omitted when all syncs succeed; got: %s", rawErrs)
 	}
 }
 

--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -125,6 +125,11 @@
     "errors": {
       "failedToLoad": "Failed to load calendar events",
       "syncFailed": "Calendar sync failed"
+    },
+    "syncErrors": {
+      "chip": "Sync issues",
+      "tooltip": "Failed to sync: {{calendars}}",
+      "ariaLabel": "Sync issues with: {{calendars}}"
     }
   },
   "family": {

--- a/web/public/locales/nb/common.json
+++ b/web/public/locales/nb/common.json
@@ -125,6 +125,11 @@
     "errors": {
       "failedToLoad": "Kunne ikke laste kalenderhendelser",
       "syncFailed": "Kalendersynkronisering mislyktes"
+    },
+    "syncErrors": {
+      "chip": "Synkroniseringsfeil",
+      "tooltip": "Kunne ikke synkronisere: {{calendars}}",
+      "ariaLabel": "Synkroniseringsfeil for: {{calendars}}"
     }
   },
   "family": {

--- a/web/public/locales/th/common.json
+++ b/web/public/locales/th/common.json
@@ -125,6 +125,11 @@
     "errors": {
       "failedToLoad": "ไม่สามารถโหลดกิจกรรมปฏิทินได้",
       "syncFailed": "การซิงค์ปฏิทินล้มเหลว"
+    },
+    "syncErrors": {
+      "chip": "ปัญหาการซิงค์",
+      "tooltip": "ซิงค์ไม่สำเร็จ: {{calendars}}",
+      "ariaLabel": "ปัญหาการซิงค์กับ: {{calendars}}"
     }
   },
   "family": {

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { RefreshCw, ChevronLeft, ChevronRight, Filter, CalendarDays, List, LayoutGrid, Columns3, Calendar } from 'lucide-react'
+import { RefreshCw, ChevronLeft, ChevronRight, Filter, CalendarDays, List, LayoutGrid, Columns3, Calendar, AlertTriangle } from 'lucide-react'
 import { useAuth } from '../auth'
 import { formatDate } from '../utils/formatDate'
 import {
@@ -19,6 +19,16 @@ import AgendaView from '../components/calendar/AgendaView'
 
 const AGENDA_DAYS = 14
 const STORAGE_KEY = 'hytte-calendar-view'
+
+interface SyncError {
+  calendar_id: string
+  message: string
+}
+
+interface EventsResponse {
+  events?: CalendarEvent[]
+  sync_errors?: SyncError[]
+}
 
 /** Format a Date as RFC3339 without fractional seconds. */
 function toRFC3339(date: Date): string {
@@ -84,6 +94,7 @@ export default function CalendarPage() {
   const [loading, setLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [syncErrors, setSyncErrors] = useState<SyncError[]>([])
   const [showSelector, setShowSelector] = useState(false)
   const [savingCalendars, setSavingCalendars] = useState(false)
   const [viewMode, setViewMode] = useState<ViewMode>(loadViewMode)
@@ -111,8 +122,11 @@ export default function CalendarPage() {
       const url = buildEventsUrl(viewMode, rangeStart, sync)
       const res = await fetch(url, { credentials: 'include', signal: ctl.signal })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const data = await res.json()
+      const data: EventsResponse = await res.json()
       setEvents(data.events ?? [])
+      // sync_errors only appears on sync requests; clear on any fetch so the
+      // chip vanishes after a successful sync or a plain reload.
+      setSyncErrors(sync ? (data.sync_errors ?? []) : [])
       setError(null)
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return
@@ -378,6 +392,27 @@ export default function CalendarPage() {
               <span className="hidden sm:inline">{t('calendar.refresh')}</span>
             </button>
           )}
+
+          {/* Sync errors chip — visible only when one or more calendars failed to sync */}
+          {connected === true && syncErrors.length > 0 && (() => {
+            const calendarNames = syncErrors.map(se => {
+              const cal = calendars.find(c => c.id === se.calendar_id)
+              return cal?.summary || se.calendar_id
+            })
+            const joined = calendarNames.join(', ')
+            const tooltip = t('calendar.syncErrors.tooltip', { calendars: joined })
+            return (
+              <span
+                role="status"
+                title={tooltip}
+                aria-label={t('calendar.syncErrors.ariaLabel', { calendars: joined })}
+                className="flex items-center gap-1.5 px-2 py-1 text-xs rounded-lg bg-amber-900/40 text-amber-300 border border-amber-700/60"
+              >
+                <AlertTriangle size={14} />
+                <span>{t('calendar.syncErrors.chip')}</span>
+              </span>
+            )
+          })()}
         </div>
       </div>
 


### PR DESCRIPTION
## Changes

- **Surface per-calendar sync failures** - The Calendar page now shows a warning chip beside the sync button when one or more calendars fail to sync, so partial staleness is visible instead of silently swallowed. The chip's tooltip lists the affected calendars. (Hytte-u8rd)

## Original Issue (feature): Surface per-calendar sync failures instead of silently swallowing them

I have enough context to write the plan.

### Scope
Make per-calendar sync failures in `GET /api/calendar/events?sync=true` visible to the user. Today the loop at `internal/calendar/handlers.go:70-74` only logs errors, so the UI silently shows stale data for failing calendars. Backend will collect failures and return them in the response; the React page will render a small warning chip near the existing sync button when any are present.

### Files to touch
- `internal/calendar/handlers.go` — collect `{calendar_id, message}` for each failed `FetchAndCacheEvents` call inside the `doSync` loop and include them in the JSON response as `sync_errors` (omit/empty when no sync was requested or all succeeded).
- `internal/calendar/handlers_test.go` — add a test that injects a `Client` (or stub) where one calendar's fetch fails and asserts `sync_errors` contains exactly that calendar id, while successful calendars are absent and `events` still returns cached data.
- `web/src/pages/CalendarPage.tsx` — extend the events response type, store `syncErrors` in state (clear on non-sync fetches and on successful sync), and render a warning chip beside the existing sync button (`AlertTriangle` from `lucide-react`) with tooltip/title listing affected calendar names where resolvable (fallback to id).
- `web/public/locales/{en,nb,th}/calendar.json` — add i18n keys for the chip label, tooltip prefix, and accessible name (e.g. `calendar.syncErrors.chip`, `calendar.syncErrors.tooltip`).

### Acceptance criteria
- When `sync=true` and at least one `FetchAndCacheEvents` call returns an error, the JSON response includes `sync_errors: [{calendar_id, message}, ...]` with one entry per failed calendar; successful calendars are not listed.
- When `sync=true` and all calendars succeed, `sync_errors` is empty or omitted; the response shape is unchanged for `sync=false` (back-compat).
- The Calendar page shows a warning chip adjacent to the sync button only when `sync_errors` is non-empty; the chip disappears after the next successful sync or a plain reload.
- The chip's accessible name and tooltip list the affected calendars (by summary when available, else id) and are sourced from `calendar.json` in en/nb/th.
- Existing happy path (events render, sync spinner) is unchanged when there are no sync errors.
- New backend test passes; `go vet`, `go test`, and `npm run lint` succeed.
- Changelog fragment added under `changelog.d/` in the `Fixed` category referencing the Hytte bead id.

### Non-goals
- No retry/backoff logic for failed calendars — surface the failure, don't auto-recover.
- No modal, toast, or per-event annotation — only the chip near the sync button.
- No changes to the `sync=false` path, the `/api/calendar/calendars` endpoint, or auth/token recovery flows.
- No telemetry/metrics emission for sync failures beyond the existing log lines.
- No translation of upstream Google error messages — they are passed through verbatim in the tooltip.

## Source

Created from Suggestions page (suggestion id 116, page slug "calendar", source=claude).

## Original suggestion

In `EventsHandler` the `sync=true` path loops calendars and only logs failures — the user sees fresh data for some calendars and stale data for others with no indication anything went wrong. Collect per-calendar sync errors into the response payload (e.g. `{events, sync_errors: [{calendar_id, message}]}`) and render a small warning chip near the sync button when present. This turns silent staleness into a visible, actionable state without changing the happy path.


---
Bead: Hytte-u8rd | Branch: forge/Hytte-u8rd
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->