### PR TITLE
Show primary threshold and last-test summary on the test list (Hytte-v8gr)

### DIFF
--- a/changelog.d/Hytte-v8gr.md
+++ b/changelog.d/Hytte-v8gr.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Lactate test list shows primary threshold at a glance** - Each test row now displays its primary threshold (method, speed, and heart rate), and a header tile summarises the most recent test's threshold with the signed delta versus the previous test. Thresholds are computed server-side on read, so no extra requests are needed. (Hytte-v8gr)

--- a/internal/lactate/lactate.go
+++ b/internal/lactate/lactate.go
@@ -119,7 +119,7 @@ func List(db *sql.DB, userID int64) ([]Test, error) {
 	for i := range tests {
 		ids[i] = tests[i].ID
 	}
-	stagesByTest, err := getStagesForTests(db, ids)
+	stagesByTest, err := getThresholdStagesForTests(db, ids)
 	if err != nil {
 		return nil, fmt.Errorf("get stages for tests: %w", err)
 	}
@@ -165,10 +165,51 @@ func getStagesForTests(db *sql.DB, testIDs []int64) (map[int64][]Stage, error) {
 		); err != nil {
 			return nil, err
 		}
-		// Notes are not needed for threshold computation, but decrypt for
-		// consistency in case callers inspect them.
 		if s.Notes, err = encryption.DecryptField(s.Notes); err != nil {
 			return nil, fmt.Errorf("decrypt stage notes: %w", err)
+		}
+		result[s.TestID] = append(result[s.TestID], s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// getThresholdStagesForTests is a lightweight variant of getStagesForTests that
+// only fetches columns needed for threshold computation (no notes/RPE), avoiding
+// unnecessary decryption overhead in the list path.
+func getThresholdStagesForTests(db *sql.DB, testIDs []int64) (map[int64][]Stage, error) {
+	result := make(map[int64][]Stage, len(testIDs))
+	if len(testIDs) == 0 {
+		return result, nil
+	}
+
+	placeholders := make([]string, len(testIDs))
+	args := make([]any, len(testIDs))
+	for i, id := range testIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `
+		SELECT test_id, stage_number, speed_kmh, lactate_mmol, heart_rate_bpm
+		FROM lactate_test_stages
+		WHERE test_id IN (` + strings.Join(placeholders, ",") + `)
+		ORDER BY test_id, stage_number`
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var s Stage
+		if err := rows.Scan(
+			&s.TestID, &s.StageNumber, &s.SpeedKmh, &s.LactateMmol,
+			&s.HeartRateBpm,
+		); err != nil {
+			return nil, err
 		}
 		result[s.TestID] = append(result[s.TestID], s)
 	}

--- a/internal/lactate/lactate.go
+++ b/internal/lactate/lactate.go
@@ -3,6 +3,7 @@ package lactate
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
@@ -20,10 +21,41 @@ type Test struct {
 	StartSpeedKmh     float64 `json:"start_speed_kmh"`
 	SpeedIncrementKmh float64 `json:"speed_increment_kmh"`
 	// WorkoutID links this test to an imported workout, if any.
-	WorkoutID         *int64  `json:"workout_id,omitempty"`
-	Stages            []Stage `json:"stages"`
-	CreatedAt         string  `json:"created_at"`
-	UpdatedAt         string  `json:"updated_at"`
+	WorkoutID *int64  `json:"workout_id,omitempty"`
+	Stages    []Stage `json:"stages"`
+	// PrimaryThreshold is a precomputed summary of this test's main threshold
+	// (preferring the valid OBLA/LT2 method), attached by List for glanceable display.
+	PrimaryThreshold *PrimaryThreshold `json:"primary_threshold,omitempty"`
+	CreatedAt        string            `json:"created_at"`
+	UpdatedAt        string            `json:"updated_at"`
+}
+
+// PrimaryThreshold is a compact summary of a test's primary threshold for list views.
+type PrimaryThreshold struct {
+	Method       string  `json:"method"`
+	SpeedKmh     float64 `json:"speed_kmh"`
+	HeartRateBpm int     `json:"heart_rate_bpm"`
+	Valid        bool    `json:"valid"`
+}
+
+// primaryThresholdFor computes the primary threshold for a set of stages,
+// preferring the first valid method (OBLA/LT2 is evaluated first by
+// CalculateThresholds). Returns nil when no valid threshold can be derived.
+func primaryThresholdFor(stages []Stage) *PrimaryThreshold {
+	if len(stages) < 2 {
+		return nil
+	}
+	for _, r := range CalculateThresholds(stages) {
+		if r.Valid {
+			return &PrimaryThreshold{
+				Method:       string(r.Method),
+				SpeedKmh:     r.SpeedKmh,
+				HeartRateBpm: r.HeartRateBpm,
+				Valid:        true,
+			}
+		}
+	}
+	return nil
 }
 
 // Stage represents a single step in a lactate test.
@@ -39,7 +71,8 @@ type Stage struct {
 }
 
 // List returns all lactate tests for a user, ordered by date descending.
-// Stages are not included; use GetByID for full test details.
+// Each test carries a precomputed PrimaryThreshold (when derivable) but no
+// stages; use GetByID for full test details including stages.
 func List(db *sql.DB, userID int64) ([]Test, error) {
 	rows, err := db.Query(`
 		SELECT id, user_id, date, comment, protocol_type,
@@ -77,9 +110,72 @@ func List(db *sql.DB, userID int64) ([]Test, error) {
 		return nil, err
 	}
 	if tests == nil {
-		tests = []Test{}
+		return []Test{}, nil
 	}
+
+	// Batch-load stages for all listed tests in one query (avoid N+1), then
+	// compute each test's primary threshold for glanceable list display.
+	ids := make([]int64, len(tests))
+	for i := range tests {
+		ids[i] = tests[i].ID
+	}
+	stagesByTest, err := getStagesForTests(db, ids)
+	if err != nil {
+		return nil, fmt.Errorf("get stages for tests: %w", err)
+	}
+	for i := range tests {
+		tests[i].PrimaryThreshold = primaryThresholdFor(stagesByTest[tests[i].ID])
+	}
+
 	return tests, nil
+}
+
+// getStagesForTests batch-loads stages for the given test IDs in a single query,
+// grouping them by test ID. Stages are returned ordered by stage number.
+func getStagesForTests(db *sql.DB, testIDs []int64) (map[int64][]Stage, error) {
+	result := make(map[int64][]Stage, len(testIDs))
+	if len(testIDs) == 0 {
+		return result, nil
+	}
+
+	placeholders := make([]string, len(testIDs))
+	args := make([]any, len(testIDs))
+	for i, id := range testIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `
+		SELECT id, test_id, stage_number, speed_kmh, lactate_mmol,
+		       heart_rate_bpm, rpe, notes
+		FROM lactate_test_stages
+		WHERE test_id IN (` + strings.Join(placeholders, ",") + `)
+		ORDER BY test_id, stage_number`
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var s Stage
+		if err := rows.Scan(
+			&s.ID, &s.TestID, &s.StageNumber, &s.SpeedKmh, &s.LactateMmol,
+			&s.HeartRateBpm, &s.RPE, &s.Notes,
+		); err != nil {
+			return nil, err
+		}
+		// Notes are not needed for threshold computation, but decrypt for
+		// consistency in case callers inspect them.
+		if s.Notes, err = encryption.DecryptField(s.Notes); err != nil {
+			return nil, fmt.Errorf("decrypt stage notes: %w", err)
+		}
+		result[s.TestID] = append(result[s.TestID], s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // GetByID returns a single lactate test with all its stages.

--- a/internal/lactate/lactate_test.go
+++ b/internal/lactate/lactate_test.go
@@ -183,6 +183,104 @@ func TestList_WithTests(t *testing.T) {
 	}
 }
 
+func TestList_PrimaryThreshold(t *testing.T) {
+	db := setupTestDB(t)
+
+	// sampleTest crosses 4.0 mmol/L between 12.5 and 13.0 km/h, so OBLA is valid.
+	if _, err := Create(db, 1, sampleTest()); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	tests, err := List(db, 1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tests) != 1 {
+		t.Fatalf("expected 1 test, got %d", len(tests))
+	}
+
+	pt := tests[0].PrimaryThreshold
+	if pt == nil {
+		t.Fatal("expected a primary threshold, got nil")
+	}
+	if !pt.Valid {
+		t.Errorf("expected valid threshold, got valid=false")
+	}
+	if pt.Method != string(MethodOBLA) {
+		t.Errorf("method = %q, want %q (first valid, prefers OBLA)", pt.Method, MethodOBLA)
+	}
+	// OBLA crosses 4.0 between (12.5, 3.4) and (13.0, 5.2): speed ~12.66 km/h.
+	if pt.SpeedKmh < 12.5 || pt.SpeedKmh > 13.0 {
+		t.Errorf("speed_kmh = %.2f, want between 12.5 and 13.0", pt.SpeedKmh)
+	}
+	if pt.HeartRateBpm < 165 || pt.HeartRateBpm > 175 {
+		t.Errorf("heart_rate_bpm = %d, want between 165 and 175", pt.HeartRateBpm)
+	}
+}
+
+func TestList_PrimaryThreshold_TooFewStages(t *testing.T) {
+	db := setupTestDB(t)
+
+	test := &Test{
+		Date:              "2026-03-14",
+		ProtocolType:      "standard",
+		WarmupDurationMin: 10,
+		StageDurationMin:  5,
+		StartSpeedKmh:     11.5,
+		SpeedIncrementKmh: 0.5,
+		Stages: []Stage{
+			{StageNumber: 0, SpeedKmh: 10.0, LactateMmol: 1.2, HeartRateBpm: 130},
+		},
+	}
+	if _, err := Create(db, 1, test); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	tests, err := List(db, 1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tests) != 1 {
+		t.Fatalf("expected 1 test, got %d", len(tests))
+	}
+	if tests[0].PrimaryThreshold != nil {
+		t.Errorf("expected nil primary threshold for too-few stages, got %+v", tests[0].PrimaryThreshold)
+	}
+}
+
+func TestList_PrimaryThreshold_NeverReachesThreshold(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Lactate never reaches 4.0 mmol/L and the curve is too short/flat for
+	// the polynomial-based methods, so no method produces a valid threshold.
+	test := &Test{
+		Date:              "2026-03-14",
+		ProtocolType:      "standard",
+		WarmupDurationMin: 10,
+		StageDurationMin:  5,
+		StartSpeedKmh:     11.5,
+		SpeedIncrementKmh: 0.5,
+		Stages: []Stage{
+			{StageNumber: 0, SpeedKmh: 10.0, LactateMmol: 1.0, HeartRateBpm: 130},
+			{StageNumber: 1, SpeedKmh: 11.0, LactateMmol: 1.2, HeartRateBpm: 140},
+		},
+	}
+	if _, err := Create(db, 1, test); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	tests, err := List(db, 1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tests) != 1 {
+		t.Fatalf("expected 1 test, got %d", len(tests))
+	}
+	if tests[0].PrimaryThreshold != nil {
+		t.Errorf("expected nil primary threshold when lactate never reaches threshold, got %+v", tests[0].PrimaryThreshold)
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/web/public/locales/en/lactate.json
+++ b/web/public/locales/en/lactate.json
@@ -33,6 +33,16 @@
     "speedSteps": "+{{increment}} km/h steps",
     "stageDuration": "{{duration}} min stages"
   },
+  "summary": {
+    "latestThreshold": "Latest threshold",
+    "value": "{{speed}} km/h · {{hr}} bpm",
+    "chip": "{{method}} {{speed}} km/h · {{hr}} bpm",
+    "delta": "{{sign}}{{value}} {{unit}}",
+    "vsPrevious": "vs previous test",
+    "noPreviousComparison": "No previous test to compare.",
+    "noResult": "No result",
+    "noResultYet": "No result yet"
+  },
   "new": {
     "title": "Record Test",
     "importFromWorkout": "Import from Workout",

--- a/web/public/locales/nb/lactate.json
+++ b/web/public/locales/nb/lactate.json
@@ -33,6 +33,16 @@
     "speedSteps": "+{{increment}} km/t trinn",
     "stageDuration": "{{duration}} min trinn"
   },
+  "summary": {
+    "latestThreshold": "Siste terskel",
+    "value": "{{speed}} km/t · {{hr}} bpm",
+    "chip": "{{method}} {{speed}} km/t · {{hr}} bpm",
+    "delta": "{{sign}}{{value}} {{unit}}",
+    "vsPrevious": "mot forrige test",
+    "noPreviousComparison": "Ingen tidligere test å sammenligne med.",
+    "noResult": "Ingen resultat",
+    "noResultYet": "Ingen resultat ennå"
+  },
   "new": {
     "title": "Registrer test",
     "importFromWorkout": "Importer fra økt",

--- a/web/public/locales/th/lactate.json
+++ b/web/public/locales/th/lactate.json
@@ -33,6 +33,16 @@
     "speedSteps": "+{{increment}} km/h ต่อช่วง",
     "stageDuration": "{{duration}} นาทีต่อช่วง"
   },
+  "summary": {
+    "latestThreshold": "เกณฑ์ล่าสุด",
+    "value": "{{speed}} km/h · {{hr}} bpm",
+    "chip": "{{method}} {{speed}} km/h · {{hr}} bpm",
+    "delta": "{{sign}}{{value}} {{unit}}",
+    "vsPrevious": "เทียบกับการทดสอบก่อนหน้า",
+    "noPreviousComparison": "ไม่มีการทดสอบก่อนหน้าให้เปรียบเทียบ",
+    "noResult": "ไม่มีผลลัพธ์",
+    "noResultYet": "ยังไม่มีผลลัพธ์"
+  },
   "new": {
     "title": "บันทึกการทดสอบ",
     "importFromWorkout": "นำเข้าจากการออกกำลังกาย",

--- a/web/src/pages/LactateTests.tsx
+++ b/web/src/pages/LactateTests.tsx
@@ -1,11 +1,46 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../auth'
-import { Activity, Plus, Calendar, ChevronRight, TrendingUp } from 'lucide-react'
+import { Activity, Plus, Calendar, ChevronRight, TrendingUp, ArrowUp, ArrowDown, Minus, Gauge } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { formatDate } from '../utils/formatDate'
-import type { LactateTest } from '../types/lactate'
+import { formatDate, formatNumber } from '../utils/formatDate'
+import type { LactateTest, PrimaryThreshold } from '../types/lactate'
 import { Skeleton } from '../components/ui/skeleton'
+
+function validThreshold(test: LactateTest | undefined): PrimaryThreshold | null {
+  const pt = test?.primary_threshold
+  return pt && pt.valid ? pt : null
+}
+
+// DeltaBadge renders a signed change with up/down/flat styling.
+function DeltaBadge({ value, unit, decimals }: { value: number; unit: string; decimals: number }) {
+  const { t } = useTranslation(['lactate'])
+  const rounded = Number(value.toFixed(decimals))
+  const magnitude = formatNumber(Math.abs(rounded), {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  })
+  let Icon = Minus
+  let color = 'text-gray-400'
+  let sign = ''
+  if (rounded > 0) {
+    Icon = ArrowUp
+    color = 'text-green-400'
+    sign = '+'
+  } else if (rounded < 0) {
+    Icon = ArrowDown
+    color = 'text-red-400'
+    sign = '−' // minus sign
+  }
+  return (
+    <span className={`inline-flex items-center gap-1 ${color}`}>
+      <Icon size={14} className="shrink-0" />
+      <span className="tabular-nums">
+        {t('summary.delta', { sign: rounded === 0 ? '' : sign, value: magnitude, unit })}
+      </span>
+    </span>
+  )
+}
 
 export default function LactateTests() {
   const { user } = useAuth()
@@ -79,6 +114,41 @@ export default function LactateTests() {
         </div>
       )}
 
+      {!loading && tests.length >= 2 && (() => {
+        const latest = validThreshold(tests[0])
+        const previous = validThreshold(tests[1])
+        return (
+          <div className="bg-gray-800 border border-gray-700 rounded-xl p-4 mb-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Gauge size={16} className="text-blue-400 shrink-0" />
+              <h2 className="text-sm font-semibold text-gray-300">{t('summary.latestThreshold')}</h2>
+            </div>
+            {latest ? (
+              <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                <span className="text-2xl font-bold text-white tabular-nums">
+                  {t('summary.value', {
+                    speed: formatNumber(latest.speed_kmh, { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
+                    hr: latest.heart_rate_bpm,
+                  })}
+                </span>
+                <span className="text-xs text-gray-500">{latest.method}</span>
+              </div>
+            ) : (
+              <p className="text-gray-400 text-sm">{t('summary.noResultYet')}</p>
+            )}
+            {latest && previous ? (
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-sm">
+                <DeltaBadge value={latest.speed_kmh - previous.speed_kmh} unit={t('units.kmh')} decimals={1} />
+                <DeltaBadge value={latest.heart_rate_bpm - previous.heart_rate_bpm} unit={t('units.bpm')} decimals={0} />
+                <span className="text-xs text-gray-500">{t('summary.vsPrevious')}</span>
+              </div>
+            ) : (
+              latest && <p className="text-xs text-gray-500 mt-2">{t('summary.noPreviousComparison')}</p>
+            )}
+          </div>
+        )
+      })()}
+
       {loading ? (
         <div className="space-y-3 py-4" role="status" aria-live="polite" aria-busy="true">
           <p className="sr-only">{t('list.loading')}</p>
@@ -123,7 +193,30 @@ export default function LactateTests() {
                     {test.comment && (
                       <p className="text-white font-medium truncate">{test.comment}</p>
                     )}
-                    <div className="flex items-center gap-4 mt-1.5 text-xs text-gray-500">
+                    <div className="mt-2">
+                      {(() => {
+                        const pt = validThreshold(test)
+                        if (!pt) {
+                          return (
+                            <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-gray-700/60 text-gray-400 text-xs">
+                              <Gauge size={12} className="shrink-0" />
+                              {t('summary.noResult')}
+                            </span>
+                          )
+                        }
+                        return (
+                          <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-blue-500/10 text-blue-300 text-xs font-medium">
+                            <Gauge size={12} className="shrink-0" />
+                            {t('summary.chip', {
+                              method: pt.method,
+                              speed: formatNumber(pt.speed_kmh, { minimumFractionDigits: 1, maximumFractionDigits: 1 }),
+                              hr: pt.heart_rate_bpm,
+                            })}
+                          </span>
+                        )
+                      })()}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1.5 text-xs text-gray-500">
                       <span>{t('list.startSpeed', { speed: test.start_speed_kmh })}</span>
                       <span>{t('list.speedSteps', { increment: test.speed_increment_kmh })}</span>
                       <span>{t('list.stageDuration', { duration: test.stage_duration_min })}</span>

--- a/web/src/types/lactate.ts
+++ b/web/src/types/lactate.ts
@@ -19,8 +19,16 @@ export interface LactateTest {
   speed_increment_kmh: number
   workout_id?: number
   stages: Stage[]
+  primary_threshold?: PrimaryThreshold
   created_at: string
   updated_at: string
+}
+
+export interface PrimaryThreshold {
+  method: string
+  speed_kmh: number
+  heart_rate_bpm: number
+  valid: boolean
 }
 
 export interface ThresholdResult {


### PR DESCRIPTION
## Changes

- **Lactate test list shows primary threshold at a glance** - Each test row now displays its primary threshold (method, speed, and heart rate), and a header tile summarises the most recent test's threshold with the signed delta versus the previous test. Thresholds are computed server-side on read, so no extra requests are needed. (Hytte-v8gr)

## Original Issue (feature): Show primary threshold and last-test summary on the test list

### Scope
Enrich the `/lactate` index so each test row shows its primary threshold (LT2/OBLA speed + HR) and add a header tile summarising the most recent test's threshold with the delta vs the previous test. Today `List` (`internal/lactate/lactate.go:43`) returns no stages and the analysis/threshold is only computed on the detail/analysis endpoints, so the list response must be enriched server-side with a precomputed primary threshold per test (computed via the existing `CalculateThresholds`, preferring the valid OBLA/LT2 method) to avoid N client round-trips.

### Files to touch
- `internal/lactate/lactate.go` — load stages for listed tests (batch) and attach a `PrimaryThreshold` (method, speed, HR, valid) to each `Test` in `List`, reusing `CalculateThresholds`.
- `internal/lactate/lactate_test.go` — cover that `List` returns a populated primary threshold and handles tests with too-few/invalid stages (nil/invalid).
- `web/src/types/lactate.ts` — add optional `primary_threshold` to `LactateTest`.
- `web/src/pages/LactateTests.tsx` — render a per-row threshold chip and a header summary tile (latest threshold + delta vs previous).
- `web/public/locales/{en,nb,th}/lactate.json` — new i18n keys (chip label, header tile labels, delta up/down/flat, "no result yet").
- `changelog.d/<id>.md` (new) — `Changed` fragment.

### Acceptance criteria
- `GET /api/lactate/tests` returns a primary threshold object per test (method, speed_kmh, heart_rate_bpm, valid) without requiring extra requests; tests with insufficient/invalid data return an absent or `valid:false` threshold.
- Each row on `/lactate` shows a threshold chip (e.g. "LT2 14.2 km/h · 168 bpm"); rows with no valid threshold show a neutral fallback (e.g. "No result") instead of breaking.
- A header tile above the list summarises the most recent test's threshold and the signed delta vs the previous test (speed and/or HR), with up/down/flat styling; it is hidden or shows a placeholder when fewer than 2 tests exist.
- All new strings are translated in en, nb, and th; no hardcoded English in JSX.
- Layout works at 375px (chip/tile wrap, no horizontal overflow).
- `go test ./...`, `go vet`, `npm run lint`, and `npm run build` pass; a changelog fragment exists.

### Non-goals
- No persisted/cached analysis table or schema change — thresholds are computed on read.
- No changes to threshold math, method selection logic, zones, or predictions.
- No redesign of the detail, new-test, or insights pages.
- No charts/sparklines on the list (only chip + single header tile).
- No new filtering, sorting, or pagination of the test list.

## Source

Created from Suggestions page (suggestion id 64, page slug "lactate", source=claude).

## Original suggestion

The list page only shows protocol metadata (start speed, increment, stage duration) for each test, which forces a click into the detail view to see the actual result. Add a small summary chip showing the primary threshold (e.g. LT2 speed/HR from the cached analysis) on each row, plus a header tile summarising the most recent test's threshold and delta vs the previous one. This turns /lactate from a navigation index into a glanceable progress page and reduces clicks for the most common task — checking how the latest test compares.


---
Bead: Hytte-v8gr | Branch: forge/Hytte-v8gr
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->