### PR TITLE
Persist the Pokémon set filter (era/owned) in URL or localStorage (Hytte-aj7f)

### DIFF
--- a/changelog.d/Hytte-aj7f.md
+++ b/changelog.d/Hytte-aj7f.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Persist the "Show older sets" expansion in the URL** - The Pokémon sets page now mirrors the older-eras expansion to `?older=true`, matching the existing `?owned=true` pattern, so the browser Back button, reloads, and shared links restore the expanded view instead of collapsing it. (Hytte-aj7f)

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -152,10 +152,17 @@ export default function PokemonSets() {
     return params.get('owned')?.toLowerCase() === 'true'
   }, [location.search])
 
+  // The "Show older sets" expansion is mirrored to ?older=true in the URL,
+  // matching the ownedOnly pattern, so the browser Back button (and reloads /
+  // shared links) restore the expanded view instead of collapsing it.
+  const showOlder = useMemo(() => {
+    const params = new URLSearchParams(location.search)
+    return params.get('older')?.toLowerCase() === 'true'
+  }, [location.search])
+
   const [sets, setSets] = useState<PokemonSet[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
-  const [showOlder, setShowOlder] = useState(false)
   const [attempt, setAttempt] = useState(0)
   const [unresolvedCount, setUnresolvedCount] = useState(0)
   const [scannerOpen, setScannerOpen] = useState(false)
@@ -174,6 +181,17 @@ export default function PokemonSets() {
     const next = params.toString()
     navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false, state: location.state })
   }, [ownedOnly, navigate, location.pathname, location.search])
+
+  const toggleShowOlder = useCallback(() => {
+    const params = new URLSearchParams(location.search)
+    if (showOlder) {
+      params.delete('older')
+    } else {
+      params.set('older', 'true')
+    }
+    const next = params.toString()
+    navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false, state: location.state })
+  }, [showOlder, navigate, location.pathname, location.search])
 
   // After the AddCardPanel consumes its initialQuery we strip the hint from
   // history so a subsequent back/forward navigation doesn't re-open the
@@ -371,7 +389,7 @@ export default function PokemonSets() {
               <section className="space-y-3 pt-2 border-t border-gray-800">
                 <button
                   type="button"
-                  onClick={() => setShowOlder(v => !v)}
+                  onClick={toggleShowOlder}
                   aria-expanded={showOlder}
                   className="flex items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors cursor-pointer"
                 >

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -180,7 +180,7 @@ export default function PokemonSets() {
     }
     const next = params.toString()
     navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false, state: location.state })
-  }, [ownedOnly, navigate, location.pathname, location.search])
+  }, [ownedOnly, navigate, location.pathname, location.search, location.state])
 
   const toggleShowOlder = useCallback(() => {
     const params = new URLSearchParams(location.search)
@@ -191,7 +191,7 @@ export default function PokemonSets() {
     }
     const next = params.toString()
     navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false, state: location.state })
-  }, [showOlder, navigate, location.pathname, location.search])
+  }, [showOlder, navigate, location.pathname, location.search, location.state])
 
   // After the AddCardPanel consumes its initialQuery we strip the hint from
   // history so a subsequent back/forward navigation doesn't re-open the


### PR DESCRIPTION
## Changes

- **Persist the "Show older sets" expansion in the URL** - The Pokémon sets page now mirrors the older-eras expansion to `?older=true`, matching the existing `?owned=true` pattern, so the browser Back button, reloads, and shared links restore the expanded view instead of collapsing it. (Hytte-aj7f)

## Original Issue (feature): Persist the Pokémon set filter (era/owned) in URL or localStorage

### Scope
Persist the "Show older sets" expansion (`showOlder`) on `PokemonSets.tsx` the same way `ownedOnly` already is — mirrored to the URL query string — so that navigating into a set and pressing the browser Back button restores the expanded view instead of collapsing it. There is currently only a single `showOlder` boolean (no per-era expansion state), so this is a one-flag change. Keeping it in the URL (rather than localStorage) matches the existing `?owned=true` pattern, restores correctly via history Back, and survives reload/shared links.

### Files to touch
- `web/src/pages/PokemonSets.tsx` — derive `showOlder` from `location.search` and write it through a toggle handler, mirroring the `ownedOnly`/`toggleOwnedOnly` pattern.

### Acceptance criteria
- Expanding "Show older sets" adds a query param (e.g. `?older=true`) to the URL; collapsing removes it. It composes correctly with `?owned=true` (both can be present).
- Clicking into a set from an older era, then pressing the browser Back button, returns to the sets page with the older eras still expanded and the page scrolled back to (or near) the user's prior position.
- Reloading the page or opening a link with the param preserves the expanded state; opening `/pokemon` with no param shows the default collapsed view.
- The toggle button's `aria-expanded` and label (`showOlder`/`hideOlder`) continue to reflect the live state.
- Toggling uses `replace: false` (so Back works), consistent with `toggleOwnedOnly`, and preserves existing `location.state`.
- No regression to the owned-only toggle, set loading, scan banner, or AddCardPanel state-clearing behavior.
- `npm run lint` and `npm run build` pass.

### Non-goals
- No new localStorage persistence (URL is the chosen mechanism, matching existing convention).
- No per-era / per-section independent expansion state — there is only one `showOlder` flag today; do not introduce new collapsible groups.
- No changes to `PokemonSet.tsx`, `PokemonTop.tsx`, or `PokemonScanned.tsx`.
- No backend, API, or schema changes.
- No new i18n keys (existing `showOlder`/`hideOlder` are reused).
- No changelog category beyond a single `Changed`/`Added` fragment for this QoL tweak.

## Source

Created from Suggestions page (suggestion id 154, page slug "pokemon", source=claude).

## Original suggestion

The sets page mirrors the 'owned only' toggle to ?owned=true, but the 'showOlder' era expansion is local state that resets on every navigation. A user who scrolls into older eras to find a set, clicks in, then hits back lands on the collapsed view and has to re-expand. Persist showOlder (and any era-specific expansion) the same way ownedOnly is persisted — via a query param or localStorage — so the browser back button restores the user's place. Small change, noticeable quality-of-life win for collectors who spend time deep in older series.


---
Bead: Hytte-aj7f | Branch: forge/Hytte-aj7f
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->