### PR TITLE
Show a pending-approval count badge on the Today tab (Hytte-sh9s)

### DIFF
--- a/changelog.d/Hytte-sh9s.md
+++ b/changelog.d/Hytte-sh9s.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Pending-approval badge populates on entry from any allowance tab** - The Today tab's pending-approval count badge now loads on page mount instead of only after opening the Today tab, so parents see queued completions from the Chores, Payouts, Extras, and Bonuses tabs. (Hytte-sh9s)

--- a/web/src/pages/AllowancePage.tsx
+++ b/web/src/pages/AllowancePage.tsx
@@ -13,6 +13,18 @@ import { useTabFetch } from '../hooks/useTabFetch'
 const formatAmount2dp = (amount: number) =>
   formatNumber(amount, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 
+// Module-level dedup so React StrictMode's double-mount reuses the same
+// in-flight request instead of firing two /api/allowance/pending fetches.
+let pendingInFlight: Promise<{ pending: CompletionWithDetails[] }> | null = null
+function fetchPendingDeduped(): Promise<{ pending: CompletionWithDetails[] }> {
+  if (!pendingInFlight) {
+    pendingInFlight = fetch('/api/allowance/pending', { credentials: 'include' })
+      .then(res => { if (!res.ok) throw new Error(); return res.json() })
+      .finally(() => { pendingInFlight = null })
+  }
+  return pendingInFlight
+}
+
 interface CompletionWithDetails {
   id: number
   chore_id: number
@@ -220,13 +232,10 @@ export default function AllowancePage() {
   // Fetch on mount regardless of the active tab so the Today tab's
   // pending-approval count badge is populated on entry from any tab. The hook
   // caches the result, so switching to Today later does not refetch.
+  // Uses module-level dedup to avoid a duplicate request from StrictMode.
   const pendingFetch = useTabFetch<{ pending: CompletionWithDetails[] }>(
     true,
-    async signal => {
-      const res = await fetch('/api/allowance/pending', { credentials: 'include', signal })
-      if (!res.ok) throw new Error()
-      return res.json()
-    },
+    () => fetchPendingDeduped(),
     data => setPending(data.pending ?? []),
     loadFailed,
   )

--- a/web/src/pages/AllowancePage.tsx
+++ b/web/src/pages/AllowancePage.tsx
@@ -217,8 +217,11 @@ export default function AllowancePage() {
 
   const loadFailed = t('errors.loadFailed')
 
+  // Fetch on mount regardless of the active tab so the Today tab's
+  // pending-approval count badge is populated on entry from any tab. The hook
+  // caches the result, so switching to Today later does not refetch.
   const pendingFetch = useTabFetch<{ pending: CompletionWithDetails[] }>(
-    tab === 'today',
+    true,
     async signal => {
       const res = await fetch('/api/allowance/pending', { credentials: 'include', signal })
       if (!res.ok) throw new Error()


### PR DESCRIPTION
## Changes

- **Pending-approval badge populates on entry from any allowance tab** - The Today tab's pending-approval count badge now loads on page mount instead of only after opening the Today tab, so parents see queued completions from the Chores, Payouts, Extras, and Bonuses tabs. (Hytte-sh9s)

## Original Issue (feature): Show a pending-approval count badge on the Today tab

### Scope
The pending-approval badge JSX already exists on the `today` `TabTrigger` (`AllowancePage.tsx:610–617`), but `pendingFetch` is gated on `tab === 'today'` (`AllowancePage.tsx:214–223`), so the count only appears after a parent has actually opened the Today tab. This plan makes the pending list fetch on page mount regardless of the active tab, so the badge is populated on entry from any tab and drains via the existing optimistic updates.

### Files to touch
- `web/src/pages/AllowancePage.tsx` — change the `pendingFetch` `useTabFetch` `active` argument from `tab === 'today'` to always-on (mount fetch), while keeping the Today panel's loading/error rendering driven by `pendingFetch`.

### Acceptance criteria
- Loading the `/allowance` page on any tab (Chores, Payouts, Extras, Bonuses) fetches `/api/allowance/pending` exactly once on mount, without first visiting Today.
- When pending completions exist, the count badge renders next to the `today` `TabTrigger` label (e.g. `Today (3)`) regardless of which tab is active on entry.
- The badge is hidden while the initial fetch is in flight and when the count is zero (existing `!pendingFetch.loading && pending.length > 0` guard preserved).
- Approving or rejecting a completion decrements/clears the badge via the existing optimistic `setPending` updates — no extra refetch needed.
- The Today panel's existing loading skeleton, error message, empty state, and refresh button continue to work unchanged.
- A switch to Today does not trigger a duplicate fetch (the mount fetch already satisfies it).
- `npm run lint` and `npm run build` pass; no new `/api/allowance/pending` calls beyond the single mount fetch (verifiable in the network tab).

### Non-goals
- No backend changes to `internal/allowance/handlers.go` or the `/api/allowance/pending` endpoint.
- No new lightweight count-only endpoint; reuse the existing full pending list response.
- No badges on the kid-facing `MyChoresPage.tsx`.
- No badges on the other tabs (Chores, Payouts, Extras, Bonuses).
- No polling, SSE, or auto-refresh of the count while the page is open.
- No restyling of the existing badge or new i18n keys.

## Source

Created from Suggestions page (suggestion id 126, page slug "allowance", source=claude).

## Original suggestion

Parents only discover that completions are waiting once they navigate to the Today tab — the other tabs (Chores, Payouts, Extras, Bonuses) give no indication that work is queued. Fetch `/api/allowance/pending` once on page mount (independent of `tab`) and render the count as a small badge next to the `today` `TabTrigger` label, e.g. `Today (3)`. This makes the page actionable on entry, mirrors the unread/pending patterns used elsewhere in the app, and clears naturally as approvals/rejections drain the list via the existing optimistic updates.


---
Bead: Hytte-sh9s | Branch: forge/Hytte-sh9s
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->