### PR TITLE
Add typing indicators over the existing SSE hub (Hytte-m9aq)

### DIFF
--- a/changelog.d/Hytte-m9aq.md
+++ b/changelog.d/Hytte-m9aq.md
@@ -1,0 +1,2 @@
+category: Added
+- **Family Chat typing indicators** - Family Chat now shows a subtle "X is typing…" row at the bottom of a conversation while another member is composing, delivered over the existing SSE hub without any database persistence. (Hytte-m9aq)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -555,6 +555,9 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Post("/familychat/conversations/{id}/messages/{messageID}/reactions", familychat.AddReactionHandler(db))
 				r.Delete("/familychat/conversations/{id}/messages/{messageID}/reactions", familychat.RemoveReactionHandler(db))
 				r.Post("/familychat/conversations/{id}/read", familychat.MarkReadHandler(db))
+				// Ephemeral typing signal (Hytte-m9aq). Publishes a "typing"
+				// event over the hub for live subscribers; nothing is persisted.
+				r.Post("/familychat/conversations/{id}/typing", familychat.TypingHandler(db))
 				r.Get("/familychat/conversations/{id}/stream", familychat.StreamHandlerWithDB(db))
 				r.Post("/familychat/conversations/{id}/upload", familychat.UploadAttachmentHandler(db))
 				r.Get("/familychat/conversations/{id}/attachments/{message_id}", familychat.GetAttachmentHandler(db))

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -548,6 +548,46 @@ func MarkReadHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
+// TypingHandler broadcasts an ephemeral "typing" signal to the conversation's
+// live SSE subscribers. Nothing is written to the database — the event is fire
+// and forget, scoped to the conversation, and carries only the conversation
+// and user ids. Non-members and unknown conversations both get 404 so the
+// endpoint never reveals whether a conversation exists.
+func TypingHandler(db *sql.DB) http.HandlerFunc {
+	return typingHandler(db, DefaultHub())
+}
+
+func typingHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		convID, ok := parseConvID(r)
+		if !ok {
+			notFound(w)
+			return
+		}
+		member, err := IsMember(db, convID, user.ID)
+		if err != nil {
+			log.Printf("familychat: typing membership conv=%d user=%d: %v", convID, user.ID, err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+			return
+		}
+		if !member {
+			notFound(w)
+			return
+		}
+		if hub != nil {
+			hub.Publish(convID, Event{
+				Type: EventTyping,
+				Data: map[string]any{
+					"conversation_id": convID,
+					"user_id":         user.ID,
+				},
+			})
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+}
+
 // DeleteConversationHandler removes a conversation. Only the owner may
 // delete; non-owners (including members) get 404.
 func DeleteConversationHandler(db *sql.DB) http.HandlerFunc {

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -1433,3 +1433,103 @@ func TestDeleteMessageHandler_NonAuthor404(t *testing.T) {
 		t.Errorf("non-author delete soft-deleted the row: %+v", deletedAt)
 	}
 }
+
+func TestTypingHandler_MemberPublishesNoPersist(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	hub := NewHub()
+	bobSub := hub.Subscribe(2, convID)
+	defer hub.Unsubscribe(convID, bobSub)
+
+	req := withChiParam(
+		withUser(httptest.NewRequest("POST", "/api/familychat/conversations/x/typing", nil), 1),
+		"id", strconv.FormatInt(convID, 10),
+	)
+	rec := httptest.NewRecorder()
+	typingHandler(db, hub).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Publish is synchronous, so the event is already buffered on bob's channel.
+	select {
+	case evt := <-bobSub.Events():
+		if evt.Type != EventTyping {
+			t.Errorf("event type = %q, want %q", evt.Type, EventTyping)
+		}
+		data, ok := evt.Data.(map[string]any)
+		if !ok {
+			t.Fatalf("event data type = %T, want map[string]any", evt.Data)
+		}
+		if data["user_id"] != int64(1) {
+			t.Errorf("user_id = %v, want 1", data["user_id"])
+		}
+		if data["conversation_id"] != convID {
+			t.Errorf("conversation_id = %v, want %d", data["conversation_id"], convID)
+		}
+	default:
+		t.Fatal("no typing event received on subscriber channel")
+	}
+
+	// Typing must never persist a message (or any chat row).
+	var msgs int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM family_chat_messages`).Scan(&msgs); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if msgs != 0 {
+		t.Errorf("typing wrote %d message row(s), want 0", msgs)
+	}
+}
+
+func TestTypingHandler_NonMember404(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	hub := NewHub()
+	// Bob is a member and subscribed — he must not receive a typing event
+	// fabricated by a non-member.
+	bobSub := hub.Subscribe(2, convID)
+	defer hub.Unsubscribe(convID, bobSub)
+
+	// Carol (id=3) is not a member of the alice/bob conversation.
+	req := withChiParam(
+		withUser(httptest.NewRequest("POST", "/api/familychat/conversations/x/typing", nil), 3),
+		"id", strconv.FormatInt(convID, 10),
+	)
+	rec := httptest.NewRecorder()
+	typingHandler(db, hub).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("non-member: got %d, want 404", rec.Code)
+	}
+
+	select {
+	case evt := <-bobSub.Events():
+		t.Errorf("non-member typing published event %q", evt.Type)
+	default:
+		// expected: nothing published
+	}
+}
+
+func TestTypingHandler_UnknownConversation404(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+
+	req := withChiParam(
+		withUser(httptest.NewRequest("POST", "/api/familychat/conversations/x/typing", nil), 1),
+		"id", "9999",
+	)
+	rec := httptest.NewRecorder()
+	typingHandler(db, NewHub()).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown conversation: got %d, want 404", rec.Code)
+	}
+}

--- a/internal/familychat/hub.go
+++ b/internal/familychat/hub.go
@@ -27,6 +27,12 @@ const (
 	EventMessageDeleted = "message_deleted"
 	EventReadReceipt    = "read_receipt"
 
+	// EventTyping is an ephemeral "X is composing" signal. It is never
+	// persisted — the typing handler publishes it straight into the hub so
+	// subscribed clients can render a transient indicator and let it expire on
+	// their own timer.
+	EventTyping = "typing"
+
 	// WebRTC signalling events. The hub relays SDP/ICE blobs verbatim — the
 	// server never inspects or persists the payload contents. The four-event
 	// shape (offer/answer/ice/end) is enough to drive a 1:1 voice/video call

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -33,6 +33,10 @@
     "lightboxClose": "Close preview",
     "connection": {
       "reconnecting": "Reconnecting…"
+    },
+    "typing": {
+      "single": "{{name}} is typing…",
+      "multiple": "{{count}} people are typing…"
     }
   },
   "composer": {

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -33,6 +33,10 @@
     "lightboxClose": "Lukk forhåndsvisning",
     "connection": {
       "reconnecting": "Kobler til på nytt…"
+    },
+    "typing": {
+      "single": "{{name}} skriver…",
+      "multiple": "{{count}} personer skriver…"
     }
   },
   "composer": {

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -33,6 +33,10 @@
     "lightboxClose": "ปิดการดูตัวอย่าง",
     "connection": {
       "reconnecting": "กำลังเชื่อมต่อใหม่…"
+    },
+    "typing": {
+      "single": "{{name}} กำลังพิมพ์…",
+      "multiple": "{{count}} คนกำลังพิมพ์…"
     }
   },
   "composer": {

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -151,6 +151,13 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // populated for missed calls where the local user was the callee (we ignore
   // missed calls that we initiated, since those aren't useful history for us).
   const [missedCalls, setMissedCalls] = useState<MissedCallEntry[]>([])
+  // typingUsers maps a member's user id to the epoch-ms timestamp of their most
+  // recent typing signal. A sweep effect drops entries older than ~5s so the
+  // indicator clears on its own when the other side stops composing.
+  const [typingUsers, setTypingUsers] = useState<Map<number, number>>(new Map())
+  // lastTypingSentRef throttles outbound typing POSTs to at most one per ~3s
+  // while the local user is composing.
+  const lastTypingSentRef = useRef(0)
   // endedCallSummary is shown briefly after a call wraps up. Tracks the final
   // duration in seconds so the banner can render "Call ended — m:ss".
   const [endedCallSummary, setEndedCallSummary] = useState<{ durationSec: number } | null>(null)
@@ -365,6 +372,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     setHasConnected(false)
     setMissedCalls([])
     setEndedCallSummary(null)
+    setTypingUsers(new Map())
+    lastTypingSentRef.current = 0
 
     // appendIncoming deduplicates by id so a message that arrives via both
     // SSE and the POST response (the sender path) or via SSE and gap-fill
@@ -372,6 +381,14 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     const appendIncoming = (msg: ChatMessage) => {
       if (msg.conversation_id !== conversationId) return
       if (msg.id > lastId) lastId = msg.id
+      // A message from a member ends their typing state immediately, so the
+      // indicator doesn't linger after their reply lands.
+      setTypingUsers(prev => {
+        if (!prev.has(msg.sender_user_id)) return prev
+        const next = new Map(prev)
+        next.delete(msg.sender_user_id)
+        return next
+      })
       setMessages(prev => {
         if (prev.some(m => m.id === msg.id)) return prev
         return [...prev, msg]
@@ -437,6 +454,18 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
             }
           : m,
       ))
+    }
+
+    // recordTyping stamps a member's latest typing signal. We never record our
+    // own id (the hub fans the event back to every subscriber, including the
+    // sender) so the local user never sees their own indicator.
+    const recordTyping = (userId: number) => {
+      if (userId === currentUserIdRef.current) return
+      setTypingUsers(prev => {
+        const next = new Map(prev)
+        next.set(userId, Date.now())
+        return next
+      })
     }
 
     const fillGap = async () => {
@@ -533,6 +562,11 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                     payload?.deleted_by !== undefined
                   ) {
                     applyMessageDeleted(payload)
+                  } else if (
+                    eventName === 'typing' &&
+                    payload?.user_id !== undefined
+                  ) {
+                    recordTyping(payload.user_id as number)
                   } else if (
                     eventName === 'call_offer'
                     || eventName === 'call_answer'
@@ -672,6 +706,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       setLoading(false)
       setMissedCalls([])
       setEndedCallSummary(null)
+      setTypingUsers(new Map())
     }
   }, [conversationId, t])
 
@@ -783,6 +818,42 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     const timer = setTimeout(() => setEndedCallSummary(null), 5000)
     return () => clearTimeout(timer)
   }, [endedCallSummary])
+
+  // Sweep stale typing indicators: drop any member whose most recent signal is
+  // older than 5s so the row clears shortly after they stop composing. The
+  // interval only runs while at least one member is typing.
+  useEffect(() => {
+    if (typingUsers.size === 0) return
+    const interval = setInterval(() => {
+      setTypingUsers(prev => {
+        const now = Date.now()
+        let changed = false
+        const next = new Map(prev)
+        for (const [uid, ts] of next) {
+          if (now - ts > 5000) {
+            next.delete(uid)
+            changed = true
+          }
+        }
+        return changed ? next : prev
+      })
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [typingUsers])
+
+  // notifyTyping fires from the composer on each keystroke; it throttles the
+  // outbound signal to at most one POST per ~3s so a fast typist doesn't flood
+  // the endpoint. Best-effort: a failed POST just means no indicator shows.
+  const notifyTyping = useCallback(() => {
+    if (conversationId === null) return
+    const now = Date.now()
+    if (now - lastTypingSentRef.current < 3000) return
+    lastTypingSentRef.current = now
+    void fetch(`/api/familychat/conversations/${conversationId}/typing`, {
+      method: 'POST',
+      credentials: 'include',
+    }).catch(() => {})
+  }, [conversationId])
 
   const handleMessageCreated = useCallback((msg: ChatMessage) => {
     // Defensive: if the user switched conversations while a send was in
@@ -950,6 +1021,14 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       }
     })
   }, [conversation, memberLookup, t, user?.id])
+
+  // Resolve the friendly labels for everyone currently typing, excluding the
+  // local user (defensive — recordTyping already skips own-id signals).
+  const typingLabels = useMemo(() => {
+    return Array.from(typingUsers.keys())
+      .filter(id => id !== user?.id)
+      .map(id => memberLookup.get(id)?.label ?? t('chat.memberFallback', { id }))
+  }, [typingUsers, memberLookup, user?.id, t])
 
   // Voice calls are 1:1 only — see useVoiceCall.ts. The phone button is
   // hidden for group conversations rather than disabled so users don't see
@@ -1482,11 +1561,28 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
           </div>
         ))}
 
+        {typingLabels.length > 0 && (
+          <div
+            className="flex items-center px-1 text-xs text-gray-400 italic"
+            role="status"
+            aria-live="polite"
+            data-testid="family-chat-typing-indicator"
+          >
+            {typingLabels.length === 1
+              ? t('chat.typing.single', { name: typingLabels[0] })
+              : t('chat.typing.multiple', { count: typingLabels.length })}
+          </div>
+        )}
+
         <div ref={messagesEndRef} />
       </div>
 
       <div className="border-t border-gray-800 bg-gray-950 shrink-0">
-        <Composer conversationId={conversationId} onMessageCreated={handleMessageCreated} />
+        <Composer
+          conversationId={conversationId}
+          onMessageCreated={handleMessageCreated}
+          onTyping={notifyTyping}
+        />
       </div>
 
       {lightbox && (

--- a/web/src/pages/familychat/Composer.tsx
+++ b/web/src/pages/familychat/Composer.tsx
@@ -11,6 +11,10 @@ import { computeWaveform, writeCachedWaveform } from './voice/waveform'
 interface ComposerProps {
   conversationId: number
   onMessageCreated: (msg: ChatMessage) => void
+  // onTyping fires on each keystroke in the message field so the parent can
+  // broadcast a debounced "typing" signal to the other members. Optional so
+  // the composer stays usable without a typing-aware parent.
+  onTyping?: () => void
 }
 
 // Match the backend cap so we surface "too long" errors locally instead of
@@ -39,7 +43,7 @@ function formatVoiceTime(ms: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`
 }
 
-export default function Composer({ conversationId, onMessageCreated }: ComposerProps) {
+export default function Composer({ conversationId, onMessageCreated, onTyping }: ComposerProps) {
   const { t } = useTranslation('familyChat')
   const [body, setBody] = useState('')
   const [sending, setSending] = useState(false)
@@ -532,7 +536,12 @@ export default function Composer({ conversationId, onMessageCreated }: ComposerP
             id="family-chat-composer-input"
             ref={textareaRef}
             value={body}
-            onChange={e => setBody(e.target.value)}
+            onChange={e => {
+              setBody(e.target.value)
+              // Only signal typing for non-empty input so clearing the field
+              // (or a programmatic reset) doesn't broadcast a phantom signal.
+              if (e.target.value.trim()) onTyping?.()
+            }}
             onKeyDown={handleKeyDown}
             placeholder={t('composer.placeholder')}
             rows={1}


### PR DESCRIPTION
## Changes

- **Family Chat typing indicators** - Family Chat now shows a subtle "X is typing…" row at the bottom of a conversation while another member is composing, delivered over the existing SSE hub without any database persistence. (Hytte-m9aq)

## Original Issue (feature): Add typing indicators over the existing SSE hub

### Scope
Add a `typing` signal to the existing family-chat SSE hub: a new POST endpoint publishes an ephemeral (no-DB) `typing` event scoped to the conversation, and `ChatView` POSTs it (debounced) while the user composes and renders a subtle "X is typing…" row at the bottom of the message list. Reuses the hub's existing publish/subscribe fan-out and the fetch-based SSE reader already in `ChatView`.

### Files to touch
- `internal/familychat/hub.go` — add `EventTyping = "typing"` constant.
- `internal/familychat/handlers.go` — add `TypingHandler(db)`: verify membership via `IsMember`/`ErrForbidden` (map to 404), then `DefaultHub().Publish(convID, Event{Type: EventTyping, ...})` with no persistence; payload carries `conversation_id` and `user_id` only.
- `internal/api/router.go` — register `POST /familychat/conversations/{id}/typing` inside the existing `family_chat` feature group (near line 556).
- `internal/familychat/handlers_test.go` — test the handler (member publishes; non-member → 404; no DB row written).
- `web/src/pages/familychat/ChatView.tsx` — debounced (~3s) POST to the typing endpoint on input change; handle incoming `typing` events in the existing SSE parse switch; render the indicator row; auto-clear stale typers after ~5s.
- `web/public/locales/{en,nb,th}/common.json` — add `chat.typing*` strings (single + multiple typers).
- `changelog.d/<id>.md` (new) — `Added` fragment.

### Acceptance criteria
- A new `POST /api/familychat/conversations/{id}/typing` exists, requires auth + `family_chat` feature, returns 200 for members and 404 for non-members/unknown conversations.
- The handler publishes a `typing` event over the hub and writes nothing to the database (verified by test).
- While another member is composing, the viewer sees a "<name> is typing…" row at the bottom of `ChatView`; it disappears within ~5s of the last keystroke or when a message arrives.
- The client throttles typing POSTs to at most roughly one per ~3s while typing; the local user never sees their own typing indicator.
- All three locale files contain the new keys; no hardcoded English in JSX.
- `go test ./...`, `go vet`, `npm run lint`, and `npm run build` pass; a changelog fragment is present.

### Non-goals
- No persistence, history, or unread/badge interaction for typing state.
- No "seen/online presence" indicator beyond typing.
- No typing signal for voice/video call or reaction activity.
- No new hub plumbing, buffering, or rate-limiting beyond the existing non-blocking `Publish`.
- No changes to message, reaction, read-receipt, or call payloads.

## Source

Created from Suggestions page (suggestion id 152, page slug "family-chat", source=claude).

## Original suggestion

The hub already supports arbitrary event types and the page has live message delivery, but there is no signal that another family member is composing a reply, which is the single most-missed affordance in a chat UI. Introduce a lightweight `typing` event (debounced ~3s, published without DB persistence via `DefaultHub().Publish`) and render a subtle 'X is typing…' row at the bottom of ChatView. This makes turn-based prompts and voice-note replies feel much more responsive without adding any storage cost.


---
Bead: Hytte-m9aq | Branch: forge/Hytte-m9aq
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->