### PR TITLE
Stop refetching all child workouts on FamilyChildDetail mount (Hytte-y64r)

### DIFF
--- a/changelog.d/Hytte-y64r.md
+++ b/changelog.d/Hytte-y64r.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Family child detail loads in one round-trip** - The Kids Stars child detail page no longer sequentially refetches every workout page on mount to power its charts. A new `GET /api/family/children/{id}/workouts/summary` endpoint returns the 8-week weekly aggregates (distance, workout count, stars) directly, and the table fetches only the first 20 rows on mount and additional pages on demand. (Hytte-y64r)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -579,6 +579,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Delete("/family/children/{id}", family.UnlinkChildHandler(db))
 				r.Get("/family/children/{id}/stats", family.ChildStatsHandler(db))
 				r.Get("/family/children/{id}/workouts", family.ChildWorkoutsHandler(db))
+				r.Get("/family/children/{id}/workouts/summary", family.ChildWorkoutsSummaryHandler(db))
 				r.Get("/family/children/{id}/settings", stars.GetChildSettingsHandler(db))
 				r.Put("/family/children/{id}/settings", stars.PutChildSettingsHandler(db))
 				r.Post("/family/invite", family.GenerateInviteHandler(db))

--- a/internal/family/handlers.go
+++ b/internal/family/handlers.go
@@ -621,6 +621,125 @@ func ChildWorkoutsHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
+// ChildWorkoutsSummaryHandler returns per-week aggregates (distance, workout count,
+// stars earned) for a child over the last 8 ISO/Monday-based weeks, in the server's
+// local timezone. Weeks are zero-filled and returned oldest→newest, always 8 entries.
+// The authenticated user must be the parent of the requested child.
+// GET /api/family/children/{id}/workouts/summary
+func ChildWorkoutsSummaryHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		childID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid child ID"})
+			return
+		}
+
+		if err := verifyParentChild(r.Context(), db, user.ID, childID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": "not authorized to view this child's workouts"})
+			} else {
+				log.Printf("family: verify parent-child user %d child %d: %v", user.ID, childID, err)
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			}
+			return
+		}
+
+		// Compute the 8 Monday-aligned week starts in the server's local timezone,
+		// oldest→newest. The last entry is the current (possibly partial) week.
+		loc := time.Now().Location()
+		now := time.Now().In(loc)
+		daysSinceMonday := (int(now.Weekday()) + 6) % 7
+		thisMonday := time.Date(now.Year(), now.Month(), now.Day()-daysSinceMonday, 0, 0, 0, 0, loc)
+
+		type weekBucket struct {
+			WeekStart      string  `json:"week_start"`
+			DistanceMeters float64 `json:"distance_meters"`
+			WorkoutCount   int     `json:"workout_count"`
+			Stars          int     `json:"stars"`
+		}
+		weeks := make([]weekBucket, 8)
+		for i := 0; i < 8; i++ {
+			ws := thisMonday.AddDate(0, 0, -7*(7-i))
+			weeks[i] = weekBucket{WeekStart: ws.Format("2006-01-02")}
+		}
+		windowStart := weeks[0].WeekStart // Monday of the oldest bucket, as YYYY-MM-DD.
+
+		// We compare workout started_at strings (stored as RFC3339 in UTC) against
+		// week-boundary local times by converting each row's started_at to local
+		// time in Go. Filter at the DB by a conservative window: anything on or
+		// after the local midnight of the oldest Monday, expressed in UTC.
+		windowStartLocal, err := time.ParseInLocation("2006-01-02", windowStart, loc)
+		if err != nil {
+			log.Printf("family: child workouts summary parse window user %d: %v", childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load summary"})
+			return
+		}
+		windowStartUTC := windowStartLocal.UTC().Format(time.RFC3339)
+
+		rows, err := db.QueryContext(r.Context(), `
+			SELECT w.started_at, w.distance_meters,
+			       COALESCE(s.stars, 0) AS stars
+			FROM workouts w
+			LEFT JOIN (
+				SELECT reference_id, user_id, SUM(amount) AS stars
+				FROM star_transactions
+				WHERE amount > 0
+				GROUP BY reference_id, user_id
+			) s ON s.reference_id = w.id AND s.user_id = w.user_id
+			WHERE w.user_id = ? AND w.started_at >= ?
+		`, childID, windowStartUTC)
+		if err != nil {
+			log.Printf("family: child workouts summary query user %d: %v", childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load summary"})
+			return
+		}
+		defer rows.Close()
+
+		// Precompute each bucket's [start, end) in local time for direct comparison.
+		bucketStarts := make([]time.Time, 8)
+		bucketEnds := make([]time.Time, 8)
+		for i := 0; i < 8; i++ {
+			ws := thisMonday.AddDate(0, 0, -7*(7-i))
+			bucketStarts[i] = ws
+			bucketEnds[i] = ws.AddDate(0, 0, 7)
+		}
+
+		for rows.Next() {
+			var startedAt string
+			var distance float64
+			var stars int
+			if err := rows.Scan(&startedAt, &distance, &stars); err != nil {
+				log.Printf("family: child workouts summary scan user %d: %v", childID, err)
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to scan summary"})
+				return
+			}
+			t, err := time.Parse(time.RFC3339, startedAt)
+			if err != nil {
+				log.Printf("family: child workouts summary parse started_at %q user %d: %v", startedAt, childID, err)
+				continue
+			}
+			local := t.In(loc)
+			for i := 0; i < 8; i++ {
+				if !local.Before(bucketStarts[i]) && local.Before(bucketEnds[i]) {
+					weeks[i].DistanceMeters += distance
+					weeks[i].WorkoutCount++
+					weeks[i].Stars += stars
+					break
+				}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			log.Printf("family: child workouts summary rows user %d: %v", childID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read summary"})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"weeks": weeks})
+	}
+}
+
 // MyFamilyHandler returns family info for the authenticated child user: their parent's
 // display info and the list of siblings with basic stats.
 // GET /api/family/my-family

--- a/internal/family/handlers.go
+++ b/internal/family/handlers.go
@@ -638,9 +638,17 @@ func ChildWorkoutsSummaryHandler(db *sql.DB) http.HandlerFunc {
 
 		if err := verifyParentChild(r.Context(), db, user.ID, childID); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				writeJSON(w, http.StatusForbidden, map[string]string{"error": "not authorized to view this child's workouts"})
+				// Distinguish between an unknown child and an unlinked child.
+				// If the child user doesn't exist at all, return 404; if the user
+				// exists but is not linked to this parent, return 403.
+				var exists int
+				if qErr := db.QueryRowContext(r.Context(), `SELECT 1 FROM users WHERE id = ?`, childID).Scan(&exists); errors.Is(qErr, sql.ErrNoRows) {
+					writeJSON(w, http.StatusNotFound, map[string]string{"error": "child not found"})
+				} else {
+					writeJSON(w, http.StatusForbidden, map[string]string{"error": "not authorized to view this child's workouts"})
+				}
 			} else {
-				log.Printf("family: verify parent-child user %d child %d: %v", user.ID, childID, err)
+				log.Printf("family: verify parent-child parent %d child %d: %v", user.ID, childID, err)
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			}
 			return
@@ -672,7 +680,7 @@ func ChildWorkoutsSummaryHandler(db *sql.DB) http.HandlerFunc {
 		// after the local midnight of the oldest Monday, expressed in UTC.
 		windowStartLocal, err := time.ParseInLocation("2006-01-02", windowStart, loc)
 		if err != nil {
-			log.Printf("family: child workouts summary parse window user %d: %v", childID, err)
+			log.Printf("family: child workouts summary parse window child %d: %v", childID, err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load summary"})
 			return
 		}
@@ -683,15 +691,15 @@ func ChildWorkoutsSummaryHandler(db *sql.DB) http.HandlerFunc {
 			       COALESCE(s.stars, 0) AS stars
 			FROM workouts w
 			LEFT JOIN (
-				SELECT reference_id, user_id, SUM(amount) AS stars
+				SELECT reference_id, SUM(amount) AS stars
 				FROM star_transactions
-				WHERE amount > 0
-				GROUP BY reference_id, user_id
-			) s ON s.reference_id = w.id AND s.user_id = w.user_id
+				WHERE amount > 0 AND user_id = ?
+				GROUP BY reference_id
+			) s ON s.reference_id = w.id
 			WHERE w.user_id = ? AND w.started_at >= ?
-		`, childID, windowStartUTC)
+		`, childID, childID, windowStartUTC)
 		if err != nil {
-			log.Printf("family: child workouts summary query user %d: %v", childID, err)
+			log.Printf("family: child workouts summary query child %d: %v", childID, err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load summary"})
 			return
 		}
@@ -711,13 +719,13 @@ func ChildWorkoutsSummaryHandler(db *sql.DB) http.HandlerFunc {
 			var distance float64
 			var stars int
 			if err := rows.Scan(&startedAt, &distance, &stars); err != nil {
-				log.Printf("family: child workouts summary scan user %d: %v", childID, err)
+				log.Printf("family: child workouts summary scan child %d: %v", childID, err)
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to scan summary"})
 				return
 			}
 			t, err := time.Parse(time.RFC3339, startedAt)
 			if err != nil {
-				log.Printf("family: child workouts summary parse started_at %q user %d: %v", startedAt, childID, err)
+				log.Printf("family: child workouts summary parse started_at %q child %d: %v", startedAt, childID, err)
 				continue
 			}
 			local := t.In(loc)
@@ -731,7 +739,7 @@ func ChildWorkoutsSummaryHandler(db *sql.DB) http.HandlerFunc {
 			}
 		}
 		if err := rows.Err(); err != nil {
-			log.Printf("family: child workouts summary rows user %d: %v", childID, err)
+			log.Printf("family: child workouts summary rows child %d: %v", childID, err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read summary"})
 			return
 		}

--- a/internal/family/handlers_test.go
+++ b/internal/family/handlers_test.go
@@ -542,8 +542,8 @@ func TestChildWorkoutsSummaryHandlerUnknownChild(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403 for unknown child (no family_links row), got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown child (user does not exist), got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/family/handlers_test.go
+++ b/internal/family/handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/go-chi/chi/v5"
@@ -480,6 +481,243 @@ func TestChildWorkoutsHandlerPagination(t *testing.T) {
 	}
 	if resp2.Offset != 2 {
 		t.Errorf("expected offset 2, got %d", resp2.Offset)
+	}
+}
+
+// ── Child workouts summary handler tests ───────────────────────────────────
+
+// summaryWeek mirrors the JSON shape returned by ChildWorkoutsSummaryHandler.
+type summaryWeek struct {
+	WeekStart      string  `json:"week_start"`
+	DistanceMeters float64 `json:"distance_meters"`
+	WorkoutCount   int     `json:"workout_count"`
+	Stars          int     `json:"stars"`
+}
+
+type summaryResp struct {
+	Weeks []summaryWeek `json:"weeks"`
+}
+
+// localMondayN returns the Monday of the ISO week N weeks before the current
+// week, at local 00:00. n=0 is this week's Monday, n=1 is last week's, etc.
+func localMondayN(now time.Time, n int) time.Time {
+	daysSinceMonday := (int(now.Weekday()) + 6) % 7
+	thisMonday := time.Date(now.Year(), now.Month(), now.Day()-daysSinceMonday, 0, 0, 0, 0, now.Location())
+	return thisMonday.AddDate(0, 0, -7*n)
+}
+
+func TestChildWorkoutsSummaryHandlerForbidden(t *testing.T) {
+	db := setupTestDB(t)
+
+	// testParent is not linked to testChild.
+	handler := ChildWorkoutsSummaryHandler(db)
+	r := withUser(withChiParam(newRequest(http.MethodGet, "/api/family/children/2/workouts/summary", nil), "id", "2"), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for unlinked parent, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestChildWorkoutsSummaryHandlerInvalidID(t *testing.T) {
+	db := setupTestDB(t)
+
+	handler := ChildWorkoutsSummaryHandler(db)
+	r := withUser(withChiParam(newRequest(http.MethodGet, "/api/family/children/abc/workouts/summary", nil), "id", "abc"), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestChildWorkoutsSummaryHandlerUnknownChild(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Child user 99 does not exist and is not linked to the parent.
+	handler := ChildWorkoutsSummaryHandler(db)
+	r := withUser(withChiParam(newRequest(http.MethodGet, "/api/family/children/99/workouts/summary", nil), "id", "99"), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for unknown child (no family_links row), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestChildWorkoutsSummaryHandlerEmpty(t *testing.T) {
+	db := setupTestDB(t)
+
+	if _, err := CreateLink(db, 1, 2, "Kiddo", "⭐"); err != nil {
+		t.Fatalf("CreateLink: %v", err)
+	}
+
+	handler := ChildWorkoutsSummaryHandler(db)
+	r := withUser(withChiParam(newRequest(http.MethodGet, "/api/family/children/2/workouts/summary", nil), "id", "2"), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp summaryResp
+	decode(t, w.Body.Bytes(), &resp)
+
+	if len(resp.Weeks) != 8 {
+		t.Fatalf("expected 8 weeks, got %d", len(resp.Weeks))
+	}
+	for i, wk := range resp.Weeks {
+		if wk.DistanceMeters != 0 || wk.WorkoutCount != 0 || wk.Stars != 0 {
+			t.Errorf("week %d: expected zero aggregates, got distance=%v count=%d stars=%d", i, wk.DistanceMeters, wk.WorkoutCount, wk.Stars)
+		}
+		if wk.WeekStart == "" {
+			t.Errorf("week %d: missing week_start", i)
+		}
+	}
+	// Weeks must be ordered oldest→newest and span exactly 7 days each.
+	for i := 1; i < len(resp.Weeks); i++ {
+		prev, err := time.Parse("2006-01-02", resp.Weeks[i-1].WeekStart)
+		if err != nil {
+			t.Fatalf("parse week_start[%d]: %v", i-1, err)
+		}
+		cur, err := time.Parse("2006-01-02", resp.Weeks[i].WeekStart)
+		if err != nil {
+			t.Fatalf("parse week_start[%d]: %v", i, err)
+		}
+		if diff := cur.Sub(prev); diff != 7*24*time.Hour {
+			t.Errorf("weeks %d→%d: expected 7-day gap, got %v", i-1, i, diff)
+		}
+	}
+}
+
+func TestChildWorkoutsSummaryHandlerBucketing(t *testing.T) {
+	db := setupTestDB(t)
+
+	if _, err := CreateLink(db, 1, 2, "Kiddo", "⭐"); err != nil {
+		t.Fatalf("CreateLink: %v", err)
+	}
+
+	now := time.Now()
+	thisMonday := localMondayN(now, 0)
+	lastMonday := localMondayN(now, 1)
+	threeWeeksAgoMonday := localMondayN(now, 3)
+
+	// Insert workouts in three different weeks. Use UTC RFC3339 strings as the
+	// schema does — the handler converts back to local time.
+	insertWorkout := func(id int64, when time.Time, distance float64) {
+		t.Helper()
+		_, err := db.Exec(`
+			INSERT INTO workouts (id, user_id, sport, started_at, duration_seconds, distance_meters, fit_file_hash, created_at)
+			VALUES (?, 2, 'running', ?, 1800, ?, ?, ?)
+		`, id, when.UTC().Format(time.RFC3339), distance, "h"+strconv.FormatInt(id, 10), when.UTC().Format(time.RFC3339))
+		if err != nil {
+			t.Fatalf("insert workout %d: %v", id, err)
+		}
+	}
+
+	// Current week: one workout, 5km, +3 stars.
+	insertWorkout(1, thisMonday.Add(2*time.Hour), 5000)
+	// Last week: two workouts (3km + 7km).
+	insertWorkout(2, lastMonday.Add(10*time.Hour), 3000)
+	insertWorkout(3, lastMonday.Add(48*time.Hour), 7000)
+	// Three weeks ago: one workout, 12km, no stars.
+	insertWorkout(4, threeWeeksAgoMonday.Add(5*time.Hour), 12000)
+
+	// Star transactions: 3 stars for workout 1, 2 stars for workout 2.
+	if _, err := db.Exec(`
+		INSERT INTO star_transactions (user_id, amount, reason, reference_id, created_at)
+		VALUES (2, 3, 'showed_up', 1, ?), (2, 2, 'showed_up', 2, ?)
+	`, thisMonday.UTC().Format(time.RFC3339), lastMonday.UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert star tx: %v", err)
+	}
+
+	handler := ChildWorkoutsSummaryHandler(db)
+	r := withUser(withChiParam(newRequest(http.MethodGet, "/api/family/children/2/workouts/summary", nil), "id", "2"), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp summaryResp
+	decode(t, w.Body.Bytes(), &resp)
+	if len(resp.Weeks) != 8 {
+		t.Fatalf("expected 8 weeks, got %d", len(resp.Weeks))
+	}
+
+	// Buckets: index 7 = current week, 6 = last week, 4 = three weeks ago, 0 = seven weeks ago.
+	if resp.Weeks[7].WorkoutCount != 1 || resp.Weeks[7].DistanceMeters != 5000 || resp.Weeks[7].Stars != 3 {
+		t.Errorf("current week: %+v", resp.Weeks[7])
+	}
+	if resp.Weeks[6].WorkoutCount != 2 || resp.Weeks[6].DistanceMeters != 10000 || resp.Weeks[6].Stars != 2 {
+		t.Errorf("last week: %+v", resp.Weeks[6])
+	}
+	if resp.Weeks[4].WorkoutCount != 1 || resp.Weeks[4].DistanceMeters != 12000 || resp.Weeks[4].Stars != 0 {
+		t.Errorf("three weeks ago: %+v", resp.Weeks[4])
+	}
+	// Other weeks must be zero.
+	for _, i := range []int{0, 1, 2, 3, 5} {
+		if resp.Weeks[i].WorkoutCount != 0 || resp.Weeks[i].DistanceMeters != 0 || resp.Weeks[i].Stars != 0 {
+			t.Errorf("week %d should be empty: %+v", i, resp.Weeks[i])
+		}
+	}
+
+	// Week-start values should be Mondays in YYYY-MM-DD format.
+	if resp.Weeks[7].WeekStart != thisMonday.Format("2006-01-02") {
+		t.Errorf("current week start: got %q want %q", resp.Weeks[7].WeekStart, thisMonday.Format("2006-01-02"))
+	}
+	if resp.Weeks[6].WeekStart != lastMonday.Format("2006-01-02") {
+		t.Errorf("last week start: got %q want %q", resp.Weeks[6].WeekStart, lastMonday.Format("2006-01-02"))
+	}
+}
+
+func TestChildWorkoutsSummaryHandlerWeekBoundary(t *testing.T) {
+	db := setupTestDB(t)
+
+	if _, err := CreateLink(db, 1, 2, "Kiddo", "⭐"); err != nil {
+		t.Fatalf("CreateLink: %v", err)
+	}
+
+	now := time.Now()
+	thisMonday := localMondayN(now, 0)
+	// One minute before this Monday (local) and one minute after.
+	beforeBoundary := thisMonday.Add(-time.Minute)
+	atBoundary := thisMonday
+
+	if _, err := db.Exec(`
+		INSERT INTO workouts (id, user_id, sport, started_at, duration_seconds, distance_meters, fit_file_hash, created_at)
+		VALUES (1, 2, 'running', ?, 1800, 1000, 'a', ?),
+		       (2, 2, 'running', ?, 1800, 2000, 'b', ?)
+	`,
+		beforeBoundary.UTC().Format(time.RFC3339), beforeBoundary.UTC().Format(time.RFC3339),
+		atBoundary.UTC().Format(time.RFC3339), atBoundary.UTC().Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("insert workouts: %v", err)
+	}
+
+	handler := ChildWorkoutsSummaryHandler(db)
+	r := withUser(withChiParam(newRequest(http.MethodGet, "/api/family/children/2/workouts/summary", nil), "id", "2"), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp summaryResp
+	decode(t, w.Body.Bytes(), &resp)
+
+	// The workout one minute before this Monday belongs to last week (index 6),
+	// the one at exactly this Monday belongs to the current week (index 7).
+	if resp.Weeks[6].WorkoutCount != 1 || resp.Weeks[6].DistanceMeters != 1000 {
+		t.Errorf("last week should hold the Sunday 23:59 workout: %+v", resp.Weeks[6])
+	}
+	if resp.Weeks[7].WorkoutCount != 1 || resp.Weeks[7].DistanceMeters != 2000 {
+		t.Errorf("current week should hold the Monday 00:00 workout: %+v", resp.Weeks[7])
 	}
 }
 

--- a/web/src/pages/FamilyChildDetail.tsx
+++ b/web/src/pages/FamilyChildDetail.tsx
@@ -192,6 +192,9 @@ export default function FamilyChildDetail() {
     if (paginationAbortRef.current) {
       paginationAbortRef.current.abort()
       paginationAbortRef.current = null
+      // Clear loading state for the aborted request — the finally block
+      // won't clear it because it guards against aborted signals.
+      setWorkoutsLoading(false)
     }
 
     const cached = pageCacheRef.current.get(newPage)

--- a/web/src/pages/FamilyChildDetail.tsx
+++ b/web/src/pages/FamilyChildDetail.tsx
@@ -67,6 +67,13 @@ interface ChildSettings {
   weekly_duration_target_min: number
 }
 
+interface WeeklySummary {
+  week_start: string
+  distance_meters: number
+  workout_count: number
+  stars: number
+}
+
 const PAGE_SIZE = 20
 
 export default function FamilyChildDetail() {
@@ -87,13 +94,14 @@ export default function FamilyChildDetail() {
   const [loading, setLoading] = useState(isValidId)
   const [error, setError] = useState(() => isValidId ? '' : t('family.detail.errors.invalidChild'))
 
-  const [chartWorkouts, setChartWorkouts] = useState<ChildWorkout[]>([])
+  const [weeklySummary, setWeeklySummary] = useState<WeeklySummary[]>([])
   const [tableWorkouts, setTableWorkouts] = useState<ChildWorkout[]>([])
   const [workoutsTotal, setWorkoutsTotal] = useState(0)
   const [workoutsPage, setWorkoutsPage] = useState(0)
   const [workoutsLoading, setWorkoutsLoading] = useState(false)
   const [workoutsError, setWorkoutsError] = useState('')
   const paginationAbortRef = useRef<AbortController | null>(null)
+  const pageCacheRef = useRef<Map<number, ChildWorkout[]>>(new Map())
 
   const [settings, setSettings] = useState<ChildSettings | null>(null)
   const [settingsSaving, setSettingsSaving] = useState(false)
@@ -108,13 +116,15 @@ export default function FamilyChildDetail() {
 
     async function loadInitialData(signal: AbortSignal) {
       setWorkoutsPage(0)
+      pageCacheRef.current = new Map()
       try {
         setLoading(true)
         setError('')
-        const [statsRes, childrenRes, workoutsRes, settingsRes] = await Promise.all([
+        const [statsRes, childrenRes, workoutsRes, summaryRes, settingsRes] = await Promise.all([
           fetch(`/api/family/children/${childId}/stats`, { credentials: 'include', signal }),
           fetch('/api/family/children', { credentials: 'include', signal }),
-          fetch(`/api/family/children/${childId}/workouts?limit=100&offset=0`, { credentials: 'include', signal }),
+          fetch(`/api/family/children/${childId}/workouts?limit=${PAGE_SIZE}&offset=0`, { credentials: 'include', signal }),
+          fetch(`/api/family/children/${childId}/workouts/summary`, { credentials: 'include', signal }),
           fetch(`/api/family/children/${childId}/settings`, { credentials: 'include', signal }),
         ])
         if (!statsRes.ok) throw new Error('failed')
@@ -136,33 +146,18 @@ export default function FamilyChildDetail() {
           const workoutsData = await workoutsRes.json()
           const firstPage: ChildWorkout[] = workoutsData.workouts ?? []
           const total: number = workoutsData.total ?? firstPage.length
-
-          const allWorkouts: ChildWorkout[] = [...firstPage]
-          let offset = firstPage.length
-
-          while (offset < total) {
-            const pageRes = await fetch(
-              `/api/family/children/${childId}/workouts?limit=100&offset=${offset}`,
-              { credentials: 'include', signal }
-            )
-            if (!pageRes.ok) {
-              setWorkoutsError(t('family.detail.errors.failedToLoad'))
-              break
-            }
-            const pageData = await pageRes.json()
-            const pageWorkouts: ChildWorkout[] = pageData.workouts ?? []
-            if (pageWorkouts.length === 0) {
-              break
-            }
-            allWorkouts.push(...pageWorkouts)
-            offset += pageWorkouts.length
-          }
-
-          setChartWorkouts(allWorkouts)
-          setTableWorkouts(allWorkouts.slice(0, PAGE_SIZE))
+          pageCacheRef.current.set(0, firstPage)
+          setTableWorkouts(firstPage)
           setWorkoutsTotal(total)
         } else {
           setWorkoutsError(t('family.detail.errors.failedToLoad'))
+        }
+
+        if (summaryRes.ok) {
+          const summaryData = await summaryRes.json()
+          setWeeklySummary(summaryData.weeks ?? [])
+        } else {
+          setWeeklySummary([])
         }
 
         if (settingsRes.ok) {
@@ -191,7 +186,6 @@ export default function FamilyChildDetail() {
     const prevPage = workoutsPage
     setWorkoutsPage(newPage)
     setWorkoutsError('')
-    const offset = newPage * PAGE_SIZE
 
     // Abort any in-flight pagination request before handling this navigation,
     // even if we end up serving data from the cache.
@@ -200,13 +194,13 @@ export default function FamilyChildDetail() {
       paginationAbortRef.current = null
     }
 
-    // Use cached chart workouts if the page is within what we have loaded
-    if (offset < chartWorkouts.length) {
-      setTableWorkouts(chartWorkouts.slice(offset, offset + PAGE_SIZE))
+    const cached = pageCacheRef.current.get(newPage)
+    if (cached) {
+      setTableWorkouts(cached)
       return
     }
 
-    // Start a new request for uncached pages
+    const offset = newPage * PAGE_SIZE
     const controller = new AbortController()
     paginationAbortRef.current = controller
 
@@ -218,7 +212,9 @@ export default function FamilyChildDetail() {
       )
       if (!res.ok) throw new Error('failed')
       const data = await res.json()
-      setTableWorkouts(data.workouts ?? [])
+      const pageWorkouts: ChildWorkout[] = data.workouts ?? []
+      pageCacheRef.current.set(newPage, pageWorkouts)
+      setTableWorkouts(pageWorkouts)
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') return
       setWorkoutsError(t('family.detail.errors.failedToLoad'))
@@ -268,33 +264,40 @@ export default function FamilyChildDetail() {
     }
   }
 
-  // Compute weekly aggregates for the last 8 weeks (Monday-based)
+  // Weekly aggregates come from the server's summary endpoint (oldest→newest,
+  // always 8 entries with zero-fill). The week_start strings are YYYY-MM-DD in
+  // the server's local timezone; parsed as local dates for label formatting.
+  // If the summary fetch failed, fall back to 8 empty buckets so the charts
+  // still render their axes instead of going blank.
   const weeklyChartData = useMemo(() => {
+    if (weeklySummary.length > 0) {
+      return weeklySummary.map(week => {
+        const [y, m, d] = week.week_start.split('-').map(Number)
+        const weekStart = new Date(y, (m ?? 1) - 1, d ?? 1)
+        return {
+          label: formatDate(weekStart, { month: 'short', day: 'numeric' }),
+          distance: Math.round(week.distance_meters / 100) / 10,
+          workouts: week.workout_count,
+          stars: week.stars,
+        }
+      })
+    }
     const now = new Date()
     const daysToMonday = (now.getDay() + 6) % 7
     const thisMonday = new Date(now)
     thisMonday.setHours(0, 0, 0, 0)
     thisMonday.setDate(now.getDate() - daysToMonday)
-
     return Array.from({ length: 8 }, (_, i) => {
       const weekStart = new Date(thisMonday)
       weekStart.setDate(thisMonday.getDate() - (7 - i) * 7)
-      const weekEnd = new Date(weekStart)
-      weekEnd.setDate(weekStart.getDate() + 7)
-
-      const wos = chartWorkouts.filter(w => {
-        const d = new Date(w.started_at)
-        return d >= weekStart && d < weekEnd
-      })
-
       return {
         label: formatDate(weekStart, { month: 'short', day: 'numeric' }),
-        distance: Math.round(wos.reduce((s, w) => s + w.distance_meters, 0) / 100) / 10,
-        workouts: wos.length,
-        stars: wos.reduce((s, w) => s + w.stars, 0),
+        distance: 0,
+        workouts: 0,
+        stars: 0,
       }
     })
-  }, [chartWorkouts])
+  }, [weeklySummary])
 
   const totalPages = Math.ceil(workoutsTotal / PAGE_SIZE)
 


### PR DESCRIPTION
## Changes

- **Family child detail loads in one round-trip** - The Kids Stars child detail page no longer sequentially refetches every workout page on mount to power its charts. A new `GET /api/family/children/{id}/workouts/summary` endpoint returns the 8-week weekly aggregates (distance, workout count, stars) directly, and the table fetches only the first 20 rows on mount and additional pages on demand. (Hytte-y64r)

## Original Issue (feature): Stop refetching all child workouts on FamilyChildDetail mount

### Scope
Eliminate the sequential pagination loop in `FamilyChildDetail` by serving chart aggregates from a dedicated server endpoint and fetching only a single page (PAGE_SIZE) for the table on mount. The page should render after one round-trip of parallel requests instead of N.

### Files to touch
- `internal/family/handlers.go` — add a new handler returning per-week aggregates for a child (distance meters, workout count, stars) over the last 8 ISO/Monday-based weeks. Reuse the existing child-access authorization the workouts list uses.
- `internal/api/router.go` — register `GET /api/family/children/{id}/workouts/summary` inside the same auth+feature group as the existing family routes.
- `internal/family/handlers_test.go` (or the file holding the workouts list tests) — add tests for the summary handler: empty child, multi-week bucketing, week boundaries (Monday 00:00 local), unauthorized parent, invalid id.
- `web/src/pages/FamilyChildDetail.tsx` — replace the `while (offset < total)` loop with a single call to the new summary endpoint, drop `chartWorkouts` state, derive `weeklyChartData` directly from the server payload, and switch the mount fetch for the table to `limit=PAGE_SIZE&offset=0`. Update `goToPage` so it always fetches uncached pages (cache map keyed by page is fine; remove the `chartWorkouts.length` heuristic).
- `changelog.d/<id>-family-child-detail.md` — `Fixed` entry referencing the bead.

### Acceptance criteria
- Opening `/family/children/:id` issues exactly one workouts list request (`limit=20&offset=0`) plus one summary request on mount, regardless of how many workouts the child has — verified via DevTools Network or a Vitest spy on `fetch`.
- The three weekly charts (distance, workouts, stars) render identical values to today's behavior for the last 8 weeks, including the current (partial) week.
- The recent-workouts table still paginates correctly: navigating to a page beyond the first triggers a `limit=20&offset=N*20` request and shows the right rows; the existing AbortController behavior for rapid page changes is preserved.
- Loading skeleton hides as soon as stats + first table page + summary resolve; it no longer waits on additional pages.
- New summary endpoint requires auth + `kids_stars` feature, enforces the same parent→child access check as the workouts list, and 404s for unknown children.
- All Go and frontend tests pass; `go vet`, `npm run lint`, `npm run build` clean.

### Non-goals
- No redesign of the charts, time window selector, or table columns.
- No change to the existing `GET /workouts` list endpoint's shape or pagination semantics.
- No caching layer, prefetching, or virtualized table.
- No changes to `Family.tsx`, `FamilyRewards.tsx`, or `FamilyChallenges.tsx`.
- No retroactive encryption/schema work — summary aggregates only over already-stored numeric fields.

## Source

Created from Suggestions page (suggestion id 40, page slug "family", source=claude).

## Original suggestion

FamilyChildDetail.tsx loads the first 100 workouts then loops `while (offset < total)` re-fetching every page just to power the chart, even though the table only renders PAGE_SIZE=20 rows at a time. For a child with hundreds of workouts this fires sequential network requests on every visit, blocks the loading skeleton, and bloats memory. Either add a dedicated lightweight `/workouts/summary` endpoint for the chart aggregates, or paginate the table on demand and cap the chart at a fixed window (e.g. last 90 days). Parents will see the page render in one round-trip instead of N.


---
Bead: Hytte-y64r | Branch: forge/Hytte-y64r
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->