### PR TITLE
Restore body scroll and focus when AllowancePage unmounts during photo preview (Hytte-4zth)

### DIFF
--- a/changelog.d/Hytte-4zth.md
+++ b/changelog.d/Hytte-4zth.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Restore body scroll and focus when leaving the allowance photo preview** - Navigating away from the allowance page while a photo is enlarged now always resets the body scroll lock, and focus is only returned to the trigger when it is still attached to the DOM, preventing a stuck-scroll bug and stray focus warnings on mobile. (Hytte-4zth)

--- a/web/src/pages/AllowancePage.tsx
+++ b/web/src/pages/AllowancePage.tsx
@@ -170,9 +170,15 @@ export default function AllowancePage() {
       enlargedCloseRef.current?.focus()
       document.body.style.overflow = 'hidden'
     } else {
-      enlargedTriggerRef.current?.focus()
-      document.body.style.overflow = ''
+      // Only restore focus when the trigger is still attached to the DOM —
+      // it may have been unmounted while the photo was enlarged.
+      const trigger = enlargedTriggerRef.current
+      if (trigger && document.body.contains(trigger)) {
+        trigger.focus()
+      }
     }
+    // Always reset overflow on cleanup so navigating away mid-preview can never
+    // leave the body scroll locked, regardless of the current photoEnlarged value.
     return () => { document.body.style.overflow = '' }
   }, [photoEnlarged])
 


### PR DESCRIPTION
## Changes

- **Restore body scroll and focus when leaving the allowance photo preview** - Navigating away from the allowance page while a photo is enlarged now always resets the body scroll lock, and focus is only returned to the trigger when it is still attached to the DOM, preventing a stuck-scroll bug and stray focus warnings on mobile. (Hytte-4zth)

## Original Issue (feature): Restore body scroll and focus when AllowancePage unmounts during photo preview

### Scope
This plan fixes a stuck-scroll and stray-focus bug in `AllowancePage`'s photo-preview effect. When the enlarged photo modal is open and the user navigates away, the effect cleanup must always restore `document.body.style.overflow`, and any focus restoration must target the trigger element only if it is still attached to the DOM. The current effect (lines ~168–177) calls `enlargedTriggerRef.current?.focus()` in the `else` branch even when the node may be detached, and relies on the `else`/cleanup paths in a way that can leave overflow hidden during state races.

### Files to touch
- `web/src/pages/AllowancePage.tsx` — harden the `photoEnlarged` effect (focus guard + unconditional overflow reset in cleanup).
- `changelog.d/<id>-fix-allowance-scroll-focus.md` (new) — changelog fragment.

### Acceptance criteria
- Opening the enlarged photo sets `document.body.style.overflow = 'hidden'` and focuses the close control (unchanged behavior).
- Closing the enlarged photo restores `document.body.style.overflow = ''` and returns focus to the trigger **only when** `document.body.contains(enlargedTriggerRef.current)` is true.
- Navigating away (unmounting `AllowancePage`) while the photo is enlarged always resets `document.body.style.overflow` to `''` via the effect cleanup, with no `.focus()` call on a detached node.
- No console errors/warnings about focusing detached nodes when navigating away mid-preview.
- After closing the modal mid-navigation and returning, the page scrolls normally (no stuck scroll), verified at 375px mobile width.
- Existing behavior for the emoji picker and other body-overflow usages is unchanged.
- `npm run lint` and `npm run build` pass; `go build`/`go vet`/`go test` unaffected.

### Non-goals
- No changes to the modal's markup, styling, or how `photoEnlarged`/`photoPreviewId` are set on click.
- No refactor into a shared `useBodyScrollLock`/`useFocusTrap` hook (could be a follow-up).
- No backend changes (`internal/allowance/handlers.go`) and no changes to `MyChoresPage.tsx`.
- No changes to the unrelated `showEmojiPicker` effect.
- No new tests harness setup; this is a small, observable DOM-behavior fix verified manually/visually.

## Source

Created from Suggestions page (suggestion id 21, page slug "allowance", source=claude).

## Original suggestion

The photoEnlarged effect sets document.body.style.overflow = 'hidden' and only restores it when photoEnlarged flips back to false; if the user navigates away while the enlarged photo is open, the cleanup runs but the focus restoration targets enlargedTriggerRef.current, which may already be detached, and the dependency-array cleanup pattern still leaves a window where overflow stays hidden if state updates race. Make the effect's cleanup unconditionally reset overflow to '' and guard the focus call with a document.body.contains check on the trigger ref. This prevents a stuck-scroll bug after closing the modal mid-navigation, which has been reported intermittently on mobile.


---
Bead: Hytte-4zth | Branch: forge/Hytte-4zth
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->