### PR TITLE
Stop SCAN_POLL_MS firing while the Scanned tab is hidden or backgrounded (Hytte-w7od)

### DIFF
--- a/web/src/pages/PokemonScanned.test.tsx
+++ b/web/src/pages/PokemonScanned.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, within, act } from '@testing-library/react'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import PokemonScanned from './PokemonScanned'
 
@@ -270,6 +270,9 @@ function renderPage() {
 afterEach(() => {
   vi.unstubAllGlobals()
   vi.clearAllMocks()
+  vi.useRealTimers()
+  // Drop any per-test override so we fall back to happy-dom's default 'visible'.
+  delete (document as unknown as Record<string, unknown>).visibilityState
 })
 
 describe('PokemonScanned – render', () => {
@@ -813,5 +816,149 @@ describe('PokemonScanned – page grid', () => {
       const block = screen.getByTestId('scan-page-42')
       expect(block).toHaveAttribute('data-highlighted', 'true')
     })
+  })
+})
+
+describe('PokemonScanned – visibility-aware polling', () => {
+  const SCAN_POLL_MS = 30000
+
+  // Counts how many times the scan-list endpoint was hit. Each background poll
+  // (silentRefetch) and the initial mount fetch both issue a GET to this URL,
+  // so the call count is a faithful proxy for "a poll fired".
+  function scanListCalls(fetchMock: ReturnType<typeof makeFetchMock>): number {
+    return fetchMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.startsWith('/api/pokemon/scans?'),
+    ).length
+  }
+
+  // Override document.visibilityState for the current test. happy-dom exposes
+  // it as a prototype getter, so we shadow it with a configurable own property
+  // (cleaned up in afterEach).
+  function setVisibility(state: 'visible' | 'hidden') {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => state,
+    })
+  }
+
+  // Flush pending microtasks (fetch → res.json → setState) so React commits the
+  // resulting render and the fetch effect runs. Works under fake timers because
+  // vitest only fakes the timer queue, not the microtask queue.
+  async function flush() {
+    await act(async () => {
+      for (let i = 0; i < 5; i++) await Promise.resolve()
+    })
+  }
+
+  it('polls /api/pokemon/scans at the SCAN_POLL_MS cadence while visible', async () => {
+    setVisibility('visible')
+    vi.useFakeTimers()
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await flush()
+
+    const baseline = scanListCalls(fetchMock)
+    expect(baseline).toBe(1) // the initial mount fetch
+
+    // Three interval ticks → three additional polls.
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(SCAN_POLL_MS)
+      })
+      await flush()
+    }
+
+    expect(scanListCalls(fetchMock)).toBe(baseline + 3)
+  })
+
+  it('stops polling once the tab becomes hidden', async () => {
+    setVisibility('visible')
+    vi.useFakeTimers()
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await flush()
+    const baseline = scanListCalls(fetchMock)
+
+    // Background the tab: the visibilitychange handler clears the interval.
+    await act(async () => {
+      setVisibility('hidden')
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await flush()
+
+    // Advancing well past the poll cadence must not fire any new polls.
+    await act(async () => {
+      vi.advanceTimersByTime(SCAN_POLL_MS * 3)
+    })
+    await flush()
+
+    expect(scanListCalls(fetchMock)).toBe(baseline)
+  })
+
+  it('refetches immediately on refocus and resumes the interval', async () => {
+    setVisibility('visible')
+    vi.useFakeTimers()
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await flush()
+
+    // Hide the tab and confirm polling has paused.
+    await act(async () => {
+      setVisibility('hidden')
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(SCAN_POLL_MS * 2)
+    })
+    await flush()
+    const beforeRefocus = scanListCalls(fetchMock)
+
+    // Refocus: exactly one immediate refetch, before any timer advances.
+    await act(async () => {
+      setVisibility('visible')
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await flush()
+    expect(scanListCalls(fetchMock)).toBe(beforeRefocus + 1)
+
+    // The 30s interval is running again.
+    await act(async () => {
+      vi.advanceTimersByTime(SCAN_POLL_MS)
+    })
+    await flush()
+    expect(scanListCalls(fetchMock)).toBe(beforeRefocus + 2)
+  })
+
+  it('clears the interval and removes the visibilitychange listener on unmount', async () => {
+    setVisibility('visible')
+    vi.useFakeTimers()
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    vi.stubGlobal('fetch', fetchMock)
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+
+    const { unmount } = renderPage()
+    await flush()
+    const baseline = scanListCalls(fetchMock)
+
+    await act(async () => {
+      unmount()
+    })
+
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+
+    // No leaked interval keeps polling after the component is gone.
+    await act(async () => {
+      vi.advanceTimersByTime(SCAN_POLL_MS * 3)
+    })
+    await flush()
+    expect(scanListCalls(fetchMock)).toBe(baseline)
+
+    removeSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Reviewer's approval notes

Test-only PR adds focused, passing coverage for visibility-aware scan polling that accurately matches the existing implementation and fully satisfies the bead's acceptance criteria.

## Original Issue (feature): Stop SCAN_POLL_MS firing while the Scanned tab is hidden or backgrounded

### Scope

The behaviour this suggestion asks for is **already implemented** in `web/src/pages/PokemonScanned.tsx` (lines ~536–571). The scan-polling `useEffect` already (a) gates each tick on `document.visibilityState === 'visible'`, (b) starts/stops the interval on `visibilitychange` so it fully pauses when hidden, (c) triggers an immediate `silentRefetch()` on refocus, and (d) clears the interval and removes the listener on unmount. The SPA-unmount case is covered because the effect cleanup runs when the user navigates away from `/pokemon`.

This plan therefore covers **verification and minor hardening only**, not a from-scratch implementation. If the reviewer confirms the existing code is sufficient, the suggestion can be closed as already-done.

### Files to touch

- `web/src/pages/PokemonScanned.tsx` — only if a gap is found during verification (e.g. tightening the interval guard or adding a regression test hook). Likely no change.
- `web/src/pages/PokemonScanned.test.tsx` (new, optional) — add a focused test proving polling pauses while hidden and resumes on refocus, if no equivalent coverage exists.
- `changelog.d/` (new) — only if a code change is actually made.

### Acceptance criteria

- With the Scanned tab focused, `/api/pokemon/scans` is polled at the `SCAN_POLL_MS` (30 s) cadence.
- When `document.visibilityState` becomes `hidden` (tab backgrounded/minimised), no further `/api/pokemon/scans` polls fire until the tab is visible again.
- Refocusing the tab triggers one immediate refetch and resumes the 30 s interval.
- Navigating away from `/pokemon` within the SPA stops all polling (effect cleanup runs; no leaked interval or `visibilitychange` listener).
- No user-visible behavioural change other than fresher data on refocus.
- `npm run lint` and `npm run build` pass; any added test passes.

### Non-goals

- Changing the 30 s poll cadence or moving to push/SSE/websockets.
- Altering polling on other Pokémon pages (`PokemonSets`, `PokemonSet`, `PokemonTop`).
- Backend changes to `/api/pokemon/scans`.
- Adding global/app-wide visibility-aware polling infrastructure.
- The per-second "elapsed time" clock tick (separate effect, intentionally always running while mounted).

**Note to reviewer:** since the requested gating already exists, the coding agent should first confirm against the current source and close the suggestion if no gap remains, rather than re-implementing what's there.

## Source

Created from Suggestions page (suggestion id 156, page slug "pokemon", source=claude).

## Original suggestion

PokemonScanned polls /api/pokemon/scans every 30s to track queued→processing→matched transitions, but the interval keeps running when the tab is hidden or the user has navigated to another route inside the SPA. That's wasted API traffic and battery, and on mobile it can keep the device awake. Gate the polling on document.visibilityState === 'visible' (and clear the interval on unmount, which the existing useEffect should already do) so polls pause when the user isn't looking. Users see no behavioural change beyond fresher data the moment they refocus the tab.


---
Bead: Hytte-w7od | Branch: forge/Hytte-w7od
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->