### PR TITLE
Reset chat scroll/state when switching conversations on mobile back-nav (Hytte-jzu0)

### DIFF
--- a/changelog.d/Hytte-jzu0.md
+++ b/changelog.d/Hytte-jzu0.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Reset family chat on conversation switch** - Switching conversations now remounts the chat view per thread, so opening a second conversation immediately shows its messages scrolled to the bottom with no flash of the previous thread's scroll position, draft text, or in-flight fetch/SSE state. (Hytte-jzu0)

--- a/web/src/pages/FamilyChat.tsx
+++ b/web/src/pages/FamilyChat.tsx
@@ -52,7 +52,11 @@ function FamilyChatInner() {
           selectedConversationId !== null ? 'flex' : 'hidden md:flex'
         } flex-1 min-w-0 flex-col`}
       >
-        <ChatView conversationId={selectedConversationId} onBack={handleBackToList} />
+        <ChatView
+          key={selectedConversationId ?? 'none'}
+          conversationId={selectedConversationId}
+          onBack={handleBackToList}
+        />
       </section>
 
       <NewConversationModal


### PR DESCRIPTION
## Changes

- **Reset family chat on conversation switch** - Switching conversations now remounts the chat view per thread, so opening a second conversation immediately shows its messages scrolled to the bottom with no flash of the previous thread's scroll position, draft text, or in-flight fetch/SSE state. (Hytte-jzu0)

## Original Issue (feature): Reset chat scroll/state when switching conversations on mobile back-nav

### Scope
Force a clean per-conversation remount of `ChatView` so switching threads (especially via mobile back-nav, where the same `ChatView` instance is reused with only visibility classes toggled) never shows the previous thread's scroll position, draft text, or in-flight network state for a frame. The fix is small and frontend-only: add `key={selectedConversationId}` to the `ChatView` element so React tears down and rebuilds it on every conversation change, and confirm `handleBackToList` leaves no pending SSE/fetch work running.

### Files to touch
- `web/src/pages/FamilyChat.tsx` — add `key` to the `<ChatView>` element (line 55).
- `web/src/pages/familychat/ChatView.tsx` — only if needed: verify the `conversationId`-change effect cleanups (AbortController abort, SSE/EventSource close, active voice-call end) also fire reliably on unmount; no behavior change expected since remount triggers existing cleanup.
- `changelog.d/<id>-reset-chat-on-switch.md` (new) — `Fixed` fragment referencing the bead ID.

### Acceptance criteria
- `ChatView` carries `key={selectedConversationId ?? 'none'}` (or equivalent stable key) so each conversation gets a fresh component instance.
- Opening conversation B after conversation A immediately renders B's messages scrolled to the bottom, with no visible flash of A's messages or scroll position (verify on a ~375px mobile viewport using the list → thread → back → other thread flow).
- A draft typed in conversation A does not appear in conversation B after switching.
- Switching away from a conversation aborts the previous thread's in-flight message fetch and closes its SSE stream (no console errors, no late state updates from the old thread); any active voice call is ended.
- `make build` equivalents pass: `npm run lint` and `npm run build` succeed.
- Changelog fragment present in `changelog.d/`.

### Non-goals
- No backend changes in `internal/familychat/handlers.go` or `hub.go`.
- No redesign of the list/thread split-pane layout or routing (still state-driven, not URL-per-conversation).
- No changes to SSE reconnection, message pagination, reactions, attachments, or voice-call logic beyond ensuring cleanup runs on remount.
- No new tests for unrelated chat features; no performance refactor of `ChatView`.

## Source

Created from Suggestions page (suggestion id 151, page slug "family-chat", source=claude).

## Original suggestion

FamilyChat.tsx keeps ChatView mounted whenever selectedConversationId changes and only toggles visibility classes, so switching from one conversation to another can leave stale scroll position, draft text, or in-flight fetches from the previous thread visible for a frame. Add a `key={selectedConversationId}` on the ChatView (or an explicit reset effect inside it) so React remounts per conversation, and ensure handleBackToList also cancels any pending SSE/fetch work. The user-visible effect is that opening a second conversation immediately shows the right messages at the bottom instead of briefly flashing the previous thread's scroll state.


---
Bead: Hytte-jzu0 | Branch: forge/Hytte-jzu0
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->