### PR TITLE
Move role-to-component mapping out of module scope and lazy-load variants (Hytte-zru3)

### DIFF
--- a/changelog.d/Hytte-zru3.md
+++ b/changelog.d/Hytte-zru3.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Code-split the /today role variants** - The parent, kid, and guest Today views are now loaded with `React.lazy` behind a `Suspense` boundary, so each ships as its own chunk and only the variant matching the current user's role is fetched. (Hytte-zru3)

--- a/web/src/pages/TodayView.tsx
+++ b/web/src/pages/TodayView.tsx
@@ -1,11 +1,12 @@
-import type { ComponentType } from 'react'
+import { lazy, Suspense, type ComponentType, type LazyExoticComponent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth'
 import { useCurrentTime } from '../hooks/useCurrentTime'
 import { formatDate, formatTime } from '../utils/formatDate'
-import ParentTodayView from '../components/today/ParentTodayView'
-import KidTodayView from '../components/today/KidTodayView'
-import GuestTodayView from '../components/today/GuestTodayView'
+
+const ParentTodayView = lazy(() => import('../components/today/ParentTodayView'))
+const KidTodayView = lazy(() => import('../components/today/KidTodayView'))
+const GuestTodayView = lazy(() => import('../components/today/GuestTodayView'))
 
 export type FamilyRole = 'parent' | 'child' | 'guest'
 
@@ -18,7 +19,7 @@ function useFamilyRole(): FamilyRole | null {
   return 'guest'
 }
 
-const widgetsByRole: Record<FamilyRole, ComponentType> = {
+const widgetsByRole: Record<FamilyRole, LazyExoticComponent<ComponentType>> = {
   parent: ParentTodayView,
   child: KidTodayView,
   guest: GuestTodayView,
@@ -53,7 +54,9 @@ export default function TodayView() {
 
       {/* Widget grid */}
       <div className="grid grid-cols-2 gap-3 sm:gap-4 flex-1 min-h-0 auto-rows-fr">
-        <Widgets />
+        <Suspense fallback={null}>
+          <Widgets />
+        </Suspense>
       </div>
     </div>
   )


### PR DESCRIPTION
## Changes

- **Code-split the /today role variants** - The parent, kid, and guest Today views are now loaded with `React.lazy` behind a `Suspense` boundary, so each ships as its own chunk and only the variant matching the current user's role is fetched. (Hytte-zru3)

## Original Issue (feature): Move role-to-component mapping out of module scope and lazy-load variants

### Scope
Convert the three role variant components in `TodayView.tsx` from static imports to `React.lazy` so each ships as its own code-split chunk, rendered behind a `Suspense` boundary. Only the variant matching the resolved `FamilyRole` is fetched, shrinking the initial `/today` bundle and isolating parent-only code from the kid/guest views.

### Files to touch
- `web/src/pages/TodayView.tsx` — replace static imports with `React.lazy`, wrap the rendered `<Widgets />` in `<Suspense>`.
- `changelog.d/` — add a changelog fragment (new) under category `Changed`.

### Acceptance criteria
- `ParentTodayView`, `KidTodayView`, and `GuestTodayView` are loaded via `React.lazy(() => import(...))` rather than top-level `import` statements.
- `widgetsByRole` continues to map each `FamilyRole` to its (now lazy) component; the `ComponentType` typing still holds with no `any` casts.
- The rendered widget is wrapped in a `<Suspense>` boundary with a non-jarring fallback (e.g. `null` or a lightweight placeholder consistent with the existing dark theme) so there is no unhandled-suspense crash.
- `vite build` produces separate chunks for each variant (verifiable in build output), and loading `/today` only requests the chunk for the current user's role.
- Switching roles (parent/child/guest) still renders the correct view; the `role === null` loading guard, clock header, and grid layout are unchanged.
- `npm run lint`, `npm run build`, `go build`, and `go test` all pass; no visible regression at 375px and desktop widths.

### Non-goals
- No changes to the internals, props, or data hooks of the three variant components.
- No change to `useFamilyRole` logic or the `FamilyRole` type.
- No new shared loading-spinner component or app-wide Suspense strategy.
- No changes to the clock/header rendering or the widget grid styling.
- No prefetching or route-level (React Router) lazy-loading work.

## Source

Created from Suggestions page (suggestion id 111, page slug "today", source=claude).

## Original suggestion

All three role variants (`ParentTodayView`, `KidTodayView`, `GuestTodayView`) are statically imported and bundled even though any given user only ever renders one. Convert `widgetsByRole` to use `React.lazy` with a `Suspense` boundary so each variant ships as its own chunk. This shrinks the initial JS for `/today` and keeps the kid view free of parent-only dependencies, which will matter as each variant grows its own widgets and data hooks.


---
Bead: Hytte-zru3 | Branch: forge/Hytte-zru3
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->