### PR TITLE
Extract shared session/timer/PB plumbing out of MathMarathon and MathBlitz (Hytte-mfte)

### DIFF
--- a/changelog.d/Hytte-mfte.md
+++ b/changelog.d/Hytte-mfte.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Shared math session plumbing** - Extracted the duplicated session state machine, wall-clock timing refs, prior-PB fetch, and finish flow from MathMarathon and MathBlitz into a shared `useMathSession` hook and a single `types.ts`. Both modes now apply the same late-POST guard, so a network failure after a run finishes can no longer clobber the result screen. No change to gameplay, scoring, or UI. (Hytte-mfte)

--- a/web/src/pages/MathBlitz.tsx
+++ b/web/src/pages/MathBlitz.tsx
@@ -5,25 +5,18 @@ import { ArrowLeft, Trophy } from 'lucide-react'
 import { MathAnswerPad } from '../components/math/MathAnswerPad'
 import { appendAnswerDigit } from '../components/math/mathUtils'
 import { FinishRank } from '../components/math/FinishRank'
-import { UnlockedAchievementsBanner, type UnlockedAchievement } from '../components/math/UnlockedAchievements'
+import { UnlockedAchievementsBanner } from '../components/math/UnlockedAchievements'
 import { MuteToggle } from '../components/math/MuteToggle'
 import { SpeedCallout, FAST_THRESHOLD_MS } from '../components/regnemester/SpeedCallout'
-import { useFeedback, emitAchievementUnlock } from '../lib/regnemester/feedback'
+import { useFeedback } from '../lib/regnemester/feedback'
 import { burst, blitzIntensityForScore } from '../lib/regnemester/confetti'
+import { useMathSession } from './math/useMathSession'
+import type { Fact } from './math/types'
 
 const DURATION_MS = 60_000
 const STREAK_MILESTONE_STEP = 5
 const STREAK_POP_CLASS = 'regnemester-streak-pop'
 const STREAK_POP_MS = 450
-
-type Op = '*' | '/'
-
-interface Fact {
-  a: number
-  b: number
-  op: Op
-  expected: number
-}
 
 interface BlitzBest {
   session_id: number
@@ -33,26 +26,6 @@ interface BlitzBest {
   total_wrong: number
   ended_at: string
 }
-
-interface FinishSummary {
-  session_id: number
-  mode: string
-  started_at: string
-  ended_at: string
-  duration_ms: number
-  total_correct: number
-  total_wrong: number
-  score_num: number
-  best_streak: number
-}
-
-interface FinishResponse {
-  summary: FinishSummary
-  unlocked_achievements?: UnlockedAchievement[]
-  leaderboard_rank?: number | null
-}
-
-type Phase = 'idle' | 'starting' | 'playing' | 'finishing' | 'done' | 'error'
 
 // Mirrors ComputeBlitzPoints in internal/math/session.go so the live score
 // displayed during play matches the server-computed score stored in Finish.
@@ -83,67 +56,30 @@ export default function MathBlitz() {
   const streakBadgeRef = useRef<HTMLSpanElement | null>(null)
   const streakPopTimerRef = useRef<number | null>(null)
 
-  const [phase, setPhase] = useState<Phase>('idle')
-  const [error, setError] = useState('')
-  const [sessionId, setSessionId] = useState<number | null>(null)
+  const session = useMathSession<BlitzBest>({ mode: 'blitz', bestPath: '/api/math/blitz/best' })
+  const {
+    phase, phaseRef, error, sessionId, priorBest, summary, unlocked,
+    endAtRef, questionShownAtRef,
+    startSession, finishSession, failActiveSession, resetSession,
+    setSummary, setPriorBest,
+  } = session
+
   const [currentFact, setCurrentFact] = useState<Fact | null>(null)
   const [score, setScore] = useState(0)
   const [streak, setStreak] = useState(0)
   const [speedMs, setSpeedMs] = useState<number | null>(null)
   const [speedKey, setSpeedKey] = useState(0)
   const [input, setInput] = useState('')
-  const [summary, setSummary] = useState<FinishSummary | null>(null)
-  const [priorBest, setPriorBest] = useState<BlitzBest | null>(null)
   const [timeLeftMs, setTimeLeftMs] = useState(DURATION_MS)
   const [submitting, setSubmitting] = useState(false)
-  const [unlocked, setUnlocked] = useState<UnlockedAchievement[]>([])
 
-  // Wall-clock anchors; kept in refs so timer updates don't thrash React state.
-  const endAtRef = useRef<number>(0)
-  const questionShownAtRef = useRef<number>(0)
-  // phaseRef mirrors phase so async callers (the attempt POST) can tell
-  // whether the run still owns the UI by the time their request lands —
-  // if Finish ran while we were in flight, we must not clobber 'done'
-  // with an 'error' from a late network failure.
-  const phaseRef = useRef<Phase>('idle')
-  useEffect(() => { phaseRef.current = phase }, [phase])
-
-  // Fetch the user's prior PB once on mount so the result screen can show
-  // a New PB badge when beaten.
-  useEffect(() => {
-    const controller = new AbortController()
-    fetch('/api/math/blitz/best', { credentials: 'include', signal: controller.signal })
-      .then(res => (res.ok ? res.json() : { best: null }))
-      .then((data: { best: BlitzBest | null }) => {
-        setPriorBest(data.best ?? null)
-      })
-      .catch(() => { /* PB lookup is non-critical */ })
-    return () => { controller.abort() }
-  }, [])
-
-  const finishGame = useCallback(async (id: number) => {
-    setPhase('finishing')
-    try {
-      const res = await fetch(`/api/math/sessions/${id}/finish`, {
-        method: 'POST',
-        credentials: 'include',
-      })
-      if (!res.ok) throw new Error(t('errors.failedToFinish'))
-      const data = await res.json() as FinishResponse
-      const s = data.summary
-      setSummary(s)
+  const finishGame = useCallback((id: number) => {
+    return finishSession(id, ({ summary: s, response, unlocked: unlockedItems }) => {
       // Trust the server's score for the result banner — the client tally
       // should already match, but the stored value is what future PB lookups
       // compare against.
       setScore(s.score_num)
       setTimeLeftMs(0)
-      const unlockedItems = data.unlocked_achievements ?? []
-      setUnlocked(unlockedItems)
-      setPhase('done')
-      // Broadcast to the global AchievementUnlockOverlay so each unlock gets
-      // its own celebration on top of the result screen. The banner below
-      // still renders as the persistent record on the page itself.
-      emitAchievementUnlock(unlockedItems)
       const beatPB = priorBest ? s.score_num > priorBest.score_num : s.score_num > 0
       if (unlockedItems.length === 0) {
         feedback.play(beatPB ? 'milestone' : 'fanfare')
@@ -151,19 +87,15 @@ export default function MathBlitz() {
       // Confetti intensity scales with score; #1 all-time leaderboard rank
       // earns the full-screen burst regardless of absolute score.
       if (s.score_num > 0) {
-        const isTopRank = data.leaderboard_rank === 1
+        const isTopRank = response.leaderboard_rank === 1
         if (isTopRank) {
           burst('full', 'rainbow')
         } else {
           burst(blitzIntensityForScore(s.score_num), beatPB ? 'golden' : 'default')
         }
       }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : t('errors.failedToFinish')
-      setError(message)
-      setPhase('error')
-    }
-  }, [t, feedback, priorBest])
+    })
+  }, [finishSession, priorBest, feedback])
 
   // Countdown timer: ticks off the wall-clock deadline so a backgrounded tab
   // still finishes at the right moment when it returns to the foreground.
@@ -185,41 +117,27 @@ export default function MathBlitz() {
     return () => {
       if (id !== null) window.clearInterval(id)
     }
-  }, [phase, sessionId, finishGame])
+  }, [phase, sessionId, finishGame, endAtRef])
 
-  const startGame = useCallback(async () => {
-    setError('')
-    setPhase('starting')
-    try {
-      const res = await fetch('/api/math/sessions', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode: 'blitz' }),
-      })
-      if (!res.ok) throw new Error(t('errors.failedToStart'))
-      const data = await res.json()
-      setSessionId(data.session_id)
-      setCurrentFact(data.first_question as Fact)
-      setScore(0)
-      setStreak(0)
-      setSpeedMs(null)
-      setSpeedKey(0)
-      setInput('')
-      setSummary(null)
-      // Anchor the countdown to "now" rather than the server-request start —
-      // the player shouldn't lose seconds to network latency.
-      const now = performance.now()
-      endAtRef.current = now + DURATION_MS
-      questionShownAtRef.current = now
-      setTimeLeftMs(DURATION_MS)
-      setPhase('playing')
-    } catch (err) {
-      const message = err instanceof Error ? err.message : t('errors.failedToStart')
-      setError(message)
-      setPhase('error')
-    }
-  }, [t])
+  const startGame = useCallback(() => {
+    return startSession({
+      onStarted: (data) => {
+        setCurrentFact(data.first_question as Fact)
+        setScore(0)
+        setStreak(0)
+        setSpeedMs(null)
+        setSpeedKey(0)
+        setInput('')
+        setSummary(null)
+        // Anchor the countdown to "now" rather than the server-request start —
+        // the player shouldn't lose seconds to network latency.
+        const now = performance.now()
+        endAtRef.current = now + DURATION_MS
+        questionShownAtRef.current = now
+        setTimeLeftMs(DURATION_MS)
+      },
+    })
+  }, [startSession, endAtRef, questionShownAtRef, setSummary])
 
   const submitAnswer = useCallback(async () => {
     if (phase !== 'playing' || submitting) return
@@ -310,15 +228,12 @@ export default function MathBlitz() {
     } catch (err) {
       // Don't override 'finishing' or 'done' with an error from a late
       // attempt POST — the timer already finished the run cleanly.
-      if (phaseRef.current === 'playing') {
-        const message = err instanceof Error ? err.message : t('errors.failedToRecord')
-        setError(message)
-        setPhase('error')
-      }
+      const message = err instanceof Error ? err.message : t('errors.failedToRecord')
+      failActiveSession(message)
     } finally {
       setSubmitting(false)
     }
-  }, [phase, submitting, sessionId, currentFact, input, streak, t, finishGame, feedback])
+  }, [phase, submitting, sessionId, currentFact, input, streak, t, finishGame, feedback, failActiveSession, phaseRef, endAtRef, questionShownAtRef])
 
   const appendDigit = useCallback((digit: string) => {
     if (phase !== 'playing' || submitting) return
@@ -453,8 +368,7 @@ export default function MathBlitz() {
             type="button"
             onClick={() => {
               const latest = summary
-              setSummary(null)
-              setSessionId(null)
+              resetSession()
               setCurrentFact(null)
               setScore(0)
               setStreak(0)
@@ -462,8 +376,6 @@ export default function MathBlitz() {
               setSpeedKey(0)
               setInput('')
               setTimeLeftMs(DURATION_MS)
-              setUnlocked([])
-              setPhase('idle')
               // Refresh prior best so a back-to-back run compares against
               // the run we just stored.
               setPriorBest(prev => {
@@ -471,7 +383,7 @@ export default function MathBlitz() {
                 const candidate: BlitzBest = {
                   session_id: latest.session_id,
                   score_num: latest.score_num,
-                  best_streak: latest.best_streak,
+                  best_streak: latest.best_streak ?? 0,
                   total_correct: latest.total_correct,
                   total_wrong: latest.total_wrong,
                   ended_at: latest.ended_at,

--- a/web/src/pages/MathMarathon.tsx
+++ b/web/src/pages/MathMarathon.tsx
@@ -5,11 +5,13 @@ import { ArrowLeft, Trophy } from 'lucide-react'
 import { MathAnswerPad } from '../components/math/MathAnswerPad'
 import { appendAnswerDigit } from '../components/math/mathUtils'
 import { FinishRank } from '../components/math/FinishRank'
-import { UnlockedAchievementsBanner, type UnlockedAchievement } from '../components/math/UnlockedAchievements'
+import { UnlockedAchievementsBanner } from '../components/math/UnlockedAchievements'
 import { MuteToggle } from '../components/math/MuteToggle'
 import { SpeedCallout, FAST_THRESHOLD_MS } from '../components/regnemester/SpeedCallout'
-import { useFeedback, emitAchievementUnlock } from '../lib/regnemester/feedback'
+import { useFeedback } from '../lib/regnemester/feedback'
 import { burst, screenShake } from '../lib/regnemester/confetti'
+import { useMathSession } from './math/useMathSession'
+import type { Fact } from './math/types'
 
 const TOTAL = 200
 
@@ -21,15 +23,6 @@ const TIMER_MILESTONES_MS = [3 * 60_000, 4 * 60_000, 5 * 60_000]
 const SUB_FIVE_MS = 5 * 60_000
 const SUB_THREE_MS = 3 * 60_000
 
-type Op = '*' | '/'
-
-interface Fact {
-  a: number
-  b: number
-  op: Op
-  expected: number
-}
-
 interface MarathonBest {
   session_id: number
   duration_ms: number
@@ -37,25 +30,6 @@ interface MarathonBest {
   total_correct: number
   ended_at: string
 }
-
-interface FinishSummary {
-  session_id: number
-  mode: string
-  started_at: string
-  ended_at: string
-  duration_ms: number
-  total_correct: number
-  total_wrong: number
-  score_num: number
-}
-
-interface FinishResponse {
-  summary: FinishSummary
-  unlocked_achievements?: UnlockedAchievement[]
-  leaderboard_rank?: number | null
-}
-
-type Phase = 'idle' | 'starting' | 'playing' | 'finishing' | 'done' | 'error'
 
 function buildAllFacts(): Fact[] {
   const facts: Fact[] = []
@@ -105,39 +79,24 @@ export default function MathMarathon() {
   // run, so a single threshold doesn't fire repeatedly as the timer ticks.
   const firedMilestonesRef = useRef<Set<number>>(new Set())
 
-  const [phase, setPhase] = useState<Phase>('idle')
-  const [error, setError] = useState('')
-  const [sessionId, setSessionId] = useState<number | null>(null)
+  const session = useMathSession<MarathonBest>({ mode: 'marathon', bestPath: '/api/math/marathon/best' })
+  const {
+    phase, error, sessionId, priorBest, summary, unlocked,
+    startedAtRef, questionShownAtRef,
+    startSession, finishSession, failActiveSession, resetSession,
+    setPriorBest,
+  } = session
+
   const [facts, setFacts] = useState<Fact[]>(() => shuffle(buildAllFacts()))
   const [index, setIndex] = useState(0)
   const [wrongCount, setWrongCount] = useState(0)
   const [input, setInput] = useState('')
-  const [summary, setSummary] = useState<FinishSummary | null>(null)
-  const [priorBest, setPriorBest] = useState<MarathonBest | null>(null)
   const [elapsed, setElapsed] = useState(0)
   const [submitting, setSubmitting] = useState(false)
-  const [unlocked, setUnlocked] = useState<UnlockedAchievement[]>([])
   const [speedMs, setSpeedMs] = useState<number | null>(null)
   const [speedKey, setSpeedKey] = useState(0)
 
-  // Refs to keep wall-clock bookkeeping out of React state churn.
-  const startedAtRef = useRef<number>(0)
-  const questionShownAtRef = useRef<number>(0)
-
   const currentFact = facts[index]
-
-  // Fetch the user's prior PB once on mount so the result screen can decide
-  // whether to award a "New PB!" badge.
-  useEffect(() => {
-    const controller = new AbortController()
-    fetch('/api/math/marathon/best', { credentials: 'include', signal: controller.signal })
-      .then(res => (res.ok ? res.json() : { best: null }))
-      .then((data: { best: MarathonBest | null }) => {
-        setPriorBest(data.best ?? null)
-      })
-      .catch(() => { /* PB lookup is non-critical; treat as no prior */ })
-    return () => { controller.abort() }
-  }, [])
 
   // Live-elapsed timer: tick from the wall-clock start, not by accumulating
   // intervals — so a backgrounded tab still reports the correct duration.
@@ -167,63 +126,34 @@ export default function MathMarathon() {
     const id = window.setInterval(tick, 100)
     tick()
     return () => window.clearInterval(id)
-  }, [phase, feedback])
+  }, [phase, feedback, startedAtRef])
 
-  const startGame = useCallback(async () => {
-    setError('')
-    setPhase('starting')
-    // Start wall clock before the server request so the displayed elapsed
-    // time accounts for start-request latency and matches duration_ms.
-    startedAtRef.current = performance.now()
-    try {
-      const res = await fetch('/api/math/sessions', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode: 'marathon' }),
-      })
-      if (!res.ok) throw new Error(t('errors.failedToStart'))
-      const data = await res.json()
-      setSessionId(data.session_id)
-      setFacts(shuffle(buildAllFacts()))
-      questionShownAtRef.current = performance.now()
-      setIndex(0)
-      setWrongCount(0)
-      setInput('')
-      setElapsed(0)
-      setSpeedMs(null)
-      setSpeedKey(0)
-      firedMilestonesRef.current = new Set()
-      setPhase('playing')
-    } catch (err) {
-      const message = err instanceof Error ? err.message : t('errors.failedToStart')
-      setError(message)
-      setPhase('error')
-    }
-  }, [t, setFacts])
+  const startGame = useCallback(() => {
+    return startSession({
+      onBeforeRequest: () => {
+        // Start wall clock before the server request so the displayed elapsed
+        // time accounts for start-request latency and matches duration_ms.
+        startedAtRef.current = performance.now()
+      },
+      onStarted: () => {
+        setFacts(shuffle(buildAllFacts()))
+        questionShownAtRef.current = performance.now()
+        setIndex(0)
+        setWrongCount(0)
+        setInput('')
+        setElapsed(0)
+        setSpeedMs(null)
+        setSpeedKey(0)
+        firedMilestonesRef.current = new Set()
+      },
+    })
+  }, [startSession, startedAtRef, questionShownAtRef])
 
-  const finishGame = useCallback(async (id: number) => {
-    setPhase('finishing')
-    try {
-      const res = await fetch(`/api/math/sessions/${id}/finish`, {
-        method: 'POST',
-        credentials: 'include',
-      })
-      if (!res.ok) throw new Error(t('errors.failedToFinish'))
-      const data = await res.json() as FinishResponse
-      // Trust the server's duration_ms and total_wrong: those are what get
-      // stored and what future PB lookups compare against. Sync elapsed so
-      // there's no visible jump between the running timer and the result.
-      const s = data.summary
-      setSummary(s)
+  const finishGame = useCallback((id: number) => {
+    return finishSession(id, ({ summary: s, unlocked: unlockedItems }) => {
+      // Sync elapsed so there's no visible jump between the running timer and
+      // the result.
       setElapsed(s.duration_ms)
-      const unlockedItems = data.unlocked_achievements ?? []
-      setUnlocked(unlockedItems)
-      setPhase('done')
-      // Broadcast to the global AchievementUnlockOverlay so each unlock gets
-      // its own celebration on top of the result screen. The banner below
-      // still renders as the persistent record on the page itself.
-      emitAchievementUnlock(unlockedItems)
       // Celebrate with milestone for a new PB, fanfare otherwise.
       let beatPB: boolean
       if (!priorBest) {
@@ -252,12 +182,8 @@ export default function MathMarathon() {
           burst('medium', 'default')
         }
       }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : t('errors.failedToFinish')
-      setError(message)
-      setPhase('error')
-    }
-  }, [t, feedback, priorBest])
+    })
+  }, [finishSession, priorBest, feedback])
 
   const submitAnswer = useCallback(async () => {
     if (phase !== 'playing' || submitting) return
@@ -316,13 +242,14 @@ export default function MathMarathon() {
         questionShownAtRef.current = performance.now()
       }
     } catch (err) {
+      // Suppress a late attempt failure that lands after the run already
+      // finished — only surface it while the run still owns the UI.
       const message = err instanceof Error ? err.message : t('errors.failedToRecord')
-      setError(message)
-      setPhase('error')
+      failActiveSession(message)
     } finally {
       setSubmitting(false)
     }
-  }, [phase, submitting, sessionId, input, index, facts, wrongCount, t, finishGame, feedback])
+  }, [phase, submitting, sessionId, input, index, facts, wrongCount, t, finishGame, feedback, failActiveSession, questionShownAtRef])
 
   const appendDigit = useCallback((digit: string) => {
     if (phase !== 'playing' || submitting) return
@@ -444,39 +371,37 @@ export default function MathMarathon() {
           <button
             type="button"
             onClick={() => {
-              setSummary(null)
-              setSessionId(null)
-              setPhase('idle')
+              const latest = summary
+              resetSession()
               setIndex(0)
               setWrongCount(0)
               setInput('')
               setElapsed(0)
-              setUnlocked([])
               setSpeedMs(null)
               setSpeedKey(0)
               // Refresh prior best so a back-to-back run compares against
               // the run we just stored.
               setPriorBest(prev => {
-                if (!summary) return prev
+                if (!latest) return prev
                 if (!prev) {
                   return {
-                    session_id: summary.session_id,
-                    duration_ms: summary.duration_ms,
-                    total_wrong: summary.total_wrong,
-                    total_correct: summary.total_correct,
-                    ended_at: summary.ended_at,
+                    session_id: latest.session_id,
+                    duration_ms: latest.duration_ms,
+                    total_wrong: latest.total_wrong,
+                    total_correct: latest.total_correct,
+                    ended_at: latest.ended_at,
                   }
                 }
                 if (
-                  summary.duration_ms < prev.duration_ms ||
-                  (summary.duration_ms === prev.duration_ms && summary.total_wrong < prev.total_wrong)
+                  latest.duration_ms < prev.duration_ms ||
+                  (latest.duration_ms === prev.duration_ms && latest.total_wrong < prev.total_wrong)
                 ) {
                   return {
-                    session_id: summary.session_id,
-                    duration_ms: summary.duration_ms,
-                    total_wrong: summary.total_wrong,
-                    total_correct: summary.total_correct,
-                    ended_at: summary.ended_at,
+                    session_id: latest.session_id,
+                    duration_ms: latest.duration_ms,
+                    total_wrong: latest.total_wrong,
+                    total_correct: latest.total_correct,
+                    ended_at: latest.ended_at,
                   }
                 }
                 return prev

--- a/web/src/pages/math/types.ts
+++ b/web/src/pages/math/types.ts
@@ -1,0 +1,50 @@
+// Shared types for the math game modes (Marathon, Blitz, and future modes).
+// These were previously re-declared independently in MathMarathon.tsx and
+// MathBlitz.tsx and had begun to drift; they now live here as the single
+// canonical source consumed by every mode page and by useMathSession.
+import type { UnlockedAchievement } from '../../components/math/UnlockedAchievements'
+
+export type { UnlockedAchievement }
+
+export type MathMode = 'marathon' | 'blitz'
+
+export type Op = '*' | '/'
+
+export interface Fact {
+  a: number
+  b: number
+  op: Op
+  expected: number
+}
+
+// FinishSummary is the canonical shape returned by the finish endpoint. It is
+// the superset of what the modes use: best_streak is only meaningful for Blitz
+// and is absent from Marathon responses, so it is optional here.
+export interface FinishSummary {
+  session_id: number
+  mode: string
+  started_at: string
+  ended_at: string
+  duration_ms: number
+  total_correct: number
+  total_wrong: number
+  score_num: number
+  best_streak?: number
+}
+
+export interface FinishResponse {
+  summary: FinishSummary
+  unlocked_achievements?: UnlockedAchievement[]
+  leaderboard_rank?: number | null
+}
+
+// Phase is the session state machine shared by all modes.
+export type Phase = 'idle' | 'starting' | 'playing' | 'finishing' | 'done' | 'error'
+
+// SessionStartResponse is the body returned by POST /api/math/sessions. Blitz
+// includes the first question inline; Marathon generates its facts client-side
+// and so leaves first_question undefined.
+export interface SessionStartResponse {
+  session_id: number
+  first_question?: Fact
+}

--- a/web/src/pages/math/useMathSession.ts
+++ b/web/src/pages/math/useMathSession.ts
@@ -113,8 +113,8 @@ export function useMathSession<TBest>({ mode, bestPath }: UseMathSessionOptions)
   const startSession = useCallback(async (handlers: StartHandlers) => {
     setError('')
     setPhase('starting')
-    handlers.onBeforeRequest?.()
     try {
+      handlers.onBeforeRequest?.()
       const res = await fetch('/api/math/sessions', {
         method: 'POST',
         credentials: 'include',
@@ -153,8 +153,11 @@ export function useMathSession<TBest>({ mode, bestPath }: UseMathSessionOptions)
       // its own celebration on top of the result screen. The in-page banner
       // still renders as the persistent record.
       emitAchievementUnlock(unlockedItems)
-      // Mode-specific score/timer syncing and confetti.
-      celebrate({ summary: s, response: data, unlocked: unlockedItems })
+      // Mode-specific score/timer syncing and confetti. Wrapped so a
+      // celebration bug doesn't flip an otherwise successful finish to 'error'.
+      try {
+        celebrate({ summary: s, response: data, unlocked: unlockedItems })
+      } catch { /* celebrate is best-effort */ }
     } catch (err) {
       const message = err instanceof Error ? err.message : t('errors.failedToFinish')
       setError(message)

--- a/web/src/pages/math/useMathSession.ts
+++ b/web/src/pages/math/useMathSession.ts
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
+import { useTranslation } from 'react-i18next'
+import { emitAchievementUnlock } from '../../lib/regnemester/feedback'
+import type {
+  FinishResponse,
+  FinishSummary,
+  MathMode,
+  Phase,
+  SessionStartResponse,
+  UnlockedAchievement,
+} from './types'
+
+// Context handed to a mode's celebration callback once the finish flow has
+// committed the shared state (summary, unlocked, phase='done'). Mode-specific
+// score/timer syncing and confetti live here, off the shared plumbing.
+export interface FinishContext {
+  summary: FinishSummary
+  response: FinishResponse
+  unlocked: UnlockedAchievement[]
+}
+
+export interface StartHandlers {
+  // Runs synchronously before the start request fires. Marathon uses this to
+  // anchor its count-up clock to the moment the player tapped Start, so the
+  // displayed elapsed time includes start-request latency.
+  onBeforeRequest?: () => void
+  // Runs after the session is created, with the server's start response. Each
+  // mode seeds its own play state (facts/score/timer anchors) here.
+  onStarted: (data: SessionStartResponse) => void
+}
+
+export interface UseMathSessionOptions {
+  mode: MathMode
+  // Endpoint for the prior personal best, e.g. '/api/math/marathon/best'.
+  bestPath: string
+}
+
+export interface UseMathSession<TBest> {
+  phase: Phase
+  phaseRef: MutableRefObject<Phase>
+  setPhase: (next: Phase) => void
+  error: string
+  setError: Dispatch<SetStateAction<string>>
+  sessionId: number | null
+  setSessionId: Dispatch<SetStateAction<number | null>>
+  priorBest: TBest | null
+  setPriorBest: Dispatch<SetStateAction<TBest | null>>
+  summary: FinishSummary | null
+  setSummary: Dispatch<SetStateAction<FinishSummary | null>>
+  unlocked: UnlockedAchievement[]
+  setUnlocked: Dispatch<SetStateAction<UnlockedAchievement[]>>
+  // Wall-clock anchors kept in refs so timer ticks don't thrash React state.
+  // startedAtRef drives Marathon's count-up; endAtRef drives Blitz's countdown.
+  startedAtRef: MutableRefObject<number>
+  endAtRef: MutableRefObject<number>
+  questionShownAtRef: MutableRefObject<number>
+  startSession: (handlers: StartHandlers) => Promise<void>
+  finishSession: (id: number, celebrate: (ctx: FinishContext) => void) => Promise<void>
+  // Surface an attempt error only if the run still owns the UI. After Finish
+  // has run (phase moved to finishing/done/error), a late attempt POST that
+  // fails must not clobber the result screen with an error.
+  failActiveSession: (message: string) => void
+  // Reset the shared state for a play-again. Mode-specific state and the prior
+  // best are reset by the page.
+  resetSession: () => void
+}
+
+// useMathSession owns the session plumbing shared by every math mode: the
+// phase state machine (mirrored into phaseRef so async callers can tell whether
+// the run still owns the UI), the wall-clock timing refs, the prior-PB fetch
+// with AbortController cleanup, and the finish flow that surfaces
+// unlocked_achievements + leaderboard_rank. Each mode page layers its own
+// scoring and UI on top.
+export function useMathSession<TBest>({ mode, bestPath }: UseMathSessionOptions): UseMathSession<TBest> {
+  const { t } = useTranslation('regnemester')
+
+  const [phase, setPhaseState] = useState<Phase>('idle')
+  const [error, setError] = useState('')
+  const [sessionId, setSessionId] = useState<number | null>(null)
+  const [priorBest, setPriorBest] = useState<TBest | null>(null)
+  const [summary, setSummary] = useState<FinishSummary | null>(null)
+  const [unlocked, setUnlocked] = useState<UnlockedAchievement[]>([])
+
+  // phaseRef mirrors phase so async callers (the attempt POST) can tell whether
+  // the run still owns the UI by the time their request lands. The setter
+  // updates the ref synchronously alongside state so the guard never lags a
+  // render behind the real phase.
+  const phaseRef = useRef<Phase>('idle')
+  const setPhase = useCallback((next: Phase) => {
+    phaseRef.current = next
+    setPhaseState(next)
+  }, [])
+
+  const startedAtRef = useRef<number>(0)
+  const endAtRef = useRef<number>(0)
+  const questionShownAtRef = useRef<number>(0)
+
+  // Fetch the user's prior PB once on mount so the result screen can decide
+  // whether to award a "New PB!" badge. Non-critical — a failed lookup is
+  // treated as no prior best.
+  useEffect(() => {
+    const controller = new AbortController()
+    fetch(bestPath, { credentials: 'include', signal: controller.signal })
+      .then(res => (res.ok ? res.json() : { best: null }))
+      .then((data: { best: TBest | null }) => {
+        setPriorBest(data.best ?? null)
+      })
+      .catch(() => { /* PB lookup is non-critical; treat as no prior */ })
+    return () => { controller.abort() }
+  }, [bestPath])
+
+  const startSession = useCallback(async (handlers: StartHandlers) => {
+    setError('')
+    setPhase('starting')
+    handlers.onBeforeRequest?.()
+    try {
+      const res = await fetch('/api/math/sessions', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode }),
+      })
+      if (!res.ok) throw new Error(t('errors.failedToStart'))
+      const data = await res.json() as SessionStartResponse
+      setSessionId(data.session_id)
+      handlers.onStarted(data)
+      setPhase('playing')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('errors.failedToStart')
+      setError(message)
+      setPhase('error')
+    }
+  }, [mode, t, setPhase])
+
+  const finishSession = useCallback(async (id: number, celebrate: (ctx: FinishContext) => void) => {
+    setPhase('finishing')
+    try {
+      const res = await fetch(`/api/math/sessions/${id}/finish`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error(t('errors.failedToFinish'))
+      const data = await res.json() as FinishResponse
+      // Trust the server's summary: those values are what get stored and what
+      // future PB lookups compare against.
+      const s = data.summary
+      setSummary(s)
+      const unlockedItems = data.unlocked_achievements ?? []
+      setUnlocked(unlockedItems)
+      setPhase('done')
+      // Broadcast to the global AchievementUnlockOverlay so each unlock gets
+      // its own celebration on top of the result screen. The in-page banner
+      // still renders as the persistent record.
+      emitAchievementUnlock(unlockedItems)
+      // Mode-specific score/timer syncing and confetti.
+      celebrate({ summary: s, response: data, unlocked: unlockedItems })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('errors.failedToFinish')
+      setError(message)
+      setPhase('error')
+    }
+  }, [t, setPhase])
+
+  const failActiveSession = useCallback((message: string) => {
+    // Don't override 'finishing'/'done' with an error from a late attempt POST
+    // — the run already finished cleanly.
+    if (phaseRef.current === 'playing') {
+      setError(message)
+      setPhase('error')
+    }
+  }, [setPhase])
+
+  const resetSession = useCallback(() => {
+    setSummary(null)
+    setSessionId(null)
+    setUnlocked([])
+    setError('')
+    setPhase('idle')
+  }, [setPhase])
+
+  return {
+    phase,
+    phaseRef,
+    setPhase,
+    error,
+    setError,
+    sessionId,
+    setSessionId,
+    priorBest,
+    setPriorBest,
+    summary,
+    setSummary,
+    unlocked,
+    setUnlocked,
+    startedAtRef,
+    endAtRef,
+    questionShownAtRef,
+    startSession,
+    finishSession,
+    failActiveSession,
+    resetSession,
+  }
+}


### PR DESCRIPTION
## Changes

- **Shared math session plumbing** - Extracted the duplicated session state machine, wall-clock timing refs, prior-PB fetch, and finish flow from MathMarathon and MathBlitz into a shared `useMathSession` hook and a single `types.ts`. Both modes now apply the same late-POST guard, so a network failure after a run finishes can no longer clobber the result screen. No change to gameplay, scoring, or UI. (Hytte-mfte)

## Original Issue (feature): Extract shared session/timer/PB plumbing out of MathMarathon and MathBlitz

### Scope
Both `MathMarathon.tsx` and `MathBlitz.tsx` (~550 lines each) re-implement the same session plumbing: the `Phase` state machine, wall-clock timing refs, the prior-PB fetch with `AbortController`, the finish flow (`unlocked_achievements` + `leaderboard_rank`), and the `Fact`/`FinishResponse` types. They've already drifted — e.g. Blitz guards late attempt POSTs with a `phaseRef` mirror that Marathon lacks. This plan extracts the shared machinery into a `useMathSession` hook plus a shared `types.ts`, leaving each page to own only its scoring and UI.

### Files to touch
- `web/src/pages/math/useMathSession.ts` (new) — the shared session hook
- `web/src/pages/math/types.ts` (new) — `Fact`, `FinishResponse`, `UnlockedAchievement`, `Phase`, finish-summary types
- `web/src/pages/MathMarathon.tsx` — consume hook/types; remove duplicated plumbing
- `web/src/pages/MathBlitz.tsx` — consume hook/types; remove duplicated plumbing
- `changelog.d/<id>.md` (new) — `Changed` fragment

### Acceptance criteria
- A single `useMathSession` hook owns `phase`/`phaseRef`, the timing refs (count-up `startedAtRef` and Blitz's countdown `endAtRef`), prior-PB fetch with `AbortController` cleanup, and the finish flow returning `unlocked_achievements` + `leaderboard_rank`.
- `Fact`, `FinishResponse`, `Phase`, and unlock/summary types are declared once in `types.ts` and imported by both pages (no local re-declarations remain).
- Both modes apply the `phaseRef` late-POST guard (Marathon gains the guard Blitz already has); late network failures after finish are suppressed identically in both.
- Marathon and Blitz behave exactly as before: starting, playing, timer display, wrong-count/score, finishing summary, achievements, and PB/rank rendering are unchanged in manual play.
- `npm run lint`, `npm run build`, and `go test` all pass; no unused imports/dead code left in either page.

### Non-goals
- No backend changes to `internal/math/handlers.go` or the API contract.
- Do not build or wire up Practice mode (only make the primitives reusable).
- No changes to `MathLeaderboard.tsx`, `MathHeatmap.tsx`, `MathAchievements.tsx`, or `Math.tsx`.
- No visual/UX redesign, no new scoring rules, and no refactor of the fact-generation/shuffle logic beyond moving shared types.

## Source

Created from Suggestions page (suggestion id 69, page slug "math", source=claude).

## Original suggestion

`MathMarathon.tsx` and `MathBlitz.tsx` independently re-implement the same machinery: the `Phase` state machine, wall-clock refs (`startedAtRef`/`endAtRef`, `questionShownAtRef`), the prior-PB fetch with `AbortController`, the `phaseRef` mirror to guard late attempt POSTs, the finish flow with `unlocked_achievements` + `leaderboard_rank` handling, and the `Fact` / `FinishResponse` types. Lift this into a `useMathSession` hook (plus shared `types.ts`) so each mode page only owns its scoring/UI specifics. It removes a real class of drift bug — the two files have already diverged in subtle ways like how late network failures are suppressed — and makes the upcoming Practice mode trivial to wire up on top of the same primitives.


---
Bead: Hytte-mfte | Branch: forge/Hytte-mfte
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->