### PR TITLE
Persist active Wordfeud tab in URL query param instead of localStorage (Hytte-z9fe)

### DIFF
--- a/changelog.d/Hytte-z9fe.md
+++ b/changelog.d/Hytte-z9fe.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Deep-linkable Wordfeud tabs** - The active Wordfeud tab (finder/board) is now driven by the `?tab=` URL query param instead of localStorage, so tabs are shareable and restored on refresh across devices. The legacy `wordfeud-tab` localStorage value is migrated once and then cleared. (Hytte-z9fe)

--- a/web/src/pages/WordfeudPage.tsx
+++ b/web/src/pages/WordfeudPage.tsx
@@ -26,18 +26,16 @@ export default function WordfeudPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTab = parseTab(searchParams.get('tab'))
 
-  // One-time migration on mount: if no `tab` param is present, adopt the legacy
-  // localStorage value (mapping old `mygames`/`games` to `board`) and clear it.
-  // With no legacy key, normalize the URL to `?tab=finder` for consistency.
-  // `replace` keeps these from adding history entries.
   useEffect(() => {
+    const legacy = localStorage.getItem(LEGACY_TAB_KEY)
+    if (legacy !== null) {
+      localStorage.removeItem(LEGACY_TAB_KEY)
+    }
+
+    if (searchParams.get('tab')) return
+
+    const tab: Tab = legacy === 'board' || legacy === 'mygames' || legacy === 'games' ? 'board' : 'finder'
     setSearchParams((prev) => {
-      if (prev.get('tab')) return prev
-      const legacy = localStorage.getItem(LEGACY_TAB_KEY)
-      const tab: Tab = legacy === 'board' || legacy === 'mygames' || legacy === 'games' ? 'board' : 'finder'
-      if (legacy !== null) {
-        localStorage.removeItem(LEGACY_TAB_KEY)
-      }
       const next = new URLSearchParams(prev)
       next.set('tab', tab)
       return next

--- a/web/src/pages/WordfeudPage.tsx
+++ b/web/src/pages/WordfeudPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 import { Search, Grid3X3 } from 'lucide-react'
 import WordfeudBoard from './WordfeudBoard'
 
@@ -11,25 +12,45 @@ interface FoundWord {
 
 type SearchMode = 'anagram' | 'starts_with' | 'ends_with' | 'contains'
 
-const TAB_KEY = 'wordfeud-tab'
+type Tab = 'finder' | 'board'
+
+const LEGACY_TAB_KEY = 'wordfeud-tab'
+
+function parseTab(value: string | null): Tab {
+  return value === 'board' ? 'board' : 'finder'
+}
 
 export default function WordfeudPage() {
   const { t } = useTranslation('wordfeud')
 
-  const [activeTab, setActiveTab] = useState<'finder' | 'board'>(() => {
-    const stored = localStorage.getItem(TAB_KEY)
-    // Migrate legacy tab values to valid ones
-    if (stored === 'mygames' || stored === 'games') {
-      localStorage.setItem(TAB_KEY, 'board')
-      return 'board'
-    }
-    const valid = ['finder', 'board'] as const
-    return (valid as readonly string[]).includes(stored ?? '') ? (stored as 'finder' | 'board') : 'finder'
-  })
+  const [searchParams, setSearchParams] = useSearchParams()
+  const activeTab = parseTab(searchParams.get('tab'))
 
-  const handleTabChange = (tab: 'finder' | 'board') => {
-    setActiveTab(tab)
-    localStorage.setItem(TAB_KEY, tab)
+  // One-time migration on mount: if no `tab` param is present, adopt the legacy
+  // localStorage value (mapping old `mygames`/`games` to `board`) and clear it.
+  // With no legacy key, normalize the URL to `?tab=finder` for consistency.
+  // `replace` keeps these from adding history entries.
+  useEffect(() => {
+    setSearchParams((prev) => {
+      if (prev.get('tab')) return prev
+      const legacy = localStorage.getItem(LEGACY_TAB_KEY)
+      const tab: Tab = legacy === 'board' || legacy === 'mygames' || legacy === 'games' ? 'board' : 'finder'
+      if (legacy !== null) {
+        localStorage.removeItem(LEGACY_TAB_KEY)
+      }
+      const next = new URLSearchParams(prev)
+      next.set('tab', tab)
+      return next
+    }, { replace: true })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleTabChange = (tab: Tab) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      next.set('tab', tab)
+      return next
+    })
   }
 
   return (


### PR DESCRIPTION
## Changes

- **Deep-linkable Wordfeud tabs** - The active Wordfeud tab (finder/board) is now driven by the `?tab=` URL query param instead of localStorage, so tabs are shareable and restored on refresh across devices. The legacy `wordfeud-tab` localStorage value is migrated once and then cleared. (Hytte-z9fe)

## Original Issue (feature): Persist active Wordfeud tab in URL query param instead of localStorage

### Scope
Replace the localStorage-backed tab state in `WordfeudPage.tsx` with URL-driven state using React Router's `useSearchParams` (`?tab=finder|board`). On first load, perform a one-time migration that reads the legacy `wordfeud-tab` localStorage key, maps it to a valid tab, writes it into the URL, and clears the key. Remove the obsolete `mygames`/`games` migration branch. This makes the active tab deep-linkable and shareable, matching how other pages (e.g. `Settings.tsx`, `PokemonSet.tsx`) drive sub-navigation from the URL.

### Files to touch
- `web/src/pages/WordfeudPage.tsx` — swap `useState`/`localStorage` for `useSearchParams`; add one-time legacy migration; update `handleTabChange`.

### Acceptance criteria
- Visiting `/wordfeud?tab=board` lands directly on the board tab; `?tab=finder` lands on the finder tab.
- Clicking a tab updates the URL query param (`?tab=board`) without a full page reload.
- Refreshing the page restores the tab encoded in the URL.
- Visiting `/wordfeud` with no `tab` param defaults to `finder` (and the URL may be normalized to `?tab=finder` for consistency, using `replace` so it doesn't add history entries).
- An invalid/unknown `tab` value falls back to `finder`.
- On first load only, if no `tab` param is present and the legacy `wordfeud-tab` localStorage key exists, its value is mapped to a valid tab (`finder`/`board`; old `mygames`/`games` → `board`), reflected in the URL, and the localStorage key is removed afterward.
- The `wordfeud-tab` localStorage key and the `mygames`/`games` migration code no longer exist in the codebase.
- Tab `aria-selected`/`hidden` panel behavior is unchanged; both tabs render correctly.
- `npm run lint` and `npm run build` pass; no new TypeScript errors.

### Non-goals
- No changes to the finder, board, or local-games functionality, layout, or styling beyond tab-state wiring.
- No new backend routes or changes to `internal/wordfeud/*`.
- No persistence of finder inputs (letters/pattern/mode) or board state in the URL.
- No changes to navigation entries in `Sidebar.tsx` or routes in `App.tsx`.
- No new i18n keys or translation changes.

## Source

Created from Suggestions page (suggestion id 101, page slug "wordfeud", source=claude).

## Original suggestion

The active tab (finder vs board) is stored in localStorage under `wordfeud-tab`, which means deep links and refreshes don't restore tab state across devices, and shared URLs always land on the user's last-used tab rather than the linked content. Replace the localStorage-backed `useState` with a `useSearchParams`-driven tab state (e.g. `?tab=board`) and keep a small migration that reads the legacy localStorage key once and rewrites it as a query param. This makes the page linkable, removes the legacy `mygames`/`games` migration code, and aligns with how other pages in Hytte handle sub-navigation.


---
Bead: Hytte-z9fe | Branch: forge/Hytte-z9fe
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->