### PR TITLE
Serve kiosk data with HTTP caching and per-source timeouts on the backend (Hytte-xegx)

### DIFF
--- a/changelog.d/Hytte-xegx.md
+++ b/changelog.d/Hytte-xegx.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Kiosk data endpoint now caches and bounds upstream calls** - `GET /api/kiosk/data` serves results from a short-TTL (20s) in-memory cache keyed by stop IDs, location, and Netatmo user, so multiple kiosk tabs no longer hammer the transit/Netatmo/weather providers on every poll. Each upstream fetch is now bounded by its own timeout so one slow provider yields partial data instead of stalling the whole response, and the response carries a matching `Cache-Control: max-age` header. (Hytte-xegx)

--- a/internal/kiosk/cache.go
+++ b/internal/kiosk/cache.go
@@ -1,0 +1,83 @@
+package kiosk
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// CacheTTL is the time-to-live for cached kiosk payloads. It is intentionally
+// short: kiosks poll roughly every 30s, so a 20s window collapses the bursts
+// of near-simultaneous polls from multiple tabs into a single upstream fetch
+// while keeping the displayed data fresh. The same value is advertised to
+// browsers/CDN via the Cache-Control: max-age header.
+const CacheTTL = 20 * time.Second
+
+// entry is a single cached kiosk payload with its expiry instant.
+type entry struct {
+	value     KioskData
+	expiresAt time.Time
+}
+
+// TTLCache is a small, self-contained, mutex-guarded in-memory cache with a
+// fixed TTL per entry. Entries are only evicted lazily on read after they
+// expire; given the tiny key space (one key per distinct kiosk config) no
+// size cap or background sweeper is needed.
+type TTLCache struct {
+	mu    sync.Mutex
+	items map[string]entry
+}
+
+// NewTTLCache returns an empty TTLCache ready for use.
+func NewTTLCache() *TTLCache {
+	return &TTLCache{items: make(map[string]entry)}
+}
+
+// Get returns the cached value for key and true if present and not expired.
+// Expired entries are treated as a miss (and removed).
+func (c *TTLCache) Get(key string) (KioskData, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.items[key]
+	if !ok {
+		return KioskData{}, false
+	}
+	if time.Now().After(e.expiresAt) {
+		delete(c.items, key)
+		return KioskData{}, false
+	}
+	return e.value, true
+}
+
+// Set stores val under key with an expiry of now+CacheTTL.
+func (c *TTLCache) Set(key string, val KioskData) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items[key] = entry{value: val, expiresAt: time.Now().Add(CacheTTL)}
+}
+
+// buildCacheKey constructs a deterministic cache key from the request's data
+// inputs. Stop IDs are sorted so ordering differences don't produce distinct
+// keys, and a stable separator scheme keeps the location and Netatmo segments
+// unambiguous. Two requests with identical kiosk config produce the same key.
+func buildCacheKey(stopIDs []string, lat, lon float64, hasLat, hasLon bool, location string, netatmoUserID int64) string {
+	sorted := append([]string(nil), stopIDs...)
+	sort.Strings(sorted)
+
+	var b strings.Builder
+	b.WriteString("stops=")
+	b.WriteString(strings.Join(sorted, ","))
+	b.WriteString("|loc=")
+	if hasLat && hasLon {
+		b.WriteString(strconv.FormatFloat(lat, 'f', -1, 64))
+		b.WriteString(",")
+		b.WriteString(strconv.FormatFloat(lon, 'f', -1, 64))
+	} else {
+		b.WriteString(location)
+	}
+	b.WriteString("|netatmo=")
+	b.WriteString(strconv.FormatInt(netatmoUserID, 10))
+	return b.String()
+}

--- a/internal/kiosk/cache_test.go
+++ b/internal/kiosk/cache_test.go
@@ -1,0 +1,71 @@
+package kiosk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTTLCache_HitWithinTTL(t *testing.T) {
+	c := NewTTLCache()
+	want := KioskData{FetchedAt: time.Now()}
+	c.Set("k", want)
+
+	got, ok := c.Get("k")
+	if !ok {
+		t.Fatal("expected cache hit within TTL")
+	}
+	if !got.FetchedAt.Equal(want.FetchedAt) {
+		t.Errorf("expected cached FetchedAt %v, got %v", want.FetchedAt, got.FetchedAt)
+	}
+}
+
+func TestTTLCache_MissForUnknownKey(t *testing.T) {
+	c := NewTTLCache()
+	if _, ok := c.Get("nope"); ok {
+		t.Error("expected miss for unknown key")
+	}
+}
+
+func TestTTLCache_ExpiredEntryIsMiss(t *testing.T) {
+	c := NewTTLCache()
+	// Insert an already-expired entry directly to avoid sleeping for CacheTTL.
+	c.mu.Lock()
+	c.items["k"] = entry{value: KioskData{}, expiresAt: time.Now().Add(-time.Second)}
+	c.mu.Unlock()
+
+	if _, ok := c.Get("k"); ok {
+		t.Error("expected expired entry to be treated as a miss")
+	}
+	// Expired entry should have been evicted on read.
+	c.mu.Lock()
+	_, present := c.items["k"]
+	c.mu.Unlock()
+	if present {
+		t.Error("expected expired entry to be removed on read")
+	}
+}
+
+func TestBuildCacheKey_IdenticalInputsMatch(t *testing.T) {
+	a := buildCacheKey([]string{"A", "B"}, 0, 0, false, "Bergen", 7)
+	// Stop ID order must not matter (keys are sorted).
+	b := buildCacheKey([]string{"B", "A"}, 0, 0, false, "Bergen", 7)
+	if a != b {
+		t.Errorf("expected identical keys regardless of stop order: %q vs %q", a, b)
+	}
+}
+
+func TestBuildCacheKey_DistinctInputsDiffer(t *testing.T) {
+	base := buildCacheKey([]string{"A"}, 0, 0, false, "Bergen", 1)
+
+	cases := map[string]string{
+		"different stop_ids":  buildCacheKey([]string{"A", "C"}, 0, 0, false, "Bergen", 1),
+		"different location":  buildCacheKey([]string{"A"}, 0, 0, false, "Oslo", 1),
+		"different netatmo":   buildCacheKey([]string{"A"}, 0, 0, false, "Bergen", 2),
+		"lat/lon vs location": buildCacheKey([]string{"A"}, 59.9, 10.7, true, "Bergen", 1),
+	}
+	for name, key := range cases {
+		if key == base {
+			t.Errorf("%s: expected distinct cache key, got same as base %q", name, base)
+		}
+	}
+}

--- a/internal/kiosk/cache_test.go
+++ b/internal/kiosk/cache_test.go
@@ -46,22 +46,22 @@ func TestTTLCache_ExpiredEntryIsMiss(t *testing.T) {
 }
 
 func TestBuildCacheKey_IdenticalInputsMatch(t *testing.T) {
-	a := buildCacheKey([]string{"A", "B"}, 0, 0, false, "Bergen", 7)
+	a := buildCacheKey([]string{"A", "B"}, 0, 0, false, false, "Bergen", 7)
 	// Stop ID order must not matter (keys are sorted).
-	b := buildCacheKey([]string{"B", "A"}, 0, 0, false, "Bergen", 7)
+	b := buildCacheKey([]string{"B", "A"}, 0, 0, false, false, "Bergen", 7)
 	if a != b {
 		t.Errorf("expected identical keys regardless of stop order: %q vs %q", a, b)
 	}
 }
 
 func TestBuildCacheKey_DistinctInputsDiffer(t *testing.T) {
-	base := buildCacheKey([]string{"A"}, 0, 0, false, "Bergen", 1)
+	base := buildCacheKey([]string{"A"}, 0, 0, false, false, "Bergen", 1)
 
 	cases := map[string]string{
-		"different stop_ids":  buildCacheKey([]string{"A", "C"}, 0, 0, false, "Bergen", 1),
-		"different location":  buildCacheKey([]string{"A"}, 0, 0, false, "Oslo", 1),
-		"different netatmo":   buildCacheKey([]string{"A"}, 0, 0, false, "Bergen", 2),
-		"lat/lon vs location": buildCacheKey([]string{"A"}, 59.9, 10.7, true, "Bergen", 1),
+		"different stop_ids":  buildCacheKey([]string{"A", "C"}, 0, 0, false, false, "Bergen", 1),
+		"different location":  buildCacheKey([]string{"A"}, 0, 0, false, false, "Oslo", 1),
+		"different netatmo":   buildCacheKey([]string{"A"}, 0, 0, false, false, "Bergen", 2),
+		"lat/lon vs location": buildCacheKey([]string{"A"}, 59.9, 10.7, true, true, "Bergen", 1),
 	}
 	for name, key := range cases {
 		if key == base {

--- a/internal/kiosk/handlers.go
+++ b/internal/kiosk/handlers.go
@@ -1,8 +1,10 @@
 package kiosk
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"sync"
@@ -12,6 +14,35 @@ import (
 	"github.com/Robin831/Hytte/internal/transit"
 	"github.com/Robin831/Hytte/internal/weather"
 )
+
+// perSourceTimeout bounds each upstream fan-out call (transit, Netatmo,
+// weather) independently so a single slow provider can't stall the whole
+// aggregated response. It is comfortably below CacheTTL and the kiosk poll
+// cadence, so a timed-out source simply yields partial data on this poll and
+// is retried on the next. It is a var (not a const) only so tests can shorten
+// it; production code never reassigns it.
+var perSourceTimeout = 8 * time.Second
+
+// kioskCache is a process-wide short-TTL cache shared across all kiosk tabs.
+// Identical kiosk configs polling within CacheTTL reuse a single upstream
+// fetch instead of each hammering the rate-limited providers.
+var kioskCache = NewTTLCache()
+
+// transitFetcher is the subset of *transit.Service used by the kiosk handler.
+// Defining it as an interface lets tests inject fakes with call counters.
+type transitFetcher interface {
+	FetchDepartures(ctx context.Context, stopID string, count int) (string, []transit.Departure, error)
+}
+
+// netatmoFetcher is the subset of *netatmo.Client used by the kiosk handler.
+type netatmoFetcher interface {
+	GetStationsData(ctx context.Context, userID int64) (*netatmo.ModuleReadings, error)
+}
+
+// weatherFetcher is the subset of *weather.Service used by the kiosk handler.
+type weatherFetcher interface {
+	FetchForecast(loc weather.Location) ([]byte, error)
+}
 
 // SunTimes holds today's sunrise and sunset times for the kiosk location.
 // Kind is "normal", "polarDay", or "polarNight".
@@ -36,7 +67,21 @@ type KioskData struct {
 // It reads stop IDs, location, and Netatmo user from the KioskConfig injected
 // by KioskAuth, then fans out to transit, Netatmo, weather, and sun time
 // sources concurrently.
-func DataHandler(db *sql.DB, transitSvc *transit.Service, netatmoClient *netatmo.Client, weatherSvc *weather.Service) http.HandlerFunc {
+func DataHandler(db *sql.DB, transitSvc transitFetcher, netatmoClient netatmoFetcher, weatherSvc weatherFetcher) http.HandlerFunc {
+	// Guard against typed-nil interface values: callers may pass a nil
+	// *transit.Service / *netatmo.Client / *weather.Service, which wraps into a
+	// non-nil interface. Normalise those back to a true nil interface so the
+	// "service configured" checks below behave as before.
+	if isNilFetcher(transitSvc) {
+		transitSvc = nil
+	}
+	if isNilFetcher(netatmoClient) {
+		netatmoClient = nil
+	}
+	if isNilFetcher(weatherSvc) {
+		weatherSvc = nil
+	}
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		cfg := GetKioskConfig(r.Context())
 
@@ -45,6 +90,14 @@ func DataHandler(db *sql.DB, transitSvc *transit.Service, netatmoClient *netatmo
 		lon, hasLon := extractFloat(cfg, "lon")
 		locationName, _ := cfg["location"].(string)
 		netatmoUserID, _ := extractInt64(cfg, "netatmo_user_id")
+
+		// Serve from cache when an identical kiosk config was fetched within the
+		// TTL window. The cached payload retains its original FetchedAt.
+		cacheKey := buildCacheKey(stopIDs, lat, lon, hasLat, hasLon, locationName, netatmoUserID)
+		if cached, ok := kioskCache.Get(cacheKey); ok {
+			writeKioskData(w, cached)
+			return
+		}
 
 		var (
 			mu     sync.Mutex
@@ -59,17 +112,25 @@ func DataHandler(db *sql.DB, transitSvc *transit.Service, netatmoClient *netatmo
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				stops := make([]transit.StopDepartures, 0, len(stopIDs))
-				for _, id := range stopIDs {
-					stopName, departures, err := transitSvc.FetchDepartures(r.Context(), id, 10)
-					if err != nil {
-						continue
+				ctx, cancel := context.WithTimeout(r.Context(), perSourceTimeout)
+				defer cancel()
+				stops, ok := runWithTimeout(ctx, func() ([]transit.StopDepartures, error) {
+					s := make([]transit.StopDepartures, 0, len(stopIDs))
+					for _, id := range stopIDs {
+						stopName, departures, err := transitSvc.FetchDepartures(ctx, id, 10)
+						if err != nil {
+							continue
+						}
+						s = append(s, transit.StopDepartures{
+							StopID:     id,
+							StopName:   stopName,
+							Departures: departures,
+						})
 					}
-					stops = append(stops, transit.StopDepartures{
-						StopID:     id,
-						StopName:   stopName,
-						Departures: departures,
-					})
+					return s, nil
+				})
+				if !ok {
+					return
 				}
 				mu.Lock()
 				result.Transit = stops
@@ -80,7 +141,7 @@ func DataHandler(db *sql.DB, transitSvc *transit.Service, netatmoClient *netatmo
 		// --- Netatmo outdoor readings ---
 		// If no netatmo_user_id in kiosk config, find the first user with a
 		// connected Netatmo account (typically the admin who set it up).
-		if netatmoUserID == 0 && netatmoClient != nil {
+		if netatmoUserID == 0 && netatmoClient != nil && db != nil {
 			var foundID int64
 			row := db.QueryRowContext(r.Context(), `SELECT user_id FROM netatmo_oauth_tokens LIMIT 1`)
 			if row.Scan(&foundID) == nil {
@@ -88,11 +149,16 @@ func DataHandler(db *sql.DB, transitSvc *transit.Service, netatmoClient *netatmo
 			}
 		}
 		if netatmoUserID > 0 && netatmoClient != nil {
+			userID := netatmoUserID
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				readings, err := netatmoClient.GetStationsData(r.Context(), netatmoUserID)
-				if err != nil {
+				ctx, cancel := context.WithTimeout(r.Context(), perSourceTimeout)
+				defer cancel()
+				readings, ok := runWithTimeout(ctx, func() (*netatmo.ModuleReadings, error) {
+					return netatmoClient.GetStationsData(ctx, userID)
+				})
+				if !ok || readings == nil {
 					return
 				}
 				mu.Lock()
@@ -124,13 +190,20 @@ func DataHandler(db *sql.DB, transitSvc *transit.Service, netatmoClient *netatmo
 		}
 
 		// --- Weather forecast ---
+		// FetchForecast has no context parameter, so it is bounded by running it
+		// under runWithTimeout: a slow MET response is abandoned after the
+		// per-source timeout and the forecast field is simply omitted.
 		if weatherLoc != nil && weatherSvc != nil {
 			capturedWeatherLoc := *weatherLoc
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				data, err := weatherSvc.FetchForecast(capturedWeatherLoc)
-				if err != nil {
+				ctx, cancel := context.WithTimeout(r.Context(), perSourceTimeout)
+				defer cancel()
+				data, ok := runWithTimeout(ctx, func() ([]byte, error) {
+					return weatherSvc.FetchForecast(capturedWeatherLoc)
+				})
+				if !ok {
 					return
 				}
 				mu.Lock()
@@ -140,6 +213,7 @@ func DataHandler(db *sql.DB, transitSvc *transit.Service, netatmoClient *netatmo
 		}
 
 		// --- Sun times (computed from lat/lon, only when explicitly configured) ---
+		// This is a local CPU computation, not an upstream call, so it needs no timeout.
 		if sunLoc != nil {
 			capturedLoc := *sunLoc
 			wg.Add(1)
@@ -154,8 +228,65 @@ func DataHandler(db *sql.DB, transitSvc *transit.Service, netatmoClient *netatmo
 
 		wg.Wait()
 
-		writeJSON(w, http.StatusOK, result)
+		kioskCache.Set(cacheKey, result)
+		writeKioskData(w, result)
 	}
+}
+
+// runWithTimeout runs fn in its own goroutine and returns its value and true if
+// fn completes successfully before ctx expires. On timeout or error it returns
+// the zero value and false. A timed-out fn goroutine is left to finish and its
+// result discarded — acceptable for the idempotent, read-only upstream fetches
+// used here, and it ensures the handler's total latency stays near the timeout
+// bound rather than the slow upstream's duration.
+func runWithTimeout[T any](ctx context.Context, fn func() (T, error)) (T, bool) {
+	type result struct {
+		val T
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		v, err := fn()
+		ch <- result{val: v, err: err}
+	}()
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			var zero T
+			return zero, false
+		}
+		return res.val, true
+	case <-ctx.Done():
+		var zero T
+		return zero, false
+	}
+}
+
+// writeKioskData writes a KioskData payload with caching headers. It sets a
+// Cache-Control: max-age matching the in-memory TTL so browsers/CDN respect the
+// same freshness window, overriding the no-store set by KioskAuth for this
+// non-sensitive aggregated data endpoint.
+func writeKioskData(w http.ResponseWriter, data KioskData) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", int(CacheTTL.Seconds())))
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(data)
+}
+
+// isNilFetcher reports whether an interface value holds a nil pointer (typed
+// nil). Plain untyped nil interfaces are reported as nil too.
+func isNilFetcher(v any) bool {
+	switch t := v.(type) {
+	case nil:
+		return true
+	case *transit.Service:
+		return t == nil
+	case *netatmo.Client:
+		return t == nil
+	case *weather.Service:
+		return t == nil
+	}
+	return false
 }
 
 // computeSunTimes computes sunrise and sunset for the given lat/lon and local date.

--- a/internal/kiosk/handlers.go
+++ b/internal/kiosk/handlers.go
@@ -91,6 +91,16 @@ func DataHandler(db *sql.DB, transitSvc transitFetcher, netatmoClient netatmoFet
 		locationName, _ := cfg["location"].(string)
 		netatmoUserID, _ := extractInt64(cfg, "netatmo_user_id")
 
+		// Resolve the effective Netatmo user ID before building the cache key
+		// so the key reflects the actual data source, not the raw config input.
+		if netatmoUserID == 0 && netatmoClient != nil && db != nil {
+			var foundID int64
+			row := db.QueryRowContext(r.Context(), `SELECT user_id FROM netatmo_oauth_tokens LIMIT 1`)
+			if row.Scan(&foundID) == nil {
+				netatmoUserID = foundID
+			}
+		}
+
 		// Serve from cache when an identical kiosk config was fetched within the
 		// TTL window. The cached payload retains its original FetchedAt.
 		cacheKey := buildCacheKey(stopIDs, lat, lon, hasLat, hasLon, locationName, netatmoUserID)
@@ -139,15 +149,6 @@ func DataHandler(db *sql.DB, transitSvc transitFetcher, netatmoClient netatmoFet
 		}
 
 		// --- Netatmo outdoor readings ---
-		// If no netatmo_user_id in kiosk config, find the first user with a
-		// connected Netatmo account (typically the admin who set it up).
-		if netatmoUserID == 0 && netatmoClient != nil && db != nil {
-			var foundID int64
-			row := db.QueryRowContext(r.Context(), `SELECT user_id FROM netatmo_oauth_tokens LIMIT 1`)
-			if row.Scan(&foundID) == nil {
-				netatmoUserID = foundID
-			}
-		}
 		if netatmoUserID > 0 && netatmoClient != nil {
 			userID := netatmoUserID
 			wg.Add(1)
@@ -228,7 +229,9 @@ func DataHandler(db *sql.DB, transitSvc transitFetcher, netatmoClient netatmoFet
 
 		wg.Wait()
 
-		kioskCache.Set(cacheKey, result)
+		if r.Context().Err() == nil {
+			kioskCache.Set(cacheKey, result)
+		}
 		writeKioskData(w, result)
 	}
 }
@@ -268,7 +271,8 @@ func runWithTimeout[T any](ctx context.Context, fn func() (T, error)) (T, bool) 
 // non-sensitive aggregated data endpoint.
 func writeKioskData(w http.ResponseWriter, data KioskData) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", int(CacheTTL.Seconds())))
+	w.Header().Set("Cache-Control", fmt.Sprintf("private, max-age=%d", int(CacheTTL.Seconds())))
+	w.Header().Set("Vary", "Authorization")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(data)
 }

--- a/internal/kiosk/handlers_test.go
+++ b/internal/kiosk/handlers_test.go
@@ -5,11 +5,56 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/Robin831/Hytte/internal/netatmo"
 	"github.com/Robin831/Hytte/internal/transit"
+	"github.com/Robin831/Hytte/internal/weather"
 )
+
+// fakeTransit is a transitFetcher that counts calls and returns a fixed stop.
+type fakeTransit struct {
+	calls atomic.Int64
+}
+
+func (f *fakeTransit) FetchDepartures(ctx context.Context, stopID string, count int) (string, []transit.Departure, error) {
+	f.calls.Add(1)
+	return "Stop " + stopID, []transit.Departure{}, nil
+}
+
+// fakeWeather is a weatherFetcher that counts calls and can sleep to simulate a
+// slow upstream.
+type fakeWeather struct {
+	calls atomic.Int64
+	delay time.Duration
+}
+
+func (f *fakeWeather) FetchForecast(loc weather.Location) ([]byte, error) {
+	f.calls.Add(1)
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	return []byte(`{"forecast":true}`), nil
+}
+
+// fakeNetatmo is a netatmoFetcher that counts calls and returns fixed readings.
+type fakeNetatmo struct {
+	calls atomic.Int64
+}
+
+func (f *fakeNetatmo) GetStationsData(ctx context.Context, userID int64) (*netatmo.ModuleReadings, error) {
+	f.calls.Add(1)
+	return &netatmo.ModuleReadings{Outdoor: &netatmo.OutdoorReadings{}}, nil
+}
+
+// resetKioskCache clears the package-level cache so tests don't see each
+// other's cached payloads.
+func resetKioskCache() {
+	kioskCache = NewTTLCache()
+}
 
 // injectConfig returns a copy of r with a KioskConfig injected into its context.
 func injectConfig(r *http.Request, cfg KioskConfig) *http.Request {
@@ -196,5 +241,161 @@ func TestComputeSunTimes_NormalDay_SunriseBeforeSunset(t *testing.T) {
 	}
 	if !sunrise.Before(sunset) {
 		t.Errorf("expected sunrise (%v) before sunset (%v)", sunrise, sunset)
+	}
+}
+
+func TestDataHandler_CacheReuseAvoidsRefetch(t *testing.T) {
+	resetKioskCache()
+
+	transitSvc := &fakeTransit{}
+	netatmoSvc := &fakeNetatmo{}
+	weatherSvc := &fakeWeather{}
+	handler := DataHandler(nil, transitSvc, netatmoSvc, weatherSvc)
+
+	cfg := KioskConfig{
+		"stop_ids":        []any{"NSR:StopPlace:1"},
+		"location":        "Oslo",
+		"netatmo_user_id": float64(42),
+	}
+
+	// Two identical requests within the TTL window.
+	for i := 0; i < 2; i++ {
+		req := injectConfig(httptest.NewRequest("GET", "/api/kiosk/data", nil), cfg)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i, rec.Code)
+		}
+	}
+
+	if got := transitSvc.calls.Load(); got != 1 {
+		t.Errorf("expected transit fetched once across two cached requests, got %d", got)
+	}
+	if got := netatmoSvc.calls.Load(); got != 1 {
+		t.Errorf("expected netatmo fetched once across two cached requests, got %d", got)
+	}
+	if got := weatherSvc.calls.Load(); got != 1 {
+		t.Errorf("expected weather fetched once across two cached requests, got %d", got)
+	}
+}
+
+func TestDataHandler_DistinctConfigTriggersFreshFetch(t *testing.T) {
+	resetKioskCache()
+
+	transitSvc := &fakeTransit{}
+	handler := DataHandler(nil, transitSvc, nil, nil)
+
+	cfgA := KioskConfig{"stop_ids": []any{"NSR:StopPlace:1"}}
+	cfgB := KioskConfig{"stop_ids": []any{"NSR:StopPlace:2"}}
+
+	for _, cfg := range []KioskConfig{cfgA, cfgB} {
+		req := injectConfig(httptest.NewRequest("GET", "/api/kiosk/data", nil), cfg)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+	}
+
+	if got := transitSvc.calls.Load(); got != 2 {
+		t.Errorf("expected two fetches for two distinct configs, got %d", got)
+	}
+}
+
+func TestDataHandler_CacheHitPreservesFetchedAt(t *testing.T) {
+	resetKioskCache()
+
+	handler := DataHandler(nil, &fakeTransit{}, nil, nil)
+	cfg := KioskConfig{"stop_ids": []any{"NSR:StopPlace:1"}}
+
+	first := injectConfig(httptest.NewRequest("GET", "/api/kiosk/data", nil), cfg)
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, first)
+	var body1 struct {
+		FetchedAt time.Time `json:"fetched_at"`
+	}
+	if err := json.NewDecoder(rec1.Body).Decode(&body1); err != nil {
+		t.Fatalf("decode first: %v", err)
+	}
+
+	// Small gap so a freshly-stamped FetchedAt would differ.
+	time.Sleep(5 * time.Millisecond)
+
+	second := injectConfig(httptest.NewRequest("GET", "/api/kiosk/data", nil), cfg)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, second)
+	var body2 struct {
+		FetchedAt time.Time `json:"fetched_at"`
+	}
+	if err := json.NewDecoder(rec2.Body).Decode(&body2); err != nil {
+		t.Fatalf("decode second: %v", err)
+	}
+
+	if !body1.FetchedAt.Equal(body2.FetchedAt) {
+		t.Errorf("expected cache hit to preserve original FetchedAt %v, got %v", body1.FetchedAt, body2.FetchedAt)
+	}
+}
+
+func TestDataHandler_CacheControlAndContentTypeHeaders(t *testing.T) {
+	resetKioskCache()
+
+	handler := DataHandler(nil, nil, nil, nil)
+	req := injectConfig(httptest.NewRequest("GET", "/api/kiosk/data", nil), KioskConfig{})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	wantCC := "max-age=" + strconv.Itoa(int(CacheTTL.Seconds()))
+	if cc := rec.Header().Get("Cache-Control"); cc != wantCC {
+		t.Errorf("expected Cache-Control %q, got %q", wantCC, cc)
+	}
+}
+
+func TestDataHandler_SlowSourceYieldsPartialData(t *testing.T) {
+	resetKioskCache()
+
+	// Shorten the per-source timeout for the duration of this test.
+	orig := perSourceTimeout
+	perSourceTimeout = 50 * time.Millisecond
+	defer func() { perSourceTimeout = orig }()
+
+	// Weather sleeps well past the timeout; sun is computed locally (fast).
+	weatherSvc := &fakeWeather{delay: 500 * time.Millisecond}
+	handler := DataHandler(nil, nil, nil, weatherSvc)
+
+	cfg := KioskConfig{
+		"lat": float64(59.9139),
+		"lon": float64(10.7522),
+	}
+	req := injectConfig(httptest.NewRequest("GET", "/api/kiosk/data", nil), cfg)
+	rec := httptest.NewRecorder()
+
+	start := time.Now()
+	handler.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	// Latency must be bound by the timeout, not the 500ms slow upstream.
+	if elapsed >= 400*time.Millisecond {
+		t.Errorf("expected handler to return near the timeout bound, took %v", elapsed)
+	}
+
+	var body struct {
+		Forecast json.RawMessage `json:"forecast"`
+		Sun      *SunTimes       `json:"sun"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Forecast) != 0 {
+		t.Errorf("expected forecast omitted when weather times out, got %s", body.Forecast)
+	}
+	if body.Sun == nil {
+		t.Error("expected fast sun source to still populate despite slow weather")
 	}
 }

--- a/internal/kiosk/handlers_test.go
+++ b/internal/kiosk/handlers_test.go
@@ -347,9 +347,12 @@ func TestDataHandler_CacheControlAndContentTypeHeaders(t *testing.T) {
 	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("expected Content-Type application/json, got %q", ct)
 	}
-	wantCC := "max-age=" + strconv.Itoa(int(CacheTTL.Seconds()))
+	wantCC := "private, max-age=" + strconv.Itoa(int(CacheTTL.Seconds()))
 	if cc := rec.Header().Get("Cache-Control"); cc != wantCC {
 		t.Errorf("expected Cache-Control %q, got %q", wantCC, cc)
+	}
+	if vary := rec.Header().Get("Vary"); vary != "Authorization" {
+		t.Errorf("expected Vary: Authorization, got %q", vary)
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Kiosk data endpoint now caches and bounds upstream calls** - `GET /api/kiosk/data` serves results from a short-TTL (20s) in-memory cache keyed by stop IDs, location, and Netatmo user, so multiple kiosk tabs no longer hammer the transit/Netatmo/weather providers on every poll. Each upstream fetch is now bounded by its own timeout so one slow provider yields partial data instead of stalling the whole response, and the response carries a matching `Cache-Control: max-age` header. (Hytte-xegx)

## Original Issue (feature): Serve kiosk data with HTTP caching and per-source timeouts on the backend

Now I have concrete grounding. Here's the plan:

### Scope
Add resilience and efficiency to the kiosk aggregation endpoint (`GET /api/kiosk/data`). Introduce a short-TTL in-memory cache keyed by the request's data inputs, bound each fan-out call (transit, Netatmo, weather, sun) with its own `context.WithTimeout` so one slow upstream can't stall the whole response, and emit `Cache-Control` headers so browsers/CDN respect the same window. The handler signature and JSON response shape stay unchanged.

### Files to touch
- `internal/kiosk/handlers.go` — wrap each goroutine in `context.WithTimeout`; build a cache key from `stop_ids`+`lat/lon`/`location`+`netatmo_user_id`; check/populate cache around the fan-out; set `Cache-Control: max-age` and `Content-Type` headers before writing.
- `internal/kiosk/cache.go` (new) — small TTL cache type (mutex-guarded `map[string]entry` with `value KioskData` + `expiresAt`), with `Get(key)`/`Set(key, val)` and a configurable TTL constant (~20s). Keep it self-contained; no external deps.
- `internal/kiosk/cache_test.go` (new) — unit tests for TTL hit/miss/expiry and key construction.
- `internal/kiosk/handlers_test.go` — extend/add tests for timeout fallback (slow source yields partial data, not a stall) and cache reuse; create if absent.
- `changelog.d/` — add a `Changed` fragment.

### Acceptance criteria
- Two requests with identical kiosk config within the TTL hit the cache: upstream services (transit/Netatmo/weather) are called only once, verifiable via a fake/mock call counter in tests.
- A request with different `stop_ids`, `location`, or `netatmo_user_id` produces a distinct cache key and a fresh fetch.
- Each fan-out call is bounded by its own timeout; a deliberately slow source returns partial `KioskData` (that field omitted) while other fields populate, and total handler latency stays near the timeout bound, not the slow upstream's duration.
- Response includes a `Cache-Control: max-age=<ttl>` header (TTL matching the in-memory window) and `Content-Type: application/json`.
- `FetchedAt` reflects when the cached payload was produced, not each cache-hit read.
- `make test` and `go vet` pass; existing kiosk behavior (JSON shape, partial-data tolerance) is unchanged.

### Non-goals
- No distributed/persistent cache (Redis, DB) — in-memory per-process only.
- No changes to `KioskPage.tsx` or frontend polling cadence.
- No changes to upstream service clients (transit/Netatmo/weather) beyond passing a bounded context.
- No new config UI or per-kiosk TTL tuning; TTL is a backend constant.
- No cache eviction beyond TTL expiry (no LRU/size cap) given the small key space.

## Source

Created from Suggestions page (suggestion id 170, page slug "kiosk", source=claude).

## Original suggestion

DataHandler in internal/kiosk/handlers.go fans out to transit, Netatmo, weather, and sun on every poll with no shared cache and no per-goroutine timeout, so a slow upstream (Netatmo or Entur) stalls the whole response and every kiosk tab hammers the same providers every 30s. Add a short in-memory TTL cache keyed by stop_ids+location+netatmo_user_id (e.g. 20s), wrap each fan-out call in context.WithTimeout, and emit Cache-Control: max-age headers. Kiosks become more resilient to upstream hiccups and we cut redundant calls to rate-limited APIs.


---
Bead: Hytte-xegx | Branch: forge/Hytte-xegx
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->