### PR TITLE
Extract duplicated formatDistance/formatPace/formatDuration helpers (Hytte-oia8)

### DIFF
--- a/changelog.d/Hytte-oia8.md
+++ b/changelog.d/Hytte-oia8.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Unified Training distance/pace/duration formatting** - Consolidated the duplicated `formatDistance`, `formatPace`, and `formatDuration` helpers that were independently re-implemented across the Training pages into a single shared `web/src/utils/training.ts` module. Distances now use a consistent two-decimal kilometer format everywhere (fixing the previous 1-vs-2 fraction-digit divergence on the workout list). (Hytte-oia8)

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -3,7 +3,8 @@ import { Link } from 'react-router-dom'
 import { Dumbbell, Upload, TrendingUp, BarChart3, RefreshCw, X, Database } from 'lucide-react'
 import { useAuth } from '../auth'
 import { useTranslation } from 'react-i18next'
-import { formatDate, formatTime, formatNumber } from '../utils/formatDate'
+import { formatDate, formatTime } from '../utils/formatDate'
+import { formatDistance, formatDuration, formatPace } from '../utils/training'
 import type { Workout, WeeklySummary } from '../types/training'
 import TagBadge from '../components/TagBadge'
 
@@ -35,26 +36,6 @@ export default function Training() {
   const [backfillResult, setBackfillResult] = useState<string | null>(null)
   const latestWorkoutIdRef = useRef<number | null>(null)
   const hasNewWorkoutsRef = useRef(false)
-
-  function formatDuration(seconds: number): string {
-    const h = Math.floor(seconds / 3600)
-    const m = Math.floor((seconds % 3600) / 60)
-    if (h > 0) return t('units.hours_minutes', { h, m })
-    return t('units.minutes', { m })
-  }
-
-  function formatDistance(meters: number): string {
-    if (meters < 1000) return `${Math.round(meters)} ${t('units.m')}`
-    return `${formatNumber(meters / 1000, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} ${t('units.km')}`
-  }
-
-  function formatPace(secPerKm: number): string {
-    if (secPerKm <= 0) return '--:--'
-    let mins = Math.floor(secPerKm / 60)
-    let secs = Math.round(secPerKm % 60)
-    if (secs === 60) { mins++; secs = 0 }
-    return `${mins}:${secs.toString().padStart(2, '0')} ${t('units.pace')}`
-  }
 
   useEffect(() => {
     if (!user) return
@@ -392,8 +373,8 @@ export default function Training() {
                 <p className="text-xs text-gray-500 mb-1">
                   {formatDate(s.week_start + 'T00:00:00', { month: 'short', day: 'numeric' })}
                 </p>
-                <p className="text-lg font-bold">{formatDuration(s.total_duration_seconds)}</p>
-                <p className="text-sm text-gray-400">{formatDistance(s.total_distance_meters)}</p>
+                <p className="text-lg font-bold">{formatDuration(s.total_duration_seconds, t, { style: 'human' })}</p>
+                <p className="text-sm text-gray-400">{formatDistance(s.total_distance_meters, t)}</p>
                 <p className="text-xs text-gray-500">{t('weeklyVolume.workoutCount', { count: s.workout_count })}</p>
               </div>
             ))}
@@ -455,8 +436,8 @@ export default function Training() {
                 </div>
                 <div className="flex gap-4 sm:gap-6 text-sm text-gray-400 flex-shrink-0">
                   <div className="text-right">
-                    <p className="font-medium text-white">{formatDuration(w.duration_seconds)}</p>
-                    <p>{formatDistance(w.distance_meters)}</p>
+                    <p className="font-medium text-white">{formatDuration(w.duration_seconds, t, { style: 'human' })}</p>
+                    <p>{formatDistance(w.distance_meters, t)}</p>
                   </div>
                   {w.avg_heart_rate > 0 && (
                     <div className="text-right hidden sm:block">
@@ -466,7 +447,7 @@ export default function Training() {
                   )}
                   {w.avg_pace_sec_per_km > 0 && (
                     <div className="text-right hidden sm:block">
-                      <p className="font-medium text-white">{formatPace(w.avg_pace_sec_per_km)}</p>
+                      <p className="font-medium text-white">{formatPace(w.avg_pace_sec_per_km, t)}</p>
                       <p>{t('workouts.pace')}</p>
                     </div>
                   )}

--- a/web/src/pages/TrainingCompare.tsx
+++ b/web/src/pages/TrainingCompare.tsx
@@ -14,7 +14,7 @@ import { useAuth } from '../auth'
 import { useTranslation } from 'react-i18next'
 import { formatDate } from '../utils/formatDate'
 import { isAutoTag, isAITag, displayTag } from '../tags'
-import type { TFunction } from 'i18next'
+import { formatDuration, formatPace } from '../utils/training'
 import type { Workout, Lap, ComparisonResult, CachedComparisonAnalysis, ComparisonAnalysisSummary } from '../types/training'
 
 function workoutOptionLabel(w: Workout): string {
@@ -25,21 +25,6 @@ function workoutOptionLabel(w: Workout): string {
   return tagPart
     ? `${w.title} — ${tagPart} — ${formatDate(w.started_at)}`
     : `${w.title} — ${formatDate(w.started_at)}`
-}
-
-function formatPace(secPerKm: number, t: TFunction<'training'>): string {
-  if (secPerKm <= 0) return '--:--'
-  let mins = Math.floor(secPerKm / 60)
-  let secs = Math.round(secPerKm % 60)
-  if (secs === 60) { mins++; secs = 0 }
-  return `${mins}:${secs.toString().padStart(2, '0')} ${t('units.pace')}`
-}
-
-function formatDuration(seconds: number): string {
-  const total = Math.round(seconds)
-  const m = Math.floor(total / 60)
-  const s = total % 60
-  return `${m}:${s.toString().padStart(2, '0')}`
 }
 
 function LapPicker({
@@ -89,7 +74,7 @@ function LapPicker({
               </span>
               <span className="text-gray-300">{t('compare.lapPicker.lapLabel', { number: lapNum })}</span>
               <span className="ml-auto text-gray-500 text-xs tabular-nums">
-                {formatDuration(lap.duration_seconds)} · {formatPace(lap.avg_pace_sec_per_km, t)} · {lap.avg_heart_rate > 0 ? `${lap.avg_heart_rate} ${t('units.bpm')}` : '-'}
+                {formatDuration(lap.duration_seconds, t)} · {formatPace(lap.avg_pace_sec_per_km, t)} · {lap.avg_heart_rate > 0 ? `${lap.avg_heart_rate} ${t('units.bpm')}` : '-'}
               </span>
             </button>
           )

--- a/web/src/pages/TrainingDetail.tsx
+++ b/web/src/pages/TrainingDetail.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Trash2, Save, GitCompareArrows, Sparkles, RefreshCw, Loader2
 import { useAuth } from '../auth'
 import { useTranslation } from 'react-i18next'
 import { formatDate, formatTime, formatNumber } from '../utils/formatDate'
+import { formatDistance, formatDuration, formatPace } from '../utils/training'
 import type { Workout, ZoneDistribution, WorkoutAnalysis, CachedInsights, Lap, RacePredictions } from '../types/training'
 import type { StrideEvaluationRecord } from '../types/stride'
 import WorkoutHRChart from '../components/charts/WorkoutHRChart'
@@ -16,14 +17,6 @@ import TagBadge from '../components/TagBadge'
 import { isAutoTag, isAITag } from '../tags'
 import LactateImportDialog from '../components/LactateImportDialog'
 
-
-function formatDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  const s = seconds % 60
-  if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
-  return `${m}:${s.toString().padStart(2, '0')}`
-}
 
 function computePacingSplit(laps: Lap[]): 'positive' | 'negative' | 'even' | null {
   // Ignore very short laps (< 200 m) such as warmup/cooldown/trailing partial laps.
@@ -91,19 +84,6 @@ export default function TrainingDetail() {
   const contextAutoOpenedRef = useRef(false)
   const contextRefetchControllerRef = useRef<AbortController | null>(null)
   const hasContext = workoutContext !== null
-
-  function formatDistance(meters: number): string {
-    if (meters < 1000) return `${Math.round(meters)} ${t('units.m')}`
-    return `${formatNumber(meters / 1000, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${t('units.km')}`
-  }
-
-  function formatPace(secPerKm: number): string {
-    if (secPerKm <= 0) return '--:--'
-    let mins = Math.floor(secPerKm / 60)
-    let secs = Math.round(secPerKm % 60)
-    if (secs === 60) { mins++; secs = 0 }
-    return `${mins}:${secs.toString().padStart(2, '0')} ${t('units.pace')}`
-  }
 
   useEffect(() => {
     if (!user || !id) return
@@ -620,16 +600,16 @@ export default function TrainingDetail() {
             <p className="text-xs text-gray-400">
               {formatDate(`${linkedRace.date}T00:00:00`, { dateStyle: 'medium' })}
               {linkedRace.target_time != null && (
-                <> &middot; {t('detail.linkedRace.targetTime')}: {formatDuration(linkedRace.target_time)}</>
+                <> &middot; {t('detail.linkedRace.targetTime')}: {formatDuration(linkedRace.target_time, t)}</>
               )}
               {linkedRace.result_time != null && (
-                <> &middot; {t('detail.linkedRace.actualTime')}: {formatDuration(linkedRace.result_time)}</>
+                <> &middot; {t('detail.linkedRace.actualTime')}: {formatDuration(linkedRace.result_time, t)}</>
               )}
               {linkedRace.target_time != null && linkedRace.result_time != null && (
                 <> &middot; {t('detail.linkedRace.difference')}: {(() => {
                   const diff = linkedRace.result_time! - linkedRace.target_time!
                   const sign = diff < 0 ? '-' : diff > 0 ? '+' : ''
-                  return `${sign}${formatDuration(Math.abs(diff))}`
+                  return `${sign}${formatDuration(Math.abs(diff), t)}`
                 })()}</>
               )}
             </p>
@@ -829,8 +809,8 @@ export default function TrainingDetail() {
 
       {/* Summary stats */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-        <StatCard label={t('detail.stats.duration')} value={formatDuration(workout.duration_seconds)} />
-        <StatCard label={t('detail.stats.distance')} value={formatDistance(workout.distance_meters)} />
+        <StatCard label={t('detail.stats.duration')} value={formatDuration(workout.duration_seconds, t)} />
+        <StatCard label={t('detail.stats.distance')} value={formatDistance(workout.distance_meters, t)} />
         {workout.avg_heart_rate > 0 && (
           <StatCard
             label={t('detail.stats.avgHR')}
@@ -839,7 +819,7 @@ export default function TrainingDetail() {
           />
         )}
         {workout.avg_pace_sec_per_km > 0 && (
-          <StatCard label={t('detail.stats.avgPace')} value={formatPace(workout.avg_pace_sec_per_km)} />
+          <StatCard label={t('detail.stats.avgPace')} value={formatPace(workout.avg_pace_sec_per_km, t)} />
         )}
         {workout.calories > 0 && <StatCard label={t('detail.stats.calories')} value={`${workout.calories}`} />}
         {workout.ascent_meters > 0 && (
@@ -893,11 +873,11 @@ export default function TrainingDetail() {
                 {workout.laps.map((lap) => (
                   <tr key={lap.lap_number} className="border-b border-gray-700/50">
                     <td className="py-2 pr-4 text-gray-400">{lap.lap_number}</td>
-                    <td className="py-2 px-4 text-right">{formatDuration(Math.round(lap.duration_seconds))}</td>
-                    <td className="py-2 px-4 text-right">{formatDistance(lap.distance_meters)}</td>
+                    <td className="py-2 px-4 text-right">{formatDuration(Math.round(lap.duration_seconds), t)}</td>
+                    <td className="py-2 px-4 text-right">{formatDistance(lap.distance_meters, t)}</td>
                     <td className="py-2 px-4 text-right">{lap.avg_heart_rate > 0 ? lap.avg_heart_rate : '-'}</td>
                     <td className="py-2 px-4 text-right">{lap.max_heart_rate > 0 ? lap.max_heart_rate : '-'}</td>
-                    <td className="py-2 pl-4 text-right">{formatPace(lap.avg_pace_sec_per_km)}</td>
+                    <td className="py-2 pl-4 text-right">{formatPace(lap.avg_pace_sec_per_km, t)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/web/src/pages/TrainingTrends.tsx
+++ b/web/src/pages/TrainingTrends.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, TrendingUp, Sparkles } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { isAutoTag, displayTag, AUTO_TAG_TOOLTIP } from '../tags'
 import { formatDate, formatNumber } from '../utils/formatDate'
+import { formatDuration, formatPace } from '../utils/training'
 import { AcrGauge } from '../components/AcrGauge'
 import { WeeklyAiSummary } from '../components/WeeklyAiSummary'
 import {
@@ -149,14 +150,6 @@ function VO2maxChart({ data }: VO2maxChartProps) {
   )
 }
 
-function formatPace(secPerKm: number): string {
-  if (secPerKm <= 0) return '--:--'
-  let mins = Math.floor(secPerKm / 60)
-  let secs = Math.round(secPerKm % 60)
-  if (secs === 60) { mins++; secs = 0 }
-  return `${mins}:${secs.toString().padStart(2, '0')}`
-}
-
 export default function TrainingTrends() {
   const { user } = useAuth()
   const { t } = useTranslation(['training', 'common'])
@@ -168,11 +161,6 @@ export default function TrainingTrends() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedGroup, setSelectedGroup] = useState<string>('')
-
-  function formatDuration(seconds: number): string {
-    const h = (seconds / 3600).toFixed(1)
-    return `${h}${t('units.h')}`
-  }
 
   useEffect(() => {
     if (!user) return
@@ -308,7 +296,7 @@ export default function TrainingTrends() {
                 <Tooltip
                   contentStyle={{ backgroundColor: '#1f2937', border: '1px solid #374151', borderRadius: '8px', color: '#e5e7eb' }}
                   formatter={(value, name) => {
-                    if (name === 'hours') return [formatDuration(Number(value) * 3600), t('trends.weeklyVolume.duration')]
+                    if (name === 'hours') return [formatDuration(Number(value) * 3600, t, { style: 'decimal' }), t('trends.weeklyVolume.duration')]
                     if (name === 'km') return [`${value} ${t('units.km')}`, t('trends.weeklyVolume.distance')]
                     return [value, name]
                   }}
@@ -386,11 +374,11 @@ export default function TrainingTrends() {
                         reversed
                         domain={['dataMin - 5', 'dataMax + 5']}
                         tick={{ fill: '#9ca3af', fontSize: 11 }}
-                        tickFormatter={(v: number) => formatPace(v)}
+                        tickFormatter={(v: number) => formatPace(v, t, { withUnit: false })}
                       />
                       <Tooltip
                         contentStyle={{ backgroundColor: '#1f2937', border: '1px solid #374151', borderRadius: '8px', color: '#e5e7eb' }}
-                        formatter={(value) => [formatPace(Number(value)), t('trends.paceTrend.avgPace')]}
+                        formatter={(value) => [formatPace(Number(value), t, { withUnit: false }), t('trends.paceTrend.avgPace')]}
                       />
                       <Line type="monotone" dataKey="avgPace" stroke="#3b82f6" strokeWidth={2} dot={{ r: 3, fill: '#3b82f6' }} name={t('trends.paceTrend.avgPace')} />
                     </LineChart>

--- a/web/src/utils/training.test.ts
+++ b/web/src/utils/training.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import type { TFunction } from 'i18next'
+import { formatDistance, formatDuration, formatPace } from './training'
+
+// Minimal stub for the i18n `t` function: returns the unit suffixes the real
+// `training` locale provides and interpolates the duration helper keys, so the
+// tests assert on predictable, locale-independent output.
+const t = ((key: string, vars?: Record<string, unknown>): string => {
+  switch (key) {
+    case 'units.m':
+      return 'm'
+    case 'units.km':
+      return 'km'
+    case 'units.h':
+      return 'h'
+    case 'units.pace':
+      return '/km'
+    case 'units.hours_minutes':
+      return `${vars?.h}h ${vars?.m}m`
+    case 'units.minutes':
+      return `${vars?.m}m`
+    default:
+      return key
+  }
+}) as unknown as TFunction<'training'>
+
+describe('formatDistance', () => {
+  it('renders sub-1km distances in whole meters', () => {
+    expect(formatDistance(0, t)).toBe('0 m')
+    expect(formatDistance(450, t)).toBe('450 m')
+    expect(formatDistance(999.4, t)).toBe('999 m')
+  })
+
+  it('renders multi-km distances with two fraction digits by default', () => {
+    expect(formatDistance(1000, t)).toBe('1.00 km')
+    expect(formatDistance(5234, t)).toBe('5.23 km')
+    expect(formatDistance(42195, t)).toBe('42.20 km')
+  })
+
+  it('honors an explicit fractionDigits override', () => {
+    expect(formatDistance(5234, t, { fractionDigits: 1 })).toBe('5.2 km')
+    expect(formatDistance(5234, t, { fractionDigits: 0 })).toBe('5 km')
+  })
+})
+
+describe('formatPace', () => {
+  it('returns --:-- for non-positive paces', () => {
+    expect(formatPace(0, t)).toBe('--:--')
+    expect(formatPace(-30, t)).toBe('--:--')
+  })
+
+  it('zero-pads seconds and appends the localized unit', () => {
+    expect(formatPace(305, t)).toBe('5:05 /km')
+    expect(formatPace(330, t)).toBe('5:30 /km')
+  })
+
+  it('rolls a rounded 60-second remainder over to the next minute', () => {
+    // 359.6s rounds to 60 seconds -> should become 6:00, not 5:60.
+    expect(formatPace(359.6, t)).toBe('6:00 /km')
+  })
+
+  it('omits the unit suffix when withUnit is false', () => {
+    expect(formatPace(305, t, { withUnit: false })).toBe('5:05')
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats clock style as M:SS without hours', () => {
+    expect(formatDuration(0, t)).toBe('0:00')
+    expect(formatDuration(65, t)).toBe('1:05')
+    expect(formatDuration(599, t)).toBe('9:59')
+  })
+
+  it('formats clock style as H:MM:SS once an hour is reached', () => {
+    expect(formatDuration(3600, t)).toBe('1:00:00')
+    expect(formatDuration(3661, t)).toBe('1:01:01')
+    expect(formatDuration(36000, t)).toBe('10:00:00')
+  })
+
+  it('rounds fractional seconds in clock style', () => {
+    expect(formatDuration(59.6, t)).toBe('1:00')
+  })
+
+  it('formats human style with localized hours and minutes', () => {
+    expect(formatDuration(0, t, { style: 'human' })).toBe('0m')
+    expect(formatDuration(1800, t, { style: 'human' })).toBe('30m')
+    expect(formatDuration(5400, t, { style: 'human' })).toBe('1h 30m')
+  })
+
+  it('formats decimal style with one fraction digit', () => {
+    expect(formatDuration(0, t, { style: 'decimal' })).toBe('0.0h')
+    expect(formatDuration(5400, t, { style: 'decimal' })).toBe('1.5h')
+    expect(formatDuration(360000, t, { style: 'decimal' })).toBe('100.0h')
+  })
+})

--- a/web/src/utils/training.test.ts
+++ b/web/src/utils/training.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import type { TFunction } from 'i18next'
-import { formatDistance, formatDuration, formatPace } from './training'
+
+vi.mock('./formatDate', () => ({
+  formatNumber: (n: number, opts?: Intl.NumberFormatOptions) =>
+    n.toLocaleString('en', opts),
+}))
+
+const { formatDistance, formatDuration, formatPace } = await import('./training')
 
 // Minimal stub for the i18n `t` function: returns the unit suffixes the real
 // `training` locale provides and interpolates the duration helper keys, so the

--- a/web/src/utils/training.ts
+++ b/web/src/utils/training.ts
@@ -1,0 +1,89 @@
+import type { TFunction } from 'i18next'
+import { formatNumber } from './formatDate'
+
+// Shared formatting helpers for the Training pages. These were previously
+// re-implemented (with subtle divergences) in Training, TrainingDetail,
+// TrainingCompare and TrainingTrends. Consolidating them here keeps unit
+// suffixes localized and the formatting rules consistent across pages.
+
+/**
+ * Format a distance given in meters.
+ *
+ * Distances below 1 km are shown in whole meters; longer distances are shown
+ * in kilometers. The kilometer fraction-digit count is fixed (default 2) so it
+ * no longer diverges between the list and detail views.
+ */
+export function formatDistance(
+  meters: number,
+  t: TFunction<'training'>,
+  opts?: { fractionDigits?: number },
+): string {
+  if (meters < 1000) return `${Math.round(meters)} ${t('units.m')}`
+  const digits = opts?.fractionDigits ?? 2
+  return `${formatNumber(meters / 1000, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  })} ${t('units.km')}`
+}
+
+/**
+ * Format a running pace given in seconds per kilometer as `M:SS`.
+ *
+ * Non-positive paces render as `--:--`. Seconds are zero-padded and rolled over
+ * to the next minute when rounding lands on 60. The localized `/km` suffix is
+ * appended unless `withUnit` is false (e.g. for chart axes that already label
+ * the unit).
+ */
+export function formatPace(
+  secPerKm: number,
+  t: TFunction<'training'>,
+  opts?: { withUnit?: boolean },
+): string {
+  if (secPerKm <= 0) return '--:--'
+  let mins = Math.floor(secPerKm / 60)
+  let secs = Math.round(secPerKm % 60)
+  if (secs === 60) {
+    mins++
+    secs = 0
+  }
+  const value = `${mins}:${secs.toString().padStart(2, '0')}`
+  return opts?.withUnit === false ? value : `${value} ${t('units.pace')}`
+}
+
+/**
+ * Format a duration given in seconds.
+ *
+ * Supports three styles:
+ * - `clock` (default): `H:MM:SS` with hours, otherwise `M:SS` — for precise
+ *   workout and lap durations.
+ * - `human`: localized `Xh Ym` / `Ym` — minute granularity for summaries.
+ * - `decimal`: localized hours with one fraction digit (e.g. `1.5h`) — for
+ *   chart axes and tooltips.
+ */
+export function formatDuration(
+  seconds: number,
+  t: TFunction<'training'>,
+  opts?: { style?: 'clock' | 'human' | 'decimal' },
+): string {
+  const style = opts?.style ?? 'clock'
+
+  if (style === 'human') {
+    const h = Math.floor(seconds / 3600)
+    const m = Math.floor((seconds % 3600) / 60)
+    if (h > 0) return t('units.hours_minutes', { h, m })
+    return t('units.minutes', { m })
+  }
+
+  if (style === 'decimal') {
+    return `${(seconds / 3600).toFixed(1)}${t('units.h')}`
+  }
+
+  const total = Math.round(seconds)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  if (h > 0) {
+    return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
+  }
+  return `${m}:${s.toString().padStart(2, '0')}`
+}

--- a/web/src/utils/training.ts
+++ b/web/src/utils/training.ts
@@ -75,7 +75,10 @@ export function formatDuration(
   }
 
   if (style === 'decimal') {
-    return `${(seconds / 3600).toFixed(1)}${t('units.h')}`
+    return `${formatNumber(seconds / 3600, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    })}${t('units.h')}`
   }
 
   const total = Math.round(seconds)


### PR DESCRIPTION
## Changes

- **Unified Training distance/pace/duration formatting** - Consolidated the duplicated `formatDistance`, `formatPace`, and `formatDuration` helpers that were independently re-implemented across the Training pages into a single shared `web/src/utils/training.ts` module. Distances now use a consistent two-decimal kilometer format everywhere (fixing the previous 1-vs-2 fraction-digit divergence on the workout list). (Hytte-oia8)

## Original Issue (feature): Extract duplicated formatDistance/formatPace/formatDuration helpers

### Scope
Consolidate the `formatDistance`, `formatPace`, and `formatDuration` helpers that are independently re-implemented across the Training pages into a single shared module `web/src/utils/training.ts`. Each helper takes the `t` function as an argument so it can render localized unit suffixes (km, min/km, etc.). All Training pages then import from this module, eliminating the current divergence (e.g. 1 vs 2 fraction digits for km). The shared behavior should standardize on the most correct existing variant; any deliberate per-call difference must be preserved via a parameter rather than a forked copy.

### Files to touch
- `web/src/utils/training.ts` (new) — exported `formatDistance`, `formatPace`, `formatDuration`, each accepting the i18n `t` function.
- `web/src/utils/training.test.ts` (new) — unit tests covering fraction-digit and seconds-handling edge cases.
- `web/src/pages/Training.tsx` — remove local helpers, import from utils.
- `web/src/pages/TrainingDetail.tsx` — remove local helpers, import from utils.
- `web/src/pages/TrainingCompare.tsx` — remove local helpers, import from utils.
- `web/src/pages/TrainingTrends.tsx` — remove its local `formatPace`/`formatDuration`, import from utils (also affected duplicates).
- `changelog.d/` — add a `Changed` fragment.

### Acceptance criteria
- `formatDistance`, `formatPace`, `formatDuration` are defined exactly once, in `web/src/utils/training.ts`, and exported.
- Training.tsx, TrainingDetail.tsx, TrainingCompare.tsx, and TrainingTrends.tsx contain no local re-definitions of these three helpers and import them from the utils module.
- The three helpers accept the `t` function as a parameter; no hardcoded English unit strings (i18n compliance preserved).
- Distance formatting uses a single, consistent fraction-digit rule across all pages; pace and duration seconds handling are identical across pages.
- New unit tests in `training.test.ts` pass and cover: sub-1km vs multi-km distances, zero/large durations, and pace seconds zero-padding.
- `npm run lint`, `npm run build`, and `npm test` all pass; rendered output on each Training page is visually unchanged except for the intentional fraction-digit fix.

### Non-goals
- Refactoring the other ~13 files that have unrelated `format*` helpers (Lactate, Stride, Family, Math, widgets, charts).
- Changing backend formatting in `internal/training/handlers.go`.
- Altering the visual layout, data fetching, or i18n key names/translation files.
- Introducing a unit-system (metric/imperial) toggle or any new user preference.

## Source

Created from Suggestions page (suggestion id 90, page slug "training", source=claude).

## Original suggestion

The same formatDistance, formatPace, and formatDuration helpers are reimplemented (with subtle differences in fraction digits and seconds handling) across Training.tsx, TrainingDetail.tsx, and TrainingCompare.tsx, which has already caused divergence (e.g. 1 vs 2 fraction digits for km). Move them into a shared web/src/utils/training.ts module that takes the t function as an argument, and import it everywhere. This eliminates a class of formatting-drift bugs and makes future i18n/unit changes a single-file edit.


---
Bead: Hytte-oia8 | Branch: forge/Hytte-oia8
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->