### PR TITLE
Stop auto-switching away from a user-selected completed worker (Hytte-t90n)

### DIFF
--- a/changelog.d/Hytte-t90n.md
+++ b/changelog.d/Hytte-t90n.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Keep a selected completed worker pinned in the Forge Dashboard** - Clicking a finished smith/warden run to read its output no longer gets interrupted when a new worker starts; the panel only falls back to the newest active (or completed) worker when the selection disappears or none was made. (Hytte-t90n)

--- a/web/src/pages/ForgeDashboardPage.test.tsx
+++ b/web/src/pages/ForgeDashboardPage.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { WorkerInfo } from '../hooks/useForgeStatus'
+
+// ── i18n mock ───────────────────────────────────────────────────────────────
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// ── Auth mock ───────────────────────────────────────────────────────────────
+vi.mock('../auth', () => ({
+  useAuth: () => ({ user: { name: 'Test', is_admin: true, features: {} } }),
+}))
+
+// ── Worker data (mutable so we can simulate polling updates) ──────────────────
+let workersData: WorkerInfo[] = []
+
+vi.mock('../hooks/useForgeStatus', () => ({
+  useForgeStatus: () => ({ status: null, error: null, loading: false, refresh: vi.fn() }),
+  useForgeWorkers: () => ({ workers: workersData, loading: false, error: null, refresh: vi.fn() }),
+}))
+
+vi.mock('../hooks/useAllPRs', () => ({
+  useAllPRs: () => ({ data: null }),
+}))
+
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ toasts: [], showToast: vi.fn() }),
+}))
+
+vi.mock('../hooks/usePanelCollapse', () => ({
+  usePanelCollapse: () => [true, vi.fn()],
+}))
+
+// ── Child components ──────────────────────────────────────────────────────────
+// WorkersCard: render a clickable button per worker so we can drive selection.
+vi.mock('../components/WorkersCard', () => ({
+  default: ({
+    workers,
+    selectedWorkerId,
+    onSelectWorker,
+  }: {
+    workers: WorkerInfo[]
+    selectedWorkerId: string | null
+    onSelectWorker: (id: string) => void
+  }) => (
+    <div>
+      <span data-testid="selected-id">{selectedWorkerId ?? 'none'}</span>
+      {workers.map(w => (
+        <button key={w.id} data-testid={`select-${w.id}`} onClick={() => onSelectWorker(w.id)}>
+          {w.bead_id}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+// LiveActivity: expose which worker the panel is showing.
+vi.mock('../components/LiveActivity', () => ({
+  default: ({ selectedWorker }: { selectedWorker: WorkerInfo | null }) => (
+    <div data-testid="live-worker">{selectedWorker?.id ?? 'none'}</div>
+  ),
+}))
+
+// Remaining cards / chrome are irrelevant to selection logic — stub them out.
+vi.mock('../components/NeedsAttentionCard', () => ({ default: () => null }))
+vi.mock('../components/ReadyToMergeCard', () => ({ default: () => null }))
+vi.mock('../components/RecentlyClosedPRsCard', () => ({ default: () => null }))
+vi.mock('../components/TodayStatsCard', () => ({ default: () => null }))
+vi.mock('../components/CostsDashboardCard', () => ({ default: () => null }))
+vi.mock('../components/FullQueueCard', () => ({ default: () => null }))
+vi.mock('../components/ReleaseCard', () => ({ default: () => null }))
+vi.mock('../components/ConfirmDialog', () => ({ default: () => null }))
+vi.mock('../components/ToastList', () => ({ default: () => null }))
+vi.mock('../components/BeadDetailModal', () => ({ default: () => null }))
+vi.mock('../components/ResizePanelHandle', () => ({ ResizePanelHandle: () => null }))
+
+import ForgeDashboardPage from './ForgeDashboardPage'
+
+function makeWorker(over: Partial<WorkerInfo> & { id: string }): WorkerInfo {
+  return {
+    bead_id: `bead-${over.id}`,
+    anvil: 'anvil',
+    branch: 'branch',
+    pid: 1,
+    status: 'running',
+    phase: 'smith',
+    title: 'title',
+    started_at: '2026-05-28T10:00:00Z',
+    log_path: '/tmp/log',
+    pr_number: 0,
+    ...over,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ForgeDashboardPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ForgeDashboardPage selectedWorkerId stickiness', () => {
+  beforeEach(() => {
+    workersData = []
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) })))
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps an explicitly selected worker pinned when a new active worker starts', () => {
+    // One active worker A.
+    workersData = [makeWorker({ id: 'A', status: 'running', started_at: '2026-05-28T10:00:00Z' })]
+    const { rerender } = renderPage()
+
+    // Default selection is the only active worker.
+    expect(screen.getByTestId('live-worker')).toHaveTextContent('A')
+
+    // User explicitly clicks worker A.
+    fireEvent.click(screen.getByTestId('select-A'))
+    expect(screen.getByTestId('live-worker')).toHaveTextContent('A')
+
+    // A completes and a brand-new active worker B starts.
+    workersData = [
+      makeWorker({ id: 'A', status: 'completed', completed_at: '2026-05-28T10:05:00Z', started_at: '2026-05-28T10:00:00Z' }),
+      makeWorker({ id: 'B', status: 'running', started_at: '2026-05-28T10:06:00Z' }),
+    ]
+    rerender(
+      <MemoryRouter>
+        <ForgeDashboardPage />
+      </MemoryRouter>,
+    )
+
+    // Selection must stay on the completed worker the user pinned.
+    expect(screen.getByTestId('live-worker')).toHaveTextContent('A')
+  })
+
+  it('falls back to the newest active worker when the selected worker disappears', () => {
+    workersData = [makeWorker({ id: 'A', status: 'running', started_at: '2026-05-28T10:00:00Z' })]
+    const { rerender } = renderPage()
+
+    fireEvent.click(screen.getByTestId('select-A'))
+    expect(screen.getByTestId('live-worker')).toHaveTextContent('A')
+
+    // A vanishes entirely; B and C are active (C started most recently).
+    workersData = [
+      makeWorker({ id: 'B', status: 'running', started_at: '2026-05-28T10:01:00Z' }),
+      makeWorker({ id: 'C', status: 'running', started_at: '2026-05-28T10:09:00Z' }),
+    ]
+    rerender(
+      <MemoryRouter>
+        <ForgeDashboardPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId('live-worker')).toHaveTextContent('C')
+  })
+
+  it('falls back to the newest completed worker when none are active and the selection vanished', () => {
+    workersData = [makeWorker({ id: 'A', status: 'running', started_at: '2026-05-28T10:00:00Z' })]
+    const { rerender } = renderPage()
+
+    fireEvent.click(screen.getByTestId('select-A'))
+
+    // A vanishes; only completed workers remain.
+    workersData = [
+      makeWorker({ id: 'X', status: 'completed', completed_at: '2026-05-28T09:00:00Z', started_at: '2026-05-28T08:00:00Z' }),
+      makeWorker({ id: 'Y', status: 'completed', completed_at: '2026-05-28T11:00:00Z', started_at: '2026-05-28T10:30:00Z' }),
+    ]
+    rerender(
+      <MemoryRouter>
+        <ForgeDashboardPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId('live-worker')).toHaveTextContent('Y')
+  })
+
+  it('uses the newest active worker by default with no manual selection', () => {
+    workersData = [
+      makeWorker({ id: 'old', status: 'running', started_at: '2026-05-28T10:00:00Z' }),
+      makeWorker({ id: 'new', status: 'running', started_at: '2026-05-28T10:08:00Z' }),
+    ]
+    renderPage()
+
+    expect(screen.getByTestId('live-worker')).toHaveTextContent('new')
+  })
+})

--- a/web/src/pages/ForgeDashboardPage.tsx
+++ b/web/src/pages/ForgeDashboardPage.tsx
@@ -77,36 +77,33 @@ export default function ForgeDashboardPage() {
   const completedWorkers = allWorkers.filter(w => w.status !== 'pending' && w.status !== 'running')
 
   // Derive the effective selected worker ID during render to avoid calling setState
-  // inside a useEffect. Auto-selects the most recently started active worker; when
-  // a worker completes, switches to the next active one (or keeps showing the
-  // completed worker's output). A user click sets userSelectedWorkerId to override.
+  // inside a useEffect. Auto-selects the most recently started active worker as the
+  // default. A user click sets userSelectedWorkerId to pin an explicit choice — even
+  // a completed worker — which stays selected until the user picks something else or
+  // that worker disappears from allWorkers entirely.
   const selectedWorkerId = useMemo(() => {
     const sortedActive = [...activeWorkers].sort(
       (a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime()
     )
 
-    if (userSelectedWorkerId === null) {
-      // Initial selection: pick most recently started active worker, or most recently
-      // completed worker as fallback so the panel is never empty.
-      if (sortedActive.length > 0) return sortedActive[0].id
-      const lastCompleted = [...completedWorkers].sort((a, b) => {
-        const bTime = Date.parse(b.completed_at ?? b.updated_at ?? '') || 0
-        const aTime = Date.parse(a.completed_at ?? a.updated_at ?? '') || 0
-        return bTime - aTime
-      })[0]
-      return lastCompleted?.id ?? null
+    // If the user explicitly selected a worker that still exists, keep it pinned —
+    // even when it is completed and a brand-new active worker starts. This prevents
+    // the panel from jumping away while the user is reading a finished run's output.
+    if (userSelectedWorkerId !== null && allWorkers.some(w => w.id === userSelectedWorkerId)) {
+      return userSelectedWorkerId
     }
 
-    // If the user-selected worker is no longer active, switch to the next active
-    // worker (if any). If none are active, keep showing the completed worker's
-    // output — its log file is still readable.
-    const selectedIsActive = activeWorkers.some(w => w.id === userSelectedWorkerId)
-    if (!selectedIsActive && sortedActive.length > 0) {
-      return sortedActive[0].id
-    }
-
-    return userSelectedWorkerId
-  }, [userSelectedWorkerId, activeWorkers, completedWorkers])
+    // Fallback (no manual selection, or the selected worker has disappeared from
+    // allWorkers): pick the most recently started active worker, or the most recently
+    // completed worker, so the panel is never empty.
+    if (sortedActive.length > 0) return sortedActive[0].id
+    const lastCompleted = [...completedWorkers].sort((a, b) => {
+      const bTime = Date.parse(b.completed_at ?? b.updated_at ?? '') || 0
+      const aTime = Date.parse(a.completed_at ?? a.updated_at ?? '') || 0
+      return bTime - aTime
+    })[0]
+    return lastCompleted?.id ?? null
+  }, [userSelectedWorkerId, allWorkers, activeWorkers, completedWorkers])
 
   const selectedWorker = allWorkers.find(w => w.id === selectedWorkerId) ?? null
 


### PR DESCRIPTION
## Changes

- **Keep a selected completed worker pinned in the Forge Dashboard** - Clicking a finished smith/warden run to read its output no longer gets interrupted when a new worker starts; the panel only falls back to the newest active (or completed) worker when the selection disappears or none was made. (Hytte-t90n)

## Original Issue (feature): Stop auto-switching away from a user-selected completed worker

### Scope
Fix the auto-switch behavior of `selectedWorkerId` in the Forge Dashboard so an explicit user selection on a completed worker remains pinned even when a new active worker starts. The fallback to the newest active worker should only apply when the previously selected worker no longer exists in `allWorkers`, or when no manual selection has been made.

### Files to touch
- `web/src/pages/ForgeDashboardPage.tsx` — adjust the `selectedWorkerId` `useMemo` so the "not active → switch" branch becomes "not present in `allWorkers` → switch".
- `web/src/pages/ForgeDashboardPage.test.tsx` (new, if no existing test file) — add a regression test covering the stickiness behavior. If a co-located test file already exists for this page, extend it instead of creating a new one.
- `changelog.d/forge-sticky-completed-worker.md` (new) — `Fixed` entry per the changelog convention.

### Acceptance criteria
- With one or more active workers running, clicking a *completed* worker in the workers panel selects it and the live output panel shows its logs.
- While that completed worker is still selected, starting a brand-new active worker does NOT change the selection; the completed worker's logs remain visible until the user clicks something else.
- If the explicitly selected worker is removed from `allWorkers` entirely (e.g., status fetch no longer returns it), the panel falls back to the most recently started active worker, or, if none, the most recently completed worker — matching today's "never empty" behavior.
- With `userSelectedWorkerId === null` (no manual selection), the initial-selection behavior is unchanged: newest active worker, falling back to newest completed.
- The `useMemo` dependency array and reference equality are correct — no infinite re-render or stale-selection bug, and no `setState` is called during render.
- A unit/component test exercises the "user picks a completed worker, then a new active worker starts" scenario and asserts the selection does not change.
- `npm run lint`, `npm run build`, and `npm test` (if applicable for this page) all pass.
- Changelog fragment exists under `changelog.d/` in the `Fixed` category referencing the Hytte bead ID.

### Non-goals
- No redesign of the workers panel UI, sorting, or how active/completed workers are split.
- No changes to backend handlers in `internal/forge/` or to the worker status polling interval.
- No new "pin" affordance or visible indicator that a selection is sticky — the existing click behavior is sufficient.
- No changes to the "panel is never empty" fallback when nothing has been selected.
- No refactor of unrelated state in `ForgeDashboardPage.tsx` (panel heights, toasts, etc.).

## Source

Created from Suggestions page (suggestion id 43, page slug "forge", source=claude).

## Original suggestion

In `ForgeDashboardPage.tsx` the `selectedWorkerId` memo switches to the most recently started active worker whenever the currently selected worker is not in the active set. If the user explicitly clicks a completed worker to read its logs and a new active worker then starts, the panel jumps away from their selection. The fix is to only fall back to the newest active worker when the previously selected ID has actually disappeared from `allWorkers` (or when no manual selection was made), so explicit clicks on completed workers stay sticky. User-visible impact: reading a finished smith/warden run's output is no longer interrupted by the next worker starting.


---
Bead: Hytte-t90n | Branch: forge/Hytte-t90n
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->