### PR TITLE
Show note updated timestamp and tag chips in the sidebar list (Hytte-ezbl)

### DIFF
--- a/changelog.d/Hytte-ezbl.md
+++ b/changelog.d/Hytte-ezbl.md
@@ -1,0 +1,2 @@
+category: Added
+- **Note list metadata** - The Notes sidebar now shows a localized relative updated time (e.g. "2h ago") and caps tag chips at three with a "+N" overflow chip for notes with more tags. (Hytte-ezbl)

--- a/web/public/locales/en/notes.json
+++ b/web/public/locales/en/notes.json
@@ -9,6 +9,7 @@
     "createFirst": "Create your first note"
   },
   "untitled": "Untitled",
+  "moreTagsCount": "+{{count}}",
   "editor": {
     "edit": "Edit",
     "preview": "Preview",

--- a/web/public/locales/nb/notes.json
+++ b/web/public/locales/nb/notes.json
@@ -9,6 +9,7 @@
     "createFirst": "Opprett ditt første notat"
   },
   "untitled": "Uten tittel",
+  "moreTagsCount": "+{{count}}",
   "editor": {
     "edit": "Rediger",
     "preview": "Forhåndsvisning",

--- a/web/public/locales/th/notes.json
+++ b/web/public/locales/th/notes.json
@@ -9,6 +9,7 @@
     "createFirst": "สร้างบันทึกแรกของคุณ"
   },
   "untitled": "ไม่มีชื่อ",
+  "moreTagsCount": "+{{count}}",
   "editor": {
     "edit": "แก้ไข",
     "preview": "ตัวอย่าง",

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../components/ui/skeleton'
 import { ConfirmDialog } from '../components/ui/dialog'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
+import { timeAgo } from '../utils/timeAgo'
 
 interface Note {
   id: number
@@ -23,6 +24,7 @@ type ViewMode = 'edit' | 'preview'
 
 export default function Notes() {
   const { t } = useTranslation('notes')
+  const { t: tCommon } = useTranslation('common')
   const [notes, setNotes] = useState<Note[]>([])
   const [allTags, setAllTags] = useState<string[]>([])
   const [selectedNote, setSelectedNote] = useState<Note | null>(null)
@@ -287,13 +289,18 @@ export default function Notes() {
                   selectedNote?.id === note.id ? 'bg-gray-800' : ''
                 }`}
               >
-                <p className="text-sm font-medium text-white truncate">
-                  {note.title || <span className="text-gray-500 italic">{t('untitled')}</span>}
-                </p>
+                <div className="flex items-baseline gap-2">
+                  <p className="text-sm font-medium text-white truncate min-w-0 flex-1">
+                    {note.title || <span className="text-gray-500 italic">{t('untitled')}</span>}
+                  </p>
+                  <span className="text-xs text-gray-500 shrink-0">
+                    {timeAgo(note.updated_at, tCommon)}
+                  </span>
+                </div>
                 <p className="text-xs text-gray-500 truncate mt-0.5">{note.content.slice(0, 60)}</p>
                 {note.tags.length > 0 && (
                   <div className="flex flex-wrap gap-1 mt-1">
-                    {note.tags.map(tag => (
+                    {note.tags.slice(0, 3).map(tag => (
                       <span
                         key={tag}
                         className="px-1.5 py-0.5 bg-gray-700 text-gray-400 text-xs rounded"
@@ -301,6 +308,11 @@ export default function Notes() {
                         {tag}
                       </span>
                     ))}
+                    {note.tags.length > 3 && (
+                      <span className="px-1.5 py-0.5 bg-gray-700 text-gray-400 text-xs rounded">
+                        {t('moreTagsCount', { count: note.tags.length - 3 })}
+                      </span>
+                    )}
                   </div>
                 )}
               </button>


### PR DESCRIPTION
## Changes

- **Note list metadata** - The Notes sidebar now shows a localized relative updated time (e.g. "2h ago") and caps tag chips at three with a "+N" overflow chip for notes with more tags. (Hytte-ezbl)

## Original Issue (feature): Show note updated timestamp and tag chips in the sidebar list

### Scope
The Notes sidebar list (`web/src/pages/Notes.tsx`) already renders titles, a content snippet, and *all* tags, but shows no timestamp and never truncates tags. This plan adds a localized relative `updated_at` (e.g. `2h ago`) to each list item and limits the tag chips to the first 2–3, appending a `+N` chip when more exist. No backend or API changes — both `updated_at` and `tags` are already on the `Note` type and in the list payload.

### Files to touch
- `web/src/pages/Notes.tsx` — render relative timestamp via the shared `timeAgo` helper; cap tag chips and add `+N` overflow chip in the existing list-item block (~lines 286–301).
- `web/src/utils/timeAgo.ts` — reuse as-is (already locale-aware via i18next; no change expected).
- `web/public/locales/{en,nb,th}/common.json` — add a `+N` overflow string key (e.g. `notes.moreTagsCount` or reuse an existing pattern) if a translated label is needed; verify required `time.*` keys already exist.

### Acceptance criteria
- Each sidebar note item displays a relative updated time (e.g. `just now`, `2h ago`, `3 days ago`) derived from `updated_at`, localized to the active `i18n.language`.
- The relative time updates wording correctly across the buckets the shared `timeAgo` helper already supports (minutes/hours/yesterday/days/weeks, then absolute date).
- At most 3 tag chips render per item; when a note has more tags, an additional `+N` chip shows the remaining count.
- Notes with no tags show no tag row and no `+N` chip; notes with ≤3 tags show all of them with no `+N`.
- All user-facing strings use `react-i18next` (no hardcoded English); the new/used keys exist in `en`, `nb`, and `th` `common.json`.
- Layout stays readable and does not overflow at 375px width; existing truncation of title/snippet is preserved.
- `npm run lint` and `npm run build` pass.

### Non-goals
- No backend changes (`internal/notes/handlers.go`), schema changes, or new API fields.
- No live ticking/auto-refresh of the relative timestamp while the page is open.
- No sorting, filtering, or grouping changes to the note list.
- No changes to the note editor/viewer panel, the tag input, or the `/api/notes/tags` flow.
- No new shared date/time utility — reuse the existing `timeAgo` helper.

## Source

Created from Suggestions page (suggestion id 121, page slug "notes", source=claude).

## Original suggestion

The sidebar list currently shows little more than titles, so users can't tell which note is most recent or what each note is about at a glance. Render a relative `updated_at` (e.g. `2h ago`, localized via `i18n.language`) and the first 2–3 tag chips under each list item, truncating with `+N` when there are more. Use the existing `Note.tags` and `updated_at` fields so no API change is required. This makes scanning a long note list far easier, especially on mobile.


---
Bead: Hytte-ezbl | Branch: forge/Hytte-ezbl
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->