### PR TITLE
Lift conversation refresh into a context instead of a numeric refreshKey (Hytte-v2q1)

### DIFF
--- a/changelog.d/Hytte-v2q1.md
+++ b/changelog.d/Hytte-v2q1.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Family chat conversation refresh via context** - Replaced the `conversationListRefreshKey` counter prop threaded from FamilyChat into ConversationList with a small FamilyChatContext exposing `refreshConversations()`, so any mutation can request a list refresh without prop threading. No user-visible behavior change. (Hytte-v2q1)

--- a/web/src/pages/FamilyChat.test.tsx
+++ b/web/src/pages/FamilyChat.test.tsx
@@ -378,5 +378,14 @@ describe('FamilyChat – new conversation modal', () => {
     expect(
       await screen.findByRole('heading', { name: 'New Family Chat' }),
     ).toBeInTheDocument()
+
+    // Creating a conversation calls refreshConversations() via FamilyChatContext,
+    // which re-fetches the list. The second fetch returns the created conversation
+    // so the sidebar reflects the new chat — no refreshKey counter prop involved.
+    await waitFor(() => {
+      expect(convListCalls).toBeGreaterThanOrEqual(2)
+    })
+    const sidebar = screen.getByTestId('family-chat-conversation-list')
+    expect(within(sidebar).getByText('New Family Chat')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/FamilyChat.tsx
+++ b/web/src/pages/FamilyChat.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react'
 import ConversationList from './familychat/ConversationList'
 import ChatView from './familychat/ChatView'
 import NewConversationModal from './familychat/NewConversationModal'
+import { FamilyChatProvider, useFamilyChat } from './familychat/FamilyChatContext'
 
-export default function FamilyChat() {
+function FamilyChatInner() {
+  const { refreshConversations } = useFamilyChat()
   const [selectedConversationId, setSelectedConversationId] = useState<number | null>(null)
   const [newConversationOpen, setNewConversationOpen] = useState(false)
-  const [conversationListRefreshKey, setConversationListRefreshKey] = useState(0)
 
   const handleSelectConversation = (id: number) => {
     setSelectedConversationId(id)
@@ -23,7 +24,7 @@ export default function FamilyChat() {
   const handleConversationCreated = (id: number) => {
     setNewConversationOpen(false)
     setSelectedConversationId(id)
-    setConversationListRefreshKey(k => k + 1)
+    refreshConversations()
   }
 
   const handleBackToList = () => {
@@ -42,7 +43,6 @@ export default function FamilyChat() {
           selectedConversationId={selectedConversationId}
           onSelectConversation={handleSelectConversation}
           onNewConversation={handleOpenNewConversation}
-          refreshKey={conversationListRefreshKey}
         />
       </aside>
 
@@ -61,5 +61,13 @@ export default function FamilyChat() {
         onCreated={handleConversationCreated}
       />
     </div>
+  )
+}
+
+export default function FamilyChat() {
+  return (
+    <FamilyChatProvider>
+      <FamilyChatInner />
+    </FamilyChatProvider>
   )
 }

--- a/web/src/pages/familychat/ConversationList.tsx
+++ b/web/src/pages/familychat/ConversationList.tsx
@@ -3,12 +3,12 @@ import { useTranslation } from 'react-i18next'
 import { Plus, MessageSquarePlus } from 'lucide-react'
 import { Skeleton } from '../../components/ui/skeleton'
 import { formatRelative } from './utils'
+import { useFamilyChat } from './FamilyChatContext'
 
 interface ConversationListProps {
   selectedConversationId: number | null
   onSelectConversation: (id: number) => void
   onNewConversation: () => void
-  refreshKey?: number
 }
 
 interface Conversation {
@@ -27,9 +27,9 @@ export default function ConversationList({
   selectedConversationId,
   onSelectConversation,
   onNewConversation,
-  refreshKey,
 }: ConversationListProps) {
   const { t, i18n } = useTranslation('familyChat')
+  const { refreshSignal } = useFamilyChat()
   const [conversations, setConversations] = useState<Conversation[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -60,7 +60,7 @@ export default function ConversationList({
       }
     })()
     return () => { controller.abort() }
-  }, [t, refreshKey])
+  }, [t, refreshSignal])
 
   return (
     <div className="flex flex-col h-full" data-testid="family-chat-conversation-list">

--- a/web/src/pages/familychat/FamilyChatContext.tsx
+++ b/web/src/pages/familychat/FamilyChatContext.tsx
@@ -28,6 +28,7 @@ export function FamilyChatProvider({ children }: { children: ReactNode }) {
   return <FamilyChatContext.Provider value={value}>{children}</FamilyChatContext.Provider>
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useFamilyChat(): FamilyChatContextValue {
   const ctx = useContext(FamilyChatContext)
   if (ctx === null) {

--- a/web/src/pages/familychat/FamilyChatContext.tsx
+++ b/web/src/pages/familychat/FamilyChatContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+
+interface FamilyChatContextValue {
+  // refreshConversations triggers a refetch of the conversation list. Any
+  // mutation (create, rename, leave, reorder-on-new-message) can call it
+  // without the parent threading a data-loading concern down as a prop.
+  refreshConversations: () => void
+  // refreshSignal increments on every refreshConversations() call. Consumers
+  // add it to a fetch effect's dependency array to refetch when it changes.
+  refreshSignal: number
+}
+
+const FamilyChatContext = createContext<FamilyChatContextValue | null>(null)
+
+export function FamilyChatProvider({ children }: { children: ReactNode }) {
+  const [refreshSignal, setRefreshSignal] = useState(0)
+
+  const refreshConversations = useCallback(() => {
+    setRefreshSignal(v => v + 1)
+  }, [])
+
+  const value = useMemo(
+    () => ({ refreshConversations, refreshSignal }),
+    [refreshConversations, refreshSignal],
+  )
+
+  return <FamilyChatContext.Provider value={value}>{children}</FamilyChatContext.Provider>
+}
+
+export function useFamilyChat(): FamilyChatContextValue {
+  const ctx = useContext(FamilyChatContext)
+  if (ctx === null) {
+    throw new Error('useFamilyChat must be used within a FamilyChatProvider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Changes

- **Family chat conversation refresh via context** - Replaced the `conversationListRefreshKey` counter prop threaded from FamilyChat into ConversationList with a small FamilyChatContext exposing `refreshConversations()`, so any mutation can request a list refresh without prop threading. No user-visible behavior change. (Hytte-v2q1)

## Original Issue (feature): Lift conversation refresh into a context instead of a numeric refreshKey

### Scope
Replace the `conversationListRefreshKey` numeric counter threaded from `FamilyChat.tsx` into `ConversationList.tsx` with a small `FamilyChatContext` that exposes a `refreshConversations()` callback. The provider owns the conversation-list fetch (or the refresh trigger) so that any mutation — create, rename, leave, reorder-on-new-message — can request a refresh without the parent passing a child's data-loading concern down as a prop. This is a frontend-only refactor preserving current behavior; an optional follow-on subscribes the list to the existing per-conversation SSE `message_new` events for automatic reordering.

### Files to touch
- `web/src/pages/familychat/FamilyChatContext.tsx` (new) — context + provider exposing `refreshConversations()` and a subscribe/version signal.
- `web/src/pages/FamilyChat.tsx` — wrap children in the provider; drop `conversationListRefreshKey` state and the `refreshKey` prop; call `refreshConversations()` from `handleConversationCreated`.
- `web/src/pages/familychat/ConversationList.tsx` — consume the context instead of the `refreshKey` prop; refetch when the refresh signal fires.
- `web/src/pages/FamilyChat.test.tsx` — update to assert refresh-on-create via context rather than the counter prop.
- `web/src/pages/familychat/ConversationList.test.tsx` (if present) — update prop/context usage.

### Acceptance criteria
- `conversationListRefreshKey` and the `refreshKey` prop no longer exist anywhere in the family-chat code.
- Creating a conversation still selects it and the list reflects the new conversation (existing behavior preserved).
- `ConversationList` refetches whenever `refreshConversations()` is invoked, regardless of which action triggered it.
- A second consumer (e.g., a future rename/leave handler) can trigger the same refresh by calling `refreshConversations()` with no prop threading.
- `npm run lint`, `npm run build`, and the updated family-chat tests pass; the `family_chat` feature behaves identically to before for end users.

### Non-goals
- Implementing rename/leave mutations themselves — only ensuring the refresh hook is reusable by them.
- Backend changes in `internal/familychat/handlers.go` or `hub.go`.
- Building a new user-level SSE stream; if SSE-driven reordering is added, it reuses the existing per-conversation `message_new` events and is optional. If it proves to need a new backend endpoint, defer it out of this plan.
- Changing conversation-list rendering, styling, sorting logic, or unread-count behavior.

## Source

Created from Suggestions page (suggestion id 153, page slug "family-chat", source=claude).

## Original suggestion

FamilyChat.tsx threads a `conversationListRefreshKey` counter into ConversationList purely to force a refetch after creating a conversation, which couples the parent to a child's data-loading concern and will break the moment another action (rename, leave, new message bumping order) needs to trigger the same refresh. Replace it with a small `FamilyChatContext` exposing `refreshConversations()` (and ideally subscribing to the SSE hub for `message_new` to reorder automatically). The page becomes simpler and conversation ordering stays correct after any mutation, not just creation.


---
Bead: Hytte-v2q1 | Branch: forge/Hytte-v2q1
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->