### PR TITLE
Fix loading flicker by gating spinner on auth resolution (Hytte-jbiy)

### DIFF
--- a/changelog.d/Hytte-jbiy.md
+++ b/changelog.d/Hytte-jbiy.md
@@ -1,2 +1,2 @@
 category: Fixed
-- **Lactate tests loading flicker** - Gate the skeleton render on auth readiness so a slow auth bootstrap no longer flashes skeleton → empty → content. The request-loading flag now starts false and is set only while a tests request is genuinely in flight. (Hytte-jbiy)
+- **Lactate tests loading flicker** - Gate the skeleton render on auth readiness so a slow auth bootstrap no longer flashes skeleton → empty → content. The loading flag now stays set through auth resolution and is only cleared once auth resolves with no user or a tests request completes, so the first paint is stable on every path. (Hytte-jbiy)

--- a/changelog.d/Hytte-jbiy.md
+++ b/changelog.d/Hytte-jbiy.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Lactate tests loading flicker** - Gate the skeleton render on auth readiness so a slow auth bootstrap no longer flashes skeleton → empty → content. The request-loading flag now starts false and is set only while a tests request is genuinely in flight. (Hytte-jbiy)

--- a/web/src/pages/LactateTests.tsx
+++ b/web/src/pages/LactateTests.tsx
@@ -43,16 +43,17 @@ function DeltaBadge({ value, unit, decimals }: { value: number; unit: string; de
 }
 
 export default function LactateTests() {
-  const { user } = useAuth()
+  const { user, loading: authLoading } = useAuth()
   const { t } = useTranslation(['lactate', 'common'])
   const [tests, setTests] = useState<LactateTest[]>([])
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
   useEffect(() => {
     if (!user) return
     const controller = new AbortController()
     const load = async () => {
+      setLoading(true)
       try {
         const res = await fetch('/api/lactate/tests', { credentials: 'include', signal: controller.signal })
         if (!res.ok) {
@@ -73,7 +74,7 @@ export default function LactateTests() {
     return () => controller.abort()
   }, [user, t])
 
-  if (!user) {
+  if (!authLoading && !user) {
     return (
       <div className="p-6">
         <p className="text-gray-400">{t('signInToView')}</p>
@@ -114,7 +115,7 @@ export default function LactateTests() {
         </div>
       )}
 
-      {!loading && tests.length >= 2 && (() => {
+      {!authLoading && !loading && tests.length >= 2 && (() => {
         const latest = validThreshold(tests[0])
         const previous = validThreshold(tests[1])
         return (
@@ -149,7 +150,7 @@ export default function LactateTests() {
         )
       })()}
 
-      {loading ? (
+      {authLoading || loading ? (
         <div className="space-y-3 py-4" role="status" aria-live="polite" aria-busy="true">
           <p className="sr-only">{t('list.loading')}</p>
           <Skeleton className="h-16 w-full" />

--- a/web/src/pages/LactateTests.tsx
+++ b/web/src/pages/LactateTests.tsx
@@ -43,23 +43,18 @@ function DeltaBadge({ value, unit, decimals }: { value: number; unit: string; de
 }
 
 export default function LactateTests() {
-  const { user, loading: authLoading } = useAuth()
+  const { user } = useAuth()
   const { t } = useTranslation(['lactate', 'common'])
   const [tests, setTests] = useState<LactateTest[]>([])
-  const [fetchLoading, setFetchLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
-  // Show skeletons while auth is resolving or while fetching data.
-  // Derived — no setState needed for the no-user early-return path.
-  const loading = authLoading || fetchLoading
-
   useEffect(() => {
-    if (!user) {
-      return
-    }
+    if (!user) return
     const controller = new AbortController()
     const load = async () => {
-      setFetchLoading(true)
+      setLoading(true)
+      setError('')
       try {
         const res = await fetch('/api/lactate/tests', { credentials: 'include', signal: controller.signal })
         if (!res.ok) {
@@ -73,20 +68,12 @@ export default function LactateTests() {
           setError(t('errors.failedToLoadLactateTests'))
         }
       } finally {
-        setFetchLoading(false)
+        setLoading(false)
       }
     }
     load()
     return () => controller.abort()
   }, [user, t])
-
-  if (!authLoading && !user) {
-    return (
-      <div className="p-6">
-        <p className="text-gray-400">{t('signInToView')}</p>
-      </div>
-    )
-  }
 
   return (
     <div className="max-w-4xl mx-auto p-4 md:p-6">
@@ -121,7 +108,7 @@ export default function LactateTests() {
         </div>
       )}
 
-      {!authLoading && !loading && tests.length >= 2 && (() => {
+      {!loading && tests.length >= 2 && (() => {
         const latest = validThreshold(tests[0])
         const previous = validThreshold(tests[1])
         return (
@@ -156,7 +143,7 @@ export default function LactateTests() {
         )
       })()}
 
-      {authLoading || loading ? (
+      {loading ? (
         <div className="space-y-3 py-4" role="status" aria-live="polite" aria-busy="true">
           <p className="sr-only">{t('list.loading')}</p>
           <Skeleton className="h-16 w-full" />

--- a/web/src/pages/LactateTests.tsx
+++ b/web/src/pages/LactateTests.tsx
@@ -43,17 +43,19 @@ function DeltaBadge({ value, unit, decimals }: { value: number; unit: string; de
 }
 
 export default function LactateTests() {
-  const { user } = useAuth()
+  const { user, loading: authLoading } = useAuth()
   const { t } = useTranslation(['lactate', 'common'])
   const [tests, setTests] = useState<LactateTest[]>([])
-  const [loading, setLoading] = useState(true)
+  const [fetchLoading, setFetchLoading] = useState(true)
   const [error, setError] = useState('')
+
+  const isLoading = authLoading || (!!user && fetchLoading)
 
   useEffect(() => {
     if (!user) return
     const controller = new AbortController()
     const load = async () => {
-      setLoading(true)
+      setFetchLoading(true)
       setError('')
       try {
         const res = await fetch('/api/lactate/tests', { credentials: 'include', signal: controller.signal })
@@ -68,7 +70,7 @@ export default function LactateTests() {
           setError(t('errors.failedToLoadLactateTests'))
         }
       } finally {
-        setLoading(false)
+        setFetchLoading(false)
       }
     }
     load()
@@ -108,7 +110,7 @@ export default function LactateTests() {
         </div>
       )}
 
-      {!loading && tests.length >= 2 && (() => {
+      {!isLoading && tests.length >= 2 && (() => {
         const latest = validThreshold(tests[0])
         const previous = validThreshold(tests[1])
         return (
@@ -143,7 +145,7 @@ export default function LactateTests() {
         )
       })()}
 
-      {loading ? (
+      {isLoading ? (
         <div className="space-y-3 py-4" role="status" aria-live="polite" aria-busy="true">
           <p className="sr-only">{t('list.loading')}</p>
           <Skeleton className="h-16 w-full" />

--- a/web/src/pages/LactateTests.tsx
+++ b/web/src/pages/LactateTests.tsx
@@ -46,11 +46,18 @@ export default function LactateTests() {
   const { user, loading: authLoading } = useAuth()
   const { t } = useTranslation(['lactate', 'common'])
   const [tests, setTests] = useState<LactateTest[]>([])
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
   useEffect(() => {
-    if (!user) return
+    if (!user) {
+      // Auth has finished resolving and there is no user: stop showing
+      // skeletons so we don't sit in a permanent loading state. While auth
+      // is still resolving we leave loading=true so the first paint stays a
+      // skeleton (no skeleton -> empty -> skeleton flicker).
+      if (!authLoading) setLoading(false)
+      return
+    }
     const controller = new AbortController()
     const load = async () => {
       setLoading(true)
@@ -72,7 +79,7 @@ export default function LactateTests() {
     }
     load()
     return () => controller.abort()
-  }, [user, t])
+  }, [user, authLoading, t])
 
   if (!authLoading && !user) {
     return (

--- a/web/src/pages/LactateTests.tsx
+++ b/web/src/pages/LactateTests.tsx
@@ -46,21 +46,20 @@ export default function LactateTests() {
   const { user, loading: authLoading } = useAuth()
   const { t } = useTranslation(['lactate', 'common'])
   const [tests, setTests] = useState<LactateTest[]>([])
-  const [loading, setLoading] = useState(true)
+  const [fetchLoading, setFetchLoading] = useState(false)
   const [error, setError] = useState('')
+
+  // Show skeletons while auth is resolving or while fetching data.
+  // Derived — no setState needed for the no-user early-return path.
+  const loading = authLoading || fetchLoading
 
   useEffect(() => {
     if (!user) {
-      // Auth has finished resolving and there is no user: stop showing
-      // skeletons so we don't sit in a permanent loading state. While auth
-      // is still resolving we leave loading=true so the first paint stays a
-      // skeleton (no skeleton -> empty -> skeleton flicker).
-      if (!authLoading) setLoading(false)
       return
     }
     const controller = new AbortController()
     const load = async () => {
-      setLoading(true)
+      setFetchLoading(true)
       try {
         const res = await fetch('/api/lactate/tests', { credentials: 'include', signal: controller.signal })
         if (!res.ok) {
@@ -74,12 +73,12 @@ export default function LactateTests() {
           setError(t('errors.failedToLoadLactateTests'))
         }
       } finally {
-        setLoading(false)
+        setFetchLoading(false)
       }
     }
     load()
     return () => controller.abort()
-  }, [user, authLoading, t])
+  }, [user, t])
 
   if (!authLoading && !user) {
     return (


### PR DESCRIPTION
## Changes

- **Lactate tests loading flicker** - Gate the skeleton render on auth readiness so a slow auth bootstrap no longer flashes skeleton → empty → content. The loading flag now stays set through auth resolution and is only cleared once auth resolves with no user or a tests request completes, so the first paint is stable on every path. (Hytte-jbiy)

## Original Issue (feature): Fix loading flicker by gating spinner on auth resolution

### Scope
LactateTests sets `loading=true` at mount but only starts (and ends) the fetch inside a `useEffect` that early-returns while `user` is unresolved. On slow auth bootstraps this paints skeletons, then can flip to the empty state and back once the request finishes — a visible flicker. This plan gates the skeleton render on auth readiness so the first paint is stable. AuthContext already exposes a `loading` boolean (`auth.tsx`), so the fix reuses it rather than inferring readiness from `user`.

### Files to touch
- `web/src/pages/LactateTests.tsx` — consume `loading` from `useAuth()`, fix the loading-state logic for skeletons
- `changelog.d/<id>.md` (new) — `Fixed` fragment

### Acceptance criteria
- `LactateTests` reads the auth `loading` flag from `useAuth()` (alongside `user`).
- Skeletons render only while auth is still resolving **or** a tests request is genuinely in flight — never in the gap between the two.
- Once auth resolves with no `user`, the component does not sit in a permanent skeleton state (the `loading` flag is no longer left stuck `true` when the effect bails).
- On a slow auth bootstrap there is no skeleton → empty → content (or skeleton → empty → skeleton) transition; the first meaningful paint is stable.
- When auth resolves to a logged-in user, the normal flow (skeleton while fetching → list or empty state) is unchanged.
- Existing error handling, `AbortController` cleanup, and the empty-state UI are preserved.
- `npm run lint` and `npm run build` pass; `make test` (Go) unaffected.

### Non-goals
- No changes to the backend (`internal/lactate/handlers.go`) or the tests API.
- No changes to `LactateNewTest.tsx`, `LactateTestDetail.tsx`, or `LactateInsights.tsx` (unless they share the identical bug — out of scope here; note it separately if spotted).
- No redesign of the skeleton/empty-state visuals or the summary cards.
- No refactor of `AuthContext` or its `loading` semantics.
- No new translation keys (this is a state-timing fix, not copy).

## Source

Created from Suggestions page (suggestion id 66, page slug "lactate", source=claude).

## Original suggestion

LactateTests initialises loading=true but only kicks off the fetch inside a useEffect that bails when user is undefined, so during the brief window before AuthContext resolves the page renders skeletons that may then flip to the empty state and back once the request completes. Initialise loading based on auth readiness (or set it inside the effect alongside the fetch) and only render skeletons while a request is genuinely in flight. The result is a stable first paint without spurious skeleton-to-empty transitions on slow auth bootstraps.


---
Bead: Hytte-jbiy | Branch: forge/Hytte-jbiy
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->