### PR TITLE
Replace /workouts/latest polling with SSE push for new workout banner (Hytte-etux)

### DIFF
--- a/changelog.d/Hytte-etux.md
+++ b/changelog.d/Hytte-etux.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Push new-workout notifications over SSE instead of polling** - The Training page now subscribes to a per-user Server-Sent Events stream (`GET /api/training/events`) and shows the "new workouts" banner within ~1-2s of a FIT upload. This replaces the 30s-5min visibility-aware `/workouts/latest` polling loop, so a quiet Training tab generates zero idle traffic. The client does a single `/latest` fetch on each (re)connect to reconcile events missed while disconnected. (Hytte-etux)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -466,6 +466,7 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Use(auth.RequireFeature(db, "training"))
 				r.Get("/training/workouts", training.ListHandler(db))
 				r.Get("/training/workouts/latest", training.LatestHandler(db))
+				r.Get("/training/events", training.StreamHandler(training.DefaultHub()))
 				r.Get("/training/workouts/{id}", training.GetHandler(db))
 				r.Put("/training/workouts/{id}", training.UpdateHandler(db))
 				r.Delete("/training/workouts/{id}", training.DeleteHandler(db))

--- a/internal/training/handlers.go
+++ b/internal/training/handlers.go
@@ -247,13 +247,8 @@ func UploadHandler(db *sql.DB) http.HandlerFunc {
 			imported = append(imported, *workout)
 		}
 
-		scheduleBackgroundAnalysis(db, user.ID, user.IsAdmin, imported)
-
-		// Notify any open Training tabs for this user that new workouts landed,
-		// so they can show the "new workouts" banner without polling. The event
-		// carries only the highest imported id as a signal — clients fetch the
-		// details themselves. Publishing is best-effort and never affects the
-		// upload response.
+		// Notify open Training tabs before kicking off background analysis,
+		// which may do synchronous DB work and delay this signal.
 		if len(imported) > 0 {
 			var latestID int64
 			for _, wkt := range imported {
@@ -263,6 +258,8 @@ func UploadHandler(db *sql.DB) http.HandlerFunc {
 			}
 			DefaultHub().Publish(user.ID, Event{Type: EventWorkoutNew, LatestID: latestID})
 		}
+
+		scheduleBackgroundAnalysis(db, user.ID, user.IsAdmin, imported)
 
 		writeJSON(w, http.StatusCreated, map[string]any{
 			"imported": imported,

--- a/internal/training/handlers.go
+++ b/internal/training/handlers.go
@@ -249,6 +249,21 @@ func UploadHandler(db *sql.DB) http.HandlerFunc {
 
 		scheduleBackgroundAnalysis(db, user.ID, user.IsAdmin, imported)
 
+		// Notify any open Training tabs for this user that new workouts landed,
+		// so they can show the "new workouts" banner without polling. The event
+		// carries only the highest imported id as a signal — clients fetch the
+		// details themselves. Publishing is best-effort and never affects the
+		// upload response.
+		if len(imported) > 0 {
+			var latestID int64
+			for _, wkt := range imported {
+				if wkt.ID > latestID {
+					latestID = wkt.ID
+				}
+			}
+			DefaultHub().Publish(user.ID, Event{Type: EventWorkoutNew, LatestID: latestID})
+		}
+
 		writeJSON(w, http.StatusCreated, map[string]any{
 			"imported": imported,
 			"errors":   errs,

--- a/internal/training/hub.go
+++ b/internal/training/hub.go
@@ -1,0 +1,119 @@
+package training
+
+import (
+	"sync"
+)
+
+// Event is a single signal broadcast to Subscribers of a user. Type is the SSE
+// `event:` line value (e.g. "workout_new"); LatestID carries the highest
+// workout id known at publish time so a freshly (re)connected client can
+// reconcile against its own last-seen id. The event deliberately carries no
+// workout payload — clients fetch /api/training/workouts/latest (or the full
+// list) when they need details.
+type Event struct {
+	Type     string `json:"-"`
+	LatestID int64  `json:"latest_id"`
+}
+
+// EventWorkoutNew is the only event type currently published. Kept as a
+// constant so callers cannot typo the name silently.
+const EventWorkoutNew = "workout_new"
+
+// Subscriber is a single SSE client subscription. The channel is buffered so a
+// publisher can fan out without blocking on a slow consumer; if the buffer
+// fills up the publish for that Subscriber is dropped (the client will pick up
+// the next event or do a /latest fetch on reconnect).
+type Subscriber struct {
+	ch chan Event
+}
+
+// SubscriberBufferSize is the per-Subscriber channel buffer. Workout inserts
+// are infrequent, but a small buffer absorbs back-to-back imports from a
+// multi-file upload without forcing the publisher to block.
+const SubscriberBufferSize = 8
+
+// Hub is an in-memory pub/sub broker keyed by user ID. Safe for concurrent
+// use. Each user's open Training tabs subscribe; the upload/import path
+// publishes a workout_new event for that user after the row is committed.
+type Hub struct {
+	mu   sync.RWMutex
+	subs map[int64]map[*Subscriber]struct{}
+}
+
+// NewHub returns an empty Hub ready for use.
+func NewHub() *Hub {
+	return &Hub{
+		subs: make(map[int64]map[*Subscriber]struct{}),
+	}
+}
+
+// Subscribe registers a new Subscriber for the given user and returns it. The
+// caller must Unsubscribe when finished, typically via defer.
+func (h *Hub) Subscribe(userID int64) *Subscriber {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := &Subscriber{ch: make(chan Event, SubscriberBufferSize)}
+	if h.subs[userID] == nil {
+		h.subs[userID] = make(map[*Subscriber]struct{})
+	}
+	h.subs[userID][s] = struct{}{}
+	return s
+}
+
+// Unsubscribe removes the Subscriber and closes its channel. Idempotent and
+// safe to call even if the Subscriber was already removed.
+func (h *Hub) Unsubscribe(userID int64, s *Subscriber) {
+	if s == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	set, ok := h.subs[userID]
+	if !ok {
+		return
+	}
+	if _, present := set[s]; !present {
+		return
+	}
+	delete(set, s)
+	if len(set) == 0 {
+		delete(h.subs, userID)
+	}
+	close(s.ch)
+}
+
+// Publish fans out the event to every Subscriber of userID. Sends are
+// non-blocking: if a Subscriber's buffer is full, that Subscriber misses this
+// event (and others still receive it). This keeps one stalled client from
+// blocking delivery to the user's other tabs. Publishing to a user with no
+// subscribers is a harmless no-op.
+func (h *Hub) Publish(userID int64, evt Event) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for s := range h.subs[userID] {
+		select {
+		case s.ch <- evt:
+		default:
+		}
+	}
+}
+
+// Events returns the receive channel for the Subscriber. Exposed as a method
+// so Subscriber's channel field can stay unexported.
+func (s *Subscriber) Events() <-chan Event {
+	return s.ch
+}
+
+// defaultHub is the process-wide hub used by request handlers. The upload
+// handler publishes into this hub after committing a workout; the SSE stream
+// handler subscribes to it. Tests construct their own hubs via NewHub and pass
+// them directly to StreamHandler so they do not share state with production
+// code.
+var defaultHub = NewHub()
+
+// DefaultHub returns the process-wide hub. The upload/import path calls
+// DefaultHub().Publish(...) after persisting a workout so subscribed SSE
+// clients see the change.
+func DefaultHub() *Hub {
+	return defaultHub
+}

--- a/internal/training/hub_test.go
+++ b/internal/training/hub_test.go
@@ -1,0 +1,164 @@
+package training
+
+import (
+	"testing"
+	"time"
+)
+
+// subscriberCount and userCount are test-only helpers for verifying hub
+// cleanup. They live here so the production build does not carry them.
+
+func (h *Hub) subscriberCount(userID int64) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.subs[userID])
+}
+
+func (h *Hub) userCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.subs)
+}
+
+// recvWithin waits up to d for an event on sub.Events(). It fails the test if
+// nothing arrives in time.
+func recvWithin(t *testing.T, sub *Subscriber, d time.Duration) Event {
+	t.Helper()
+	select {
+	case evt, ok := <-sub.Events():
+		if !ok {
+			t.Fatal("subscriber channel closed unexpectedly")
+		}
+		return evt
+	case <-time.After(d):
+		t.Fatalf("no event received within %s", d)
+	}
+	return Event{}
+}
+
+func TestHub_PublishFanout(t *testing.T) {
+	h := NewHub()
+	a := h.Subscribe(1)
+	defer h.Unsubscribe(1, a)
+	b := h.Subscribe(1)
+	defer h.Unsubscribe(1, b)
+
+	h.Publish(1, Event{Type: EventWorkoutNew, LatestID: 42})
+
+	gotA := recvWithin(t, a, time.Second)
+	gotB := recvWithin(t, b, time.Second)
+	if gotA.Type != EventWorkoutNew || gotB.Type != EventWorkoutNew {
+		t.Fatalf("unexpected event types: a=%q b=%q", gotA.Type, gotB.Type)
+	}
+	if gotA.LatestID != 42 || gotB.LatestID != 42 {
+		t.Fatalf("unexpected latest ids: a=%d b=%d", gotA.LatestID, gotB.LatestID)
+	}
+}
+
+func TestHub_IsolationBetweenUsers(t *testing.T) {
+	h := NewHub()
+	a := h.Subscribe(10)
+	defer h.Unsubscribe(10, a)
+	b := h.Subscribe(11)
+	defer h.Unsubscribe(11, b)
+
+	// Publish only to user 11 — user 10 must not see it.
+	h.Publish(11, Event{Type: EventWorkoutNew, LatestID: 7})
+
+	gotB := recvWithin(t, b, time.Second)
+	if gotB.Type != EventWorkoutNew || gotB.LatestID != 7 {
+		t.Fatalf("b expected workout_new latest=7, got %+v", gotB)
+	}
+
+	select {
+	case evt := <-a.Events():
+		t.Fatalf("a received cross-user event: %+v", evt)
+	case <-time.After(50 * time.Millisecond):
+		// good — no event leaked across users
+	}
+}
+
+func TestHub_UnsubscribeCleanup(t *testing.T) {
+	h := NewHub()
+	a := h.Subscribe(1)
+	b := h.Subscribe(1)
+
+	if got := h.subscriberCount(1); got != 2 {
+		t.Fatalf("expected 2 subscribers, got %d", got)
+	}
+
+	h.Unsubscribe(1, a)
+	if got := h.subscriberCount(1); got != 1 {
+		t.Fatalf("after first unsubscribe expected 1, got %d", got)
+	}
+
+	h.Unsubscribe(1, b)
+	if got := h.subscriberCount(1); got != 0 {
+		t.Fatalf("after second unsubscribe expected 0, got %d", got)
+	}
+	if got := h.userCount(); got != 0 {
+		t.Fatalf("expected map key reclaimed, userCount=%d", got)
+	}
+
+	// Subscriber channels must be closed after unsubscribe.
+	if _, open := <-a.Events(); open {
+		t.Fatal("expected a.Events() channel closed after unsubscribe")
+	}
+	if _, open := <-b.Events(); open {
+		t.Fatal("expected b.Events() channel closed after unsubscribe")
+	}
+
+	// Idempotent: unsubscribing again should not panic.
+	h.Unsubscribe(1, a)
+}
+
+func TestHub_UnsubscribeUnknownSubscriberNoPanic(t *testing.T) {
+	h := NewHub()
+	// Unsubscribe with a nil subscriber and one from an unknown user should
+	// both be no-ops.
+	h.Unsubscribe(9, nil)
+	stranger := &Subscriber{ch: make(chan Event, 1)}
+	h.Unsubscribe(9, stranger)
+}
+
+func TestHub_SlowSubscriberDoesNotBlock(t *testing.T) {
+	h := NewHub()
+	slow := h.Subscribe(1)
+	defer h.Unsubscribe(1, slow)
+
+	// Saturate the slow subscriber's buffer so any further publish would block
+	// if Publish were a synchronous send.
+	for i := 0; i < SubscriberBufferSize; i++ {
+		h.Publish(1, Event{Type: EventWorkoutNew, LatestID: int64(i)})
+	}
+
+	// Add a fast subscriber with an empty buffer.
+	fast := h.Subscribe(1)
+	defer h.Unsubscribe(1, fast)
+
+	// Publish must return promptly even though slow is full.
+	done := make(chan struct{})
+	go func() {
+		h.Publish(1, Event{Type: EventWorkoutNew, LatestID: 999})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Publish blocked when slow subscriber's buffer was full")
+	}
+
+	evt := recvWithin(t, fast, time.Second)
+	if evt.LatestID != 999 {
+		t.Fatalf("fast subscriber got unexpected event: %+v", evt)
+	}
+}
+
+func TestHub_NoSubscribersIsHarmless(t *testing.T) {
+	h := NewHub()
+	// Publish to a user that has no subscribers — should be a no-op.
+	h.Publish(99, Event{Type: EventWorkoutNew, LatestID: 1})
+	if h.userCount() != 0 {
+		t.Fatalf("expected no users, got %d", h.userCount())
+	}
+}

--- a/internal/training/stream.go
+++ b/internal/training/stream.go
@@ -1,0 +1,77 @@
+package training
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+)
+
+// streamHeartbeatInterval is how often the SSE handler writes a comment-only
+// heartbeat line to keep proxies and load balancers from idling out the
+// connection.
+const streamHeartbeatInterval = 30 * time.Second
+
+// StreamHandler returns an SSE handler at GET /api/training/events that pushes
+// workout_new events as they are published into hub for the authenticated
+// user. Only the requesting user's events are delivered — the hub is keyed on
+// user ID, so there is no cross-user leakage.
+//
+// hub is the pub/sub the handler subscribes to; callers wiring this into a
+// router should pass DefaultHub() so it shares state with the upload handler.
+func StreamHandler(hub *Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if user == nil {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "streaming not supported"})
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+		flusher.Flush()
+
+		sub := hub.Subscribe(user.ID)
+		defer hub.Unsubscribe(user.ID, sub)
+
+		ticker := time.NewTicker(streamHeartbeatInterval)
+		defer ticker.Stop()
+
+		ctx := r.Context()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
+					return
+				}
+				flusher.Flush()
+			case evt, open := <-sub.Events():
+				if !open {
+					return
+				}
+				data, err := json.Marshal(evt)
+				if err != nil {
+					log.Printf("training: marshal event %s for user %d: %v", evt.Type, user.ID, err)
+					continue
+				}
+				if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", evt.Type, data); err != nil {
+					return
+				}
+				flusher.Flush()
+			}
+		}
+	}
+}

--- a/internal/training/stream_test.go
+++ b/internal/training/stream_test.go
@@ -1,0 +1,254 @@
+package training
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+// newStreamRouter wires the SSE handler at the real route path with a fake user
+// injected into the request context.
+func newStreamRouter(t *testing.T, hub *Hub, user *auth.User) http.Handler {
+	t.Helper()
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := auth.ContextWithUser(req.Context(), user)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	r.Get("/api/training/events", StreamHandler(hub))
+	return r
+}
+
+func TestStreamHandler_Unauthenticated(t *testing.T) {
+	hub := NewHub()
+	// Router that injects no user into the context.
+	r := chi.NewRouter()
+	r.Get("/api/training/events", StreamHandler(hub))
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/training/events")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unauthenticated, got %d", resp.StatusCode)
+	}
+}
+
+func TestStreamHandler_SetsSSEHeaders(t *testing.T) {
+	hub := NewHub()
+	user := &auth.User{ID: 1, Email: "a@example.com", Name: "A"}
+
+	srv := httptest.NewServer(newStreamRouter(t, hub, user))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/training/events", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("expected SSE content type, got %q", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-cache" {
+		t.Fatalf("expected Cache-Control no-cache, got %q", cc)
+	}
+}
+
+func TestStreamHandler_ReceivesWorkoutNew(t *testing.T) {
+	hub := NewHub()
+	const userID int64 = 1
+	user := &auth.User{ID: userID, Email: "a@example.com", Name: "A"}
+
+	srv := httptest.NewServer(newStreamRouter(t, hub, user))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/training/events", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Wait until the handler has subscribed before publishing, otherwise the
+	// publish races the subscribe and the event is dropped.
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.subscriberCount(userID) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("subscriber never registered with hub")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	hub.Publish(userID, Event{Type: EventWorkoutNew, LatestID: 123})
+
+	type result struct {
+		event string
+		data  string
+		err   error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		var event, data string
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				event = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if event != "" {
+					resCh <- result{event: event, data: data}
+					return
+				}
+			}
+		}
+		resCh <- result{err: scanner.Err()}
+	}()
+
+	select {
+	case r := <-resCh:
+		if r.err != nil {
+			t.Fatalf("scanner: %v", r.err)
+		}
+		if r.event != EventWorkoutNew {
+			t.Fatalf("expected event %q, got %q", EventWorkoutNew, r.event)
+		}
+		if !strings.Contains(r.data, `"latest_id":123`) {
+			t.Fatalf("expected data to contain latest_id, got %q", r.data)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("did not receive SSE event in time")
+	}
+}
+
+func TestStreamHandler_NoCrossUserLeakage(t *testing.T) {
+	hub := NewHub()
+	const userID int64 = 1
+	user := &auth.User{ID: userID, Email: "a@example.com", Name: "A"}
+
+	srv := httptest.NewServer(newStreamRouter(t, hub, user))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/training/events", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.subscriberCount(userID) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("subscriber never registered with hub")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Publish for a different user — user 1's stream must not receive it.
+	hub.Publish(2, Event{Type: EventWorkoutNew, LatestID: 999})
+
+	gotCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "event: ") {
+				gotCh <- line
+				return
+			}
+		}
+	}()
+
+	select {
+	case line := <-gotCh:
+		t.Fatalf("received event meant for another user: %q", line)
+	case <-time.After(300 * time.Millisecond):
+		// good — no cross-user event delivered
+	}
+}
+
+func TestStreamHandler_UnsubscribesOnClientDisconnect(t *testing.T) {
+	hub := NewHub()
+	const userID int64 = 1
+	user := &auth.User{ID: userID, Email: "a@example.com", Name: "A"}
+
+	srv := httptest.NewServer(newStreamRouter(t, hub, user))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/training/events", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	// Wait for the subscriber to register.
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.subscriberCount(userID) == 0 {
+		if time.Now().After(deadline) {
+			resp.Body.Close()
+			cancel()
+			t.Fatal("subscriber never registered with hub")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Cancel the client request — the handler should unsubscribe.
+	cancel()
+	_ = resp.Body.Close()
+
+	deadline = time.Now().Add(2 * time.Second)
+	for hub.subscriberCount(userID) != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("expected subscriber removed after disconnect, still have %d", hub.subscriberCount(userID))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := hub.userCount(); got != 0 {
+		t.Fatalf("expected hub to reclaim user key, got %d", got)
+	}
+}

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -88,93 +88,63 @@ export default function Training() {
 
   useEffect(() => {
     if (!user) return
-    // Visibility-aware polling with exponential backoff: hit a cheap /latest
-    // endpoint that returns only the max workout id, and only the existing
-    // banner flow trips when a new id appears. Interval starts at 30s and
-    // doubles up to a 5min cap when no new workout is seen; visibility
-    // changes reset it.
-    const MIN_INTERVAL_MS = 30_000
-    const MAX_INTERVAL_MS = 5 * 60_000
-    const BACKOFF_FACTOR = 2
-
-    let timeoutId: ReturnType<typeof setTimeout> | null = null
-    let controller: AbortController | null = null
+    // Subscribe to a per-user SSE stream that the backend pings whenever a
+    // workout is imported. This replaces the old visibility-aware polling
+    // loop: a quiet page makes zero periodic /latest requests, and the "new
+    // workouts" banner appears within ~1-2s of an upload. EventSource handles
+    // reconnection automatically; on each (re)connect we do a single /latest
+    // fetch to cover any events missed while disconnected.
     let cancelled = false
-    let inFlight = false
-    let intervalMs = MIN_INTERVAL_MS
 
-    const schedule = (delay: number) => {
-      if (cancelled) return
-      timeoutId = setTimeout(poll, delay)
-    }
-
-    const poll = async () => {
-      if (cancelled) return
-      // Don't poll while hidden or while the banner is already pending.
-      // The visibilitychange handler will resume when the tab becomes visible.
-      if (document.hidden || hasNewWorkoutsRef.current) return
-      inFlight = true
-      controller = new AbortController()
+    // reconcile checks the cheap /latest endpoint and trips the banner if a
+    // workout id higher than what we've seen has appeared. Used on connect and
+    // reconnect so missed events are not lost.
+    const reconcile = async () => {
       try {
-        const res = await fetch('/api/training/workouts/latest', {
-          credentials: 'include',
-          signal: controller.signal,
-        })
-        if (!res.ok) {
-          intervalMs = Math.min(intervalMs * BACKOFF_FACTOR, MAX_INTERVAL_MS)
-          schedule(intervalMs)
-          return
-        }
+        const res = await fetch('/api/training/workouts/latest', { credentials: 'include' })
+        if (!res.ok) return
         const data = await res.json()
         const maxId: number = typeof data.latest_id === 'number' ? data.latest_id : 0
+        if (cancelled) return
         const seen = latestWorkoutIdRef.current
         if (maxId > 0 && (seen === null || maxId > seen)) {
           latestWorkoutIdRef.current = maxId
           hasNewWorkoutsRef.current = true
           setHasNewWorkouts(true)
-          intervalMs = MIN_INTERVAL_MS
-        } else {
-          intervalMs = Math.min(intervalMs * BACKOFF_FACTOR, MAX_INTERVAL_MS)
         }
       } catch {
-        // AbortError on unmount or transient network failure — back off.
-        intervalMs = Math.min(intervalMs * BACKOFF_FACTOR, MAX_INTERVAL_MS)
-      } finally {
-        inFlight = false
+        // Transient network failure — EventSource will reconnect and we will
+        // reconcile again on the next open.
       }
-      schedule(intervalMs)
     }
 
-    const handleVisibilityChange = () => {
-      if (document.hidden) {
-        // Pause polling while hidden: cancel any pending timeout.
-        if (timeoutId !== null) {
-          clearTimeout(timeoutId)
-          timeoutId = null
-        }
-        return
-      }
-      // Tab became visible — abort any in-flight request and poll immediately.
-      intervalMs = MIN_INTERVAL_MS
-      if (inFlight && controller !== null) {
-        controller.abort()
-        inFlight = false
-      }
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId)
-        timeoutId = null
-      }
-      schedule(0)
-    }
+    const es = new EventSource('/api/training/events', { withCredentials: true })
 
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    schedule(intervalMs)
+    // onopen fires on the initial connection and after every automatic
+    // reconnect, so this single /latest fetch covers the reconnect-reconcile
+    // requirement without any manual backoff/visibility bookkeeping.
+    es.onopen = () => { reconcile() }
+
+    es.addEventListener('workout_new', (e: MessageEvent) => {
+      if (cancelled) return
+      let maxId = 0
+      try {
+        const data = JSON.parse(e.data)
+        if (typeof data.latest_id === 'number') maxId = data.latest_id
+      } catch {
+        // Malformed payload — fall back to trusting the signal itself below.
+      }
+      const seen = latestWorkoutIdRef.current
+      if (maxId === 0 || seen === null || maxId > seen) {
+        if (maxId > 0) latestWorkoutIdRef.current = maxId
+        hasNewWorkoutsRef.current = true
+        setHasNewWorkouts(true)
+      }
+    })
 
     return () => {
       cancelled = true
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-      if (timeoutId !== null) clearTimeout(timeoutId)
-      if (controller !== null) controller.abort()
+      es.close()
     }
   }, [user])
 


### PR DESCRIPTION
## Changes

- **Push new-workout notifications over SSE instead of polling** - The Training page now subscribes to a per-user Server-Sent Events stream (`GET /api/training/events`) and shows the "new workouts" banner within ~1-2s of a FIT upload. This replaces the 30s-5min visibility-aware `/workouts/latest` polling loop, so a quiet Training tab generates zero idle traffic. The client does a single `/latest` fetch on each (re)connect to reconcile events missed while disconnected. (Hytte-etux)

## Original Issue (feature): Replace /workouts/latest polling with SSE push for new workout banner

I have enough context to write a concrete plan.

### Scope
Replace the visibility-aware polling loop in `Training.tsx` (which hits `/api/training/workouts/latest` on a 30s–5min backoff) with a per-user Server-Sent Events stream at `GET /api/training/events`. The backend publishes a lightweight `workout_new` event into an in-memory per-user hub whenever a workout row is inserted for that user; the frontend subscribes via `EventSource`, shows the "new workouts" banner on receipt, and does one `/latest` fetch on (re)connect to cover events missed while disconnected. Mirror the existing `internal/familychat` hub + SSE pattern, but key the hub on `userID` instead of conversation ID.

### Files to touch
- `internal/training/hub.go` (new) — in-memory pub/sub keyed by `userID`, modeled on `internal/familychat/hub.go`.
- `internal/training/stream.go` (new) — SSE handler (`text/event-stream`, heartbeat, `r.Context()` lifecycle), modeled on `familychat/stream.go`.
- `internal/training/hub_test.go`, `internal/training/stream_test.go` (new).
- `internal/training/analysis.go` — publish a `workout_new` event after the workout `INSERT` succeeds (~line 230 upload/import path).
- `internal/api/router.go` — register `GET /api/training/events` under `RequireAuth` + `RequireFeature(db, "training")`.
- `web/src/pages/Training.tsx` — remove polling/backoff/visibility state machine; add `EventSource` subscription + single `/latest` fetch on connect.
- `changelog.d/Hytte-xxxx.md` (new).

### Acceptance criteria
- After a FIT upload completes for a user, any open Training tab for that user shows the "new workouts" banner within ~1–2s, without a page reload.
- A quiet Training page generates zero periodic `/api/training/workouts/latest` requests (verify in network tab); only an open `EventSource` to `/api/training/events` plus heartbeats remain.
- On SSE reconnect (tab sleep/network drop), the client does exactly one `/latest` fetch and reconciles the banner, so events missed while disconnected are not lost.
- The stream requires auth and the `training` feature flag; only the workout owner's tabs receive that user's events (no cross-user leakage).
- `make test` passes including new hub/stream tests; existing `LatestHandler` and its tests remain intact.

### Non-goals
- Removing or deprecating `GET /api/training/workouts/latest` — it stays as the reconnect/fallback fetch.
- Streaming workout payloads, trends, VO2max, or Claude-analysis updates over SSE (event carries only a signal/`latest_id`).
- Changes to `TrainingDetail.tsx`, `TrainingTrends.tsx`, or `TrainingCompare.tsx`.
- Persistence, replay history, or external push (webpush) integration for these events.
- Refactoring or consolidating with the `familychat` hub into a shared package.

## Source

Created from Suggestions page (suggestion id 159, page slug "training", source=claude).

## Original suggestion

The Training page currently polls /api/training/workouts/latest on a 30s–5min visibility-aware backoff loop just to detect when a new FIT file has been imported and show the 'new workouts' banner. Even with backoff, every active tab generates idle traffic and the banner can lag up to 5 minutes after an upload. Replace the polling loop with a Server-Sent Events stream (e.g. /api/training/events) that the backend pings whenever a workout is inserted for the authenticated user, falling back to a single fetch on reconnect. The result is near-instant banner appearance after an upload, zero idle traffic on a quiet page, and the visibility/backoff state machine in Training.tsx disappears.


---
Bead: Hytte-etux | Branch: forge/Hytte-etux
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->