### PR TITLE
Update clock immediately when tab regains visibility or system wakes (Hytte-vbj2)

### DIFF
--- a/changelog.d/Hytte-vbj2.md
+++ b/changelog.d/Hytte-vbj2.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Today clock resyncs on wake/resume** - The watch-face header time now updates immediately when the tab regains visibility or the window regains focus (e.g. after laptop sleep/resume), instead of staying stale until the next minute tick. The clock stays aligned to the top of each minute after resyncing. (Hytte-vbj2)

--- a/web/src/hooks/useCurrentTime.test.ts
+++ b/web/src/hooks/useCurrentTime.test.ts
@@ -90,6 +90,76 @@ describe('useCurrentTime', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
+  it('snaps to the current time on window focus (wake/resume)', () => {
+    vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
+    const { result } = renderHook(() => useCurrentTime())
+    const initial = result.current
+
+    // The device sleeps/resumes without a visibility change; wall-clock time
+    // jumps forward while no timer fired.
+    act(() => {
+      vi.setSystemTime(new Date('2026-06-02T11:05:42.000Z'))
+    })
+    expect(result.current).toBe(initial)
+
+    // Focus resyncs immediately to the real current time.
+    act(() => {
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(result.current).not.toBe(initial)
+    expect(result.current.getMinutes()).toBe(5)
+    expect(result.current.getSeconds()).toBe(42)
+
+    // The next tick stays aligned to the top of the minute (18s away), not
+    // drifted to the resume offset.
+    act(() => {
+      vi.advanceTimersByTime(17_999)
+    })
+    expect(result.current.getSeconds()).toBe(42)
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current.getMinutes()).toBe(6)
+    expect(result.current.getSeconds()).toBe(0)
+  })
+
+  it('ignores focus while hidden so the hook stays paused', () => {
+    vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
+    const { result } = renderHook(() => useCurrentTime())
+    const initial = result.current
+
+    setHidden(true)
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(vi.getTimerCount()).toBe(0)
+
+    // A focus event while hidden must not re-arm timers or update the time.
+    act(() => {
+      vi.setSystemTime(new Date('2026-06-02T10:50:00.000Z'))
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(result.current).toBe(initial)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('removes the focus listener on unmount (no resync after unmount)', () => {
+    vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
+    const { result, unmount } = renderHook(() => useCurrentTime())
+    const initial = result.current
+
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+
+    // Late focus event must not revive the hook.
+    act(() => {
+      vi.setSystemTime(new Date('2026-06-02T10:50:00.000Z'))
+      window.dispatchEvent(new Event('focus'))
+    })
+    expect(result.current).toBe(initial)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('pauses while hidden and snaps to the current time when visible again', () => {
     vi.setSystemTime(new Date('2026-06-02T10:30:15.000Z'))
     const { result } = renderHook(() => useCurrentTime())

--- a/web/src/hooks/useCurrentTime.ts
+++ b/web/src/hooks/useCurrentTime.ts
@@ -7,6 +7,11 @@ import { useState, useEffect } from 'react'
  * Unlike {@link useNow} (which ticks every second), this hook re-renders only
  * once per minute, so it suits surfaces that show minute-granularity time
  * without incurring per-second re-renders.
+ *
+ * Both `visibilitychange` (returning to a backgrounded tab) and `focus`
+ * (covers laptop wake/resume, where visibility may not change) trigger an
+ * immediate recompute and re-align the next-minute timeout, so the displayed
+ * time is never left stale after sleep/resume.
  */
 export function useCurrentTime(): Date {
   const [now, setNow] = useState<Date>(() => new Date())
@@ -37,16 +42,25 @@ export function useCurrentTime(): Date {
         intervalId = null
       }
     }
+    // Recompute the time immediately and re-align the next-minute timeout.
+    // Skipped while hidden so the hook stays paused per its visibility contract.
+    function resync() {
+      if (document.hidden) return
+      tick()
+      start()
+    }
     function handleVisibility() {
       if (document.hidden) stop()
-      else { tick(); start() }
+      else resync()
     }
 
     if (!document.hidden) start()
     document.addEventListener('visibilitychange', handleVisibility)
+    window.addEventListener('focus', resync)
     return () => {
       stop()
       document.removeEventListener('visibilitychange', handleVisibility)
+      window.removeEventListener('focus', resync)
     }
   }, [])
 


### PR DESCRIPTION
## Changes

- **Today clock resyncs on wake/resume** - The watch-face header time now updates immediately when the tab regains visibility or the window regains focus (e.g. after laptop sleep/resume), instead of staying stale until the next minute tick. The clock stays aligned to the top of each minute after resyncing. (Hytte-vbj2)

## Original Issue (feature): Update clock immediately when tab regains visibility or system wakes

### Scope
The minute-aligned clock in `TodayView` only advances while the tab is foregrounded and the device awake. After sleep/resume or returning to a backgrounded tab, the header time stays stale until the next interval tick. This plan refactors the existing `useEffect` clock so it immediately recomputes `now` and re-aligns the next-minute timeout whenever the tab regains visibility or window focus.

### Files to touch
- `web/src/pages/TodayView.tsx` — extend the clock `useEffect` (lines ~30–51) to add `visibilitychange` and `focus` listeners that call `updateNow()` and reschedule the next-minute timeout.
- `changelog.d/` — add a new `Fixed` changelog fragment (new).

### Acceptance criteria
- On returning to a backgrounded/hidden tab (`visibilitychange` → visible), the header time updates immediately to the real current time without waiting for the next interval tick.
- On window `focus` (covers laptop wake/resume where visibility may not change), the time also updates immediately.
- After such a resync, the clock remains aligned to the top of each minute (next tick fires within ~1s of the actual minute boundary, not drifted to the resume offset).
- All timers and the `visibilitychange`/`focus` listeners are removed in the effect cleanup; no leaked intervals/timeouts/listeners across mount/unmount (verifiable via no duplicate ticks).
- No regression to the steady-state behavior: while the tab stays active, the clock still updates once per minute.
- `npm run lint` and `npm run build` pass; existing behavior for `formatTime`/`now` consumers is unchanged.

### Non-goals
- No change to how time is formatted, localized, or displayed (`formatTime`, i18n).
- No backend, API, or other Today subcomponents (weather/calendar refresh logic).
- No second-level or seconds-resolution clock; the header stays minute-granular.
- No new dependencies, hooks library, or shared `useClock` abstraction unless trivially extracted within this file.
- No changes to other pages that may have similar timers.

## Source

Created from Suggestions page (suggestion id 4, page slug "today", source=claude).

## Original suggestion

The minute-aligned timer in TodayView only fires while the tab is active and the device is awake. After a laptop resumes from sleep or the user returns to a backgrounded tab, the displayed time can be stale by many minutes until the next interval tick. Add a `visibilitychange` listener (and ideally a `focus` listener) that calls `updateNow()` and recomputes the next-minute timeout, so the watch-face header always reflects the real time the moment the user looks at it.


---
Bead: Hytte-vbj2 | Branch: forge/Hytte-vbj2
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->