### PR TITLE
Extract the minute-tick clock into a reusable useCurrentTime hook (Hytte-4mh0)

### DIFF
--- a/changelog.d/Hytte-4mh0.md
+++ b/changelog.d/Hytte-4mh0.md
@@ -1,2 +1,2 @@
 category: Changed
-- **Extract minute-tick clock into a reusable hook** - Moved the minute-aligned clock logic out of TodayView into a new `useCurrentTime` hook that ticks on wall-clock minute boundaries and pauses while the tab is hidden. No change to the Today page behavior. (Hytte-4mh0)
+- **Extract minute-tick clock into a reusable hook** - Moved the minute-aligned clock logic out of TodayView into a new `useCurrentTime` hook that ticks on wall-clock minute boundaries. The hook pauses while the tab is hidden and snaps to the current time on resume. (Hytte-4mh0)

--- a/changelog.d/Hytte-4mh0.md
+++ b/changelog.d/Hytte-4mh0.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Extract minute-tick clock into a reusable hook** - Moved the minute-aligned clock logic out of TodayView into a new `useCurrentTime` hook that ticks on wall-clock minute boundaries and pauses while the tab is hidden. No change to the Today page behavior. (Hytte-4mh0)

--- a/web/src/hooks/useCurrentTime.test.ts
+++ b/web/src/hooks/useCurrentTime.test.ts
@@ -17,7 +17,6 @@ describe('useCurrentTime', () => {
   })
 
   afterEach(() => {
-    vi.runOnlyPendingTimers()
     vi.useRealTimers()
     vi.restoreAllMocks()
   })

--- a/web/src/hooks/useCurrentTime.test.ts
+++ b/web/src/hooks/useCurrentTime.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCurrentTime } from './useCurrentTime'
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => hidden,
+  })
+}
+
+describe('useCurrentTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setHidden(false)
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('returns a Date', () => {
+    vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
+    const { result } = renderHook(() => useCurrentTime())
+    expect(result.current).toBeInstanceOf(Date)
+  })
+
+  it('re-renders at the start of the next wall-clock minute', () => {
+    vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
+    const { result } = renderHook(() => useCurrentTime())
+
+    const initial = result.current
+    expect(initial.getSeconds()).toBe(15)
+
+    // Advance to just before the minute boundary — no tick yet.
+    act(() => {
+      vi.advanceTimersByTime(44_999)
+    })
+    expect(result.current).toBe(initial)
+
+    // Cross the :00 boundary — the hook should snap to the new minute.
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).not.toBe(initial)
+    expect(result.current.getMinutes()).toBe(31)
+    expect(result.current.getSeconds()).toBe(0)
+  })
+
+  it('keeps ticking every minute after the first aligned fire', () => {
+    vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
+    const { result } = renderHook(() => useCurrentTime())
+
+    act(() => {
+      vi.advanceTimersByTime(45_000) // -> 10:31:00
+    })
+    const afterFirst = result.current
+    expect(afterFirst.getMinutes()).toBe(31)
+
+    act(() => {
+      vi.advanceTimersByTime(60_000) // -> 10:32:00
+    })
+    expect(result.current).not.toBe(afterFirst)
+    expect(result.current.getMinutes()).toBe(32)
+  })
+
+  it('clears all timers on unmount with no leaks', () => {
+    vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
+    const { unmount } = renderHook(() => useCurrentTime())
+
+    // The initial alignment timeout is pending.
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('clears the interval timer on unmount after the boundary fired', () => {
+    vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
+    const { unmount } = renderHook(() => useCurrentTime())
+
+    act(() => {
+      vi.advanceTimersByTime(45_000) // alignment timeout fires, interval armed
+    })
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('pauses while hidden and snaps to the current time when visible again', () => {
+    vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
+    const { result } = renderHook(() => useCurrentTime())
+    const initial = result.current
+
+    // Tab becomes hidden -> timers are cleared, hook pauses.
+    setHidden(true)
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(vi.getTimerCount()).toBe(0)
+
+    // Time moves on while hidden; the paused hook does not update.
+    act(() => {
+      vi.setSystemTime(new Date('2026-06-02T10:45:30.000Z'))
+    })
+    expect(result.current).toBe(initial)
+
+    // Becoming visible snaps to the current time and re-arms the timer.
+    setHidden(false)
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(result.current).not.toBe(initial)
+    expect(result.current.getMinutes()).toBe(45)
+    expect(result.current.getSeconds()).toBe(30)
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+  })
+})

--- a/web/src/hooks/useCurrentTime.ts
+++ b/web/src/hooks/useCurrentTime.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * Returns a live Date that updates on each wall-clock minute boundary
+ * (aligned to `:00` seconds), pausing while the tab is hidden.
+ *
+ * Unlike {@link useNow} (which ticks every second), this hook re-renders only
+ * once per minute, so it suits surfaces that show minute-granularity time
+ * without incurring per-second re-renders.
+ */
+export function useCurrentTime(): Date {
+  const [now, setNow] = useState<Date>(() => new Date())
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+    let intervalId: ReturnType<typeof setInterval> | null = null
+
+    const tick = () => setNow(new Date())
+
+    function start() {
+      stop()
+      const current = new Date()
+      const msUntilNextMinute =
+        (60 - current.getSeconds()) * 1000 - current.getMilliseconds()
+      timeoutId = setTimeout(() => {
+        tick()
+        intervalId = setInterval(tick, 60_000)
+      }, msUntilNextMinute)
+    }
+    function stop() {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+        timeoutId = null
+      }
+      if (intervalId !== null) {
+        clearInterval(intervalId)
+        intervalId = null
+      }
+    }
+    function handleVisibility() {
+      if (document.hidden) stop()
+      else { tick(); start() }
+    }
+
+    if (!document.hidden) start()
+    document.addEventListener('visibilitychange', handleVisibility)
+    return () => {
+      stop()
+      document.removeEventListener('visibilitychange', handleVisibility)
+    }
+  }, [])
+
+  return now
+}

--- a/web/src/pages/TodayView.tsx
+++ b/web/src/pages/TodayView.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react'
 import type { ComponentType } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth'
+import { useCurrentTime } from '../hooks/useCurrentTime'
 import { formatDate, formatTime } from '../utils/formatDate'
 import ParentTodayView from '../components/today/ParentTodayView'
 import KidTodayView from '../components/today/KidTodayView'
@@ -27,28 +27,7 @@ const widgetsByRole: Record<FamilyRole, ComponentType> = {
 export default function TodayView() {
   const { t } = useTranslation('today')
   const role = useFamilyRole()
-  const [now, setNow] = useState(() => new Date())
-
-  useEffect(() => {
-    let intervalId: ReturnType<typeof setInterval> | undefined
-
-    const updateNow = () => setNow(new Date())
-    const current = new Date()
-    const msUntilNextMinute =
-      (60 - current.getSeconds()) * 1000 - current.getMilliseconds()
-
-    const timeoutId = setTimeout(() => {
-      updateNow()
-      intervalId = setInterval(updateNow, 60_000)
-    }, msUntilNextMinute)
-
-    return () => {
-      clearTimeout(timeoutId)
-      if (intervalId) {
-        clearInterval(intervalId)
-      }
-    }
-  }, [])
+  const now = useCurrentTime()
 
   if (role === null) return null
 


### PR DESCRIPTION
## Changes

- **Extract minute-tick clock into a reusable hook** - Moved the minute-aligned clock logic out of TodayView into a new `useCurrentTime` hook that ticks on wall-clock minute boundaries and pauses while the tab is hidden. No change to the Today page behavior. (Hytte-4mh0)

## Original Issue (feature): Extract the minute-tick clock into a reusable useCurrentTime hook

### Scope
Extract the minute-aligned clock currently inlined in `TodayView` (`web/src/pages/TodayView.tsx:30-51`) into a reusable hook at `web/src/hooks/useCurrentTime.ts` that returns a live `Date` ticking on minute boundaries. `TodayView` consumes the hook and drops its local `now` state plus the `setTimeout`/`setInterval` effect. Note: a related `useNow` hook already exists (`web/src/hooks/useNow.ts`) but ticks every **second** and is not minute-aligned; this plan adds a distinct minute-granularity hook rather than reusing it, since the surfaces named in the suggestion want minute-level updates without per-second re-renders.

### Files to touch
- `web/src/hooks/useCurrentTime.ts` (new) — the extracted hook
- `web/src/hooks/useCurrentTime.test.ts` (new) — unit test with fake timers
- `web/src/pages/TodayView.tsx` — consume the hook, remove inline clock state/effect and now-unused `useState`/`useEffect` imports if no longer referenced

### Acceptance criteria
- `useCurrentTime()` returns a `Date` and triggers a re-render at the start of each wall-clock minute (aligned to `:00` seconds), matching the existing inline behavior.
- The hook clears its timeout/interval on unmount with no leaked timers (verified by test).
- `TodayView` renders the same time-derived content as before with no local clock state or timer effect remaining.
- The hook follows the visibility-change pattern from `useNow.ts` (pause while `document.hidden`, snap to current time and resume on becoming visible), so the "visibility-change fix" referenced in the suggestion is centralized.
- `npm run lint` and `npm run build` pass; `npm test` (or the project test runner) passes including the new hook test.
- No visual or behavioral regression on `/today` at 375px and desktop widths.

### Non-goals
- Wiring the hook into the sidebar header, dashboard, or child view — that adoption is follow-up work, not part of this extraction.
- Refactoring, replacing, or deduplicating the existing `useNow.ts` second-tick hook.
- Adding i18n keys, changing time formatting, or altering `TodayView` layout/role-dispatch logic.
- Configurable tick intervals or a generalized clock abstraction beyond minute granularity.

## Source

Created from Suggestions page (suggestion id 6, page slug "today", source=claude).

## Original suggestion

The minute-aligned `setTimeout`/`setInterval` dance lives inline in `TodayView` but is generic clock logic that other surfaces (sidebar header, dashboard, child view) will likely want. Move it into `web/src/hooks/useCurrentTime.ts` returning a `Date`, and have TodayView consume it. This keeps the page component focused on layout and role dispatch, and makes the visibility-change fix above easier to apply consistently across the app.


---
Bead: Hytte-4mh0 | Branch: forge/Hytte-4mh0
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->