### PR TITLE
Add keyboard shortcuts for save, new note, and search focus (Hytte-rchr)

### DIFF
--- a/changelog.d/Hytte-rchr.md
+++ b/changelog.d/Hytte-rchr.md
@@ -1,0 +1,2 @@
+category: Added
+- **Keyboard shortcuts on the Notes page** - Press Ctrl/Cmd+S to save the open note (without the browser's native save dialog), Ctrl/Cmd+N to start a new note, and `/` to focus the search box. The Save, New note, and search controls now show their shortcut in tooltips. (Hytte-rchr)

--- a/web/public/locales/en/notes.json
+++ b/web/public/locales/en/notes.json
@@ -10,6 +10,11 @@
   },
   "untitled": "Untitled",
   "moreTagsCount": "+{{count}}",
+  "shortcuts": {
+    "save": "Save (Ctrl/Cmd+S)",
+    "newNote": "New note (Ctrl/Cmd+N)",
+    "focusSearch": "Search notes (press /)"
+  },
   "editor": {
     "edit": "Edit",
     "preview": "Preview",

--- a/web/public/locales/nb/notes.json
+++ b/web/public/locales/nb/notes.json
@@ -10,6 +10,11 @@
   },
   "untitled": "Uten tittel",
   "moreTagsCount": "+{{count}}",
+  "shortcuts": {
+    "save": "Lagre (Ctrl/Cmd+S)",
+    "newNote": "Nytt notat (Ctrl/Cmd+N)",
+    "focusSearch": "Søk i notater (trykk /)"
+  },
   "editor": {
     "edit": "Rediger",
     "preview": "Forhåndsvisning",

--- a/web/public/locales/th/notes.json
+++ b/web/public/locales/th/notes.json
@@ -10,6 +10,11 @@
   },
   "untitled": "ไม่มีชื่อ",
   "moreTagsCount": "+{{count}}",
+  "shortcuts": {
+    "save": "บันทึก (Ctrl/Cmd+S)",
+    "newNote": "บันทึกใหม่ (Ctrl/Cmd+N)",
+    "focusSearch": "ค้นหาบันทึก (กด /)"
+  },
   "editor": {
     "edit": "แก้ไข",
     "preview": "ตัวอย่าง",

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { forwardRef, useImperativeHandle, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -22,6 +22,12 @@ interface NoteEditorProps {
   onClose: () => void
 }
 
+/** Imperative handle so the page can trigger a save from a keyboard shortcut. */
+export interface NoteEditorHandle {
+  /** Persist the current draft if there are unsaved changes and no save is in flight. */
+  save: () => void
+}
+
 function parseTags(raw: string): string[] {
   return raw
     .split(',')
@@ -34,7 +40,10 @@ function parseTags(raw: string): string[] {
  * the markdown rendering. The parent re-mounts this (via a `key`) when the
  * active note changes so drafts initialize cleanly from props.
  */
-export default function NoteEditor({ note, isCreating, error, onSave, onDelete, onClose }: NoteEditorProps) {
+const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEditor(
+  { note, isCreating, error, onSave, onDelete, onClose },
+  ref,
+) {
   const { t } = useTranslation('notes')
   const [draftTitle, setDraftTitle] = useState(note?.title ?? '')
   const [draftContent, setDraftContent] = useState(note?.content ?? '')
@@ -62,6 +71,15 @@ export default function NoteEditor({ note, isCreating, error, onSave, onDelete, 
       setSaving(false)
     }
   }
+
+  // Expose save() so the page-level Cmd/Ctrl+S shortcut can persist the draft.
+  // Mirror the Save button's disabled state so the shortcut is a no-op when
+  // there is nothing to save or a save is already in flight.
+  useImperativeHandle(ref, () => ({
+    save() {
+      if (!saving && hasChanges) handleSave()
+    },
+  }), [saving, hasChanges])
 
   return (
     <>
@@ -98,6 +116,7 @@ export default function NoteEditor({ note, isCreating, error, onSave, onDelete, 
             onClick={handleSave}
             disabled={saving || !hasChanges}
             className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-default text-white rounded text-sm transition-colors cursor-pointer"
+            title={t('shortcuts.save')}
           >
             <Save size={14} />
             {saving ? t('editor.saving') : t('editor.save')}
@@ -266,4 +285,6 @@ export default function NoteEditor({ note, isCreating, error, onSave, onDelete, 
       )}
     </>
   )
-}
+})
+
+export default NoteEditor

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -74,12 +74,19 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
 
   // Expose save() so the page-level Cmd/Ctrl+S shortcut can persist the draft.
   // Mirror the Save button's disabled state so the shortcut is a no-op when
-  // there is nothing to save or a save is already in flight.
+  // there is nothing to save or a save is already in flight. The handle is
+  // kept stable but defers to a ref that is refreshed every render, so the
+  // shortcut always saves the *current* draft rather than a stale closure
+  // captured the first time `hasChanges`/`saving` changed.
+  const saveRef = useRef(() => {})
+  saveRef.current = () => {
+    if (!saving && hasChanges) handleSave()
+  }
   useImperativeHandle(ref, () => ({
     save() {
-      if (!saving && hasChanges) handleSave()
+      saveRef.current()
     },
-  }), [saving, hasChanges])
+  }), [])
 
   return (
     <>

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -50,17 +50,19 @@ export default function Notes() {
   // The listener lives on `window` only while this page is mounted.
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+      if (e.repeat) return
+      const mod = e.metaKey || e.ctrlKey
+      if (mod && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 's') {
         e.preventDefault()
         editorRef.current?.save()
         return
       }
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'n') {
+      if (mod && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'n') {
         e.preventDefault()
         startCreating()
         return
       }
-      if (e.key === '/' && !isTypingTarget(e.target)) {
+      if (e.key === '/' && !mod && !e.shiftKey && !e.altKey && !isTypingTarget(e.target)) {
         e.preventDefault()
         searchInputRef.current?.focus()
       }

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -1,12 +1,19 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Plus, Search, FileText } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../components/ui/skeleton'
 import { ConfirmDialog } from '../components/ui/dialog'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
 import { timeAgo } from '../utils/timeAgo'
-import NoteEditor from '../components/notes/NoteEditor'
+import NoteEditor, { type NoteEditorHandle } from '../components/notes/NoteEditor'
 import { useNotes, type Note, type NoteInput } from '../hooks/useNotes'
+
+/** True when the event target is a field where `/` should type literally. */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable
+}
 
 export default function Notes() {
   const { t } = useTranslation('notes')
@@ -22,17 +29,45 @@ export default function Notes() {
 
   const { notes, allTags, loading, error, save, remove, clearError } = useNotes(debouncedSearch, activeTag)
 
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const editorRef = useRef<NoteEditorHandle>(null)
+
   function openNote(note: Note) {
     setSelectedNote(note)
     setIsCreating(false)
     clearError()
   }
 
-  function startCreating() {
+  const startCreating = useCallback(() => {
     setSelectedNote(null)
     setIsCreating(true)
     clearError()
-  }
+  }, [clearError])
+
+  // Keyboard shortcuts: Cmd/Ctrl+S saves the open note (suppressing the
+  // browser's native save dialog), Cmd/Ctrl+N starts a new note, and `/`
+  // focuses search unless the user is already typing in a field/editor.
+  // The listener lives on `window` only while this page is mounted.
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault()
+        editorRef.current?.save()
+        return
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'n') {
+        e.preventDefault()
+        startCreating()
+        return
+      }
+      if (e.key === '/' && !isTypingTarget(e.target)) {
+        e.preventDefault()
+        searchInputRef.current?.focus()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [startCreating])
 
   function closeEditor() {
     setSelectedNote(null)
@@ -75,18 +110,20 @@ export default function Notes() {
             <div className="relative flex-1">
               <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-500" />
               <input
+                ref={searchInputRef}
                 type="text"
                 placeholder={t('searchPlaceholder')}
                 value={search}
                 onChange={e => setSearch(e.target.value)}
                 className="w-full pl-8 pr-3 py-1.5 bg-gray-800 border border-gray-700 rounded text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
                 aria-label={t('searchLabel')}
+                title={t('shortcuts.focusSearch')}
               />
             </div>
             <button
               onClick={startCreating}
               className="flex items-center gap-1 px-2 py-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded text-sm transition-colors cursor-pointer shrink-0"
-              title={t('newNote')}
+              title={t('shortcuts.newNote')}
               aria-label={t('newNote')}
             >
               <Plus size={16} />
@@ -189,6 +226,7 @@ export default function Notes() {
         {isCreating || selectedNote ? (
           <NoteEditor
             key={selectedNote?.id ?? 'new'}
+            ref={editorRef}
             note={selectedNote}
             isCreating={isCreating}
             error={error}


### PR DESCRIPTION
## Changes

- **Keyboard shortcuts on the Notes page** - Press Ctrl/Cmd+S to save the open note (without the browser's native save dialog), Ctrl/Cmd+N to start a new note, and `/` to focus the search box. The Save, New note, and search controls now show their shortcut in tooltips. (Hytte-rchr)

## Original Issue (feature): Add keyboard shortcuts for save, new note, and search focus

### Scope
Add three keyboard shortcuts to the Notes page (`/notes`): Cmd/Ctrl+S to save the current note (suppressing the browser's native save dialog), Cmd/Ctrl+N to start a new note, and `/` to focus the search input when the user is not already typing in a text field or editor. Surface the shortcuts in the relevant button `title` tooltips for discoverability. This is a frontend-only change spanning `Notes.tsx` and `NoteEditor.tsx`; no backend, API, or schema changes. The `NoteEditor` component gains a `forwardRef` + imperative `save()` handle so the page-level Cmd/Ctrl+S shortcut can trigger the editor's save behavior, and its Save button tooltip is localized.

### Files to touch
- `web/src/pages/Notes.tsx` — add a keydown handler (effect + listener), guard logic, refs, and `title`/tooltip text on the search input and New Note button.
- `web/src/components/notes/NoteEditor.tsx` — add `forwardRef` + `useImperativeHandle` to expose an imperative `save()` handle; add localized Save button tooltip.
- `web/public/locales/en/notes.json` — tooltip strings (e.g. "Save (Ctrl+S)").
- `web/public/locales/nb/notes.json` — same keys, Norwegian.
- `web/public/locales/th/notes.json` — same keys, Thai.
- `changelog.d/<slug>.md` (new) — `Added` fragment with the bead ID.

### Acceptance criteria
- Pressing Cmd/Ctrl+S anywhere on the Notes page calls the existing `saveNote()` and the browser's native save dialog never appears (`preventDefault`).
- Pressing Cmd/Ctrl+N calls `startCreating()` and does not trigger the browser's new-window action.
- Pressing `/` focuses the search input only when focus is not inside an input, textarea, or contentEditable note editor; otherwise `/` types normally.
- Shortcuts only fire on the first keydown (not on key-repeat) and do not intercept modified variants (e.g. Cmd+Shift+S, Cmd+Shift+N).
- Shortcuts only fire while the Notes page is mounted; the listener is removed on unmount (no leaks, no firing on other pages).
- Save and New Note buttons show their shortcut in a `title` tooltip, fully localized in en/nb/th.
- Cmd+S works on macOS (metaKey) and Ctrl+S on Windows/Linux (ctrlKey).
- A changelog fragment exists in `changelog.d/`.

### Non-goals
- No changes to backend (`internal/notes/handlers.go`), API routes, or DB schema.
- No new shortcuts beyond the three specified (no delete, navigation, or tag shortcuts).
- No global/app-wide shortcut system, command palette, or help/cheat-sheet modal.
- No user-configurable or remappable key bindings.
- No changes to the Notes UI layout or visual design beyond tooltip text.

## Source

Created from Suggestions page (suggestion id 120, page slug "notes", source=claude).

## Original suggestion

Notes is a heavy keyboard-driven page but currently requires mouse clicks for every action. Add Cmd/Ctrl+S to trigger `saveNote()` (preventing the browser save dialog), Cmd/Ctrl+N to call `startCreating()`, and `/` to focus the search input when not already in a text field. Show the shortcuts in button tooltips/`title` attributes so they are discoverable. This makes note-taking dramatically faster for power users without changing the UI.


---
Bead: Hytte-rchr | Branch: forge/Hytte-rchr
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->