### PR TITLE
Stop auto-scrolling during streaming when the user has scrolled up (Hytte-si3c)

### DIFF
--- a/changelog.d/Hytte-si3c.md
+++ b/changelog.d/Hytte-si3c.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Stop auto-scrolling chat when reading history** - The chat page no longer yanks the view back to the bottom on every streamed token when you have scrolled up. Auto-scroll now only follows the latest reply while you are near the bottom, and a "Jump to latest" button appears when you have scrolled away. (Hytte-si3c)

--- a/web/public/locales/en/chat.json
+++ b/web/public/locales/en/chat.json
@@ -1,6 +1,7 @@
 {
   "title": "Chats",
   "newChat": "New chat",
+  "jumpToLatest": "Jump to latest",
   "empty": {
     "noConversations": "No conversations yet",
     "startNew": "Start a new chat to begin"

--- a/web/public/locales/nb/chat.json
+++ b/web/public/locales/nb/chat.json
@@ -1,6 +1,7 @@
 {
   "title": "Samtaler",
   "newChat": "Ny samtale",
+  "jumpToLatest": "Hopp til nyeste",
   "empty": {
     "noConversations": "Ingen samtaler ennå",
     "startNew": "Start en ny samtale for å begynne"

--- a/web/public/locales/th/chat.json
+++ b/web/public/locales/th/chat.json
@@ -1,6 +1,7 @@
 {
   "title": "แชท",
   "newChat": "แชทใหม่",
+  "jumpToLatest": "ไปยังข้อความล่าสุด",
   "empty": {
     "noConversations": "ยังไม่มีการสนทนา",
     "startNew": "เริ่มแชทใหม่เพื่อเริ่มต้น"

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -79,7 +79,6 @@ export default function Chat() {
   // jump-to-latest scroll is in flight — cleared once the container
   // actually reaches the pinned zone.
   const jumpingRef = useRef(false)
-  const prevConversationIdRef = useRef<number | undefined>(activeConversation?.id)
   // Track locally deleted conversation IDs so we don't resurrect them if a
   // send response arrives after the user deleted the conversation mid-flight.
   const deletedConversationIds = useRef<Set<number>>(new Set())
@@ -149,16 +148,10 @@ export default function Chat() {
   }, [])
 
   // On conversation switch, re-pin to the bottom and scroll instantly so the
-  // latest message is shown without animating a long history. State is reset
-  // during render (React's "adjusting state from previous renders" pattern) to
-  // avoid a cascading re-render; refs are reset in the effect below.
-  if (activeConversation?.id !== prevConversationIdRef.current) {
-    prevConversationIdRef.current = activeConversation?.id
-    setIsPinned(true)
-  }
-
+  // latest message is shown without animating a long history.
   useEffect(() => {
     isPinnedRef.current = true
+    setIsPinned(true) // eslint-disable-line react-hooks/set-state-in-effect -- resetting derived state on key change
     instantScrollRef.current = true
   }, [activeConversation?.id])
 

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -75,6 +75,7 @@ export default function Chat() {
   // animation) — used on conversation switch / initial load so the button
   // does not flash while a long history animates into view.
   const instantScrollRef = useRef(false)
+  const prevConversationIdRef = useRef<number | undefined>(activeConversation?.id)
   // Track locally deleted conversation IDs so we don't resurrect them if a
   // send response arrives after the user deleted the conversation mid-flight.
   const deletedConversationIds = useRef<Set<number>>(new Set())
@@ -133,11 +134,17 @@ export default function Chat() {
     return () => el.removeEventListener('scroll', handleScroll)
   }, [])
 
-  // On conversation switch / initial load, re-pin to the bottom and scroll
-  // instantly so the latest message is shown without animating a long history.
+  // On conversation switch, re-pin to the bottom and scroll instantly so the
+  // latest message is shown without animating a long history. State is reset
+  // during render (React's "adjusting state from previous renders" pattern) to
+  // avoid a cascading re-render; refs are reset in the effect below.
+  if (activeConversation?.id !== prevConversationIdRef.current) {
+    prevConversationIdRef.current = activeConversation?.id
+    setIsPinned(true)
+  }
+
   useEffect(() => {
     isPinnedRef.current = true
-    setIsPinned(true)
     instantScrollRef.current = true
   }, [activeConversation?.id])
 

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -18,6 +18,7 @@ import {
   User,
   Copy,
   CheckCheck,
+  ArrowDown,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { formatDate, formatTime as fmtTime } from '../utils/formatDate'
@@ -39,6 +40,11 @@ interface Message {
   created_at: string
 }
 
+// Distance from the bottom (px) within which the messages view is considered
+// "pinned": new streamed tokens keep the view glued to the latest message.
+// Past this, the user has scrolled up to read history and we leave them be.
+const PIN_THRESHOLD = 80
+
 export default function Chat() {
   const { t } = useTranslation('chat')
   const [conversations, setConversations] = useState<Conversation[]>([])
@@ -57,8 +63,18 @@ export default function Chat() {
   const [renameTitle, setRenameTitle] = useState('')
   const [deletingId, setDeletingId] = useState<number | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const renameInputRef = useRef<HTMLInputElement>(null)
+  // Whether the messages view is glued to the bottom. `isPinned` drives the
+  // "jump to latest" button; `isPinnedRef` mirrors it so the streaming-token
+  // scroll effect reads the latest value without re-subscribing.
+  const [isPinned, setIsPinned] = useState(true)
+  const isPinnedRef = useRef(true)
+  // Set when the next scroll-to-bottom should jump instantly (no smooth
+  // animation) — used on conversation switch / initial load so the button
+  // does not flash while a long history animates into view.
+  const instantScrollRef = useRef(false)
   // Track locally deleted conversation IDs so we don't resurrect them if a
   // send response arrives after the user deleted the conversation mid-flight.
   const deletedConversationIds = useRef<Set<number>>(new Set())
@@ -66,9 +82,15 @@ export default function Chat() {
   // so a conversation switch can abort the in-flight stream.
   const streamAbortRef = useRef<AbortController | null>(null)
 
-  const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    messagesEndRef.current?.scrollIntoView({ behavior })
   }, [])
+
+  const jumpToLatest = useCallback(() => {
+    isPinnedRef.current = true
+    setIsPinned(true)
+    scrollToBottom('smooth')
+  }, [scrollToBottom])
 
   const addSendingConversation = useCallback((id: number) => {
     setSendingConversationIds(prev => {
@@ -86,9 +108,38 @@ export default function Chat() {
     })
   }, [])
 
+  // Keep the view glued to the latest message only while the user is pinned
+  // near the bottom. If they have scrolled up to read history, leave their
+  // position untouched so streamed tokens no longer yank them back down.
   useEffect(() => {
-    scrollToBottom()
+    if (isPinnedRef.current) {
+      scrollToBottom(instantScrollRef.current ? 'auto' : 'smooth')
+    }
+    instantScrollRef.current = false
   }, [messages, scrollToBottom])
+
+  // Track how far the messages container is from the bottom so we know whether
+  // to auto-scroll and whether to show the "jump to latest" button.
+  useEffect(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+    const handleScroll = () => {
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+      const pinned = distanceFromBottom <= PIN_THRESHOLD
+      isPinnedRef.current = pinned
+      setIsPinned(pinned)
+    }
+    el.addEventListener('scroll', handleScroll, { passive: true })
+    return () => el.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  // On conversation switch / initial load, re-pin to the bottom and scroll
+  // instantly so the latest message is shown without animating a long history.
+  useEffect(() => {
+    isPinnedRef.current = true
+    setIsPinned(true)
+    instantScrollRef.current = true
+  }, [activeConversation?.id])
 
   // Load conversations
   useEffect(() => {
@@ -277,6 +328,10 @@ export default function Chat() {
       created_at: new Date().toISOString(),
     }
     setMessages(prev => [...prev, tempUserMsg, tempAssistantMsg])
+    // Sending is a deliberate action: re-pin to the bottom so the user's new
+    // message and the streamed reply stay in view, even if they had scrolled up.
+    isPinnedRef.current = true
+    setIsPinned(true)
 
     // Abort any earlier in-flight stream before starting this one. The
     // useEffect on activeConversationId also calls abort on conversation
@@ -705,7 +760,8 @@ export default function Chat() {
         </div>
 
         {/* Messages area */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="relative flex-1 min-h-0">
+        <div ref={scrollContainerRef} className="h-full overflow-y-auto">
           {!activeConversation ? (
             <div className="flex flex-col items-center justify-center h-full text-gray-500">
               <Bot size={48} className="mb-4 opacity-30" />
@@ -760,6 +816,18 @@ export default function Chat() {
               })}
               <div ref={messagesEndRef} />
             </div>
+          )}
+        </div>
+          {/* Jump to latest — shown only while scrolled away from the bottom */}
+          {activeConversation && messages.length > 0 && !isPinned && (
+            <button
+              onClick={jumpToLatest}
+              className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 px-3 py-2 rounded-full bg-gray-800 hover:bg-gray-700 text-gray-200 text-xs font-medium shadow-lg border border-gray-700 transition-colors cursor-pointer"
+              aria-label={t('jumpToLatest')}
+            >
+              <ArrowDown size={14} />
+              {t('jumpToLatest')}
+            </button>
           )}
         </div>
 

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -75,6 +75,10 @@ export default function Chat() {
   // animation) — used on conversation switch / initial load so the button
   // does not flash while a long history animates into view.
   const instantScrollRef = useRef(false)
+  // Suppresses unpin detection in the scroll handler while a smooth
+  // jump-to-latest scroll is in flight — cleared once the container
+  // actually reaches the pinned zone.
+  const jumpingRef = useRef(false)
   const prevConversationIdRef = useRef<number | undefined>(activeConversation?.id)
   // Track locally deleted conversation IDs so we don't resurrect them if a
   // send response arrives after the user deleted the conversation mid-flight.
@@ -88,6 +92,7 @@ export default function Chat() {
   }, [])
 
   const jumpToLatest = useCallback(() => {
+    jumpingRef.current = true
     isPinnedRef.current = true
     setIsPinned(true)
     scrollToBottom('smooth')
@@ -127,8 +132,17 @@ export default function Chat() {
     const handleScroll = () => {
       const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
       const pinned = distanceFromBottom <= PIN_THRESHOLD
-      isPinnedRef.current = pinned
-      setIsPinned(pinned)
+      if (jumpingRef.current) {
+        if (pinned) {
+          jumpingRef.current = false
+        } else {
+          return
+        }
+      }
+      if (pinned !== isPinnedRef.current) {
+        isPinnedRef.current = pinned
+        setIsPinned(pinned)
+      }
     }
     el.addEventListener('scroll', handleScroll, { passive: true })
     return () => el.removeEventListener('scroll', handleScroll)


### PR DESCRIPTION
## Changes

- **Stop auto-scrolling chat when reading history** - The chat page no longer yanks the view back to the bottom on every streamed token when you have scrolled up. Auto-scroll now only follows the latest reply while you are near the bottom, and a "Jump to latest" button appears when you have scrolled away. (Hytte-si3c)

## Original Issue (feature): Stop auto-scrolling during streaming when the user has scrolled up

### Scope
The chat page auto-scrolls on every `messages` change with smooth behavior (`Chat.tsx:69-91`), so each streamed token snaps the viewport to the bottom. This plan changes the scroll-to-bottom effect to only fire when the messages scroll container is already pinned near the bottom (within ~80px), preserving the user's scroll position when they've scrolled up. A small "jump to latest" button appears while the user is scrolled away from the bottom during/after streaming.

### Files to touch
- `web/src/pages/Chat.tsx` — add a ref to the scroll container (`div.flex-1.overflow-y-auto`, ~line 708), track an "is pinned to bottom" state via a scroll listener, gate `scrollToBottom` on that state, and render an optional "jump to latest" affordance.
- `web/public/locales/en/chat.json`, `web/public/locales/nb/chat.json`, `web/public/locales/th/chat.json` — add the "jump to latest" button label key (if the affordance is included).

### Acceptance criteria
- When the user is at (or within ~80px of) the bottom, new streamed tokens continue to keep the view pinned to the bottom, as today.
- When the user scrolls up mid-stream, the viewport stays put — incoming tokens no longer yank it back down.
- Switching conversations or sending a new message still scrolls to the latest message (initial load behaves as before).
- A "jump to latest" button is shown only while the container is scrolled away from the bottom; clicking it scrolls smoothly to the latest message and dismisses the button. The button is hidden when already pinned.
- The "jump to latest" label uses `react-i18next` (`t(...)`) with keys present in en/nb/th — no hardcoded strings.
- Layout works at 375px width; the button does not overlap the input box.
- `npm run lint` and `npm run build` pass.

### Non-goals
- No changes to the SSE streaming backend (`internal/chat/handlers.go`) or message-fetch logic.
- No change to how the streaming placeholder/indicator renders.
- No new scroll library or virtualization; use the existing container and `scrollIntoView`.
- No persistence of scroll position across reloads or conversation switches.
- No unread-message counter on the affordance — a simple button is sufficient.

## Source

Created from Suggestions page (suggestion id 160, page slug "chat", source=claude).

## Original suggestion

`scrollToBottom` runs on every `messages` change with `behavior: 'smooth'`, so each streamed token yanks the viewport back to the bottom. If the user scrolls up mid-stream to re-read an earlier message or scan a long code block, the page jumps down again on the next token, making it effectively impossible to read history while Claude is responding. Track whether the messages container is pinned within ~80px of the bottom and only call `scrollIntoView` when it is; otherwise leave the scroll position alone and optionally show a small "jump to latest" affordance. This is a one-day fix that removes the worst ergonomic problem introduced by the SSE streaming work in #793.


---
Bead: Hytte-si3c | Branch: forge/Hytte-si3c
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->