### PR TITLE
Extract notes data layer into a useNotes hook and split editor into a subcomponent (Hytte-62fw)

### DIFF
--- a/changelog.d/Hytte-62fw.md
+++ b/changelog.d/Hytte-62fw.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Refactored the Notes page internals** - Extracted the notes data layer into a `useNotes` hook and split the editor pane into a `NoteEditor` subcomponent, leaving `Notes.tsx` as a thin list/search/tag shell. No user-visible behavior changes. (Hytte-62fw)

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -162,9 +162,9 @@ export default function NoteEditor({ note, isCreating, error, onSave, onDelete, 
           </h1>
           {draftTags && (
             <div className="flex flex-wrap gap-1 mb-4">
-              {parseTags(draftTags).map(tag => (
+              {parseTags(draftTags).map((tag, i) => (
                 <span
-                  key={tag}
+                  key={`${i}-${tag}`}
                   className="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs rounded"
                 >
                   {tag}

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -50,14 +50,17 @@ export default function NoteEditor({ note, isCreating, error, onSave, onDelete, 
 
   async function handleSave() {
     setSaving(true)
-    const tags = parseTags(draftTags)
-    const saved = await onSave({ id: note?.id, title: draftTitle, content: draftContent, tags })
-    if (saved) {
-      setDraftTitle(saved.title)
-      setDraftContent(saved.content)
-      setDraftTags(saved.tags.join(', '))
+    try {
+      const tags = parseTags(draftTags)
+      const saved = await onSave({ id: note?.id, title: draftTitle, content: draftContent, tags })
+      if (saved) {
+        setDraftTitle(saved.title)
+        setDraftContent(saved.content)
+        setDraftTags(saved.tags.join(', '))
+      }
+    } finally {
+      setSaving(false)
     }
-    setSaving(false)
   }
 
   return (

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -1,0 +1,266 @@
+import { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import { Tag, Trash2, Save, Eye, Edit3, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { Note, NoteInput, ViewMode } from '../../hooks/useNotes'
+
+interface NoteEditorProps {
+  /** The note being edited, or null when creating a new note. */
+  note: Note | null
+  /** True when in create mode (no existing note yet). */
+  isCreating: boolean
+  /** Error message to surface in the toolbar (from the data layer). */
+  error: string
+  /** Persist the draft. Returns the saved note, or null on failure. */
+  onSave: (input: NoteInput) => Promise<Note | null>
+  /** Request deletion of the given note (the page owns the confirm dialog). */
+  onDelete: (note: Note) => void
+  /** Close the editor without saving. */
+  onClose: () => void
+}
+
+function parseTags(raw: string): string[] {
+  return raw
+    .split(',')
+    .map(t => t.trim())
+    .filter(t => t.length > 0)
+}
+
+/**
+ * Editor pane for a single note. Owns draft state, edit/preview toggling, and
+ * the markdown rendering. The parent re-mounts this (via a `key`) when the
+ * active note changes so drafts initialize cleanly from props.
+ */
+export default function NoteEditor({ note, isCreating, error, onSave, onDelete, onClose }: NoteEditorProps) {
+  const { t } = useTranslation('notes')
+  const [draftTitle, setDraftTitle] = useState(note?.title ?? '')
+  const [draftContent, setDraftContent] = useState(note?.content ?? '')
+  const [draftTags, setDraftTags] = useState(note ? note.tags.join(', ') : '')
+  const [viewMode, setViewMode] = useState<ViewMode>('edit')
+  const [saving, setSaving] = useState(false)
+
+  const hasChanges = note
+    ? draftTitle !== note.title ||
+      draftContent !== note.content ||
+      draftTags !== note.tags.join(', ')
+    : isCreating
+
+  async function handleSave() {
+    setSaving(true)
+    const tags = parseTags(draftTags)
+    const saved = await onSave({ id: note?.id, title: draftTitle, content: draftContent, tags })
+    if (saved) {
+      setDraftTitle(saved.title)
+      setDraftContent(saved.content)
+      setDraftTags(saved.tags.join(', '))
+    }
+    setSaving(false)
+  }
+
+  return (
+    <>
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-800 shrink-0">
+        <div className="flex rounded overflow-hidden border border-gray-700">
+          <button
+            onClick={() => setViewMode('edit')}
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors cursor-pointer ${
+              viewMode === 'edit'
+                ? 'bg-gray-700 text-white'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            <Edit3 size={14} />
+            {t('editor.edit')}
+          </button>
+          <button
+            onClick={() => setViewMode('preview')}
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors cursor-pointer ${
+              viewMode === 'preview'
+                ? 'bg-gray-700 text-white'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            <Eye size={14} />
+            {t('editor.preview')}
+          </button>
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          {error && <span className="text-red-400 text-sm">{error}</span>}
+          <button
+            onClick={handleSave}
+            disabled={saving || !hasChanges}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-default text-white rounded text-sm transition-colors cursor-pointer"
+          >
+            <Save size={14} />
+            {saving ? t('editor.saving') : t('editor.save')}
+          </button>
+          {note && (
+            <button
+              onClick={() => onDelete(note)}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-red-400 hover:text-red-300 hover:bg-gray-800 rounded text-sm transition-colors cursor-pointer"
+              title={t('editor.deleteNote')}
+              aria-label={t('editor.deleteNote')}
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="flex items-center gap-1 px-2 py-1.5 text-gray-400 hover:text-white hover:bg-gray-800 rounded text-sm transition-colors cursor-pointer"
+            title={t('editor.closeLabel')}
+            aria-label={t('editor.closeLabel')}
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Note meta: title + tags */}
+      {viewMode === 'edit' && (
+        <div className="px-6 pt-4 space-y-2 shrink-0">
+          <input
+            type="text"
+            placeholder={t('fields.titlePlaceholder')}
+            value={draftTitle}
+            onChange={e => setDraftTitle(e.target.value)}
+            className="w-full bg-transparent text-2xl font-bold text-white placeholder-gray-600 focus:outline-none"
+            aria-label={t('fields.titleLabel')}
+          />
+          <div className="flex items-center gap-2">
+            <Tag size={14} className="text-gray-500 shrink-0" />
+            <input
+              type="text"
+              placeholder={t('fields.tagsPlaceholder')}
+              value={draftTags}
+              onChange={e => setDraftTags(e.target.value)}
+              className="flex-1 bg-transparent text-sm text-gray-400 placeholder-gray-600 focus:outline-none"
+              aria-label={t('fields.tagsLabel')}
+            />
+          </div>
+          <hr className="border-gray-800" />
+        </div>
+      )}
+
+      {viewMode === 'edit' ? (
+        <textarea
+          value={draftContent}
+          onChange={e => setDraftContent(e.target.value)}
+          placeholder={t('fields.contentPlaceholder')}
+          className="flex-1 px-6 py-4 bg-transparent text-gray-200 text-sm font-mono leading-relaxed resize-none focus:outline-none placeholder-gray-600"
+          aria-label={t('fields.contentLabel')}
+          spellCheck
+        />
+      ) : (
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          <h1 className="text-2xl font-bold text-white mb-1">
+            {draftTitle || <span className="text-gray-500 italic">{t('untitled')}</span>}
+          </h1>
+          {draftTags && (
+            <div className="flex flex-wrap gap-1 mb-4">
+              {parseTags(draftTags).map(tag => (
+                <span
+                  key={tag}
+                  className="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs rounded"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="prose prose-invert prose-sm max-w-none">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                code({ className, children, ...props }) {
+                  const match = /language-(\S+)/.exec(className ?? '')
+                  const isBlock = !!match
+                  return isBlock ? (
+                    <SyntaxHighlighter
+                      style={vscDarkPlus}
+                      language={match![1]}
+                      PreTag="div"
+                    >
+                      {String(children).replace(/\n$/, '')}
+                    </SyntaxHighlighter>
+                  ) : (
+                    <code
+                      className="px-1 py-0.5 bg-gray-800 rounded text-sm font-mono text-gray-200"
+                      {...props}
+                    >
+                      {children}
+                    </code>
+                  )
+                },
+                h1: ({ children }) => (
+                  <h1 className="text-2xl font-bold text-white mt-6 mb-3">{children}</h1>
+                ),
+                h2: ({ children }) => (
+                  <h2 className="text-xl font-semibold text-white mt-5 mb-2">{children}</h2>
+                ),
+                h3: ({ children }) => (
+                  <h3 className="text-lg font-semibold text-white mt-4 mb-2">{children}</h3>
+                ),
+                p: ({ children }) => (
+                  <p className="text-gray-300 mb-3 leading-relaxed">{children}</p>
+                ),
+                ul: ({ children }) => (
+                  <ul className="list-disc list-inside text-gray-300 mb-3 space-y-1">
+                    {children}
+                  </ul>
+                ),
+                ol: ({ children }) => (
+                  <ol className="list-decimal list-inside text-gray-300 mb-3 space-y-1">
+                    {children}
+                  </ol>
+                ),
+                li: ({ children }) => <li className="text-gray-300">{children}</li>,
+                blockquote: ({ children }) => (
+                  <blockquote className="border-l-4 border-gray-600 pl-4 text-gray-400 italic mb-3">
+                    {children}
+                  </blockquote>
+                ),
+                a: ({ href, children }) => (
+                  <a
+                    href={href}
+                    className="text-blue-400 hover:text-blue-300 underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {children}
+                  </a>
+                ),
+                strong: ({ children }) => (
+                  <strong className="font-semibold text-white">{children}</strong>
+                ),
+                em: ({ children }) => <em className="italic text-gray-200">{children}</em>,
+                hr: () => <hr className="border-gray-700 my-4" />,
+                table: ({ children }) => (
+                  <div className="overflow-x-auto mb-3">
+                    <table className="w-full text-sm text-gray-300 border-collapse">
+                      {children}
+                    </table>
+                  </div>
+                ),
+                th: ({ children }) => (
+                  <th className="border border-gray-700 px-3 py-1.5 bg-gray-800 font-semibold text-white text-left">
+                    {children}
+                  </th>
+                ),
+                td: ({ children }) => (
+                  <td className="border border-gray-700 px-3 py-1.5">{children}</td>
+                ),
+              }}
+            >
+              {draftContent || t('fields.nothingToPreview')}
+            </ReactMarkdown>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/web/src/hooks/useNotes.ts
+++ b/web/src/hooks/useNotes.ts
@@ -117,6 +117,7 @@ export function useNotes(search: string, activeTag: string): UseNotesResult {
   }, [t, refresh])
 
   const remove = useCallback(async (id: number): Promise<boolean> => {
+    setError('')
     try {
       const res = await fetch(`/api/notes/${id}`, {
         method: 'DELETE',

--- a/web/src/hooks/useNotes.ts
+++ b/web/src/hooks/useNotes.ts
@@ -30,6 +30,8 @@ export interface UseNotesResult {
   save: (input: NoteInput) => Promise<Note | null>
   /** Delete a note by id. Returns true on success, false on failure. */
   remove: (id: number) => Promise<boolean>
+  /** Clear any surfaced error (e.g. when switching notes). */
+  clearError: () => void
   /** Re-trigger the list + tag fetches. */
   refresh: () => void
 }
@@ -48,6 +50,7 @@ export function useNotes(search: string, activeTag: string): UseNotesResult {
   const [refreshKey, setRefreshKey] = useState(0)
 
   const refresh = useCallback(() => setRefreshKey(k => k + 1), [])
+  const clearError = useCallback(() => setError(''), [])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -131,5 +134,5 @@ export function useNotes(search: string, activeTag: string): UseNotesResult {
     }
   }, [t, refresh])
 
-  return { notes, allTags, loading, error, save, remove, refresh }
+  return { notes, allTags, loading, error, save, remove, clearError, refresh }
 }

--- a/web/src/hooks/useNotes.ts
+++ b/web/src/hooks/useNotes.ts
@@ -1,0 +1,135 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export interface Note {
+  id: number
+  user_id: number
+  title: string
+  content: string
+  tags: string[]
+  created_at: string
+  updated_at: string
+}
+
+export type ViewMode = 'edit' | 'preview'
+
+/** Payload for creating (no id) or updating (with id) a note. */
+export interface NoteInput {
+  id?: number
+  title: string
+  content: string
+  tags: string[]
+}
+
+export interface UseNotesResult {
+  notes: Note[]
+  allTags: string[]
+  loading: boolean
+  error: string
+  /** Create (POST when id is absent) or update (PUT when id is present). Returns the saved note, or null on failure. */
+  save: (input: NoteInput) => Promise<Note | null>
+  /** Delete a note by id. Returns true on success, false on failure. */
+  remove: (id: number) => Promise<boolean>
+  /** Re-trigger the list + tag fetches. */
+  refresh: () => void
+}
+
+/**
+ * Owns the notes data layer: list/tag fetching (with abort handling) plus
+ * save/delete mutations. `search` and `activeTag` drive the list query; an
+ * empty `activeTag` means "all tags".
+ */
+export function useNotes(search: string, activeTag: string): UseNotesResult {
+  const { t } = useTranslation('notes')
+  const [notes, setNotes] = useState<Note[]>([])
+  const [allTags, setAllTags] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const refresh = useCallback(() => setRefreshKey(k => k + 1), [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    ;(async () => {
+      setLoading(true)
+      try {
+        const params = new URLSearchParams()
+        if (search) params.set('search', search)
+        if (activeTag) params.set('tag', activeTag)
+        const res = await fetch(`/api/notes?${params}`, { credentials: 'include', signal: controller.signal })
+        if (!res.ok) throw new Error(t('errors.failedToLoad'))
+        const data = await res.json()
+        setNotes(data.notes ?? [])
+        setError('')
+      } catch (err) {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          setError(err.message)
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    })()
+    return () => { controller.abort() }
+  }, [search, activeTag, refreshKey, t])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    ;(async () => {
+      try {
+        const res = await fetch('/api/notes/tags', { credentials: 'include', signal: controller.signal })
+        if (!res.ok) return
+        const data = await res.json()
+        setAllTags(data.tags ?? [])
+      } catch {
+        // non-critical
+      }
+    })()
+    return () => { controller.abort() }
+  }, [refreshKey])
+
+  const save = useCallback(async (input: NoteInput): Promise<Note | null> => {
+    setError('')
+    const isUpdate = input.id != null
+    const body = JSON.stringify({ title: input.title, content: input.content, tags: input.tags })
+    try {
+      const res = await fetch(isUpdate ? `/api/notes/${input.id}` : '/api/notes', {
+        method: isUpdate ? 'PUT' : 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      })
+      if (!res.ok) {
+        let msg = isUpdate ? t('errors.failedToSave') : t('errors.failedToCreate')
+        try { const data = await res.json(); msg = data.error ?? msg } catch { /* non-JSON body */ }
+        throw new Error(msg)
+      }
+      const data = await res.json()
+      refresh()
+      return data.note as Note
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('errors.saveFailed'))
+      return null
+    }
+  }, [t, refresh])
+
+  const remove = useCallback(async (id: number): Promise<boolean> => {
+    try {
+      const res = await fetch(`/api/notes/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error ?? t('errors.failedToDelete'))
+      }
+      refresh()
+      return true
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('errors.deleteFailed'))
+      return false
+    }
+  }, [t, refresh])
+
+  return { notes, allTags, loading, error, save, remove, refresh }
+}

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -1,205 +1,65 @@
-import { useState, useEffect } from 'react'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import { Plus, Search, Tag, Trash2, Save, Eye, Edit3, X, FileText } from 'lucide-react'
+import { useState } from 'react'
+import { Plus, Search, FileText } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../components/ui/skeleton'
 import { ConfirmDialog } from '../components/ui/dialog'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
 import { timeAgo } from '../utils/timeAgo'
-
-interface Note {
-  id: number
-  user_id: number
-  title: string
-  content: string
-  tags: string[]
-  created_at: string
-  updated_at: string
-}
-
-type ViewMode = 'edit' | 'preview'
+import NoteEditor from '../components/notes/NoteEditor'
+import { useNotes, type Note, type NoteInput } from '../hooks/useNotes'
 
 export default function Notes() {
   const { t } = useTranslation('notes')
   const { t: tCommon } = useTranslation('common')
-  const [notes, setNotes] = useState<Note[]>([])
-  const [allTags, setAllTags] = useState<string[]>([])
-  const [selectedNote, setSelectedNote] = useState<Note | null>(null)
-  const [isCreating, setIsCreating] = useState(false)
   const [search, setSearch] = useState('')
   // Debounce the search term so typing only fires one request after a pause,
   // not one per keystroke. The input stays bound to `search` for instant text.
   const debouncedSearch = useDebouncedValue(search, 250)
   const [activeTag, setActiveTag] = useState('')
-  const [viewMode, setViewMode] = useState<ViewMode>('edit')
-  const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState('')
-  const [refreshKey, setRefreshKey] = useState(0)
+  const [selectedNote, setSelectedNote] = useState<Note | null>(null)
+  const [isCreating, setIsCreating] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<Note | null>(null)
 
-  // Draft state for the editor
-  const [draftTitle, setDraftTitle] = useState('')
-  const [draftContent, setDraftContent] = useState('')
-  const [draftTags, setDraftTags] = useState('')
-
-  useEffect(() => {
-    const controller = new AbortController()
-    ;(async () => {
-      setLoading(true)
-      try {
-        const params = new URLSearchParams()
-        if (debouncedSearch) params.set('search', debouncedSearch)
-        if (activeTag) params.set('tag', activeTag)
-        const res = await fetch(`/api/notes?${params}`, { credentials: 'include', signal: controller.signal })
-        if (!res.ok) throw new Error(t('errors.failedToLoad'))
-        const data = await res.json()
-        setNotes(data.notes ?? [])
-        setError('')
-      } catch (err) {
-        if (err instanceof Error && err.name !== 'AbortError') {
-          setError(err.message)
-        }
-      } finally {
-        if (!controller.signal.aborted) setLoading(false)
-      }
-    })()
-    return () => { controller.abort() }
-  }, [debouncedSearch, activeTag, refreshKey, t])
-
-  useEffect(() => {
-    const controller = new AbortController()
-    ;(async () => {
-      try {
-        const res = await fetch('/api/notes/tags', { credentials: 'include', signal: controller.signal })
-        if (!res.ok) return
-        const data = await res.json()
-        setAllTags(data.tags ?? [])
-      } catch {
-        // non-critical
-      }
-    })()
-    return () => { controller.abort() }
-  }, [refreshKey])
+  const { notes, allTags, loading, error, save, remove } = useNotes(debouncedSearch, activeTag)
 
   function openNote(note: Note) {
     setSelectedNote(note)
     setIsCreating(false)
-    setDraftTitle(note.title)
-    setDraftContent(note.content)
-    setDraftTags(note.tags.join(', '))
-    setViewMode('edit')
-    setError('')
   }
 
   function startCreating() {
     setSelectedNote(null)
     setIsCreating(true)
-    setDraftTitle('')
-    setDraftContent('')
-    setDraftTags('')
-    setViewMode('edit')
-    setError('')
   }
 
-  function cancelEdit() {
+  function closeEditor() {
     setSelectedNote(null)
     setIsCreating(false)
-    setError('')
   }
 
-  function parseTags(raw: string): string[] {
-    return raw
-      .split(',')
-      .map(t => t.trim())
-      .filter(t => t.length > 0)
+  async function handleSave(input: NoteInput): Promise<Note | null> {
+    const saved = await save(input)
+    if (saved) {
+      setSelectedNote(saved)
+      setIsCreating(false)
+    }
+    return saved
   }
 
-  async function saveNote() {
-    setSaving(true)
-    setError('')
-    const tags = parseTags(draftTags)
-
-    try {
-      if (isCreating) {
-        const res = await fetch('/api/notes', {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: draftTitle, content: draftContent, tags }),
-        })
-        if (!res.ok) {
-          let msg = t('errors.failedToCreate')
-          try { const data = await res.json(); msg = data.error ?? msg } catch { /* non-JSON body */ }
-          throw new Error(msg)
-        }
-        const data = await res.json()
-        setIsCreating(false)
-        setSelectedNote(data.note)
-        setDraftTitle(data.note.title)
-        setDraftContent(data.note.content)
-        setDraftTags(data.note.tags.join(', '))
-      } else if (selectedNote) {
-        const res = await fetch(`/api/notes/${selectedNote.id}`, {
-          method: 'PUT',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: draftTitle, content: draftContent, tags }),
-        })
-        if (!res.ok) {
-          let msg = t('errors.failedToSave')
-          try { const data = await res.json(); msg = data.error ?? msg } catch { /* non-JSON body */ }
-          throw new Error(msg)
-        }
-        const data = await res.json()
-        setSelectedNote(data.note)
-        setDraftTitle(data.note.title)
-        setDraftContent(data.note.content)
-        setDraftTags(data.note.tags.join(', '))
-      }
-      setRefreshKey(k => k + 1)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t('errors.saveFailed'))
-    } finally {
-      setSaving(false)
+  async function handleDelete(note: Note) {
+    const ok = await remove(note.id)
+    if (ok && selectedNote?.id === note.id) {
+      setSelectedNote(null)
+      setIsCreating(false)
     }
   }
-
-  async function doDeleteNote(note: Note) {
-    try {
-      const res = await fetch(`/api/notes/${note.id}`, {
-        method: 'DELETE',
-        credentials: 'include',
-      })
-      if (!res.ok) {
-        const data = await res.json()
-        throw new Error(data.error ?? t('errors.failedToDelete'))
-      }
-      if (selectedNote?.id === note.id) {
-        setSelectedNote(null)
-        setIsCreating(false)
-      }
-      setRefreshKey(k => k + 1)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t('errors.deleteFailed'))
-    }
-  }
-
-  const hasChanges = selectedNote
-    ? draftTitle !== selectedNote.title ||
-      draftContent !== selectedNote.content ||
-      draftTags !== selectedNote.tags.join(', ')
-    : isCreating
 
   return (
     <>
     <ConfirmDialog
       open={deleteTarget !== null}
       onClose={() => setDeleteTarget(null)}
-      onConfirm={() => deleteTarget && doDeleteNote(deleteTarget)}
+      onConfirm={() => deleteTarget && handleDelete(deleteTarget)}
       title={t('editor.deleteNote')}
       message={deleteTarget ? t('confirmDelete', { title: deleteTarget.title || t('untitled') }) : undefined}
     />
@@ -324,207 +184,15 @@ export default function Notes() {
       {/* Right panel — editor / viewer */}
       <main className="flex-1 min-w-0 flex flex-col bg-gray-900">
         {isCreating || selectedNote ? (
-          <>
-            {/* Toolbar */}
-            <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-800 shrink-0">
-              <div className="flex rounded overflow-hidden border border-gray-700">
-                <button
-                  onClick={() => setViewMode('edit')}
-                  className={`flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors cursor-pointer ${
-                    viewMode === 'edit'
-                      ? 'bg-gray-700 text-white'
-                      : 'text-gray-400 hover:text-white'
-                  }`}
-                >
-                  <Edit3 size={14} />
-                  {t('editor.edit')}
-                </button>
-                <button
-                  onClick={() => setViewMode('preview')}
-                  className={`flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors cursor-pointer ${
-                    viewMode === 'preview'
-                      ? 'bg-gray-700 text-white'
-                      : 'text-gray-400 hover:text-white'
-                  }`}
-                >
-                  <Eye size={14} />
-                  {t('editor.preview')}
-                </button>
-              </div>
-
-              <div className="ml-auto flex items-center gap-2">
-                {error && <span className="text-red-400 text-sm">{error}</span>}
-                <button
-                  onClick={saveNote}
-                  disabled={saving || !hasChanges}
-                  className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-default text-white rounded text-sm transition-colors cursor-pointer"
-                >
-                  <Save size={14} />
-                  {saving ? t('editor.saving') : t('editor.save')}
-                </button>
-                {selectedNote && (
-                  <button
-                    onClick={() => setDeleteTarget(selectedNote)}
-                    className="flex items-center gap-1.5 px-3 py-1.5 text-red-400 hover:text-red-300 hover:bg-gray-800 rounded text-sm transition-colors cursor-pointer"
-                    title={t('editor.deleteNote')}
-                    aria-label={t('editor.deleteNote')}
-                  >
-                    <Trash2 size={14} />
-                  </button>
-                )}
-                <button
-                  onClick={cancelEdit}
-                  className="flex items-center gap-1 px-2 py-1.5 text-gray-400 hover:text-white hover:bg-gray-800 rounded text-sm transition-colors cursor-pointer"
-                  title={t('editor.closeLabel')}
-                  aria-label={t('editor.closeLabel')}
-                >
-                  <X size={16} />
-                </button>
-              </div>
-            </div>
-
-            {/* Note meta: title + tags */}
-            {viewMode === 'edit' && (
-              <div className="px-6 pt-4 space-y-2 shrink-0">
-                <input
-                  type="text"
-                  placeholder={t('fields.titlePlaceholder')}
-                  value={draftTitle}
-                  onChange={e => setDraftTitle(e.target.value)}
-                  className="w-full bg-transparent text-2xl font-bold text-white placeholder-gray-600 focus:outline-none"
-                  aria-label={t('fields.titleLabel')}
-                />
-                <div className="flex items-center gap-2">
-                  <Tag size={14} className="text-gray-500 shrink-0" />
-                  <input
-                    type="text"
-                    placeholder={t('fields.tagsPlaceholder')}
-                    value={draftTags}
-                    onChange={e => setDraftTags(e.target.value)}
-                    className="flex-1 bg-transparent text-sm text-gray-400 placeholder-gray-600 focus:outline-none"
-                    aria-label={t('fields.tagsLabel')}
-                  />
-                </div>
-                <hr className="border-gray-800" />
-              </div>
-            )}
-
-            {viewMode === 'edit' ? (
-              <textarea
-                value={draftContent}
-                onChange={e => setDraftContent(e.target.value)}
-                placeholder={t('fields.contentPlaceholder')}
-                className="flex-1 px-6 py-4 bg-transparent text-gray-200 text-sm font-mono leading-relaxed resize-none focus:outline-none placeholder-gray-600"
-                aria-label={t('fields.contentLabel')}
-                spellCheck
-              />
-            ) : (
-              <div className="flex-1 overflow-y-auto px-6 py-4">
-                <h1 className="text-2xl font-bold text-white mb-1">
-                  {draftTitle || <span className="text-gray-500 italic">{t('untitled')}</span>}
-                </h1>
-                {draftTags && (
-                  <div className="flex flex-wrap gap-1 mb-4">
-                    {parseTags(draftTags).map(tag => (
-                      <span
-                        key={tag}
-                        className="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs rounded"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                <div className="prose prose-invert prose-sm max-w-none">
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
-                    components={{
-                      code({ className, children, ...props }) {
-                        const match = /language-(\S+)/.exec(className ?? '')
-                        const isBlock = !!match
-                        return isBlock ? (
-                          <SyntaxHighlighter
-                            style={vscDarkPlus}
-                            language={match![1]}
-                            PreTag="div"
-                          >
-                            {String(children).replace(/\n$/, '')}
-                          </SyntaxHighlighter>
-                        ) : (
-                          <code
-                            className="px-1 py-0.5 bg-gray-800 rounded text-sm font-mono text-gray-200"
-                            {...props}
-                          >
-                            {children}
-                          </code>
-                        )
-                      },
-                      h1: ({ children }) => (
-                        <h1 className="text-2xl font-bold text-white mt-6 mb-3">{children}</h1>
-                      ),
-                      h2: ({ children }) => (
-                        <h2 className="text-xl font-semibold text-white mt-5 mb-2">{children}</h2>
-                      ),
-                      h3: ({ children }) => (
-                        <h3 className="text-lg font-semibold text-white mt-4 mb-2">{children}</h3>
-                      ),
-                      p: ({ children }) => (
-                        <p className="text-gray-300 mb-3 leading-relaxed">{children}</p>
-                      ),
-                      ul: ({ children }) => (
-                        <ul className="list-disc list-inside text-gray-300 mb-3 space-y-1">
-                          {children}
-                        </ul>
-                      ),
-                      ol: ({ children }) => (
-                        <ol className="list-decimal list-inside text-gray-300 mb-3 space-y-1">
-                          {children}
-                        </ol>
-                      ),
-                      li: ({ children }) => <li className="text-gray-300">{children}</li>,
-                      blockquote: ({ children }) => (
-                        <blockquote className="border-l-4 border-gray-600 pl-4 text-gray-400 italic mb-3">
-                          {children}
-                        </blockquote>
-                      ),
-                      a: ({ href, children }) => (
-                        <a
-                          href={href}
-                          className="text-blue-400 hover:text-blue-300 underline"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {children}
-                        </a>
-                      ),
-                      strong: ({ children }) => (
-                        <strong className="font-semibold text-white">{children}</strong>
-                      ),
-                      em: ({ children }) => <em className="italic text-gray-200">{children}</em>,
-                      hr: () => <hr className="border-gray-700 my-4" />,
-                      table: ({ children }) => (
-                        <div className="overflow-x-auto mb-3">
-                          <table className="w-full text-sm text-gray-300 border-collapse">
-                            {children}
-                          </table>
-                        </div>
-                      ),
-                      th: ({ children }) => (
-                        <th className="border border-gray-700 px-3 py-1.5 bg-gray-800 font-semibold text-white text-left">
-                          {children}
-                        </th>
-                      ),
-                      td: ({ children }) => (
-                        <td className="border border-gray-700 px-3 py-1.5">{children}</td>
-                      ),
-                    }}
-                  >
-                    {draftContent || t('fields.nothingToPreview')}
-                  </ReactMarkdown>
-                </div>
-              </div>
-            )}
-          </>
+          <NoteEditor
+            key={selectedNote?.id ?? 'new'}
+            note={selectedNote}
+            isCreating={isCreating}
+            error={error}
+            onSave={handleSave}
+            onDelete={note => setDeleteTarget(note)}
+            onClose={closeEditor}
+          />
         ) : (
           <div className="flex-1 flex flex-col items-center justify-center text-center p-8">
             <FileText size={48} className="text-gray-700 mb-4" />

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -20,21 +20,24 @@ export default function Notes() {
   const [isCreating, setIsCreating] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<Note | null>(null)
 
-  const { notes, allTags, loading, error, save, remove } = useNotes(debouncedSearch, activeTag)
+  const { notes, allTags, loading, error, save, remove, clearError } = useNotes(debouncedSearch, activeTag)
 
   function openNote(note: Note) {
     setSelectedNote(note)
     setIsCreating(false)
+    clearError()
   }
 
   function startCreating() {
     setSelectedNote(null)
     setIsCreating(true)
+    clearError()
   }
 
   function closeEditor() {
     setSelectedNote(null)
     setIsCreating(false)
+    clearError()
   }
 
   async function handleSave(input: NoteInput): Promise<Note | null> {

--- a/web/src/pages/__tests__/Notes.test.tsx
+++ b/web/src/pages/__tests__/Notes.test.tsx
@@ -96,7 +96,7 @@ describe('Notes', () => {
     render(<Notes />)
     await screen.findByText('First note')
 
-    fireEvent.click(screen.getByRole('button', { name: 'newNote' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'newNote' })[0])
     fireEvent.change(screen.getByLabelText('fields.titleLabel'), { target: { value: 'Created' } })
 
     fetchMock.mockImplementationOnce(() =>

--- a/web/src/pages/__tests__/Notes.test.tsx
+++ b/web/src/pages/__tests__/Notes.test.tsx
@@ -71,8 +71,9 @@ describe('Notes', () => {
     render(<Notes />)
     await screen.findByText('First note')
 
-    // Tag filter chips render once tags load; click "work".
-    fireEvent.click(screen.getByRole('button', { name: 'work' }))
+    // Tag filter chips render once tags load; wait for the button before clicking.
+    const workTag = await screen.findByRole('button', { name: 'work' })
+    fireEvent.click(workTag)
 
     await waitFor(() => {
       expect(

--- a/web/src/pages/__tests__/Notes.test.tsx
+++ b/web/src/pages/__tests__/Notes.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import Notes from '../Notes'
+import type { Note } from '../../hooks/useNotes'
+
+// t returns interpolated keys so assertions can target stable strings.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts && 'title' in opts ? `${key}:${opts.title}` : key,
+    i18n: { language: 'en', changeLanguage: () => {} },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// ReactMarkdown + syntax highlighter are heavy and irrelevant to wiring tests.
+vi.mock('react-markdown', () => ({ default: ({ children }: { children: string }) => <div>{children}</div> }))
+vi.mock('remark-gfm', () => ({ default: () => {} }))
+vi.mock('react-syntax-highlighter', () => ({ Prism: ({ children }: { children: string }) => <pre>{children}</pre> }))
+vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ vscDarkPlus: {} }))
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: 1,
+    user_id: 1,
+    title: 'First note',
+    content: 'Hello world',
+    tags: ['work'],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as unknown as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  // Default: notes list + tags endpoints.
+  fetchMock.mockImplementation((url: string) => {
+    if (url.startsWith('/api/notes/tags')) {
+      return Promise.resolve(jsonResponse({ tags: ['work', 'personal'] }))
+    }
+    if (url.startsWith('/api/notes')) {
+      return Promise.resolve(jsonResponse({ notes: [makeNote()] }))
+    }
+    return Promise.reject(new Error(`unexpected url: ${url}`))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('Notes', () => {
+  it('loads and renders the note list', async () => {
+    render(<Notes />)
+    expect(await screen.findByText('First note')).toBeInTheDocument()
+  })
+
+  it('filters by tag by issuing a query with the tag param', async () => {
+    render(<Notes />)
+    await screen.findByText('First note')
+
+    // Tag filter chips render once tags load; click "work".
+    fireEvent.click(screen.getByRole('button', { name: 'work' }))
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url]) => typeof url === 'string' && url.includes('tag=work'))
+      ).toBe(true)
+    })
+  })
+
+  it('keeps the save button disabled until an opened note is edited', async () => {
+    render(<Notes />)
+    fireEvent.click(await screen.findByText('First note'))
+
+    const saveButton = screen.getByRole('button', { name: /editor.save/ })
+    expect(saveButton).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('fields.titleLabel'), { target: { value: 'First note edited' } })
+    expect(saveButton).not.toBeDisabled()
+  })
+
+  it('creates a note via POST when saving a new draft', async () => {
+    render(<Notes />)
+    await screen.findByText('First note')
+
+    fireEvent.click(screen.getByRole('button', { name: 'newNote' }))
+    fireEvent.change(screen.getByLabelText('fields.titleLabel'), { target: { value: 'Created' } })
+
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(jsonResponse({ note: makeNote({ id: 2, title: 'Created' }) }))
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /editor.save/ }))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(([, opts]) => opts?.method === 'POST')
+      expect(post).toBeTruthy()
+      expect(post![0]).toBe('/api/notes')
+    })
+  })
+
+  it('opens the delete confirmation dialog and issues DELETE on confirm', async () => {
+    render(<Notes />)
+    fireEvent.click(await screen.findByText('First note'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'editor.deleteNote' }))
+
+    // ConfirmDialog renders with the interpolated title message.
+    expect(await screen.findByText('confirmDelete:First note')).toBeInTheDocument()
+
+    fetchMock.mockImplementationOnce(() => Promise.resolve(jsonResponse({})))
+    fireEvent.click(screen.getByRole('button', { name: 'confirm.delete' }))
+
+    await waitFor(() => {
+      const del = fetchMock.mock.calls.find(([, opts]) => opts?.method === 'DELETE')
+      expect(del).toBeTruthy()
+      expect(del![0]).toBe('/api/notes/1')
+    })
+  })
+})


### PR DESCRIPTION
## Changes

- **Refactored the Notes page internals** - Extracted the notes data layer into a `useNotes` hook and split the editor pane into a `NoteEditor` subcomponent, leaving `Notes.tsx` as a thin list/search/tag shell. No user-visible behavior changes. (Hytte-62fw)

## Original Issue (feature): Extract notes data layer into a useNotes hook and split editor into a subcomponent

### Scope
This plan refactors `web/src/pages/Notes.tsx` (currently a single ~530-line component) into three units: a `useNotes` data-layer hook that owns list/tag fetching plus save/delete mutations, a `NoteEditor` subcomponent that owns draft state, view-mode toggling, and markdown rendering, and a thinned `Notes.tsx` page that wires the two together with the list/search/tag-filter shell. This is a pure structural refactor — no behavioral or API changes.

### Files to touch
- `web/src/pages/Notes.tsx` — reduce to layout shell (list panel, search, tag filters, selection state) consuming the hook + editor
- `web/src/hooks/useNotes.ts` (new) — fetch effects, save/remove mutations, abort handling
- `web/src/components/notes/NoteEditor.tsx` (new) — toolbar, title/tags/content inputs, edit↔preview toggle, ReactMarkdown component map
- `web/src/pages/__tests__/Notes.test.tsx` or equivalent (new/updated, if a test harness exists) — cover hook + editor wiring
- Shared `Note` / `ViewMode` types relocated to a colocated module if helpful (e.g. exported from `useNotes.ts`)

### Acceptance criteria
- `useNotes(search, activeTag)` returns `{ notes, allTags, loading, error, save, remove, refresh }`; the two `useEffect` fetchers (notes + tags) and their `AbortController` cleanup live entirely inside it.
- `save` handles both create (POST) and update (PUT) and returns the saved note; `remove` issues DELETE; both surface errors via the hook's `error` value. `refresh` re-triggers fetches (replacing the `refreshKey` mechanism).
- `NoteEditor` owns `draftTitle/draftContent/draftTags`, `viewMode`, and the `hasChanges` dirty check; it receives the active note (or create mode) plus `onSave`/`onDelete`/`onClose` callbacks.
- `Notes.tsx` no longer contains `fetch` calls, draft `useState`, or the markdown component map — only list/search/tag/selection layout.
- All existing user-visible behavior is unchanged: search, tag filtering, create, edit, save (disabled until dirty), preview rendering, delete confirmation dialog, empty/loading states.
- All strings still go through `useTranslation('notes')`; no new hardcoded English. `npm run lint`, `npm run build`, and `go build` all pass.

### Non-goals
- No new autosave or improved dirty-tracking behavior — only making a clean home for that future work (the hook/editor seam).
- No backend changes to `internal/notes/handlers.go` or the API contract.
- No changes to markdown styling, the syntax highlighter, or the visual layout.
- No new dependencies, routing, or feature-flag changes.
- No migration of other pages to the same pattern.

## Source

Created from Suggestions page (suggestion id 15, page slug "notes", source=claude).

## Original suggestion

Notes.tsx mixes list fetching, tag fetching, draft state, save/delete mutations, and markdown rendering in one component, making the dirty-check, autosave, and abort-controller logic hard to evolve safely. Move the two `useEffect` fetchers and the save/delete functions into a `useNotes(search, activeTag)` hook returning `{notes, allTags, save, remove, refresh}`, and lift the editor pane into `NoteEditor.tsx` owning draft state and view-mode toggling. The page becomes a thin layout shell, and the new hook gives autosave and dirty-check work a single place to land.


---
Bead: Hytte-62fw | Branch: forge/Hytte-62fw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->