### PR TITLE
Add a portfolio-value summary card across all owned Pokémon cards (Hytte-lmgj)

### DIFF
--- a/changelog.d/Hytte-lmgj.md
+++ b/changelog.d/Hytte-lmgj.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pokémon collection-value summary card** - The Pokémon sets page now shows a portfolio-value card at the top with the total NOK worth of every owned variant and the count of owned cards, backed by a new `GET /api/pokemon/collection/value` aggregate endpoint. (Hytte-lmgj)

--- a/changelog.d/Hytte-lmgj.md
+++ b/changelog.d/Hytte-lmgj.md
@@ -1,2 +1,2 @@
 category: Added
-- **Pokémon collection-value summary card** - The Pokémon sets page now shows a portfolio-value card at the top with the total NOK worth of every owned variant and the count of owned cards, backed by a new `GET /api/pokemon/collection/value` aggregate endpoint. (Hytte-lmgj)
+- **Pokémon collection-value summary card** - The Pokémon sets page now shows a portfolio-value card at the top with the total NOK worth of every owned variant and the count of owned variants, backed by a new `GET /api/pokemon/collection/value` aggregate endpoint. (Hytte-lmgj)

--- a/internal/pokemon/handlers.go
+++ b/internal/pokemon/handlers.go
@@ -168,6 +168,19 @@ type CollectionRow struct {
 	AcquiredAt string `json:"acquired_at"`
 }
 
+// CollectionValueDTO is the JSON shape returned by /api/pokemon/collection/value.
+// It answers "what is my whole collection worth?" by summing the NOK value of
+// every owned variant the user holds. TotalNOK is a pointer so it serializes as
+// null when no EUR/NOK rate is available (mirroring VariantDTO.PriceNOK). The
+// raw TotalEUR is always present so the UI can still show a figure — or recover
+// — when the rate is missing. OwnedVariantCount is the number of distinct owned
+// variants (collection rows with quantity > 0).
+type CollectionValueDTO struct {
+	TotalEUR          float64  `json:"total_eur"`
+	TotalNOK          *float64 `json:"total_nok"`
+	OwnedVariantCount int      `json:"owned_variant_count"`
+}
+
 // RegisterRoutes mounts all Pokémon Collection routes on r under the "pokemon"
 // feature gate. It is called by both the production API router and tests so
 // both exercise the same middleware chain — if the gate or admin check changes
@@ -178,6 +191,9 @@ func RegisterRoutes(r chi.Router, db *sql.DB) {
 		r.Get("/pokemon/sets", ListSetsHandler(db))
 		r.Get("/pokemon/sets/{id}/cards", ListSetCardsHandler(db))
 		r.Get("/pokemon/cards/search", SearchCardsHandler(db))
+		// Portfolio-value summary (Hytte-lmgj): one aggregate over the user's
+		// whole collection for the summary card at the top of the sets page.
+		r.Get("/pokemon/collection/value", CollectionValueHandler(db))
 		// /pokemon/top is intentionally accessible to all pokemon-feature users,
 		// not admin-only — it's a fun highlights surface for every collector.
 		r.Get("/pokemon/top", TopHandler(db))
@@ -757,6 +773,56 @@ func MissingFromSetHandler(db *sql.DB) http.HandlerFunc {
 		rate, ok := loadRate(r, db)
 		applyNOK(w, missing, rate, ok)
 		respondJSON(w, http.StatusOK, map[string]any{"cards": missing})
+	}
+}
+
+// CollectionValueHandler aggregates the authenticated user's whole collection
+// into a single portfolio value: the summed NOK worth of every owned variant
+// and the count of distinct owned variants. The EUR total multiplies each
+// variant's price by the held quantity (a user holding three copies owns three
+// copies of value), matching the per-set computeSetValue convention in the UI.
+// The NOK total reuses the shared EUR→NOK rate via loadRate; when no rate is
+// available TotalNOK is null and the X-Pokemon-Rate-Missing header is set, so
+// the front end behaves exactly as it does for the other priced endpoints.
+// Variants with no price contribute 0 (price_eur defaults to 0), never an error.
+func CollectionValueHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			respondError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+
+		var totalEUR float64
+		var ownedCount int
+		// COALESCE keeps the SUM at 0 for an empty collection (SUM over no rows
+		// is NULL in SQLite). Only rows with quantity > 0 count as "owned".
+		err := db.QueryRowContext(r.Context(), `
+			SELECT COALESCE(SUM(v.price_eur * col.quantity), 0), COUNT(*)
+			FROM pokemon_collections col
+			JOIN pokemon_card_variants v ON v.id = col.variant_id
+			WHERE col.user_id = ? AND col.quantity > 0
+		`, user.ID).Scan(&totalEUR, &ownedCount)
+		if err != nil {
+			log.Printf("pokemon: collection value: %v", err)
+			respondError(w, http.StatusInternalServerError, "failed to compute collection value")
+			return
+		}
+
+		out := CollectionValueDTO{
+			TotalEUR:          totalEUR,
+			OwnedVariantCount: ownedCount,
+		}
+		if rate, ok := loadRate(r, db); ok {
+			nok := totalEUR * rate
+			out.TotalNOK = &nok
+		} else {
+			// Mirror the per-card endpoints so the client can surface a
+			// "price unavailable" hint instead of a misleading zero.
+			w.Header().Set("X-Pokemon-Rate-Missing", "1")
+		}
+
+		respondJSON(w, http.StatusOK, out)
 	}
 }
 

--- a/internal/pokemon/handlers_test.go
+++ b/internal/pokemon/handlers_test.go
@@ -1085,6 +1085,182 @@ func TestMissingFromSetHandler_RequiresSetID(t *testing.T) {
 	}
 }
 
+// --- CollectionValueHandler ---------------------------------------------------
+
+// ownCollection inserts a (user, card, variant) row with the given quantity so
+// the value tests can build a collection without repeating the INSERT.
+func ownCollection(t *testing.T, db *sql.DB, userID int64, cardID, kind string, quantity int) {
+	t.Helper()
+	vid := variantID(t, db, cardID, kind)
+	if _, err := db.Exec(`
+		INSERT INTO pokemon_collections (user_id, card_id, variant_id, quantity, condition, acquired_at)
+		VALUES (?, ?, ?, ?, '', ?)
+	`, userID, cardID, vid, quantity, time.Now().UTC()); err != nil {
+		t.Fatalf("own %s/%s: %v", cardID, kind, err)
+	}
+}
+
+func TestCollectionValueHandler_EmptyCollection(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	seedRate(t, db, 11.5)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/collection/value", nil), u)
+	rec := httptest.NewRecorder()
+	CollectionValueHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[CollectionValueDTO](t, rec)
+	if body.OwnedVariantCount != 0 {
+		t.Errorf("expected owned_variant_count=0, got %d", body.OwnedVariantCount)
+	}
+	if body.TotalEUR != 0 {
+		t.Errorf("expected total_eur=0, got %v", body.TotalEUR)
+	}
+	if body.TotalNOK == nil || *body.TotalNOK != 0 {
+		t.Errorf("expected total_nok=0 with a rate present, got %v", body.TotalNOK)
+	}
+}
+
+func TestCollectionValueHandler_SingleOwnedVariant(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	seedRate(t, db, 11.5)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	// sv1-25 normal is 10 EUR; one copy → 10 EUR, 115 NOK.
+	ownCollection(t, db, u.ID, "sv1-25", "normal", 1)
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/collection/value", nil), u)
+	rec := httptest.NewRecorder()
+	CollectionValueHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[CollectionValueDTO](t, rec)
+	if body.OwnedVariantCount != 1 {
+		t.Errorf("expected owned_variant_count=1, got %d", body.OwnedVariantCount)
+	}
+	if body.TotalEUR != 10.0 {
+		t.Errorf("expected total_eur=10.0, got %v", body.TotalEUR)
+	}
+	if body.TotalNOK == nil || *body.TotalNOK != 115.0 {
+		t.Errorf("expected total_nok=115.0, got %v", body.TotalNOK)
+	}
+}
+
+func TestCollectionValueHandler_MultipleOwnedVariantsWithQuantity(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	seedRate(t, db, 10.0)
+	u := seedUser(t, db, 1, "a@example.com")
+	other := seedUser(t, db, 2, "b@example.com")
+
+	// User 1: sv1-25 normal (10 EUR ×2), sv1-25 reverse_holofoil (14.5 EUR ×1),
+	// sv1-100 normal (2.5 EUR ×1) → 20 + 14.5 + 2.5 = 37 EUR across 3 variants.
+	ownCollection(t, db, u.ID, "sv1-25", "normal", 2)
+	ownCollection(t, db, u.ID, "sv1-25", "reverse_holofoil", 1)
+	ownCollection(t, db, u.ID, "sv1-100", "normal", 1)
+	// Another user's holdings must not leak into user 1's total.
+	ownCollection(t, db, other.ID, "swsh1-1", "normal", 5)
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/collection/value", nil), u)
+	rec := httptest.NewRecorder()
+	CollectionValueHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[CollectionValueDTO](t, rec)
+	if body.OwnedVariantCount != 3 {
+		t.Errorf("expected owned_variant_count=3, got %d", body.OwnedVariantCount)
+	}
+	if body.TotalEUR != 37.0 {
+		t.Errorf("expected total_eur=37.0, got %v", body.TotalEUR)
+	}
+	if body.TotalNOK == nil || *body.TotalNOK != 370.0 {
+		t.Errorf("expected total_nok=370.0 (rate 10), got %v", body.TotalNOK)
+	}
+}
+
+func TestCollectionValueHandler_MissingRate(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	u := seedUser(t, db, 1, "a@example.com")
+	ownCollection(t, db, u.ID, "sv1-25", "normal", 1)
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/collection/value", nil), u)
+	rec := httptest.NewRecorder()
+	CollectionValueHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("X-Pokemon-Rate-Missing") != "1" {
+		t.Errorf("expected X-Pokemon-Rate-Missing=1 header, got %q", rec.Header().Get("X-Pokemon-Rate-Missing"))
+	}
+	body := decode[CollectionValueDTO](t, rec)
+	if body.TotalNOK != nil {
+		t.Errorf("expected total_nok=nil when rate missing, got %v", *body.TotalNOK)
+	}
+	// EUR total is still computed so the figure is recoverable client-side.
+	if body.TotalEUR != 10.0 {
+		t.Errorf("expected total_eur=10.0 even without a rate, got %v", body.TotalEUR)
+	}
+	if body.OwnedVariantCount != 1 {
+		t.Errorf("expected owned_variant_count=1, got %d", body.OwnedVariantCount)
+	}
+}
+
+func TestCollectionValueHandler_ZeroPriceContributesZero(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+	seedRate(t, db, 11.5)
+	u := seedUser(t, db, 1, "a@example.com")
+
+	// Add a variant with no price so the row contributes 0, not an error. Give
+	// it a card+kind not already in the fixture to keep prices unambiguous.
+	if _, err := db.Exec(`
+		INSERT INTO pokemon_card_variants (card_id, kind, price_eur, price_at)
+		VALUES ('sv1-100', 'reverse_holofoil', 0, ?)
+	`, time.Now().UTC()); err != nil {
+		t.Fatalf("seed zero-price variant: %v", err)
+	}
+	ownCollection(t, db, u.ID, "sv1-100", "reverse_holofoil", 3) // 0 EUR
+	ownCollection(t, db, u.ID, "sv1-25", "normal", 1)            // 10 EUR
+
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/pokemon/collection/value", nil), u)
+	rec := httptest.NewRecorder()
+	CollectionValueHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode[CollectionValueDTO](t, rec)
+	if body.OwnedVariantCount != 2 {
+		t.Errorf("expected owned_variant_count=2 (zero-price still owned), got %d", body.OwnedVariantCount)
+	}
+	if body.TotalEUR != 10.0 {
+		t.Errorf("expected total_eur=10.0 (zero-price contributes 0), got %v", body.TotalEUR)
+	}
+}
+
+func TestCollectionValueHandler_Unauthorized(t *testing.T) {
+	db := setupTestDB(t)
+	seedCatalogue(t, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/pokemon/collection/value", nil)
+	rec := httptest.NewRecorder()
+	CollectionValueHandler(db).ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
 // --- Feature-flag enforcement -------------------------------------------------
 
 // TestFeatureFlagEnforcement_All wires every endpoint through the real
@@ -1118,6 +1294,7 @@ func TestFeatureFlagEnforcement_All(t *testing.T) {
 			r.Get("/api/pokemon/sets/{id}/cards", ListSetCardsHandler(db))
 			r.Get("/api/pokemon/cards/search", SearchCardsHandler(db))
 			r.Get("/api/pokemon/top", TopHandler(db))
+			r.Get("/api/pokemon/collection/value", CollectionValueHandler(db))
 			r.Post("/api/pokemon/collection", UpsertCollectionHandler(db))
 			r.Patch("/api/pokemon/collection/{id}", UpdateCollectionHandler(db))
 			r.Delete("/api/pokemon/collection/{id}", DeleteCollectionHandler(db))
@@ -1136,6 +1313,7 @@ func TestFeatureFlagEnforcement_All(t *testing.T) {
 		{http.MethodGet, "/api/pokemon/sets/sv1/cards"},
 		{http.MethodGet, "/api/pokemon/cards/search?q=pika"},
 		{http.MethodGet, "/api/pokemon/top"},
+		{http.MethodGet, "/api/pokemon/collection/value"},
 		{http.MethodPost, "/api/pokemon/collection"},
 		{http.MethodPatch, "/api/pokemon/collection/1"},
 		{http.MethodDelete, "/api/pokemon/collection/1"},

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -7,6 +7,13 @@
     "filterOwnedOnly": "Owned only",
     "emptyOwned": "You don't own any cards yet — go scan some!"
   },
+  "value": {
+    "title": "Collection value",
+    "ownedVariants_one": "{{count}} owned card",
+    "ownedVariants_other": "{{count}} owned cards",
+    "unavailable": "Price unavailable",
+    "error": "Couldn't load collection value"
+  },
   "tile": {
     "totalCards_one": "{{count}} card",
     "totalCards_other": "{{count}} cards",

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -9,8 +9,8 @@
   },
   "value": {
     "title": "Collection value",
-    "ownedVariants_one": "{{count}} owned card",
-    "ownedVariants_other": "{{count}} owned cards",
+    "ownedVariants_one": "{{count}} owned variant",
+    "ownedVariants_other": "{{count}} owned variants",
     "unavailable": "Price unavailable",
     "error": "Couldn't load collection value"
   },

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -9,8 +9,8 @@
   },
   "value": {
     "title": "Samlingsverdi",
-    "ownedVariants_one": "{{count}} eid kort",
-    "ownedVariants_other": "{{count}} eide kort",
+    "ownedVariants_one": "{{count}} eid variant",
+    "ownedVariants_other": "{{count}} eide varianter",
     "unavailable": "Pris utilgjengelig",
     "error": "Kunne ikke laste samlingsverdien"
   },

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -7,6 +7,13 @@
     "filterOwnedOnly": "Bare eide",
     "emptyOwned": "Du eier ingen kort enda — gå og scan noen!"
   },
+  "value": {
+    "title": "Samlingsverdi",
+    "ownedVariants_one": "{{count}} eid kort",
+    "ownedVariants_other": "{{count}} eide kort",
+    "unavailable": "Pris utilgjengelig",
+    "error": "Kunne ikke laste samlingsverdien"
+  },
   "tile": {
     "totalCards_one": "{{count}} kort",
     "totalCards_other": "{{count}} kort",

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -9,8 +9,8 @@
   },
   "value": {
     "title": "มูลค่าคอลเลกชัน",
-    "ownedVariants_one": "การ์ดที่มี {{count}} ใบ",
-    "ownedVariants_other": "การ์ดที่มี {{count}} ใบ",
+    "ownedVariants_one": "แบบที่มี {{count}} ชนิด",
+    "ownedVariants_other": "แบบที่มี {{count}} ชนิด",
     "unavailable": "ไม่มีข้อมูลราคา",
     "error": "ไม่สามารถโหลดมูลค่าคอลเลกชันได้"
   },

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -7,6 +7,13 @@
     "filterOwnedOnly": "เฉพาะที่มี",
     "emptyOwned": "คุณยังไม่มีการ์ดเลย — ไปสแกนก่อนสิ!"
   },
+  "value": {
+    "title": "มูลค่าคอลเลกชัน",
+    "ownedVariants_one": "การ์ดที่มี {{count}} ใบ",
+    "ownedVariants_other": "การ์ดที่มี {{count}} ใบ",
+    "unavailable": "ไม่มีข้อมูลราคา",
+    "error": "ไม่สามารถโหลดมูลค่าคอลเลกชันได้"
+  },
   "tile": {
     "totalCards_one": "{{count}} ใบ",
     "totalCards_other": "{{count}} ใบ",

--- a/web/src/components/pokemon/CollectionValueCard.tsx
+++ b/web/src/components/pokemon/CollectionValueCard.tsx
@@ -3,9 +3,7 @@ import { Coins } from 'lucide-react'
 import { Skeleton } from '../ui/skeleton'
 
 export interface CollectionValueCardProps {
-  // totalNok is null when no EUR/NOK rate is available; the card then shows a
-  // "price unavailable" hint instead of a misleading zero. totalEur is kept as
-  // a fallback figure the caller may surface in the future.
+  // null when no EUR/NOK rate is available; the card shows "price unavailable".
   totalNok: number | null
   ownedVariantCount: number
   loading?: boolean

--- a/web/src/components/pokemon/CollectionValueCard.tsx
+++ b/web/src/components/pokemon/CollectionValueCard.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'react-i18next'
+import { Coins } from 'lucide-react'
+import { Skeleton } from '../ui/skeleton'
+
+export interface CollectionValueCardProps {
+  // totalNok is null when no EUR/NOK rate is available; the card then shows a
+  // "price unavailable" hint instead of a misleading zero. totalEur is kept as
+  // a fallback figure the caller may surface in the future.
+  totalNok: number | null
+  ownedVariantCount: number
+  loading?: boolean
+  error?: boolean
+}
+
+// formatNok mirrors PokemonSet.formatNok: render whole NOK with the active
+// locale's grouping. Unlike the per-card helper we keep an explicit zero here —
+// an empty collection legitimately worth 0 NOK should read "0 kr", not "—".
+function formatNok(amount: number, locale: string): string {
+  return amount.toLocaleString(locale, {
+    style: 'currency',
+    currency: 'NOK',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+// CollectionValueCard is the portfolio-value summary shown at the top of the
+// Pokémon sets page: the total NOK worth of every owned variant plus the count
+// of distinct owned variants. It is purely presentational — the page owns the
+// fetch and passes loading/error/value state in.
+export default function CollectionValueCard({
+  totalNok,
+  ownedVariantCount,
+  loading = false,
+  error = false,
+}: CollectionValueCardProps) {
+  const { t, i18n } = useTranslation('pokemon')
+
+  return (
+    <section
+      aria-label={t('value.title')}
+      data-testid="pokemon-collection-value-card"
+      className="flex items-center gap-3 p-4 bg-gray-800/40 border border-gray-800 rounded-lg"
+    >
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-600/20 text-amber-300">
+        <Coins size={22} aria-hidden="true" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs uppercase tracking-wide text-gray-500">{t('value.title')}</p>
+        {loading ? (
+          <Skeleton className="mt-1 h-7 w-32" />
+        ) : error ? (
+          <p className="mt-0.5 text-sm text-gray-400" data-testid="pokemon-collection-value-error">
+            {t('value.error')}
+          </p>
+        ) : (
+          <>
+            <p
+              className="mt-0.5 text-2xl font-semibold text-white"
+              data-testid="pokemon-collection-value-total"
+            >
+              {totalNok == null ? t('value.unavailable') : formatNok(totalNok, i18n.language)}
+            </p>
+            <p className="text-xs text-gray-400">
+              {t('value.ownedVariants', { count: ownedVariantCount })}
+            </p>
+          </>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/web/src/pages/PokemonSets.test.tsx
+++ b/web/src/pages/PokemonSets.test.tsx
@@ -28,7 +28,7 @@ function mockT(key: string, opts?: Record<string, string | number>): string {
   }
   if (key === 'value.ownedVariants') {
     const count = Number(opts?.count ?? 0)
-    return count === 1 ? `${count} owned card` : `${count} owned cards`
+    return count === 1 ? `${count} owned variant` : `${count} owned variants`
   }
   return TRANSLATIONS[key] ?? key
 }
@@ -358,7 +358,7 @@ describe('PokemonSets – collection value card', () => {
     await waitFor(() => {
       expect(screen.getByTestId('pokemon-collection-value-total')).toHaveTextContent('115')
     })
-    expect(screen.getByText('3 owned cards')).toBeInTheDocument()
+    expect(screen.getByText('3 owned variants')).toBeInTheDocument()
   })
 
   it('renders a zero/empty state for an empty collection, not an error', async () => {
@@ -373,7 +373,7 @@ describe('PokemonSets – collection value card', () => {
     await waitFor(() => {
       expect(screen.getByTestId('pokemon-collection-value-total')).toHaveTextContent('0')
     })
-    expect(screen.getByText('0 owned cards')).toBeInTheDocument()
+    expect(screen.getByText('0 owned variants')).toBeInTheDocument()
     expect(screen.queryByTestId('pokemon-collection-value-error')).not.toBeInTheDocument()
   })
 

--- a/web/src/pages/PokemonSets.test.tsx
+++ b/web/src/pages/PokemonSets.test.tsx
@@ -14,6 +14,9 @@ const TRANSLATIONS: Record<string, string> = {
   'setDetail.comingSoon': 'Set detail coming soon',
   'sets.filterOwnedOnly': 'Owned only',
   'sets.emptyOwned': "You don't own any cards yet — go scan some!",
+  'value.title': 'Collection value',
+  'value.unavailable': 'Price unavailable',
+  'value.error': "Couldn't load collection value",
 }
 
 function mockT(key: string, opts?: Record<string, string | number>): string {
@@ -22,6 +25,10 @@ function mockT(key: string, opts?: Record<string, string | number>): string {
   if (key === 'tile.totalCards') {
     const count = Number(opts?.count ?? 0)
     return count === 1 ? `${count} card` : `${count} cards`
+  }
+  if (key === 'value.ownedVariants') {
+    const count = Number(opts?.count ?? 0)
+    return count === 1 ? `${count} owned card` : `${count} owned cards`
   }
   return TRANSLATIONS[key] ?? key
 }
@@ -313,6 +320,86 @@ describe('PokemonSets – owned-only filter', () => {
       expect(screen.getByTestId('pokemon-sets-empty-owned')).toBeInTheDocument()
     })
     expect(screen.getByText("You don't own any cards yet — go scan some!")).toBeInTheDocument()
+  })
+})
+
+describe('PokemonSets – collection value card', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  // routedFetch returns the sets list for /sets, the given value payload for
+  // /collection/value, and a zero unresolved-count for everything else.
+  function routedFetch(sets: SetShape[], valueResponse: { ok: boolean; body?: unknown }) {
+    return vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/api/pokemon/sets')) {
+        return Promise.resolve(setsResponse(sets))
+      }
+      if (url.startsWith('/api/pokemon/collection/value')) {
+        return Promise.resolve({
+          ok: valueResponse.ok,
+          json: () => Promise.resolve(valueResponse.body ?? {}),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ unresolved: 0 }) })
+    })
+  }
+
+  it('renders the total NOK and owned-variant count once loaded', async () => {
+    const sv = makeSet({ id: 'sv1', name: 'SV Base' })
+    vi.stubGlobal('fetch', routedFetch([sv], {
+      ok: true,
+      body: { total_eur: 10, total_nok: 115, owned_variant_count: 3 },
+    }))
+
+    renderPage()
+
+    const card = await screen.findByTestId('pokemon-collection-value-card')
+    expect(card).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('pokemon-collection-value-total')).toHaveTextContent('115')
+    })
+    expect(screen.getByText('3 owned cards')).toBeInTheDocument()
+  })
+
+  it('renders a zero/empty state for an empty collection, not an error', async () => {
+    const sv = makeSet({ id: 'sv1', name: 'SV Base' })
+    vi.stubGlobal('fetch', routedFetch([sv], {
+      ok: true,
+      body: { total_eur: 0, total_nok: 0, owned_variant_count: 0 },
+    }))
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pokemon-collection-value-total')).toHaveTextContent('0')
+    })
+    expect(screen.getByText('0 owned cards')).toBeInTheDocument()
+    expect(screen.queryByTestId('pokemon-collection-value-error')).not.toBeInTheDocument()
+  })
+
+  it('shows a price-unavailable hint when the rate is missing (total_nok null)', async () => {
+    const sv = makeSet({ id: 'sv1', name: 'SV Base' })
+    vi.stubGlobal('fetch', routedFetch([sv], {
+      ok: true,
+      body: { total_eur: 10, total_nok: null, owned_variant_count: 2 },
+    }))
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pokemon-collection-value-total')).toHaveTextContent('Price unavailable')
+    })
+  })
+
+  it('shows an error state when the value endpoint fails', async () => {
+    const sv = makeSet({ id: 'sv1', name: 'SV Base' })
+    vi.stubGlobal('fetch', routedFetch([sv], { ok: false }))
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pokemon-collection-value-error')).toBeInTheDocument()
+    })
   })
 })
 

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '../components/ui/skeleton'
 import AddCardPanel from '../components/pokemon/AddCardPanel'
 import CardScanner from '../components/pokemon/CardScanner'
 import PageScanner from '../components/pokemon/PageScanner'
+import CollectionValueCard from '../components/pokemon/CollectionValueCard'
 import { formatDate } from '../utils/formatDate'
 
 // PokemonSetsLocationState carries the optional "open AddCardPanel pre-filled
@@ -27,6 +28,15 @@ interface PokemonSet {
   symbol_url: string
   logo_url: string
   owned_count: number
+}
+
+// CollectionValue is the portfolio-value summary from
+// /api/pokemon/collection/value. total_nok is null when no EUR/NOK rate is
+// available.
+interface CollectionValue {
+  total_eur: number
+  total_nok: number | null
+  owned_variant_count: number
 }
 
 // eraSlug converts a series name into a safe HTML id fragment so values like
@@ -158,6 +168,9 @@ export default function PokemonSets() {
   const [showOlder, setShowOlder] = useState(false)
   const [attempt, setAttempt] = useState(0)
   const [unresolvedCount, setUnresolvedCount] = useState(0)
+  const [value, setValue] = useState<CollectionValue | null>(null)
+  const [valueLoading, setValueLoading] = useState(true)
+  const [valueError, setValueError] = useState(false)
   const [scannerOpen, setScannerOpen] = useState(false)
   const [pageScannerOpen, setPageScannerOpen] = useState(false)
 
@@ -244,6 +257,32 @@ export default function PokemonSets() {
     return () => { controller.abort() }
   }, [attempt])
 
+  // Fetch the portfolio-value summary on mount and whenever the page reloads
+  // after a collection change (AddCardPanel / scanner). The card sits above the
+  // sets grid and answers "what is my whole collection worth?".
+  useEffect(() => {
+    const controller = new AbortController()
+    setValueLoading(true)
+    setValueError(false)
+    ;(async () => {
+      try {
+        const res = await fetch('/api/pokemon/collection/value', {
+          credentials: 'include',
+          signal: controller.signal,
+        })
+        if (!res.ok) throw new Error('failed')
+        const data: CollectionValue = await res.json()
+        if (!controller.signal.aborted) setValue(data)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        if (!controller.signal.aborted) setValueError(true)
+      } finally {
+        if (!controller.signal.aborted) setValueLoading(false)
+      }
+    })()
+    return () => { controller.abort() }
+  }, [attempt])
+
   // The top 3 series ranked by the most-recent release_date in each series are
   // shown expanded; everything else is hidden behind the "Show older sets"
   // toggle. Older series are sorted newest-first by their max release_date,
@@ -316,6 +355,13 @@ export default function PokemonSets() {
             </Link>
           </div>
         </header>
+
+        <CollectionValueCard
+          totalNok={value?.total_nok ?? null}
+          ownedVariantCount={value?.owned_variant_count ?? 0}
+          loading={valueLoading}
+          error={valueError}
+        />
 
         {unresolvedCount > 0 && (
           <Link

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -262,9 +262,9 @@ export default function PokemonSets() {
   // sets grid and answers "what is my whole collection worth?".
   useEffect(() => {
     const controller = new AbortController()
-    setValueLoading(true)
-    setValueError(false)
     ;(async () => {
+      setValueLoading(true)
+      setValueError(false)
       try {
         const res = await fetch('/api/pokemon/collection/value', {
           credentials: 'include',


### PR DESCRIPTION
## Changes

- **Pokémon collection-value summary card** - The Pokémon sets page now shows a portfolio-value card at the top with the total NOK worth of every owned variant and the count of owned cards, backed by a new `GET /api/pokemon/collection/value` aggregate endpoint. (Hytte-lmgj)

## Original Issue (feature): Add a portfolio-value summary card across all owned Pokémon cards

### Scope
Add a portfolio-value summary that answers "what is my whole Pokémon collection worth?" The backend gains one aggregate endpoint that sums `price_nok` across every *owned* variant (reusing the existing EUR→NOK rate via `loadRate`/`applyNOK`). The frontend adds a single summary card at the top of `PokemonSets.tsx` showing total NOK and owned-variant count. A week-over-week delta is included only if a price-history source exists (see Non-goals / open question below).

### Files to touch
- `internal/pokemon/handlers.go` — new `CollectionValueHandler(db)` aggregating total NOK + owned variant count over the user's collection joined to variants.
- `internal/pokemon/handlers.go` (RegisterRoutes block, ~line 175) — register `r.Get("/pokemon/collection/value", …)` inside the `RequireFeature(db, "pokemon")` group.
- `internal/pokemon/handlers_test.go` — table tests for empty collection, single/multiple owned variants, NOK-rate applied, missing-rate fallback.
- `web/src/pages/PokemonSets.tsx` — fetch and render the summary card.
- `web/src/components/pokemon/CollectionValueCard.tsx` (new) — presentational card (total, count, optional delta).
- `web/src/pages/PokemonSets.test.tsx` — render/loading/empty-state assertions.
- `web/public/locales/{en,nb,th}/common.json` — new i18n keys (title, total label, count, delta).
- `changelog.d/pokemon-value-card.md` (new) — `Added` fragment.

### Acceptance criteria
- `GET /api/pokemon/collection/value` returns JSON with at least `total_nok`, `owned_variant_count`, and `price_nok` available (null when no FX rate), scoped to the authenticated user; 403 without the `pokemon` feature.
- Total equals the sum of `price_nok` over every owned variant the user holds; cards with no price contribute 0, not an error.
- `PokemonSets.tsx` shows a summary card at page top with total NOK formatted via `Intl.NumberFormat(i18n.language)`, plus owned-variant count.
- Empty collection renders a sensible zero/empty state, not an error or blank.
- All visible strings use `t(...)` and exist in en/nb/th; card is readable at 375px width.
- `go test ./internal/pokemon/...` and `npm run lint`/`build` pass; changelog fragment present.

### Non-goals
- Building a true historical price-snapshot table. `price_at` is a *last-updated* timestamp, not a weekly snapshot, so a real "vs last week" delta is **not** implementable from current data. Either omit the delta or scope a follow-up bead for a snapshot table — do not invent history in this PR.
- Per-set or per-card value breakdowns (already covered by `computeSetValue` / Top page).
- A separate `/pokemon/value` route, multi-currency display, or charts/graphs.
- Changing the FX-rate fetching mechanism.

## Source

Created from Suggestions page (suggestion id 155, page slug "pokemon", source=claude).

## Original suggestion

Today value is computed per-set in PokemonSet.tsx via computeSetValue, and the Top page shows individual prices, but there is no single place that answers 'what is my whole collection worth?'. Add a small summary card on PokemonSets.tsx (or a tiny /pokemon/value route) showing total NOK across every owned variant, plus a delta vs. last week using the existing price_at timestamps. This gives the page a real dashboard feel and rewards the work the async scanner is already doing to ingest cards. Backend likely needs one new aggregate endpoint; frontend is a single component.


---
Bead: Hytte-lmgj | Branch: forge/Hytte-lmgj
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->