### PR TITLE
Surface PB, rank and weakest facts on the math landing page (Hytte-zptt)

### DIFF
--- a/changelog.d/Hytte-zptt.md
+++ b/changelog.d/Hytte-zptt.md
@@ -1,0 +1,2 @@
+category: Added
+- **Personalized summary banner on the math landing page** - The `/math` page now shows your Marathon PB, Blitz PB with current leaderboard rank, and a "weakest 3 facts" chip row that deep-links into the mastery heatmap, rendered above the mode grid. (Hytte-zptt)

--- a/changelog.d/Hytte-zptt.md
+++ b/changelog.d/Hytte-zptt.md
@@ -1,2 +1,3 @@
 category: Added
 - **Personalized summary banner on the math landing page** - The `/math` page now shows your Marathon PB, Blitz PB with current leaderboard rank, and a "weakest 3 facts" chip row that deep-links into the mastery heatmap, rendered above the mode grid. (Hytte-zptt)
+

--- a/web/public/locales/en/regnemester.json
+++ b/web/public/locales/en/regnemester.json
@@ -22,6 +22,15 @@
       "blurb": "See every fact colour-coded by how well you know it."
     }
   },
+  "summary": {
+    "heading": "Your progress",
+    "marathonLabel": "Marathon best",
+    "blitzLabel": "Blitz best",
+    "noPbYet": "No PB yet",
+    "rank": "#{{rank}}",
+    "weakestHeading": "Weakest facts",
+    "chipAria": "{{problem}}, {{accuracy}}% accuracy — open the mastery heatmap"
+  },
   "keypad": {
     "answerInputLabel": "Your answer",
     "backspaceAria": "Backspace",

--- a/web/public/locales/nb/regnemester.json
+++ b/web/public/locales/nb/regnemester.json
@@ -22,6 +22,15 @@
       "blurb": "Se alle stykker fargelagt etter hvor godt du kan dem."
     }
   },
+  "summary": {
+    "heading": "Din fremgang",
+    "marathonLabel": "Maraton-rekord",
+    "blitzLabel": "Blitz-rekord",
+    "noPbYet": "Ingen rekord ennå",
+    "rank": "#{{rank}}",
+    "weakestHeading": "Svakeste stykker",
+    "chipAria": "{{problem}}, {{accuracy}} % treffsikkerhet — åpne mestringskartet"
+  },
   "keypad": {
     "answerInputLabel": "Svaret ditt",
     "backspaceAria": "Slett",

--- a/web/public/locales/th/regnemester.json
+++ b/web/public/locales/th/regnemester.json
@@ -22,6 +22,15 @@
       "blurb": "ดูโจทย์ทุกข้อที่แสดงสีตามความแม่นยำของคุณ"
     }
   },
+  "summary": {
+    "heading": "ความคืบหน้าของคุณ",
+    "marathonLabel": "สถิติมาราธอน",
+    "blitzLabel": "สถิติบลิตซ์",
+    "noPbYet": "ยังไม่มีสถิติ",
+    "rank": "#{{rank}}",
+    "weakestHeading": "โจทย์ที่อ่อนที่สุด",
+    "chipAria": "{{problem}} ความแม่นยำ {{accuracy}}% — เปิดแผนที่ความเชี่ยวชาญ"
+  },
   "keypad": {
     "answerInputLabel": "คำตอบของคุณ",
     "backspaceAria": "ลบ",

--- a/web/src/pages/Math.tsx
+++ b/web/src/pages/Math.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { ParseKeys } from 'i18next'
 import { Calculator, Timer, Zap, Target, Trophy, Award } from 'lucide-react'
+import MathSummary from './MathSummary'
 
 interface ModeTile {
   to: string
@@ -46,6 +47,8 @@ export default function MathLanding() {
           {t('achievements.viewLink')}
         </Link>
       </div>
+
+      <MathSummary />
 
       <section aria-labelledby="modes-heading">
         <h2 id="modes-heading" className="sr-only">{t('modePickerHeading')}</h2>

--- a/web/src/pages/MathSummary.test.tsx
+++ b/web/src/pages/MathSummary.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest'
-import { computeWeakestFacts, findUserRank } from './MathSummary'
+import { computeWeakestFacts, findUserRank } from './mathSummaryUtils'
 
 type Op = '*' | '/'
 type Level = 'unseen' | 'red' | 'yellow' | 'green'

--- a/web/src/pages/MathSummary.test.tsx
+++ b/web/src/pages/MathSummary.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import { computeWeakestFacts, findUserRank } from './MathSummary'
+
+type Op = '*' | '/'
+type Level = 'unseen' | 'red' | 'yellow' | 'green'
+
+interface Cell {
+  a: number
+  b: number
+  op: Op
+  count: number
+  accuracy_pct: number
+  level: Level
+}
+
+function makeGrid(op: Op, overrides: Partial<Cell>[][] = []): Cell[][] {
+  return Array.from({ length: 10 }, (_, row) =>
+    Array.from({ length: 10 }, (_, col) => ({
+      a: row + 1,
+      b: col + 1,
+      op,
+      count: 0,
+      accuracy_pct: 0,
+      level: 'unseen' as Level,
+      ...(overrides[row]?.[col] ?? {}),
+    }))
+  )
+}
+
+describe('computeWeakestFacts', () => {
+  it('returns only attempted cells, weakest accuracy first, capped at the limit', () => {
+    const mult = makeGrid('*')
+    // Three attempted multiplication cells with varying accuracy.
+    mult[0][0] = { a: 1, b: 1, op: '*', count: 5, accuracy_pct: 80, level: 'green' }
+    mult[1][2] = { a: 2, b: 3, op: '*', count: 4, accuracy_pct: 20, level: 'red' }
+    mult[6][7] = { a: 7, b: 8, op: '*', count: 6, accuracy_pct: 50, level: 'yellow' }
+    const div = makeGrid('/')
+    div[3][1] = { a: 4, b: 2, op: '/', count: 3, accuracy_pct: 10, level: 'red' }
+
+    const weakest = computeWeakestFacts({ multiplication: mult, division: div }, 3)
+
+    expect(weakest).toHaveLength(3)
+    expect(weakest.map(c => c.accuracy_pct)).toEqual([10, 20, 50])
+    // The 80%/green cell is the strongest and falls outside the top 3.
+    expect(weakest.some(c => c.accuracy_pct === 80)).toBe(false)
+  })
+
+  it('ignores cells that have never been attempted', () => {
+    const mult = makeGrid('*')
+    const div = makeGrid('/')
+    expect(computeWeakestFacts({ multiplication: mult, division: div }, 3)).toEqual([])
+  })
+
+  it('breaks accuracy ties by mastery level (red is weaker than yellow)', () => {
+    const mult = makeGrid('*')
+    mult[0][0] = { a: 1, b: 1, op: '*', count: 5, accuracy_pct: 50, level: 'yellow' }
+    mult[0][1] = { a: 1, b: 2, op: '*', count: 5, accuracy_pct: 50, level: 'red' }
+    const weakest = computeWeakestFacts({ multiplication: mult, division: makeGrid('/') }, 2)
+    expect(weakest[0].level).toBe('red')
+    expect(weakest[1].level).toBe('yellow')
+  })
+})
+
+describe('findUserRank', () => {
+  const entries = [
+    { user_id: 1, rank: 1 },
+    { user_id: 7, rank: 2 },
+    { user_id: 9, rank: null },
+  ]
+
+  it('returns the rank of the matching user', () => {
+    expect(findUserRank(entries, 7)).toBe(2)
+  })
+
+  it('returns null when the user has no entry', () => {
+    expect(findUserRank(entries, 42)).toBeNull()
+  })
+
+  it('returns null when the user id is undefined', () => {
+    expect(findUserRank(entries, undefined)).toBeNull()
+  })
+
+  it('returns null when the matching entry has no rank', () => {
+    expect(findUserRank(entries, 9)).toBeNull()
+  })
+})

--- a/web/src/pages/MathSummary.tsx
+++ b/web/src/pages/MathSummary.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { Timer, Zap, AlertTriangle } from 'lucide-react'
+import { useAuth } from '../auth'
+
+type Op = '*' | '/'
+type Level = 'unseen' | 'red' | 'yellow' | 'green'
+
+interface MarathonBest {
+  duration_ms: number
+  total_wrong: number
+}
+
+interface BlitzBest {
+  score_num: number
+  best_streak: number
+}
+
+interface LeaderboardEntry {
+  user_id: number
+  rank: number | null
+}
+
+interface LeaderboardResponse {
+  entries: LeaderboardEntry[]
+}
+
+interface StatsCell {
+  a: number
+  b: number
+  op: Op
+  count: number
+  accuracy_pct: number
+  level: Level
+}
+
+interface StatsResponse {
+  multiplication: StatsCell[][]
+  division: StatsCell[][]
+}
+
+interface SummaryData {
+  marathon: MarathonBest | null
+  blitz: BlitzBest | null
+  rank: number | null
+  weakest: StatsCell[]
+}
+
+// Tie-break ordering when two facts share the same accuracy: a "red" cell is
+// weaker than a "yellow" one, which is weaker than a "green" one.
+const LEVEL_WEAKNESS: Record<Level, number> = { red: 0, yellow: 1, green: 2, unseen: 3 }
+
+// Format a duration in milliseconds as mm:ss, matching the leaderboard's
+// Marathon score format.
+function formatMarathonTime(ms: number): string {
+  const totalSeconds = Math.max(0, ms) / 1000
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = Math.floor(totalSeconds - minutes * 60)
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+}
+
+// Render a fact cell as a human-readable problem, e.g. "7 × 8" or "56 ÷ 8".
+function cellProblem(cell: StatsCell): string {
+  if (cell.op === '*') return `${cell.a} × ${cell.b}`
+  return `${cell.a * cell.b} ÷ ${cell.b}`
+}
+
+// Compute the weakest facts from the heatmap stats: only cells that have been
+// attempted (count > 0), sorted by accuracy ascending, breaking ties by
+// mastery level then by attempt count (more attempts at low accuracy is
+// weaker). Returns at most `limit` cells.
+export function computeWeakestFacts(stats: StatsResponse, limit: number): StatsCell[] {
+  const cells: StatsCell[] = []
+  for (const grid of [stats.multiplication, stats.division]) {
+    if (!grid) continue
+    for (const row of grid) {
+      for (const cell of row) {
+        if (cell.count > 0) cells.push(cell)
+      }
+    }
+  }
+  cells.sort((x, y) => {
+    if (x.accuracy_pct !== y.accuracy_pct) return x.accuracy_pct - y.accuracy_pct
+    const lx = LEVEL_WEAKNESS[x.level] ?? 3
+    const ly = LEVEL_WEAKNESS[y.level] ?? 3
+    if (lx !== ly) return lx - ly
+    return y.count - x.count
+  })
+  return cells.slice(0, limit)
+}
+
+// Derive the current user's leaderboard rank from a leaderboard response by
+// matching on user_id. Returns null when the user has no entry/rank.
+export function findUserRank(entries: LeaderboardEntry[], userId: number | undefined): number | null {
+  if (userId == null) return null
+  const entry = entries.find(e => e.user_id === userId)
+  return entry?.rank ?? null
+}
+
+async function fetchJSON<T>(url: string, signal: AbortSignal): Promise<T> {
+  const res = await fetch(url, { credentials: 'include', signal })
+  if (!res.ok) throw new Error('fetch failed')
+  return res.json() as Promise<T>
+}
+
+export default function MathSummary() {
+  const { t } = useTranslation('regnemester')
+  const { user } = useAuth()
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [data, setData] = useState<SummaryData | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const { signal } = controller
+
+    async function load() {
+      const results = await Promise.allSettled([
+        fetchJSON<{ best: MarathonBest | null }>('/api/math/marathon/best', signal),
+        fetchJSON<{ best: BlitzBest | null }>('/api/math/blitz/best', signal),
+        fetchJSON<LeaderboardResponse>('/api/math/leaderboard?mode=blitz&period=all', signal),
+        fetchJSON<StatsResponse>('/api/math/stats', signal),
+      ])
+      if (signal.aborted) return
+
+      // If every call failed, hide the banner entirely; the mode grid still
+      // renders below. A single failing call only blanks that one metric.
+      if (results.every(r => r.status === 'rejected')) {
+        setError(true)
+        setLoading(false)
+        return
+      }
+
+      const marathon = results[0].status === 'fulfilled' ? results[0].value.best : null
+      const blitz = results[1].status === 'fulfilled' ? results[1].value.best : null
+      const entries = results[2].status === 'fulfilled' ? results[2].value.entries : []
+      const stats = results[3].status === 'fulfilled' ? results[3].value : null
+
+      setData({
+        marathon,
+        blitz,
+        rank: findUserRank(entries, user?.id),
+        weakest: stats ? computeWeakestFacts(stats, 3) : [],
+      })
+      setLoading(false)
+    }
+
+    load().catch(() => {
+      if (!signal.aborted) {
+        setError(true)
+        setLoading(false)
+      }
+    })
+
+    return () => { controller.abort() }
+  }, [user?.id])
+
+  if (error) return null
+
+  if (loading) {
+    return (
+      <div
+        className="mb-6 rounded-lg border border-gray-700 bg-gray-800/60 p-4 sm:p-5 animate-pulse"
+        aria-hidden="true"
+      >
+        <div className="grid grid-cols-2 gap-3 sm:gap-4 mb-4">
+          <div className="h-16 rounded-md bg-gray-700/60" />
+          <div className="h-16 rounded-md bg-gray-700/60" />
+        </div>
+        <div className="h-4 w-24 rounded bg-gray-700/60 mb-2" />
+        <div className="flex gap-2">
+          <div className="h-7 w-20 rounded-full bg-gray-700/60" />
+          <div className="h-7 w-20 rounded-full bg-gray-700/60" />
+          <div className="h-7 w-20 rounded-full bg-gray-700/60" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) return null
+
+  const noPb = t('summary.noPbYet')
+
+  return (
+    <section
+      aria-labelledby="summary-heading"
+      className="mb-6 rounded-lg border border-gray-700 bg-gray-800/60 p-4 sm:p-5"
+    >
+      <h2 id="summary-heading" className="sr-only">{t('summary.heading')}</h2>
+
+      <div className="grid grid-cols-2 gap-3 sm:gap-4">
+        <div className="rounded-md border border-gray-700 bg-gray-800 p-3 sm:p-4">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-gray-400 mb-1">
+            <Timer size={16} className="text-blue-400 shrink-0" />
+            {t('summary.marathonLabel')}
+          </div>
+          {data.marathon ? (
+            <div className="text-2xl sm:text-3xl font-bold text-white tabular-nums">
+              {formatMarathonTime(data.marathon.duration_ms)}
+            </div>
+          ) : (
+            <div className="text-base sm:text-lg font-medium text-gray-500">{noPb}</div>
+          )}
+        </div>
+
+        <div className="rounded-md border border-gray-700 bg-gray-800 p-3 sm:p-4">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-gray-400 mb-1">
+            <Zap size={16} className="text-yellow-400 shrink-0" />
+            {t('summary.blitzLabel')}
+          </div>
+          {data.blitz ? (
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <span className="text-2xl sm:text-3xl font-bold text-white tabular-nums">
+                {data.blitz.score_num.toLocaleString()}
+              </span>
+              {data.rank != null && (
+                <span className="text-sm font-semibold text-yellow-300 tabular-nums">
+                  {t('summary.rank', { rank: data.rank })}
+                </span>
+              )}
+            </div>
+          ) : (
+            <div className="text-base sm:text-lg font-medium text-gray-500">{noPb}</div>
+          )}
+        </div>
+      </div>
+
+      {data.weakest.length > 0 && (
+        <div className="mt-4">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-gray-400 mb-2">
+            <AlertTriangle size={16} className="text-red-400 shrink-0" />
+            {t('summary.weakestHeading')}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {data.weakest.map(cell => {
+              const problem = cellProblem(cell)
+              const accuracy = Math.round(cell.accuracy_pct)
+              return (
+                <Link
+                  key={`${cell.op}-${cell.a}-${cell.b}`}
+                  to="/math/heatmap"
+                  aria-label={t('summary.chipAria', { problem, accuracy })}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-red-500/40 bg-red-500/10 px-3 py-1 text-sm font-medium text-red-200 hover:border-red-400 hover:bg-red-500/20 transition-colors tabular-nums"
+                >
+                  <span>{problem}</span>
+                  <span className="text-xs text-red-300/80">{accuracy}%</span>
+                </Link>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/web/src/pages/MathSummary.tsx
+++ b/web/src/pages/MathSummary.tsx
@@ -58,6 +58,9 @@ export default function MathSummary() {
     const { signal } = controller
 
     async function load() {
+      setLoading(true)
+      setError(false)
+
       const results = await Promise.allSettled([
         fetchJSON<{ best: MarathonBest | null }>('/api/math/marathon/best', signal),
         fetchJSON<{ best: BlitzBest | null }>('/api/math/blitz/best', signal),

--- a/web/src/pages/MathSummary.tsx
+++ b/web/src/pages/MathSummary.tsx
@@ -3,9 +3,8 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Timer, Zap, AlertTriangle } from 'lucide-react'
 import { useAuth } from '../auth'
-
-type Op = '*' | '/'
-type Level = 'unseen' | 'red' | 'yellow' | 'green'
+import { computeWeakestFacts, findUserRank } from './mathSummaryUtils'
+import type { LeaderboardEntry, StatsCell, StatsResponse } from './mathSummaryUtils'
 
 interface MarathonBest {
   duration_ms: number
@@ -17,27 +16,8 @@ interface BlitzBest {
   best_streak: number
 }
 
-interface LeaderboardEntry {
-  user_id: number
-  rank: number | null
-}
-
 interface LeaderboardResponse {
   entries: LeaderboardEntry[]
-}
-
-interface StatsCell {
-  a: number
-  b: number
-  op: Op
-  count: number
-  accuracy_pct: number
-  level: Level
-}
-
-interface StatsResponse {
-  multiplication: StatsCell[][]
-  division: StatsCell[][]
 }
 
 interface SummaryData {
@@ -47,12 +27,6 @@ interface SummaryData {
   weakest: StatsCell[]
 }
 
-// Tie-break ordering when two facts share the same accuracy: a "red" cell is
-// weaker than a "yellow" one, which is weaker than a "green" one.
-const LEVEL_WEAKNESS: Record<Level, number> = { red: 0, yellow: 1, green: 2, unseen: 3 }
-
-// Format a duration in milliseconds as mm:ss, matching the leaderboard's
-// Marathon score format.
 function formatMarathonTime(ms: number): string {
   const totalSeconds = Math.max(0, ms) / 1000
   const minutes = Math.floor(totalSeconds / 60)
@@ -60,42 +34,9 @@ function formatMarathonTime(ms: number): string {
   return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
 }
 
-// Render a fact cell as a human-readable problem, e.g. "7 × 8" or "56 ÷ 8".
 function cellProblem(cell: StatsCell): string {
   if (cell.op === '*') return `${cell.a} × ${cell.b}`
   return `${cell.a * cell.b} ÷ ${cell.b}`
-}
-
-// Compute the weakest facts from the heatmap stats: only cells that have been
-// attempted (count > 0), sorted by accuracy ascending, breaking ties by
-// mastery level then by attempt count (more attempts at low accuracy is
-// weaker). Returns at most `limit` cells.
-export function computeWeakestFacts(stats: StatsResponse, limit: number): StatsCell[] {
-  const cells: StatsCell[] = []
-  for (const grid of [stats.multiplication, stats.division]) {
-    if (!grid) continue
-    for (const row of grid) {
-      for (const cell of row) {
-        if (cell.count > 0) cells.push(cell)
-      }
-    }
-  }
-  cells.sort((x, y) => {
-    if (x.accuracy_pct !== y.accuracy_pct) return x.accuracy_pct - y.accuracy_pct
-    const lx = LEVEL_WEAKNESS[x.level] ?? 3
-    const ly = LEVEL_WEAKNESS[y.level] ?? 3
-    if (lx !== ly) return lx - ly
-    return y.count - x.count
-  })
-  return cells.slice(0, limit)
-}
-
-// Derive the current user's leaderboard rank from a leaderboard response by
-// matching on user_id. Returns null when the user has no entry/rank.
-export function findUserRank(entries: LeaderboardEntry[], userId: number | undefined): number | null {
-  if (userId == null) return null
-  const entry = entries.find(e => e.user_id === userId)
-  return entry?.rank ?? null
 }
 
 async function fetchJSON<T>(url: string, signal: AbortSignal): Promise<T> {

--- a/web/src/pages/MathSummary.tsx
+++ b/web/src/pages/MathSummary.tsx
@@ -69,24 +69,22 @@ export default function MathSummary() {
       ])
       if (signal.aborted) return
 
-      // If every call failed, hide the banner entirely; the mode grid still
-      // renders below. A single failing call only blanks that one metric.
-      if (results.every(r => r.status === 'rejected')) {
+      if (results.some(r => r.status === 'rejected')) {
         setError(true)
         setLoading(false)
         return
       }
 
-      const marathon = results[0].status === 'fulfilled' ? results[0].value.best : null
-      const blitz = results[1].status === 'fulfilled' ? results[1].value.best : null
-      const entries = results[2].status === 'fulfilled' ? results[2].value.entries : []
-      const stats = results[3].status === 'fulfilled' ? results[3].value : null
+      const marathon = (results[0] as PromiseFulfilledResult<{ best: MarathonBest | null }>).value.best
+      const blitz = (results[1] as PromiseFulfilledResult<{ best: BlitzBest | null }>).value.best
+      const entries = (results[2] as PromiseFulfilledResult<LeaderboardResponse>).value.entries
+      const stats = (results[3] as PromiseFulfilledResult<StatsResponse>).value
 
       setData({
         marathon,
         blitz,
         rank: findUserRank(entries, user?.id),
-        weakest: stats ? computeWeakestFacts(stats, 3) : [],
+        weakest: computeWeakestFacts(stats, 3),
       })
       setLoading(false)
     }

--- a/web/src/pages/mathSummaryUtils.ts
+++ b/web/src/pages/mathSummaryUtils.ts
@@ -1,0 +1,49 @@
+type Op = '*' | '/'
+type Level = 'unseen' | 'red' | 'yellow' | 'green'
+
+export interface LeaderboardEntry {
+  user_id: number
+  rank: number | null
+}
+
+export interface StatsCell {
+  a: number
+  b: number
+  op: Op
+  count: number
+  accuracy_pct: number
+  level: Level
+}
+
+export interface StatsResponse {
+  multiplication: StatsCell[][]
+  division: StatsCell[][]
+}
+
+const LEVEL_WEAKNESS: Record<Level, number> = { red: 0, yellow: 1, green: 2, unseen: 3 }
+
+export function computeWeakestFacts(stats: StatsResponse, limit: number): StatsCell[] {
+  const cells: StatsCell[] = []
+  for (const grid of [stats.multiplication, stats.division]) {
+    if (!grid) continue
+    for (const row of grid) {
+      for (const cell of row) {
+        if (cell.count > 0) cells.push(cell)
+      }
+    }
+  }
+  cells.sort((x, y) => {
+    if (x.accuracy_pct !== y.accuracy_pct) return x.accuracy_pct - y.accuracy_pct
+    const lx = LEVEL_WEAKNESS[x.level] ?? 3
+    const ly = LEVEL_WEAKNESS[y.level] ?? 3
+    if (lx !== ly) return lx - ly
+    return y.count - x.count
+  })
+  return cells.slice(0, limit)
+}
+
+export function findUserRank(entries: LeaderboardEntry[], userId: number | undefined): number | null {
+  if (userId == null) return null
+  const entry = entries.find(e => e.user_id === userId)
+  return entry?.rank ?? null
+}


### PR DESCRIPTION
## Changes

- **Personalized summary banner on the math landing page** - The `/math` page now shows your Marathon PB, Blitz PB with current leaderboard rank, and a "weakest 3 facts" chip row that deep-links into the mastery heatmap, rendered above the mode grid. (Hytte-zptt)

## Original Issue (feature): Surface PB, rank and weakest facts on the math landing page

### Scope
Replace the static intro of the `/math` landing page with a personalized summary banner rendered above the existing mode grid. On mount it fetches the user's Marathon PB, Blitz PB + leaderboard rank, and computes the weakest three facts, rendering them as a stat row plus deep-linking chips. The mode tiles and link buttons are untouched. No new backend endpoints are required — the four existing endpoints already expose everything needed.

### Files to touch
- `web/src/pages/Math.tsx` — add summary fetch + render above `<section aria-labelledby="modes-heading">`.
- `web/src/pages/MathSummary.tsx` (new) — optional extracted component for the banner + chip row, to keep `Math.tsx` readable.
- `web/public/locales/en/regnemester.json` — new keys (summary labels, "no PB yet", rank, weakest-facts heading, chip aria).
- `web/public/locales/nb/regnemester.json` — same keys (Norwegian).
- `web/public/locales/th/regnemester.json` — same keys (Thai).

### Acceptance criteria
- On load, the page calls `/api/math/marathon/best`, `/api/math/blitz/best`, `/api/math/leaderboard?mode=blitz&period=all`, and `/api/math/stats` with `credentials: 'include'`.
- Marathon PB renders as a formatted time; Blitz PB renders as a score with the user's current rank derived from the leaderboard entries (e.g. "#2"). When a metric has no data, a friendly "no PB yet" placeholder shows instead of a crash or blank.
- A "weakest 3 facts" chip row is computed from the `/api/math/stats` grids (lowest `accuracy_pct`/`level` among cells with `count > 0`); each chip is a `<Link>` deep-linking to `/math/heatmap` (and ready to retarget to Practice mode later).
- While loading, a non-layout-shifting skeleton/placeholder shows; on fetch error the banner is hidden and the mode grid still renders.
- All new strings come from `t('regnemester:…')`; keys exist in en, nb and th. No hardcoded English in JSX.
- Banner and chips are usable at 375px width; mode grid and link buttons render exactly as before.
- A changelog fragment is added under `changelog.d/`.

### Non-goals
- No new or modified backend handlers/endpoints; reuse the four existing ones.
- No Practice mode implementation — chips target the heatmap for now.
- No changes to Marathon, Blitz, Leaderboard, Heatmap or Achievements pages.
- No new caching layer, polling, or auto-refresh; one fetch on mount is sufficient.
- No redesign of the mode tiles or the leaderboard/achievements link buttons.

## Source

Created from Suggestions page (suggestion id 68, page slug "math", source=claude).

## Original suggestion

Today `/math` is a static set of four mode tiles plus two link buttons — there is zero personalization, even though the backend already exposes `/api/math/marathon/best`, `/api/math/blitz/best`, `/api/math/leaderboard` and `/api/math/stats`. Fetch a small summary on mount and render it above the mode grid: current Marathon PB time, Blitz PB score with current leaderboard rank, and a 'weakest 3 facts' chip row that deep-links into the heatmap (or the new Practice mode). The landing becomes a useful dashboard rather than a menu, and it pulls returning users straight into the action that matters most for them.


---
Bead: Hytte-zptt | Branch: forge/Hytte-zptt
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->