### PR TITLE
Add autosave with debounced PUT and a visible save status indicator (Hytte-qlly)

### DIFF
--- a/changelog.d/Hytte-qlly.md
+++ b/changelog.d/Hytte-qlly.md
@@ -1,0 +1,2 @@
+category: Added
+- **Notes autosave** - Existing notes now save automatically about 1.5s after you stop typing, with a status label near the toolbar showing "Saving…", "Saved <time> ago", or "Offline" if a save fails. The manual Save button still works and new notes are still created explicitly. (Hytte-qlly)

--- a/changelog.d/Hytte-qlly.md
+++ b/changelog.d/Hytte-qlly.md
@@ -1,2 +1,2 @@
 category: Added
-- **Notes autosave** - Existing notes now save automatically about 1.5s after you stop typing, with a status label near the toolbar showing "Saving…", "Saved <time> ago", or "Offline" if a save fails. The manual Save button still works and new notes are still created explicitly. (Hytte-qlly)
+- **Notes autosave** - Existing notes now save automatically about 1.5s after you stop typing, with a status label near the toolbar showing "Saving…", "Saved `<time>` ago", or "Offline" if a save fails. The manual Save button still works and new notes are still created explicitly. (Hytte-qlly)

--- a/web/public/locales/en/notes.json
+++ b/web/public/locales/en/notes.json
@@ -23,6 +23,14 @@
     "deleteNote": "Delete note",
     "closeLabel": "Close note editor"
   },
+  "status": {
+    "saving": "Saving…",
+    "savedJustNow": "Saved just now",
+    "savedSecondsAgo": "Saved {{count}}s ago",
+    "savedMinutesAgo": "Saved {{count}}m ago",
+    "savedHoursAgo": "Saved {{count}}h ago",
+    "offline": "Offline"
+  },
   "fields": {
     "titlePlaceholder": "Note title…",
     "titleLabel": "Note title",

--- a/web/public/locales/nb/notes.json
+++ b/web/public/locales/nb/notes.json
@@ -23,6 +23,14 @@
     "deleteNote": "Slett notat",
     "closeLabel": "Lukk notatredigerer"
   },
+  "status": {
+    "saving": "Lagrer…",
+    "savedJustNow": "Lagret nå nettopp",
+    "savedSecondsAgo": "Lagret for {{count}} s siden",
+    "savedMinutesAgo": "Lagret for {{count}} min siden",
+    "savedHoursAgo": "Lagret for {{count}} t siden",
+    "offline": "Frakoblet"
+  },
   "fields": {
     "titlePlaceholder": "Notatets tittel…",
     "titleLabel": "Notatets tittel",

--- a/web/public/locales/th/notes.json
+++ b/web/public/locales/th/notes.json
@@ -23,6 +23,14 @@
     "deleteNote": "ลบบันทึก",
     "closeLabel": "ปิดตัวแก้ไขบันทึก"
   },
+  "status": {
+    "saving": "กำลังบันทึก…",
+    "savedJustNow": "บันทึกเมื่อสักครู่",
+    "savedSecondsAgo": "บันทึกเมื่อ {{count}} วินาทีที่แล้ว",
+    "savedMinutesAgo": "บันทึกเมื่อ {{count}} นาทีที่แล้ว",
+    "savedHoursAgo": "บันทึกเมื่อ {{count}} ชั่วโมงที่แล้ว",
+    "offline": "ออฟไลน์"
+  },
   "fields": {
     "titlePlaceholder": "ชื่อบันทึก…",
     "titleLabel": "ชื่อบันทึก",

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -120,6 +120,10 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
     return () => onDirtyChange(false)
   }, [hasChanges, onDirtyChange])
 
+  if (hasChanges && saveState === 'saved') {
+    setSaveState('idle')
+  }
+
   async function handleSave(input?: NoteInput) {
     setSaving(true)
     setSaveState('saving')
@@ -148,22 +152,13 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
   }
 
   // Expose save() so the page-level Cmd/Ctrl+S shortcut can persist the draft.
-  // Mirror the Save button's disabled state so the shortcut is a no-op when
-  // there is nothing to save or a save is already in flight. The handle is
-  // kept stable but defers to a ref that is refreshed every render, so the
-  // shortcut always saves the *current* draft rather than a stale closure
-  // captured the first time `hasChanges`/`saving` changed.
-  const saveRef = useRef(() => {})
-  useEffect(() => {
-    saveRef.current = () => {
-      if (!saving && hasChanges) handleSave()
-    }
-  })
+  // No dep array → runs as a layout effect after every render, guaranteeing the
+  // latest closure is available immediately (before paint) without a separate ref.
   useImperativeHandle(ref, () => ({
     save() {
-      saveRef.current()
+      if (!saving && hasChanges) handleSave()
     },
-  }), [])
+  }))
 
   // Debounced autosave for existing notes. The latest save logic lives on a ref
   // so the effect can depend only on the draft/guard values (resetting the

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -120,9 +120,9 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
     return () => onDirtyChange(false)
   }, [hasChanges, onDirtyChange])
 
-  if (hasChanges && saveState === 'saved') {
-    setSaveState('idle')
-  }
+  // Hide the "Saved" indicator once the user resumes typing — derived, not
+  // mutated, so we avoid both render-time and effect-based setState.
+  const displaySaveState = (hasChanges && saveState === 'saved') ? 'idle' : saveState
 
   async function handleSave(input?: NoteInput) {
     setSaving(true)
@@ -217,7 +217,7 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
         </div>
 
         <div className="ml-auto flex items-center gap-2">
-          {saveState !== 'idle' && <SaveStatus state={saveState} lastSavedAt={lastSavedAt} />}
+          {displaySaveState !== 'idle' && <SaveStatus state={displaySaveState} lastSavedAt={lastSavedAt} />}
           {error && <span className="text-red-400 text-sm">{error}</span>}
           <button
             onClick={() => handleSave()}

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -154,9 +154,11 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
   // shortcut always saves the *current* draft rather than a stale closure
   // captured the first time `hasChanges`/`saving` changed.
   const saveRef = useRef(() => {})
-  saveRef.current = () => {
-    if (!saving && hasChanges) handleSave()
-  }
+  useEffect(() => {
+    saveRef.current = () => {
+      if (!saving && hasChanges) handleSave()
+    }
+  })
   useImperativeHandle(ref, () => ({
     save() {
       saveRef.current()
@@ -168,9 +170,11 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
   // timer on each keystroke) without re-subscribing to a fresh `handleSave`
   // closure every render.
   const autosaveRef = useRef((_input: NoteInput) => {})
-  autosaveRef.current = (input: NoteInput) => {
-    if (note && !isCreating && hasChanges && !saving) handleSave(input)
-  }
+  useEffect(() => {
+    autosaveRef.current = (input: NoteInput) => {
+      if (note && !isCreating && hasChanges && !saving) handleSave(input)
+    }
+  })
   useEffect(() => {
     // New-note creation stays on the manual Save button; never autosave it.
     // Also hold off while a save is in flight to avoid request pileups.

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -3,9 +3,16 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import { Tag, Trash2, Save, Eye, Edit3, X } from 'lucide-react'
+import { Tag, Trash2, Save, Eye, Edit3, X, Check, Loader2, CloudOff } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useNow } from '../../hooks/useNow'
 import type { Note, NoteInput, ViewMode } from '../../hooks/useNotes'
+
+/** Delay after the last keystroke before an existing note autosaves. */
+const AUTOSAVE_DELAY_MS = 1500
+
+/** Lifecycle of the most recent save attempt, surfaced in the status label. */
+type SaveState = 'idle' | 'saving' | 'saved' | 'error'
 
 interface NoteEditorProps {
   /** The note being edited, or null when creating a new note. */
@@ -41,6 +48,50 @@ function parseTags(raw: string): string[] {
 }
 
 /**
+ * Small label near the toolbar reflecting the autosave/save lifecycle:
+ * "Saving…" while a request is in flight, "Saved <relative time> ago" after a
+ * success (refreshing once a second), and "Offline" when a save fails. Renders
+ * nothing while idle; mounting only after the first save keeps the per-second
+ * tick from {@link useNow} off the hot editing path.
+ */
+function SaveStatus({ state, lastSavedAt }: { state: SaveState; lastSavedAt: number | null }) {
+  const { t } = useTranslation('notes')
+  const now = useNow()
+
+  if (state === 'saving') {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-gray-400" role="status" aria-live="polite">
+        <Loader2 size={12} className="animate-spin" />
+        {t('status.saving')}
+      </span>
+    )
+  }
+  if (state === 'error') {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-amber-400" role="status" aria-live="polite">
+        <CloudOff size={12} />
+        {t('status.offline')}
+      </span>
+    )
+  }
+  if (state === 'saved' && lastSavedAt !== null) {
+    const secs = Math.max(0, Math.floor((now.getTime() - lastSavedAt) / 1000))
+    let label: string
+    if (secs < 5) label = t('status.savedJustNow')
+    else if (secs < 60) label = t('status.savedSecondsAgo', { count: secs })
+    else if (secs < 3600) label = t('status.savedMinutesAgo', { count: Math.floor(secs / 60) })
+    else label = t('status.savedHoursAgo', { count: Math.floor(secs / 3600) })
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-gray-500" role="status" aria-live="polite">
+        <Check size={12} />
+        {label}
+      </span>
+    )
+  }
+  return null
+}
+
+/**
  * Editor pane for a single note. Owns draft state, edit/preview toggling, and
  * the markdown rendering. The parent re-mounts this (via a `key`) when the
  * active note changes so drafts initialize cleanly from props.
@@ -55,6 +106,8 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
   const [draftTags, setDraftTags] = useState(note ? note.tags.join(', ') : '')
   const [viewMode, setViewMode] = useState<ViewMode>('edit')
   const [saving, setSaving] = useState(false)
+  const [saveState, setSaveState] = useState<SaveState>('idle')
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null)
 
   const hasChanges = note
     ? draftTitle !== note.title ||
@@ -62,24 +115,32 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
       draftTags !== note.tags.join(', ')
     : isCreating
 
-  // Keep the parent informed of the dirty state so it can intercept attempts to
-  // switch notes, start a new note, or close the editor. The cleanup resets the
-  // flag to false when this editor unmounts (note swap or close) so a stale
-  // "dirty" state can't linger once no draft is on screen.
   useEffect(() => {
     onDirtyChange(hasChanges)
     return () => onDirtyChange(false)
   }, [hasChanges, onDirtyChange])
 
-  async function handleSave() {
+  async function handleSave(input?: NoteInput) {
     setSaving(true)
+    setSaveState('saving')
     try {
-      const tags = parseTags(draftTags)
-      const saved = await onSave({ id: note?.id, title: draftTitle, content: draftContent, tags })
+      const payload = input ?? {
+        id: note?.id,
+        title: draftTitle,
+        content: draftContent,
+        tags: parseTags(draftTags),
+      }
+      const saved = await onSave(payload)
       if (saved) {
         setDraftTitle(saved.title)
         setDraftContent(saved.content)
         setDraftTags(saved.tags.join(', '))
+        setSaveState('saved')
+        setLastSavedAt(Date.now())
+      } else {
+        // onSave swallows the failure and surfaces a message via `error`;
+        // mark the status as offline/errored so the indicator reflects it.
+        setSaveState('error')
       }
     } finally {
       setSaving(false)
@@ -101,6 +162,31 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
       saveRef.current()
     },
   }), [])
+
+  // Debounced autosave for existing notes. The latest save logic lives on a ref
+  // so the effect can depend only on the draft/guard values (resetting the
+  // timer on each keystroke) without re-subscribing to a fresh `handleSave`
+  // closure every render.
+  const autosaveRef = useRef((_input: NoteInput) => {})
+  autosaveRef.current = (input: NoteInput) => {
+    if (note && !isCreating && hasChanges && !saving) handleSave(input)
+  }
+  useEffect(() => {
+    // New-note creation stays on the manual Save button; never autosave it.
+    // Also hold off while a save is in flight to avoid request pileups.
+    if (!note || isCreating || !hasChanges || saving) return
+    const input: NoteInput = {
+      id: note.id,
+      title: draftTitle,
+      content: draftContent,
+      tags: parseTags(draftTags),
+    }
+    const timer = setTimeout(() => autosaveRef.current(input), AUTOSAVE_DELAY_MS)
+    // Clearing on every dependency change debounces rapid typing into a single
+    // request; the same cleanup runs on unmount and when the parent re-mounts
+    // this editor for a different note, so no stray PUT targets the old note.
+    return () => clearTimeout(timer)
+  }, [draftTitle, draftContent, draftTags, note, isCreating, hasChanges, saving])
 
   return (
     <>
@@ -132,9 +218,10 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
         </div>
 
         <div className="ml-auto flex items-center gap-2">
+          {saveState !== 'idle' && <SaveStatus state={saveState} lastSavedAt={lastSavedAt} />}
           {error && <span className="text-red-400 text-sm">{error}</span>}
           <button
-            onClick={handleSave}
+            onClick={() => handleSave()}
             disabled={saving || !hasChanges}
             className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-default text-white rounded text-sm transition-colors cursor-pointer"
             title={t('shortcuts.save')}

--- a/web/src/components/notes/NoteEditor.tsx
+++ b/web/src/components/notes/NoteEditor.tsx
@@ -172,13 +172,13 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
   const autosaveRef = useRef((_input: NoteInput) => {})
   useEffect(() => {
     autosaveRef.current = (input: NoteInput) => {
-      if (note && !isCreating && hasChanges && !saving) handleSave(input)
+      if (note && input.id === note.id && !isCreating && hasChanges && !saving && saveState !== 'error') handleSave(input)
     }
   })
   useEffect(() => {
     // New-note creation stays on the manual Save button; never autosave it.
     // Also hold off while a save is in flight to avoid request pileups.
-    if (!note || isCreating || !hasChanges || saving) return
+    if (!note || isCreating || !hasChanges || saving || saveState === 'error') return
     const input: NoteInput = {
       id: note.id,
       title: draftTitle,
@@ -190,7 +190,7 @@ const NoteEditor = forwardRef<NoteEditorHandle, NoteEditorProps>(function NoteEd
     // request; the same cleanup runs on unmount and when the parent re-mounts
     // this editor for a different note, so no stray PUT targets the old note.
     return () => clearTimeout(timer)
-  }, [draftTitle, draftContent, draftTags, note, isCreating, hasChanges, saving])
+  }, [draftTitle, draftContent, draftTags, note, isCreating, hasChanges, saving, saveState])
 
   return (
     <>


### PR DESCRIPTION
## Changes

- **Notes autosave** - Existing notes now save automatically about 1.5s after you stop typing, with a status label near the toolbar showing "Saving…", "Saved <time> ago", or "Offline" if a save fails. The manual Save button still works and new notes are still created explicitly. (Hytte-qlly)

## Original Issue (feature): Add autosave with debounced PUT and a visible save status indicator

### Scope
Add client-side debounced autosave to the Notes editor for existing notes, reusing the current `PUT /api/notes/:id` flow in `saveNote()`. After 1.5s of keystroke inactivity (and only when there are unsaved changes, a note is selected, and `saving` is false), persist silently. Add a small status indicator near the title showing the current save state. This is frontend-only; the backend PUT endpoint already exists and needs no change. New-note creation keeps using the explicit Save button.

### Files to touch
- `web/src/pages/Notes.tsx` — debounce effect, refactored save path, status indicator, save-state tracking
- `web/public/locales/en/notes.json` — new status strings
- `web/public/locales/nb/notes.json` — new status strings
- `web/public/locales/th/notes.json` — new status strings
- `changelog.d/<id>.md` (new) — `Added` fragment

### Acceptance criteria
- Editing an existing note and pausing ~1.5s triggers a PUT without clicking Save; the change survives a page refresh.
- Autosave only fires when `selectedNote` exists, `hasChanges` is true, and `saving` is false; rapid typing collapses to a single request after the pause (debounce resets on each keystroke).
- No autosave fires for new-note creation (`isCreating`); the manual Save button still creates new notes.
- The manual Save button remains functional for existing notes as an explicit affordance.
- A status label near the title reflects: "Saving…" during a request, "Saved <relative time> ago" after success, and "Offline" / error state when a save fails.
- The pending debounce timer is cleared on unmount and when switching between notes (no stray PUT to the previously selected note).
- All new user-facing strings use `react-i18next` keys present in en, nb, and th.
- `npm run lint` and `npm run build` pass.

### Non-goals
- No backend changes to `internal/notes/handlers.go` or the PUT contract.
- No conflict resolution / multi-tab or multi-device merge handling.
- No offline draft persistence (e.g. localStorage) or service-worker queueing of failed saves.
- No autosave for tag-only edge cases beyond what the existing `hasChanges` check covers.
- No change to delete, search, or note-list behavior.

## Source

Created from Suggestions page (suggestion id 14, page slug "notes", source=claude).

## Original suggestion

The editor only persists on an explicit Save click, which is risky for long-form encrypted notes — a tab close or refresh wipes the draft. Add a debounced autosave (e.g. 1.5s after the last keystroke) for existing notes that calls the same PUT endpoint, plus a small status label ("Saving…" / "Saved 2s ago" / "Offline") near the title. Keep the manual Save button for new-note creation and as an explicit affordance, and suppress autosave while `saving` is true to avoid request pileups.


---
Bead: Hytte-qlly | Branch: forge/Hytte-qlly
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->