### PR TITLE
Track in-flight sends per conversation instead of one global id (Hytte-p83n)

### DIFF
--- a/changelog.d/Hytte-p83n.md
+++ b/changelog.d/Hytte-p83n.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Track in-flight chat sends per conversation** - The Chat page now tracks pending sends in a set keyed by conversation id instead of a single scalar, so starting a send in one conversation no longer clears the "thinking" indicator or re-enables the input/send button of another conversation that is still waiting on its own response. (Hytte-p83n)

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -47,7 +47,10 @@ export default function Chat() {
   const [input, setInput] = useState('')
   const [loadingConversations, setLoadingConversations] = useState(true)
   const [loadingMessages, setLoadingMessages] = useState(false)
-  const [sendingConversationId, setSendingConversationId] = useState<number | null>(null)
+  // Track every conversation with an in-flight send so concurrent sends in
+  // different conversations don't clobber each other's pending state. Kept
+  // immutably (a fresh Set on each update) so React re-renders fire.
+  const [sendingConversationIds, setSendingConversationIds] = useState<Set<number>>(new Set())
   const [error, setError] = useState('')
   const [showSidebar, setShowSidebar] = useState(true)
   const [renamingId, setRenamingId] = useState<number | null>(null)
@@ -65,6 +68,22 @@ export default function Chat() {
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [])
+
+  const addSendingConversation = useCallback((id: number) => {
+    setSendingConversationIds(prev => {
+      const next = new Set(prev)
+      next.add(id)
+      return next
+    })
+  }, [])
+
+  const removeSendingConversation = useCallback((id: number) => {
+    setSendingConversationIds(prev => {
+      const next = new Set(prev)
+      next.delete(id)
+      return next
+    })
   }, [])
 
   useEffect(() => {
@@ -230,11 +249,11 @@ export default function Chat() {
   }
 
   async function sendMessage() {
-    if (!input.trim() || !activeConversation || sendingConversationId === activeConversation.id) return
+    if (!input.trim() || !activeConversation || sendingConversationIds.has(activeConversation.id)) return
     const content = input.trim()
     const sentConversationId = activeConversation.id
     setInput('')
-    setSendingConversationId(sentConversationId)
+    addSendingConversation(sentConversationId)
     setError('')
 
     // Optimistic rows: the user bubble and an empty assistant bubble that
@@ -459,7 +478,7 @@ export default function Chat() {
       if (streamAbortRef.current === controller) {
         streamAbortRef.current = null
       }
-      setSendingConversationId(null)
+      removeSendingConversation(sentConversationId)
       inputRef.current?.focus()
     }
   }
@@ -717,7 +736,8 @@ export default function Chat() {
                 // indicator only when its content is still empty so once
                 // tokens arrive the user sees the live text.
                 const isStreamingPlaceholder =
-                  sendingConversationId === activeConversation?.id &&
+                  activeConversation != null &&
+                  sendingConversationIds.has(activeConversation.id) &&
                   msg.role === 'assistant' &&
                   msg.id < 0 &&
                   msg.content === ''
@@ -770,14 +790,14 @@ export default function Chat() {
                 rows={1}
                 className="flex-1 bg-gray-800 border border-gray-600 rounded-xl px-4 py-3 text-white text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-500 max-h-40 overflow-y-auto"
                 style={{ minHeight: '48px' }}
-                disabled={sendingConversationId === activeConversation?.id}
+                disabled={sendingConversationIds.has(activeConversation.id)}
                 onInput={e => {
                   const el = e.currentTarget
                   el.style.height = 'auto'
                   el.style.height = Math.min(el.scrollHeight, 160) + 'px'
                 }}
               />
-              {sendingConversationId === activeConversation?.id ? (
+              {sendingConversationIds.has(activeConversation.id) ? (
                 <button
                   onClick={stopStreaming}
                   className="self-end p-3 rounded-xl bg-red-600 hover:bg-red-500 text-white transition-colors cursor-pointer shrink-0"


### PR DESCRIPTION
## Changes

- **Track in-flight chat sends per conversation** - The Chat page now tracks pending sends in a set keyed by conversation id instead of a single scalar, so starting a send in one conversation no longer clears the "thinking" indicator or re-enables the input/send button of another conversation that is still waiting on its own response. (Hytte-p83n)

## Original Issue (feature): Track in-flight sends per conversation instead of one global id

### Scope
Replace the scalar `sendingConversationId` state in the Chat page with a set-based tracker so that multiple conversations can have an in-flight send simultaneously. The UI checks (thinking indicator, disabled input, disabled send button) must test membership in that set rather than equality with a single id. This fixes the bug where starting a send in conversation B clears the pending state of an earlier send in conversation A.

### Files to touch
- `web/src/pages/Chat.tsx` — replace the scalar state with a `Set<number>` (kept in state immutably) and update all read/write sites listed below.

### Acceptance criteria
- The `sendingConversationId` scalar is gone; in-flight sends are tracked in a `Set<number>` (or equivalent collection keyed by conversation id) held in React state and updated immutably so re-renders fire.
- Starting a send in conversation A, switching to B, and starting a send in B does not clear A's pending state. Switching back to A still shows the "thinking" indicator and keeps the input and send button disabled until A's request resolves.
- Each conversation's pending entry is removed in the `finally`/cleanup path of its own send, regardless of the order in which the two requests complete.
- The send handler's guard against double-submission for the active conversation still works (sending is blocked while the active conversation is already in the set).
- The thinking indicator at line ~530 and the disabled props at lines ~575 / ~584 / ~588 are driven by set membership for the currently active conversation.
- `npm run lint` and `npm run build` pass in `web/`; `go build` and `go test ./...` still pass.
- Manual smoke test in dev: open two conversations, fire a slow send in each, verify both indicators stay visible until each request resolves independently.
- A changelog fragment is added under `changelog.d/` in the `Fixed` category referencing the bead id.

### Non-goals
- No backend changes to `internal/chat/handlers.go` or any API contract.
- No introduction of `AbortController` cancellation behavior (the `Map<id, AbortController>` option in the suggestion is out of scope unless trivially needed; a plain `Set<number>` is sufficient).
- No refactor of the broader Chat component, message rendering, conversation list, or streaming logic.
- No new tests beyond manual verification unless an existing test harness for Chat already exists and is trivially extendable.
- No changes to other pages that may have similar single-flight patterns.

## Source

Created from Suggestions page (suggestion id 38, page slug "chat", source=claude).

## Original suggestion

`sendingConversationId` is a single number, but a user can start a send in conversation A, switch to B, and start another send — the second `setSendingConversationId(B)` overwrites A, so when the user navigates back to A they no longer see the 'thinking' indicator and the input is wrongly enabled even though A's request is still pending. Replace the scalar with a `Set<number>` (or `Map<id, AbortController>`) and update the disabled/indicator checks to test membership. This fixes inconsistent UI when switching between concurrently active conversations.


---
Bead: Hytte-p83n | Branch: forge/Hytte-p83n
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->