### PR TITLE
Fix viewport height on mobile browsers with dynamic toolbars (Hytte-buh5)

### DIFF
--- a/changelog.d/Hytte-buh5.md
+++ b/changelog.d/Hytte-buh5.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Today page viewport height on mobile** - Switched the Today view's root container from static `100vh` to dynamic viewport units (`100dvh`) so the widget grid is no longer clipped behind iOS Safari / Chrome Android dynamic toolbars. (Hytte-buh5)

--- a/web/src/pages/TodayView.tsx
+++ b/web/src/pages/TodayView.tsx
@@ -58,7 +58,7 @@ export default function TodayView() {
   const Widgets = widgetsByRole[role]
 
   return (
-    <div className="h-[calc(100vh-3.5rem)] md:h-screen flex flex-col p-4 sm:p-6 overflow-hidden">
+    <div className="h-[calc(100dvh-3.5rem)] md:h-[100dvh] flex flex-col p-4 sm:p-6 overflow-hidden">
       {/* Header: time + date, watch-face style */}
       <header className="text-center mb-4 sm:mb-6 shrink-0">
         <time className="text-4xl sm:text-5xl font-light tabular-nums tracking-tight">


### PR DESCRIPTION
## Changes

- **Today page viewport height on mobile** - Switched the Today view's root container from static `100vh` to dynamic viewport units (`100dvh`) so the widget grid is no longer clipped behind iOS Safari / Chrome Android dynamic toolbars. (Hytte-buh5)

## Original Issue (feature): Fix viewport height on mobile browsers with dynamic toolbars

### Scope
This bugfix replaces the static `100vh`-based viewport sizing on the Today page with dynamic viewport units (`100dvh`) so the widget grid is no longer clipped behind iOS Safari / Chrome Android dynamic toolbars. The change is isolated to the single root container of `TodayView`; it does not touch the shared layout or other pages.

### Files to touch
- `web/src/pages/TodayView.tsx` — update the root container height classes on the `overflow-hidden` flex column.
- `changelog.d/<Hytte-xxxx>.md` (new) — changelog fragment under category `Fixed`.

### Acceptance criteria
- The root container in `TodayView.tsx` (currently `h-[calc(100vh-3.5rem)] md:h-screen`) uses dynamic viewport units, e.g. `h-[calc(100dvh-3.5rem)] md:h-[100dvh]` (or `md:h-dvh`), while preserving the existing `3.5rem` mobile header offset and the `md:` breakpoint behavior.
- On iOS Safari and Chrome Android, with the browser address bar visible, the full Today widget grid is reachable — no content is clipped behind the dynamic toolbar.
- Desktop (`md` and up) layout is unchanged: the view still fills the available height with no new scrollbars or layout shift.
- `overflow-hidden` and the `flex flex-col p-4 sm:p-6` layout on the container are retained; no inner widget sizing is altered.
- A changelog fragment exists in `changelog.d/` under `Fixed` referencing the bead ID.
- `npm run lint` and `npm run build` pass.

### Non-goals
- Migrating any of the other ~26 files that use `100vh`/`h-screen` (Notes, Chat, Math pages, Sidebar, etc.) — those are out of scope and may be tracked separately.
- Introducing a shared height utility, Tailwind config change, or global CSS custom property for viewport height.
- Any JS-based viewport measurement (e.g. `--vh` resize listeners) — this is a pure CSS-unit swap.
- Redesigning the Today widget grid, its content, or scroll behavior.

## Source

Created from Suggestions page (suggestion id 110, page slug "today", source=claude).

## Original suggestion

The container uses `h-[calc(100vh-3.5rem)] md:h-screen` with `overflow-hidden`, which on iOS Safari and Chrome Android causes the bottom of the widget grid to be clipped behind the dynamic address bar since `100vh` reflects the largest viewport size. Switch to `100dvh` (dynamic viewport units) so the layout adapts as the toolbar shows and hides. Users on mobile will see the full widget grid without content being hidden under browser chrome, which matters because Today is meant to be a glanceable view often opened on phones.


---
Bead: Hytte-buh5 | Branch: forge/Hytte-buh5
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->