### PR TITLE
Abort in-flight solver request when board or rack changes (Hytte-enz3)

### DIFF
--- a/changelog.d/Hytte-enz3.md
+++ b/changelog.d/Hytte-enz3.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Abort stale Wordfeud solver requests on position change** - Editing the board or changing the rack while a solve is in flight now aborts that request so its slow response can no longer overwrite the current results, and clears the move selection/hover so preview overlays never highlight squares that no longer match the board. (Hytte-enz3)

--- a/web/src/pages/WordfeudBoard.tsx
+++ b/web/src/pages/WordfeudBoard.tsx
@@ -437,6 +437,29 @@ export default function WordfeudBoard() {
     handleSolveRef.current = handleSolve
   }, [handleSolve])
 
+  // Stable serialized signature of the current position (board + rack). It changes
+  // only on real board/rack edits, not on unrelated re-renders or object-identity
+  // churn, so the abort effect below fires precisely when the position changes.
+  const positionSignature = useMemo(() => {
+    const boardSig = board
+      .map(row => row.map(cell => (cell ? `${cell.letter}${cell.isBlank ? '*' : ''}` : '')).join(','))
+      .join('|')
+    return `${boardSig}#${rackInput}`
+  }, [board, rackInput])
+
+  // When the board or rack changes, abort any solve started against the now-stale
+  // position so its (potentially slow) response can never overwrite solverMoves, and
+  // clear move selection/hover so no preview overlay highlights squares that no longer
+  // match the displayed board. Keyed only on the serialized signature. This runs before
+  // the auto-solve effect below (declaration order), so a fresh auto-solve started for
+  // the new position is not aborted by it.
+  useEffect(() => {
+    solveControllerRef.current?.abort()
+    setSolving(false)
+    setSelectedMoveIdx(null)
+    setHoveredMoveIdx(null)
+  }, [positionSignature])
+
   useEffect(() => {
     if (!autoSolvePending || loadingGame) return
 

--- a/web/src/pages/WordfeudBoard.tsx
+++ b/web/src/pages/WordfeudBoard.tsx
@@ -447,17 +447,13 @@ export default function WordfeudBoard() {
     return `${boardSig}#${rackInput}`
   }, [board, rackInput])
 
-  // When the board or rack changes, abort any solve started against the now-stale
-  // position so its (potentially slow) response can never overwrite solverMoves, and
-  // clear move selection/hover so no preview overlay highlights squares that no longer
-  // match the displayed board. Keyed only on the serialized signature. This runs before
-  // the auto-solve effect below (declaration order), so a fresh auto-solve started for
-  // the new position is not aborted by it.
   useEffect(() => {
     solveControllerRef.current?.abort()
-    setSolving(false)
-    setSelectedMoveIdx(null)
-    setHoveredMoveIdx(null)
+    startTransition(() => {
+      setSolving(false)
+      setSelectedMoveIdx(null)
+      setHoveredMoveIdx(null)
+    })
   }, [positionSignature])
 
   useEffect(() => {


### PR DESCRIPTION
## Changes

- **Abort stale Wordfeud solver requests on position change** - Editing the board or changing the rack while a solve is in flight now aborts that request so its slow response can no longer overwrite the current results, and clears the move selection/hover so preview overlays never highlight squares that no longer match the board. (Hytte-enz3)

## Original Issue (feature): Abort in-flight solver request when board or rack changes

### Scope
`WordfeudBoard` aborts the prior solve when a new solve starts, but rack (`rackInput`) and board edits don't abort an in-flight request. A slow solve against an old position can resolve after the user changed things and overwrite `solverMoves` with stale data, leaving preview overlays (`highlightCells`/hover) pointing at squares that no longer match the board. This plan adds a position-change effect that aborts the in-flight request and clears stale selection/hover state in `WordfeudBoard.tsx` only.

### Files to touch
- `web/src/pages/WordfeudBoard.tsx` — add a `useEffect` keyed on a serialized board+rack signature that aborts `solveControllerRef.current` and resets `selectedMoveIdx`/`hoveredMoveIdx`.
- `changelog.d/` — add a `Fixed` fragment (new).

### Acceptance criteria
- Editing the board (placing/removing tiles) or changing the rack input while a solve is in flight aborts that request; its result never overwrites `solverMoves`.
- A stale/aborted solve response does not replace results computed for the current position (no flash of moves for the old board).
- When the underlying board or rack changes, `selectedMoveIdx` and `hoveredMoveIdx` reset to `null`, so no preview overlay highlights squares that don't match the displayed board.
- The abort effect is keyed on a stable serialized signature of board + rack (a memoized string), not on object identity, so it fires only on real position changes — not on unrelated re-renders.
- Existing behavior is preserved: starting a new solve still aborts the previous one; the unmount cleanup `solveControllerRef.current?.abort()` still runs.
- `npm run lint` and `npm run build` pass; no new TypeScript errors.

### Non-goals
- No backend changes (`internal/wordfeud/*`) — purely a frontend race fix.
- No change to the solve request API, debounce/auto-solve behavior, or how moves are rendered/highlighted.
- No new tests harness setup beyond what the file already uses; no refactor of solver state management.
- Does not address other pages (`WordfeudPage.tsx`, `WordfeudLocalGames.tsx`).

## Source

Created from Suggestions page (suggestion id 103, page slug "wordfeud", source=claude).

## Original suggestion

`WordfeudBoard` keeps `solveControllerRef` for cancelling solver requests, but the rack input and board edits don't trigger an abort, so a slow solve started against an old position can land after the user has changed the board and overwrite `solverMoves` with stale results (which then highlight wrong squares on hover/select). Call `solveControllerRef.current?.abort()` from a `useEffect` keyed on a serialized board+rack hash, and also clear `selectedMoveIdx`/`hoveredMoveIdx` when the underlying position changes. This prevents the confusing case where preview overlays point at squares that no longer match the displayed board.


---
Bead: Hytte-enz3 | Branch: forge/Hytte-enz3
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->