### PR TITLE
Debounce search input to avoid a request per keystroke (Hytte-3g8r)

### DIFF
--- a/changelog.d/Hytte-3g8r.md
+++ b/changelog.d/Hytte-3g8r.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Debounced Notes search** - Typing in the Notes search box now waits 250ms after you stop before fetching, so a multi-character query fires a single `/api/notes?search=...` request instead of one per keystroke. The input stays instantly responsive and in-flight requests are still cancelled, keeping the list consistent on slow connections. (Hytte-3g8r)

--- a/web/src/hooks/useDebouncedValue.ts
+++ b/web/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delayMs`
+ * has elapsed without further changes. Useful for driving effects (e.g.
+ * network requests) off rapidly-changing input without firing on every change.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(id)
+  }, [value, delayMs])
+
+  return debounced
+}

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -7,6 +7,7 @@ import { Plus, Search, Tag, Trash2, Save, Eye, Edit3, X, FileText } from 'lucide
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../components/ui/skeleton'
 import { ConfirmDialog } from '../components/ui/dialog'
+import { useDebouncedValue } from '../hooks/useDebouncedValue'
 
 interface Note {
   id: number
@@ -27,6 +28,9 @@ export default function Notes() {
   const [selectedNote, setSelectedNote] = useState<Note | null>(null)
   const [isCreating, setIsCreating] = useState(false)
   const [search, setSearch] = useState('')
+  // Debounce the search term so typing only fires one request after a pause,
+  // not one per keystroke. The input stays bound to `search` for instant text.
+  const debouncedSearch = useDebouncedValue(search, 250)
   const [activeTag, setActiveTag] = useState('')
   const [viewMode, setViewMode] = useState<ViewMode>('edit')
   const [loading, setLoading] = useState(true)
@@ -46,7 +50,7 @@ export default function Notes() {
       setLoading(true)
       try {
         const params = new URLSearchParams()
-        if (search) params.set('search', search)
+        if (debouncedSearch) params.set('search', debouncedSearch)
         if (activeTag) params.set('tag', activeTag)
         const res = await fetch(`/api/notes?${params}`, { credentials: 'include', signal: controller.signal })
         if (!res.ok) throw new Error(t('errors.failedToLoad'))
@@ -62,7 +66,7 @@ export default function Notes() {
       }
     })()
     return () => { controller.abort() }
-  }, [search, activeTag, refreshKey, t])
+  }, [debouncedSearch, activeTag, refreshKey, t])
 
   useEffect(() => {
     const controller = new AbortController()


### PR DESCRIPTION
## Changes

- **Debounced Notes search** - Typing in the Notes search box now waits 250ms after you stop before fetching, so a multi-character query fires a single `/api/notes?search=...` request instead of one per keystroke. The input stays instantly responsive and in-flight requests are still cancelled, keeping the list consistent on slow connections. (Hytte-3g8r)

## Original Issue (feature): Debounce search input to avoid a request per keystroke

### Scope
Eliminate the per-keystroke `/api/notes?search=...` request storm on the Notes page by introducing a debounced search value (200–300ms) that drives the fetch effect. Typing updates the input immediately, but the network request only fires after the user pauses, while the existing `AbortController` continues to cancel any in-flight request when a newer one starts. This is a frontend-only change in `Notes.tsx`.

### Files to touch
- `web/src/pages/Notes.tsx` — add a debounced search value and feed it to the fetch effect.
- `web/src/hooks/useDebouncedValue.ts` (new, optional) — small reusable debounce hook, only if no equivalent already exists in the codebase; otherwise inline the debounce with `useState` + `useEffect` + `setTimeout`.
- `changelog.d/<slug>.md` (new) — changelog fragment under category `Changed`.

### Acceptance criteria
- Typing a multi-character query in the Notes search box fires at most one `/api/notes?search=...` request after the user stops typing (verifiable in the Network tab), not one per keystroke.
- The debounce delay is between 200ms and 300ms.
- The input field remains fully responsive: the text updates on every keystroke with no lag, independent of the debounced fetch.
- The existing `AbortController` still cancels superseded in-flight requests, so the displayed list always reflects the latest query (no out-of-order overwrites).
- Clearing the search box returns to the unfiltered list after the debounce interval.
- A trailing search (e.g. typing then immediately deleting) settles on the correct final result.
- `npm run lint` and `npm run build` pass; no new TypeScript errors.
- A changelog fragment is added under `changelog.d/`.

### Non-goals
- No backend changes to `internal/notes/handlers.go` or the search query logic.
- No change to search semantics, ranking, matching, or tag filtering.
- No new dependency (e.g. lodash) — implement debounce with native React/`setTimeout`.
- No broader refactor of the Notes page data-fetching, pagination, or loading-state UI beyond what debouncing requires.
- No reuse of this debounce pattern on other pages in this task.

## Source

Created from Suggestions page (suggestion id 119, page slug "notes", source=claude).

## Original suggestion

The search effect re-runs on every change to `search`, firing a `/api/notes?search=...` request for each keystroke. On a slow connection this floods the server, causes flickering loading states, and can return out-of-order results that overwrite the latest list. Wrap the search term in a debounced value (200–300ms) before passing it to the fetch effect, and keep the existing AbortController to cancel in-flight requests. Users get smoother typing, less server load, and consistent results.


---
Bead: Hytte-3g8r | Branch: forge/Hytte-3g8r
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->