### PR TITLE
Pause auto-refresh when the tab is hidden to avoid wasted Entur calls (Hytte-kc37)

### DIFF
--- a/changelog.d/Hytte-kc37.md
+++ b/changelog.d/Hytte-kc37.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Pause transit auto-refresh when the tab is hidden** - The Transit page no longer polls the Entur departures endpoint while the browser tab is backgrounded, saving API budget and battery. When the tab becomes visible again it performs an immediate refresh and resumes the 30-second cadence. (Hytte-kc37)

--- a/web/src/pages/Transit.tsx
+++ b/web/src/pages/Transit.tsx
@@ -117,9 +117,10 @@ export default function Transit() {
       }
     }
 
-    // Initial fetch, then begin polling if the tab is currently visible.
-    void fetchDepartures()
-    startPolling()
+    if (!document.hidden) {
+      void fetchDepartures()
+      startPolling()
+    }
     document.addEventListener('visibilitychange', handleVisibilityChange)
 
     return () => {

--- a/web/src/pages/Transit.tsx
+++ b/web/src/pages/Transit.tsx
@@ -69,12 +69,14 @@ export default function Transit() {
 
   const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const searchAbortRef = useRef<AbortController | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
 
-  // Initial load + auto-refresh every 30 seconds.
+  // Initial load + auto-refresh every 30 seconds, paused while the tab is hidden.
   useEffect(() => {
     const controller = new AbortController()
-    ;(async () => {
+
+    const fetchDepartures = async () => {
       setLoading(true)
       try {
         const res = await fetch('/api/transit/departures', { credentials: 'include', signal: controller.signal })
@@ -89,13 +91,41 @@ export default function Transit() {
       } finally {
         setLoading(false)
       }
-    })()
+    }
 
-    const interval = setInterval(() => setRefreshKey(k => k + 1), REFRESH_INTERVAL_MS)
+    const stopPolling = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+
+    // Only poll while the tab is visible; guard against accumulating intervals.
+    const startPolling = () => {
+      if (intervalRef.current || document.hidden) return
+      intervalRef.current = setInterval(() => setRefreshKey(k => k + 1), REFRESH_INTERVAL_MS)
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        // Pause polling so backgrounded tabs don't burn Entur API budget.
+        stopPolling()
+      } else {
+        // On return, immediately refresh and resume the regular cadence.
+        void fetchDepartures()
+        startPolling()
+      }
+    }
+
+    // Initial fetch, then begin polling if the tab is currently visible.
+    void fetchDepartures()
+    startPolling()
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 
     return () => {
       controller.abort()
-      clearInterval(interval)
+      stopPolling()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
   }, [refreshKey, t])
 


### PR DESCRIPTION
## Changes

- **Pause transit auto-refresh when the tab is hidden** - The Transit page no longer polls the Entur departures endpoint while the browser tab is backgrounded, saving API budget and battery. When the tab becomes visible again it performs an immediate refresh and resumes the 30-second cadence. (Hytte-kc37)

## Original Issue (feature): Pause auto-refresh when the tab is hidden to avoid wasted Entur calls

### Scope
The Transit page (`/transit`) uses a 30-second `setInterval` to poll the Entur-backed departures endpoint, and that interval keeps firing while the browser tab is backgrounded — wasting Entur API budget and battery, and overwriting any data the user hasn't yet seen on return. This plan adds a `visibilitychange` listener that pauses polling when `document.hidden` is true and performs an immediate refresh when the tab becomes visible again. The change is frontend-only and confined to `web/src/pages/Transit.tsx`.

### Files to touch
- `web/src/pages/Transit.tsx` — gate the refresh interval on tab visibility; add/clean up the `visibilitychange` listener; trigger an immediate fetch on becoming visible.
- `changelog.d/` — add a `Fixed` changelog fragment (new).

### Acceptance criteria
- When the tab is hidden (`document.hidden === true`), no departures fetch fires; the 30s interval is cleared or skipped while hidden.
- When the tab returns to visible, a single immediate refresh fires and the regular 30s interval resumes.
- No duplicate/overlapping intervals accumulate after repeated hide/show cycles (listener and interval are cleaned up correctly in the effect's teardown).
- Behavior while the tab is continuously visible is unchanged: departures still refresh roughly every 30 seconds.
- Stale background data is no longer silently overwritten before the user sees it — the first thing a returning user sees is a fresh fetch, not an overwrite-on-arrival of unviewed data.
- No new console errors/warnings; `npm run lint` and `npm run build` pass.
- A changelog fragment exists in `changelog.d/` under the `Fixed` category referencing the bead ID.

### Non-goals
- No backend changes to `internal/transit/handlers.go` (no server-side rate limiting or caching changes).
- No change to the 30-second polling interval value or making it user-configurable.
- No broader refactor of the Transit page's data-fetching, loading, or error-state logic.
- No applying the same visibility-pause pattern to other polling pages (dashboard, weather, etc.).
- No Page Visibility throttling beyond simple pause/resume (e.g. no backoff or partial-rate polling while hidden).

## Source

Created from Suggestions page (suggestion id 92, page slug "transit", source=claude).

## Original suggestion

The 30-second interval keeps firing while the tab is in the background, which burns through the Entur API budget and battery for no user benefit, and the stale data when the user returns is overwritten before they can see it. Add a `visibilitychange` listener that pauses the interval when `document.hidden` is true and triggers an immediate refresh on becoming visible again. This keeps departures fresh when the user is actually looking and stops the wasted traffic otherwise.


---
Bead: Hytte-kc37 | Branch: forge/Hytte-kc37
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->