### PR TITLE
Render last forecast from localStorage immediately on load (stale-while-revalidate) (Hytte-2e8d)

### DIFF
--- a/changelog.d/Hytte-2e8d.md
+++ b/changelog.d/Hytte-2e8d.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Instant weather forecast on revisit** - The Weather page now renders the last successful forecast for a location immediately from a local cache (stale-while-revalidate), then refreshes it in the background, so revisits no longer flash skeleton placeholders. The cache keeps up to five recently viewed locations. (Hytte-2e8d)

--- a/web/src/lib/weatherCache.test.ts
+++ b/web/src/lib/weatherCache.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { keyFor, readForecastCache, writeForecastCache } from './weatherCache'
 
-const STORAGE_KEY = 'weather:forecastCache'
+const ANON_KEY = 'weather:forecastCache:anon'
 
 // Minimal forecast-like payload — the cache treats the response as opaque JSON.
 function makeResponse(temp: number) {
@@ -52,7 +52,7 @@ describe('weatherCache', () => {
       writeForecastCache(i, i, makeResponse(i))
     }
 
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as Array<{ key: string }>
+    const stored = JSON.parse(localStorage.getItem(ANON_KEY)!) as Array<{ key: string }>
     expect(stored).toHaveLength(5)
     // Oldest (0,0) evicted; (1,1)..(5,5) retained.
     expect(readForecastCache(0, 0)).toBeNull()
@@ -79,7 +79,7 @@ describe('weatherCache', () => {
     expect(refreshed!.response).toEqual(makeResponse(99))
     expect(refreshed!.lastUpdated).toBe(new Date('2026-06-03T11:00:00Z').getTime())
 
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as Array<{ key: string }>
+    const stored = JSON.parse(localStorage.getItem(ANON_KEY)!) as Array<{ key: string }>
     expect(stored).toHaveLength(5)
     // (0,0) is now most-recently-used (last), (1,1) is now oldest.
     expect(stored.map((e) => e.key)).toEqual(['1,1', '2,2', '3,3', '4,4', '0,0'])
@@ -90,20 +90,38 @@ describe('weatherCache', () => {
     expect(readForecastCache(0, 0)).not.toBeNull()
   })
 
+  it('reading an entry promotes it to most-recently-used', () => {
+    // Fill with 5 locations: 0,0 through 4,4.
+    for (let i = 0; i < 5; i++) {
+      writeForecastCache(i, i, makeResponse(i))
+    }
+
+    // Read the oldest entry (0,0) — it should be promoted to the tail.
+    readForecastCache(0, 0)
+
+    const stored = JSON.parse(localStorage.getItem(ANON_KEY)!) as Array<{ key: string }>
+    expect(stored.map((e) => e.key)).toEqual(['1,1', '2,2', '3,3', '4,4', '0,0'])
+
+    // Adding a 6th location should now evict (1,1) — the new oldest — not (0,0).
+    writeForecastCache(9, 9, makeResponse(9))
+    expect(readForecastCache(1, 1)).toBeNull()
+    expect(readForecastCache(0, 0)).not.toBeNull()
+  })
+
   it('falls back to null on corrupt (non-JSON) localStorage data', () => {
-    localStorage.setItem(STORAGE_KEY, 'not-json{')
+    localStorage.setItem(ANON_KEY, 'not-json{')
     expect(() => readForecastCache(59.91, 10.75)).not.toThrow()
     expect(readForecastCache(59.91, 10.75)).toBeNull()
   })
 
   it('falls back to null when stored data is not an array', () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ key: '1,1' }))
+    localStorage.setItem(ANON_KEY, JSON.stringify({ key: '1,1' }))
     expect(readForecastCache(1, 1)).toBeNull()
   })
 
   it('ignores malformed entries within the array', () => {
     localStorage.setItem(
-      STORAGE_KEY,
+      ANON_KEY,
       JSON.stringify([
         { key: '1,1' }, // missing response + lastUpdated
         { key: '2,2', response: makeResponse(2), lastUpdated: 123 },
@@ -114,13 +132,13 @@ describe('weatherCache', () => {
   })
 
   it('recovers from corrupt data on write by starting fresh', () => {
-    localStorage.setItem(STORAGE_KEY, 'garbage')
+    localStorage.setItem(ANON_KEY, 'garbage')
     expect(() => writeForecastCache(59.91, 10.75, makeResponse(21))).not.toThrow()
 
     const entry = readForecastCache<ReturnType<typeof makeResponse>>(59.91, 10.75)
     expect(entry).not.toBeNull()
     expect(entry!.response).toEqual(makeResponse(21))
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as unknown[]
+    const stored = JSON.parse(localStorage.getItem(ANON_KEY)!) as unknown[]
     expect(stored).toHaveLength(1)
   })
 
@@ -130,5 +148,30 @@ describe('weatherCache', () => {
     })
     expect(() => writeForecastCache(59.91, 10.75, makeResponse(21))).not.toThrow()
     spy.mockRestore()
+  })
+
+  describe('user-scoped isolation', () => {
+    it('scopes cache entries by user ID', () => {
+      writeForecastCache(59.91, 10.75, makeResponse(21), 1)
+      writeForecastCache(59.91, 10.75, makeResponse(42), 2)
+
+      const user1 = readForecastCache<ReturnType<typeof makeResponse>>(59.91, 10.75, 1)
+      const user2 = readForecastCache<ReturnType<typeof makeResponse>>(59.91, 10.75, 2)
+      const anon = readForecastCache<ReturnType<typeof makeResponse>>(59.91, 10.75)
+
+      expect(user1!.response).toEqual(makeResponse(21))
+      expect(user2!.response).toEqual(makeResponse(42))
+      expect(anon).toBeNull()
+    })
+
+    it('uses separate storage keys per user', () => {
+      writeForecastCache(59.91, 10.75, makeResponse(10), 1)
+      writeForecastCache(59.91, 10.75, makeResponse(20))
+
+      expect(localStorage.getItem('weather:forecastCache:1')).not.toBeNull()
+      expect(localStorage.getItem(ANON_KEY)).not.toBeNull()
+      expect(JSON.parse(localStorage.getItem('weather:forecastCache:1')!)).toHaveLength(1)
+      expect(JSON.parse(localStorage.getItem(ANON_KEY)!)).toHaveLength(1)
+    })
   })
 })

--- a/web/src/lib/weatherCache.test.ts
+++ b/web/src/lib/weatherCache.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { keyFor, readForecastCache, writeForecastCache } from './weatherCache'
+
+const STORAGE_KEY = 'weather:forecastCache'
+
+// Minimal forecast-like payload — the cache treats the response as opaque JSON.
+function makeResponse(temp: number) {
+  return { properties: { timeseries: [{ time: '2026-06-03T12:00:00Z', temp }] } }
+}
+
+describe('weatherCache', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    localStorage.clear()
+  })
+
+  it('keyFor builds a `lat,lon` key', () => {
+    expect(keyFor(59.91, 10.75)).toBe('59.91,10.75')
+  })
+
+  it('round-trips a written response and timestamp', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-03T10:00:00Z'))
+    const response = makeResponse(21)
+
+    writeForecastCache(59.91, 10.75, response)
+    const entry = readForecastCache<ReturnType<typeof makeResponse>>(59.91, 10.75)
+
+    expect(entry).not.toBeNull()
+    expect(entry!.key).toBe('59.91,10.75')
+    expect(entry!.response).toEqual(response)
+    expect(entry!.lastUpdated).toBe(Date.now())
+  })
+
+  it('returns null for a never-written location', () => {
+    writeForecastCache(59.91, 10.75, makeResponse(21))
+    expect(readForecastCache(60.39, 5.32)).toBeNull()
+  })
+
+  it('returns null when the store key is missing', () => {
+    expect(readForecastCache(59.91, 10.75)).toBeNull()
+  })
+
+  it('caps the store at 5 entries, evicting the oldest', () => {
+    // Write 6 distinct locations; the first (oldest) should be evicted.
+    for (let i = 0; i < 6; i++) {
+      writeForecastCache(i, i, makeResponse(i))
+    }
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as Array<{ key: string }>
+    expect(stored).toHaveLength(5)
+    // Oldest (0,0) evicted; (1,1)..(5,5) retained.
+    expect(readForecastCache(0, 0)).toBeNull()
+    expect(readForecastCache(1, 1)).not.toBeNull()
+    expect(readForecastCache(5, 5)).not.toBeNull()
+    expect(stored.map((e) => e.key)).toEqual(['1,1', '2,2', '3,3', '4,4', '5,5'])
+  })
+
+  it('re-writing an existing key refreshes it without growing the array', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-03T10:00:00Z'))
+
+    // Fill with 5 locations.
+    for (let i = 0; i < 5; i++) {
+      writeForecastCache(i, i, makeResponse(i))
+    }
+
+    // Re-write the oldest entry (0,0) — it should move to most-recently-used and
+    // refresh its timestamp, and adding a new 6th location must then evict (1,1).
+    vi.setSystemTime(new Date('2026-06-03T11:00:00Z'))
+    writeForecastCache(0, 0, makeResponse(99))
+
+    const refreshed = readForecastCache<ReturnType<typeof makeResponse>>(0, 0)
+    expect(refreshed!.response).toEqual(makeResponse(99))
+    expect(refreshed!.lastUpdated).toBe(new Date('2026-06-03T11:00:00Z').getTime())
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as Array<{ key: string }>
+    expect(stored).toHaveLength(5)
+    // (0,0) is now most-recently-used (last), (1,1) is now oldest.
+    expect(stored.map((e) => e.key)).toEqual(['1,1', '2,2', '3,3', '4,4', '0,0'])
+
+    // Adding a 6th distinct location evicts the new oldest (1,1), not (0,0).
+    writeForecastCache(9, 9, makeResponse(9))
+    expect(readForecastCache(1, 1)).toBeNull()
+    expect(readForecastCache(0, 0)).not.toBeNull()
+  })
+
+  it('falls back to null on corrupt (non-JSON) localStorage data', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-json{')
+    expect(() => readForecastCache(59.91, 10.75)).not.toThrow()
+    expect(readForecastCache(59.91, 10.75)).toBeNull()
+  })
+
+  it('falls back to null when stored data is not an array', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ key: '1,1' }))
+    expect(readForecastCache(1, 1)).toBeNull()
+  })
+
+  it('ignores malformed entries within the array', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { key: '1,1' }, // missing response + lastUpdated
+        { key: '2,2', response: makeResponse(2), lastUpdated: 123 },
+      ]),
+    )
+    expect(readForecastCache(1, 1)).toBeNull()
+    expect(readForecastCache(2, 2)).not.toBeNull()
+  })
+
+  it('recovers from corrupt data on write by starting fresh', () => {
+    localStorage.setItem(STORAGE_KEY, 'garbage')
+    expect(() => writeForecastCache(59.91, 10.75, makeResponse(21))).not.toThrow()
+
+    const entry = readForecastCache<ReturnType<typeof makeResponse>>(59.91, 10.75)
+    expect(entry).not.toBeNull()
+    expect(entry!.response).toEqual(makeResponse(21))
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as unknown[]
+    expect(stored).toHaveLength(1)
+  })
+
+  it('does not throw when localStorage.setItem fails (quota)', () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+    expect(() => writeForecastCache(59.91, 10.75, makeResponse(21))).not.toThrow()
+    spy.mockRestore()
+  })
+})

--- a/web/src/lib/weatherCache.ts
+++ b/web/src/lib/weatherCache.ts
@@ -4,9 +4,17 @@
 // localStorage so revisits can render real numbers instantly while a fresh forecast
 // is fetched in the background. A single localStorage key holds a JSON array of
 // entries; array order encodes recency (oldest first, most-recently-used last) so
-// the store can be bounded with simple LRU eviction.
+// the store can be bounded with simple LRU eviction. Reads promote the accessed
+// entry to the tail so actively viewed locations are not evicted.
+//
+// The storage key is scoped by user ID to prevent cross-account data leakage on
+// shared browsers. Anonymous sessions share a single "anon" namespace.
 
-const STORAGE_KEY = 'weather:forecastCache'
+const STORAGE_KEY_PREFIX = 'weather:forecastCache'
+
+function storageKey(userId?: number): string {
+  return userId != null ? `${STORAGE_KEY_PREFIX}:${userId}` : `${STORAGE_KEY_PREFIX}:anon`
+}
 
 // Maximum number of distinct locations to retain. Adding a new location beyond this
 // evicts the oldest (least-recently-used) entry.
@@ -43,10 +51,10 @@ function isValidEntry(item: unknown): item is ForecastCacheEntry {
  * Read the stored entry array, tolerating missing/corrupt/non-array data.
  * Returns only well-formed entries; anything malformed is treated as empty.
  */
-function readEntries(): ForecastCacheEntry[] {
+function readEntries(userId?: number): ForecastCacheEntry[] {
   let raw: string | null
   try {
-    raw = localStorage.getItem(STORAGE_KEY)
+    raw = localStorage.getItem(storageKey(userId))
   } catch {
     return []
   }
@@ -62,12 +70,26 @@ function readEntries(): ForecastCacheEntry[] {
 
 /**
  * Read the cached forecast for a location, or null when there is no valid entry.
- * Never throws — corrupt or missing data falls back to null.
+ * Promotes the accessed entry to the most-recently-used position so actively
+ * viewed locations are not evicted. Never throws — corrupt or missing data falls
+ * back to null.
  */
-export function readForecastCache<T = unknown>(lat: number, lon: number): ForecastCacheEntry<T> | null {
+export function readForecastCache<T = unknown>(lat: number, lon: number, userId?: number): ForecastCacheEntry<T> | null {
   const key = keyFor(lat, lon)
-  const entry = readEntries().find((e) => e.key === key)
-  return (entry as ForecastCacheEntry<T> | undefined) ?? null
+  const entries = readEntries(userId)
+  const idx = entries.findIndex((e) => e.key === key)
+  if (idx === -1) return null
+  // Promote to tail (most-recently-used) if not already there.
+  if (idx < entries.length - 1) {
+    const [entry] = entries.splice(idx, 1)
+    entries.push(entry)
+    try {
+      localStorage.setItem(storageKey(userId), JSON.stringify(entries))
+    } catch {
+      // Best-effort — promotion failure doesn't affect the read.
+    }
+  }
+  return entries[entries.length - 1] as ForecastCacheEntry<T>
 }
 
 /**
@@ -75,17 +97,17 @@ export function readForecastCache<T = unknown>(lat: number, lon: number): Foreca
  * Moves the location to the most-recently-used end and evicts the oldest entries
  * beyond MAX_ENTRIES. Never throws — storage/serialization errors are ignored.
  */
-export function writeForecastCache<T = unknown>(lat: number, lon: number, response: T): void {
+export function writeForecastCache<T = unknown>(lat: number, lon: number, response: T, userId?: number): void {
   const key = keyFor(lat, lon)
   // Drop any existing entry for this key, then append it as most-recently-used.
-  const entries = readEntries().filter((e) => e.key !== key)
+  const entries = readEntries(userId).filter((e) => e.key !== key)
   entries.push({ key, response, lastUpdated: Date.now() })
   // Evict from the oldest (front) end until within the bound.
   while (entries.length > MAX_ENTRIES) {
     entries.shift()
   }
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+    localStorage.setItem(storageKey(userId), JSON.stringify(entries))
   } catch {
     // Quota exceeded or serialization failure — caching is best-effort.
   }

--- a/web/src/lib/weatherCache.ts
+++ b/web/src/lib/weatherCache.ts
@@ -1,0 +1,94 @@
+// Stale-while-revalidate cache for weather forecasts.
+//
+// The last successful `ForecastResponse` for each viewed location is persisted to
+// localStorage so revisits can render real numbers instantly while a fresh forecast
+// is fetched in the background. A single localStorage key holds a JSON array of
+// entries; array order encodes recency (oldest first, most-recently-used last) so
+// the store can be bounded with simple LRU eviction.
+
+const STORAGE_KEY = 'weather:forecastCache'
+
+// Maximum number of distinct locations to retain. Adding a new location beyond this
+// evicts the oldest (least-recently-used) entry.
+const MAX_ENTRIES = 5
+
+export interface ForecastCacheEntry<T = unknown> {
+  /** `lat,lon` identifier for the cached location. */
+  key: string
+  /** The last successful forecast response for this location. */
+  response: T
+  /** Epoch milliseconds at which the response was cached. */
+  lastUpdated: number
+}
+
+/** Build the cache key for a location from its coordinates. */
+export function keyFor(lat: number, lon: number): string {
+  return `${lat},${lon}`
+}
+
+/** Type guard for a single well-formed cache entry. */
+function isValidEntry(item: unknown): item is ForecastCacheEntry {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    typeof (item as ForecastCacheEntry).key === 'string' &&
+    typeof (item as ForecastCacheEntry).lastUpdated === 'number' &&
+    Number.isFinite((item as ForecastCacheEntry).lastUpdated) &&
+    'response' in (item as ForecastCacheEntry) &&
+    (item as ForecastCacheEntry).response != null
+  )
+}
+
+/**
+ * Read the stored entry array, tolerating missing/corrupt/non-array data.
+ * Returns only well-formed entries; anything malformed is treated as empty.
+ */
+function readEntries(): ForecastCacheEntry[] {
+  let raw: string | null = null
+  try {
+    raw = localStorage.getItem(STORAGE_KEY)
+  } catch {
+    // localStorage may be unavailable (private mode, disabled storage).
+    return []
+  }
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(isValidEntry)
+  } catch {
+    // Not valid JSON — fall back to an empty cache.
+    return []
+  }
+}
+
+/**
+ * Read the cached forecast for a location, or null when there is no valid entry.
+ * Never throws — corrupt or missing data falls back to null.
+ */
+export function readForecastCache<T = unknown>(lat: number, lon: number): ForecastCacheEntry<T> | null {
+  const key = keyFor(lat, lon)
+  const entry = readEntries().find((e) => e.key === key)
+  return (entry as ForecastCacheEntry<T> | undefined) ?? null
+}
+
+/**
+ * Persist a successful forecast response for a location, refreshing its timestamp.
+ * Moves the location to the most-recently-used end and evicts the oldest entries
+ * beyond MAX_ENTRIES. Never throws — storage/serialization errors are ignored.
+ */
+export function writeForecastCache<T = unknown>(lat: number, lon: number, response: T): void {
+  const key = keyFor(lat, lon)
+  // Drop any existing entry for this key, then append it as most-recently-used.
+  const entries = readEntries().filter((e) => e.key !== key)
+  entries.push({ key, response, lastUpdated: Date.now() })
+  // Evict from the oldest (front) end until within the bound.
+  while (entries.length > MAX_ENTRIES) {
+    entries.shift()
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+  } catch {
+    // Quota exceeded or serialization failure — caching is best-effort.
+  }
+}

--- a/web/src/lib/weatherCache.ts
+++ b/web/src/lib/weatherCache.ts
@@ -44,11 +44,10 @@ function isValidEntry(item: unknown): item is ForecastCacheEntry {
  * Returns only well-formed entries; anything malformed is treated as empty.
  */
 function readEntries(): ForecastCacheEntry[] {
-  let raw: string | null = null
+  let raw: string | null
   try {
     raw = localStorage.getItem(STORAGE_KEY)
   } catch {
-    // localStorage may be unavailable (private mode, disabled storage).
     return []
   }
   if (!raw) return []
@@ -57,7 +56,6 @@ function readEntries(): ForecastCacheEntry[] {
     if (!Array.isArray(parsed)) return []
     return parsed.filter(isValidEntry)
   } catch {
-    // Not valid JSON — fall back to an empty cache.
     return []
   }
 }

--- a/web/src/pages/Weather.tsx
+++ b/web/src/pages/Weather.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useReducer, useCallback, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useReducer, useCallback, useRef } from 'react'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth'
@@ -90,9 +90,9 @@ function fetchReducer(state: FetchState, action: FetchAction): FetchState {
 }
 
 /** Build the initial fetch state, seeding from the per-location cache when available. */
-function initFetchState(loc: RecentLocation | null): FetchState {
+function initFetchState({ loc, userId }: { loc: RecentLocation | null; userId?: number }): FetchState {
   if (loc) {
-    const cached = readForecastCache<ForecastResponse>(loc.lat, loc.lon)
+    const cached = readForecastCache<ForecastResponse>(loc.lat, loc.lon, userId)
     if (cached) {
       return { loading: true, error: null, forecast: cached.response, lastUpdated: new Date(cached.lastUpdated) }
     }
@@ -339,7 +339,7 @@ export default function Weather() {
   // on first paint (no skeleton flash) while a fresh forecast loads in the background.
   const [{ forecast, loading, error, lastUpdated }, dispatch] = useReducer(
     fetchReducer,
-    initialState.location,
+    { loc: initialState.location, userId: user?.id },
     initFetchState,
   )
   const [, setTick] = useState(0)
@@ -493,7 +493,9 @@ export default function Weather() {
 
   // Re-seed displayed data when the active location changes: show the location's
   // cached forecast instantly, or clear to skeletons when it was never viewed.
-  useEffect(() => {
+  // useLayoutEffect runs synchronously before paint, preventing a brief flash of
+  // the previous location's forecast under the newly selected location name.
+  useLayoutEffect(() => {
     if (!selectedLocation) return
     const cached = readForecastCache<ForecastResponse>(selectedLocation.lat, selectedLocation.lon, user?.id)
     if (cached) {

--- a/web/src/pages/Weather.tsx
+++ b/web/src/pages/Weather.tsx
@@ -13,6 +13,7 @@ import {
   buildDefaultLocations,
 } from '../recentLocations'
 import LocationSearch from '../components/LocationSearch'
+import { readForecastCache, writeForecastCache } from '../lib/weatherCache'
 import { getWeatherIcon, getWeatherDescription } from '../weatherUtils'
 import { formatDate, formatTime } from '../utils/formatDate'
 import {
@@ -72,14 +73,31 @@ type FetchAction =
   | { type: 'start' }
   | { type: 'success'; data: ForecastResponse }
   | { type: 'error'; message: string }
+  // Seed displayed data from a cached response (stale-while-revalidate).
+  | { type: 'seed'; data: ForecastResponse; lastUpdated: Date }
+  // Clear displayed data so skeletons show (location with no cached forecast).
+  | { type: 'reset' }
 
 function fetchReducer(state: FetchState, action: FetchAction): FetchState {
   switch (action.type) {
     case 'start': return { ...state, loading: true, error: null }
     case 'success': return { loading: false, error: null, forecast: action.data, lastUpdated: new Date() }
     case 'error': return { loading: false, error: action.message, forecast: state.forecast, lastUpdated: state.lastUpdated }
+    case 'seed': return { loading: true, error: null, forecast: action.data, lastUpdated: action.lastUpdated }
+    case 'reset': return { loading: true, error: null, forecast: null, lastUpdated: null }
     default: return state
   }
+}
+
+/** Build the initial fetch state, seeding from the per-location cache when available. */
+function initFetchState(loc: RecentLocation | null): FetchState {
+  if (loc) {
+    const cached = readForecastCache<ForecastResponse>(loc.lat, loc.lon)
+    if (cached) {
+      return { loading: true, error: null, forecast: cached.response, lastUpdated: new Date(cached.lastUpdated) }
+    }
+  }
+  return { loading: true, error: null, forecast: null, lastUpdated: null }
 }
 
 const AUTO_REFRESH_MS = 10 * 60 * 1000 // 10 minutes
@@ -317,12 +335,13 @@ export default function Weather() {
       cancelled = true
     }
   }, [])
-  const [{ forecast, loading, error, lastUpdated }, dispatch] = useReducer(fetchReducer, {
-    loading: true,
-    error: null,
-    forecast: null,
-    lastUpdated: null,
-  })
+  // Seed the reducer from the per-location cache so a revisit renders real numbers
+  // on first paint (no skeleton flash) while a fresh forecast loads in the background.
+  const [{ forecast, loading, error, lastUpdated }, dispatch] = useReducer(
+    fetchReducer,
+    initialState.location,
+    initFetchState,
+  )
   const [, setTick] = useState(0)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -472,6 +491,21 @@ export default function Weather() {
     [saveState],
   )
 
+  // Re-seed displayed data when the active location changes: show the location's
+  // cached forecast instantly, or clear to skeletons when it was never viewed.
+  useEffect(() => {
+    if (!selectedLocation) return
+    const cached = readForecastCache<ForecastResponse>(selectedLocation.lat, selectedLocation.lon)
+    if (cached) {
+      dispatch({ type: 'seed', data: cached.response, lastUpdated: new Date(cached.lastUpdated) })
+    } else {
+      dispatch({ type: 'reset' })
+    }
+    // Key on coordinates so reconciling the location object (same lat/lon, new
+    // reference) does not spuriously clear freshly fetched data.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedLocation?.lat, selectedLocation?.lon])
+
   // Fetch forecast once we know the correct location.
   useEffect(() => {
     if (!locationResolved || !selectedLocation) return
@@ -485,7 +519,10 @@ export default function Weather() {
         return r.json()
       })
       .then((data) => {
-        if (!cancelled) dispatch({ type: 'success', data })
+        if (cancelled) return
+        dispatch({ type: 'success', data })
+        // Persist/refresh this location's cache so future revisits render instantly.
+        writeForecastCache(selectedLocation.lat, selectedLocation.lon, data)
       })
       .catch((err) => {
         if (!cancelled) dispatch({ type: 'error', message: err.message })
@@ -607,7 +644,7 @@ export default function Weather() {
         </div>
       )}
 
-      {error && (
+      {error && !forecast && (
         <div className="bg-red-900/30 border border-red-800 rounded-xl p-4 mb-6">
           <p className="text-red-400 text-sm">{error}</p>
         </div>

--- a/web/src/pages/Weather.tsx
+++ b/web/src/pages/Weather.tsx
@@ -495,16 +495,17 @@ export default function Weather() {
   // cached forecast instantly, or clear to skeletons when it was never viewed.
   useEffect(() => {
     if (!selectedLocation) return
-    const cached = readForecastCache<ForecastResponse>(selectedLocation.lat, selectedLocation.lon)
+    const cached = readForecastCache<ForecastResponse>(selectedLocation.lat, selectedLocation.lon, user?.id)
     if (cached) {
       dispatch({ type: 'seed', data: cached.response, lastUpdated: new Date(cached.lastUpdated) })
     } else {
       dispatch({ type: 'reset' })
     }
-    // Key on coordinates so reconciling the location object (same lat/lon, new
-    // reference) does not spuriously clear freshly fetched data.
+    // Key on coordinates + user so reconciling the location object (same lat/lon,
+    // new reference) does not spuriously clear freshly fetched data, and switching
+    // accounts reads from the correct user-scoped cache.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedLocation?.lat, selectedLocation?.lon])
+  }, [selectedLocation?.lat, selectedLocation?.lon, user?.id])
 
   // Fetch forecast once we know the correct location.
   useEffect(() => {
@@ -522,7 +523,7 @@ export default function Weather() {
         if (cancelled) return
         dispatch({ type: 'success', data })
         // Persist/refresh this location's cache so future revisits render instantly.
-        writeForecastCache(selectedLocation.lat, selectedLocation.lon, data)
+        writeForecastCache(selectedLocation.lat, selectedLocation.lon, data, user?.id)
       })
       .catch((err) => {
         if (!cancelled) dispatch({ type: 'error', message: err.message })
@@ -531,6 +532,8 @@ export default function Weather() {
     return () => {
       cancelled = true
     }
+    // user?.id is read only for cache-key scoping, not to trigger a re-fetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedLocation, locationResolved, refreshKey])
 
   // Auto-refresh every 10 minutes, pausing when the tab is hidden.


### PR DESCRIPTION
## Changes

- **Instant weather forecast on revisit** - The Weather page now renders the last successful forecast for a location immediately from a local cache (stale-while-revalidate), then refreshes it in the background, so revisits no longer flash skeleton placeholders. The cache keeps up to five recently viewed locations. (Hytte-2e8d)

## Original Issue (feature): Render last forecast from localStorage immediately on load (stale-while-revalidate)

### Scope
Add stale-while-revalidate behavior to the Weather page so revisits render the last successful forecast instantly from localStorage instead of skeleton placeholders. On mount, seed the forecast reducer from a per-location cached `ForecastResponse` (with timestamp), then fetch in the background and replace on success. Persist each successful response keyed by `lat,lon`, bounding the store to ~5 entries (LRU/oldest-out). The existing `lastUpdated` timestamp continues to signal staleness; no backend changes.

### Files to touch
- `web/src/pages/Weather.tsx` — seed reducer initial state from cache; write cache on successful fetch; keep skeleton only when no cache exists for the active location.
- `web/src/lib/weatherCache.ts` (new) — small typed helper: `readForecastCache(lat, lon)`, `writeForecastCache(lat, lon, response)`, with 5-entry bound and key `lat,lon`. Keeps localStorage logic out of the component and testable.
- `web/src/lib/weatherCache.test.ts` (new) — unit tests for read/write, eviction at >5 entries, and corrupt/missing-data fallback.
- `changelog.d/<Hytte-xxxx>.md` (new) — `Changed` fragment.

### Acceptance criteria
- On first-ever visit to a location, skeletons still appear while the request is in flight (no cached data yet).
- On a revisit (same `lat,lon`), real forecast numbers render immediately on mount with no skeleton flash, then update in place once the background fetch resolves.
- Switching to a previously viewed location shows its cached data instantly; a never-viewed location shows skeletons.
- A successful fetch always writes/refreshes that location's cache entry and its timestamp.
- The cache never holds more than ~5 location entries; adding a 6th evicts the oldest/least-recently-used.
- Corrupt, missing, or unparseable localStorage data is handled gracefully — it falls back to skeletons + fetch, never throws or renders broken UI.
- A failed background fetch leaves the displayed cached data intact (does not clear to an error/skeleton state if cache was shown).
- `lastUpdated` reflects the timestamp of the currently displayed data (cached or fresh).
- Unit tests cover read/write, eviction, and corrupt-data fallback; `npm run lint` and `npm run build` pass.

### Non-goals
- No backend changes to `internal/weather/handler.go` or MET caching.
- No service worker, IndexedDB, or cross-tab sync.
- No change to refetch triggers, polling cadence, or the forecast data shape.
- No offline mode or explicit "stale" badge beyond the existing `lastUpdated` display.
- No caching of weather data for locations other than those the user actually views.

## Source

Created from Suggestions page (suggestion id 115, page slug "weather", source=claude).

## Original suggestion

Today the page shows skeleton placeholders on every visit while `/api/weather/forecast` round-trips, even though the backend already caches MET responses for 30 minutes. Persist the last successful `ForecastResponse` per-location in localStorage (with a timestamp) and seed `useReducer` with it on mount, then refetch in the background and replace on success. The user sees real numbers instantly on revisit and the existing `lastUpdated` timestamp already communicates staleness. Bound the cache to ~5 entries keyed by `lat,lon` so it doesn't grow unbounded.


---
Bead: Hytte-2e8d | Branch: forge/Hytte-2e8d
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->