### PR TITLE
Extract event fetching and abort plumbing into a useCalendarEvents hook (Hytte-flmg)

### DIFF
--- a/web/src/hooks/calendarUrl.ts
+++ b/web/src/hooks/calendarUrl.ts
@@ -1,0 +1,52 @@
+import {
+  type ViewMode,
+  startOfDay,
+  endOfDay,
+  addDays,
+  startOfWeekMonday,
+} from '../components/calendar/types'
+
+/** Number of days shown in the agenda view (and per agenda navigation step). */
+export const AGENDA_DAYS = 14
+
+/** Format a Date as RFC3339 without fractional seconds. */
+function toRFC3339(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
+function getStartOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
+/** Calculate the date range to fetch based on view mode and rangeStart. */
+export function getViewRange(view: ViewMode, rangeStart: Date): { start: Date; end: Date } {
+  switch (view) {
+    case 'month': {
+      // Fetch from start of first visible week to end of last visible week
+      const firstOfMonth = getStartOfMonth(rangeStart)
+      const lastOfMonth = new Date(rangeStart.getFullYear(), rangeStart.getMonth() + 1, 0)
+      const gridStart = startOfWeekMonday(firstOfMonth)
+      const gridEnd = endOfDay(addDays(startOfWeekMonday(addDays(lastOfMonth, 7)), -1))
+      // Extend end to cover full 6th row if needed, using date-based arithmetic
+      // to avoid DST-sensitive millisecond day calculations.
+      const sixWeekEnd = endOfDay(addDays(gridStart, 41))
+      const endDate = gridEnd.getTime() < sixWeekEnd.getTime() ? sixWeekEnd : gridEnd
+      return { start: gridStart, end: endDate }
+    }
+    case 'week': {
+      const ws = startOfWeekMonday(rangeStart)
+      return { start: ws, end: endOfDay(addDays(ws, 6)) }
+    }
+    case 'day':
+      return { start: startOfDay(rangeStart), end: endOfDay(rangeStart) }
+    case 'agenda':
+    default:
+      return { start: startOfDay(rangeStart), end: endOfDay(addDays(rangeStart, AGENDA_DAYS - 1)) }
+  }
+}
+
+/** Build the events fetch URL for a given view mode and range start. */
+export function buildEventsUrl(view: ViewMode, rangeStart: Date, sync = false): string {
+  const { start, end } = getViewRange(view, rangeStart)
+  return `/api/calendar/events?start=${encodeURIComponent(toRFC3339(start))}&end=${encodeURIComponent(toRFC3339(end))}${sync ? '&sync=true' : ''}`
+}

--- a/web/src/hooks/useCalendarEvents.test.ts
+++ b/web/src/hooks/useCalendarEvents.test.ts
@@ -5,10 +5,14 @@ import { useCalendarEvents } from './useCalendarEvents'
 import type { CalendarEvent, ViewMode } from '../components/calendar/types'
 
 // ── i18n mock ─────────────────────────────────────────────────────────────────
-// Return the key verbatim so error assertions are deterministic.
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
-}))
+// Return the key verbatim so error assertions are deterministic. The t function
+// must be a stable reference (matching real react-i18next) so useCallback deps
+// that include t don't invalidate on every render.
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key
+  const i18n = { language: 'en' }
+  return { useTranslation: () => ({ t, i18n }) }
+})
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -153,6 +157,25 @@ describe('useCalendarEvents', () => {
 
     unmount()
     expect(signal?.aborted).toBe(true)
+  })
+
+  it('aborts a refetch-initiated request on unmount', async () => {
+    const calls = installFetch()
+    const { result, unmount } = renderEvents({ viewMode: 'month', rangeStart: RANGE_A, user: USER })
+
+    // Resolve the initial fetch so we can call refetch.
+    await act(async () => {
+      calls[0].resolve(okJson({ events: [] }))
+    })
+
+    // Start a refetch (no external signal chained).
+    act(() => { void result.current.refetch() })
+    expect(calls.length).toBe(2)
+    const refetchSignal = calls[1].signal
+    expect(refetchSignal?.aborted).toBe(false)
+
+    unmount()
+    expect(refetchSignal?.aborted).toBe(true)
   })
 
   it('refetch() re-runs the current query without changing inputs', async () => {

--- a/web/src/hooks/useCalendarEvents.test.ts
+++ b/web/src/hooks/useCalendarEvents.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useCalendarEvents } from './useCalendarEvents'
+import type { CalendarEvent, ViewMode } from '../components/calendar/types'
+
+// ── i18n mock ─────────────────────────────────────────────────────────────────
+// Return the key verbatim so error assertions are deterministic.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+// ── Controllable fetch mock ───────────────────────────────────────────────────
+//
+// Each call records its url + signal and exposes resolve/reject so tests can
+// drive the in-flight request by hand. Aborting the request's signal rejects
+// the pending promise with an AbortError, mirroring the real fetch contract the
+// hook relies on for race-safety.
+interface FetchCall {
+  url: string
+  signal: AbortSignal | undefined
+  resolve: (value: { ok: boolean; status?: number; json: () => Promise<unknown> }) => void
+  reject: (reason: unknown) => void
+}
+
+function installFetch(): FetchCall[] {
+  const calls: FetchCall[] = []
+  const fetchMock = vi.fn((url: string, opts?: { signal?: AbortSignal }) => {
+    return new Promise((resolve, reject) => {
+      const signal = opts?.signal
+      calls.push({ url, signal, resolve, reject })
+      if (signal) {
+        signal.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      }
+    })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return calls
+}
+
+function okJson(data: unknown) {
+  return { ok: true, json: () => Promise.resolve(data) }
+}
+
+const USER = { id: 1 }
+const RANGE_A = new Date(2026, 3, 8) // Apr 8 2026
+const RANGE_B = new Date(2026, 4, 8) // May 8 2026
+
+function makeEvent(id: string): CalendarEvent {
+  return {
+    id,
+    calendar_id: 'primary',
+    title: `Event ${id}`,
+    start_time: '2026-04-08T10:00:00Z',
+    end_time: '2026-04-08T11:00:00Z',
+    all_day: false,
+    status: 'confirmed',
+  }
+}
+
+function renderEvents(initial: { viewMode: ViewMode; rangeStart: Date; user: { id: number } | null }) {
+  return renderHook(
+    ({ viewMode, rangeStart, user }) => useCalendarEvents(viewMode, rangeStart, user),
+    { initialProps: initial },
+  )
+}
+
+describe('useCalendarEvents', () => {
+  it('starts loading and does not fetch without a user', () => {
+    const calls = installFetch()
+    const { result } = renderEvents({ viewMode: 'month', rangeStart: RANGE_A, user: null })
+    expect(result.current.loading).toBe(true)
+    expect(calls.length).toBe(0)
+  })
+
+  it('populates events and clears loading on a successful fetch', async () => {
+    const calls = installFetch()
+    const { result } = renderEvents({ viewMode: 'month', rangeStart: RANGE_A, user: USER })
+
+    expect(result.current.loading).toBe(true)
+    expect(calls.length).toBe(1)
+    expect(calls[0].url).toContain('/api/calendar/events')
+
+    const ev = makeEvent('1')
+    await act(async () => {
+      calls[0].resolve(okJson({ events: [ev] }))
+    })
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.events).toEqual([ev])
+    expect(result.current.error).toBeNull()
+    expect(result.current.syncErrors).toEqual([])
+  })
+
+  it('sets the error message and stops loading on a failed fetch', async () => {
+    const calls = installFetch()
+    const { result } = renderEvents({ viewMode: 'month', rangeStart: RANGE_A, user: USER })
+
+    await act(async () => {
+      calls[0].resolve({ ok: false, status: 500, json: () => Promise.resolve({}) })
+    })
+
+    expect(result.current.error).toBe('calendar.errors.failedToLoad')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('aborts the in-flight request and never applies a stale response when inputs change', async () => {
+    const calls = installFetch()
+    const { result, rerender } = renderEvents({ viewMode: 'month', rangeStart: RANGE_A, user: USER })
+
+    expect(calls.length).toBe(1)
+    const firstSignal = calls[0].signal
+
+    // Change rangeStart while the first request is still in flight.
+    await act(async () => {
+      rerender({ viewMode: 'month', rangeStart: RANGE_B, user: USER })
+    })
+
+    // The first request must have been aborted, and a second one started.
+    expect(firstSignal?.aborted).toBe(true)
+    expect(calls.length).toBe(2)
+
+    // A late stale response for the first request must never overwrite state.
+    await act(async () => {
+      calls[0].resolve(okJson({ events: [makeEvent('stale')] }))
+    })
+    expect(result.current.events).toEqual([])
+
+    // The newer request's response is applied.
+    await act(async () => {
+      calls[1].resolve(okJson({ events: [makeEvent('fresh')] }))
+    })
+    expect(result.current.events).toEqual([makeEvent('fresh')])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('aborts the pending request on unmount', async () => {
+    const calls = installFetch()
+    const { unmount } = renderEvents({ viewMode: 'month', rangeStart: RANGE_A, user: USER })
+
+    expect(calls.length).toBe(1)
+    const signal = calls[0].signal
+    expect(signal?.aborted).toBe(false)
+
+    unmount()
+    expect(signal?.aborted).toBe(true)
+  })
+
+  it('refetch() re-runs the current query without changing inputs', async () => {
+    const calls = installFetch()
+    const { result } = renderEvents({ viewMode: 'month', rangeStart: RANGE_A, user: USER })
+
+    await act(async () => {
+      calls[0].resolve(okJson({ events: [makeEvent('1')] }))
+    })
+    expect(calls.length).toBe(1)
+
+    // Fire refetch without awaiting it — the request stays in flight until we
+    // resolve it below.
+    act(() => { void result.current.refetch() })
+    expect(calls.length).toBe(2)
+    expect(calls[1].url).toContain('/api/calendar/events')
+    expect(calls[1].url).not.toContain('sync=true')
+
+    await act(async () => {
+      calls[1].resolve(okJson({ events: [makeEvent('2')] }))
+    })
+    expect(result.current.events).toEqual([makeEvent('2')])
+  })
+
+  it('refetch(true) requests a server-side sync and surfaces sync errors', async () => {
+    const calls = installFetch()
+    const { result } = renderEvents({ viewMode: 'month', rangeStart: RANGE_A, user: USER })
+
+    await act(async () => {
+      calls[0].resolve(okJson({ events: [] }))
+    })
+
+    act(() => { void result.current.refetch(true) })
+    expect(calls[1].url).toContain('sync=true')
+
+    const syncErrors = [{ calendar_id: 'primary', message: 'boom' }]
+    await act(async () => {
+      calls[1].resolve(okJson({ events: [], sync_errors: syncErrors }))
+    })
+    await waitFor(() => expect(result.current.syncErrors).toEqual(syncErrors))
+  })
+})

--- a/web/src/hooks/useCalendarEvents.ts
+++ b/web/src/hooks/useCalendarEvents.ts
@@ -44,16 +44,6 @@ export function useCalendarEvents(
 
   const fetchControllerRef = useRef<AbortController | null>(null)
 
-  // When the query inputs change, show the loading spinner immediately during
-  // render so stale content for the previous range never flashes. Using state
-  // (not a ref) so React sees the comparison without accessing a ref in render.
-  const inputKey = `${viewMode}|${rangeStart.getTime()}`
-  const [prevInputKey, setPrevInputKey] = useState<string | null>(null)
-  if (prevInputKey !== inputKey) {
-    setPrevInputKey(inputKey)
-    if (!loading) setLoading(true)
-  }
-
   const fetchEvents = useCallback(async (sync = false, signal?: AbortSignal) => {
     if (!user) return
     // Cancel any previous in-flight fetch so stale responses can't overwrite newer results
@@ -62,6 +52,7 @@ export function useCalendarEvents(
     fetchControllerRef.current = ctl
     // Chain caller's signal (e.g. effect cleanup) so it propagates to our controller
     if (signal) signal.addEventListener('abort', () => ctl.abort(), { once: true })
+    setLoading(true)
     try {
       const url = buildEventsUrl(viewMode, rangeStart, sync)
       const res = await fetch(url, { credentials: 'include', signal: ctl.signal })
@@ -81,15 +72,16 @@ export function useCalendarEvents(
     }
   }, [user, rangeStart, viewMode, t])
 
-  // Fetch events whenever rangeStart, viewMode, or user changes (fetchEvents
-  // identity already depends on all three).
   useEffect(() => {
     if (!user) return
     const controller = new AbortController()
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- setState calls in fetchEvents are all async (after await)
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- setLoading(true) inside fetchEvents is intentional to show the spinner as soon as a fetch starts
     void fetchEvents(false, controller.signal)
-    return () => controller.abort()
-  }, [fetchEvents])
+    return () => {
+      controller.abort()
+      fetchControllerRef.current?.abort()
+    }
+  }, [user, fetchEvents])
 
   const refetch = useCallback((sync = false) => fetchEvents(sync), [fetchEvents])
 

--- a/web/src/hooks/useCalendarEvents.ts
+++ b/web/src/hooks/useCalendarEvents.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { type CalendarEvent, type ViewMode } from '../components/calendar/types'
 import { buildEventsUrl } from './calendarUrl'
@@ -45,12 +45,12 @@ export function useCalendarEvents(
   const fetchControllerRef = useRef<AbortController | null>(null)
 
   // When the query inputs change, show the loading spinner immediately during
-  // render so stale content for the previous range never flashes. This mirrors
-  // the eager setLoading(true) the page used to do in its navigation handlers.
+  // render so stale content for the previous range never flashes. Using state
+  // (not a ref) so React sees the comparison without accessing a ref in render.
   const inputKey = `${viewMode}|${rangeStart.getTime()}`
-  const prevInputKeyRef = useRef<string | null>(null)
-  if (prevInputKeyRef.current !== inputKey) {
-    prevInputKeyRef.current = inputKey
+  const [prevInputKey, setPrevInputKey] = useState<string | null>(null)
+  if (prevInputKey !== inputKey) {
+    setPrevInputKey(inputKey)
     if (!loading) setLoading(true)
   }
 

--- a/web/src/hooks/useCalendarEvents.ts
+++ b/web/src/hooks/useCalendarEvents.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { type CalendarEvent, type ViewMode } from '../components/calendar/types'
+import { buildEventsUrl } from './calendarUrl'
+
+export interface SyncError {
+  calendar_id: string
+  message: string
+}
+
+interface EventsResponse {
+  events?: CalendarEvent[]
+  sync_errors?: SyncError[]
+}
+
+export interface UseCalendarEventsResult {
+  events: CalendarEvent[]
+  loading: boolean
+  error: string | null
+  syncErrors: SyncError[]
+  /** Re-run the current query without changing inputs. Pass `true` to request a server-side sync. */
+  refetch: (sync?: boolean) => Promise<void>
+}
+
+/**
+ * Owns the calendar events data layer: fetch lifecycle, AbortController
+ * plumbing, signal chaining, and the events/loading/error/syncErrors state.
+ *
+ * Changing `viewMode`, `rangeStart`, or `user` triggers a refetch and aborts
+ * any in-flight request, so a stale response can never overwrite a newer one.
+ * Unmounting aborts the pending request.
+ */
+export function useCalendarEvents(
+  viewMode: ViewMode,
+  rangeStart: Date,
+  user: { id: number } | null,
+): UseCalendarEventsResult {
+  const { t } = useTranslation('common')
+
+  const [events, setEvents] = useState<CalendarEvent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [syncErrors, setSyncErrors] = useState<SyncError[]>([])
+
+  const fetchControllerRef = useRef<AbortController | null>(null)
+
+  // When the query inputs change, show the loading spinner immediately during
+  // render so stale content for the previous range never flashes. This mirrors
+  // the eager setLoading(true) the page used to do in its navigation handlers.
+  const inputKey = `${viewMode}|${rangeStart.getTime()}`
+  const prevInputKeyRef = useRef<string | null>(null)
+  if (prevInputKeyRef.current !== inputKey) {
+    prevInputKeyRef.current = inputKey
+    if (!loading) setLoading(true)
+  }
+
+  const fetchEvents = useCallback(async (sync = false, signal?: AbortSignal) => {
+    if (!user) return
+    // Cancel any previous in-flight fetch so stale responses can't overwrite newer results
+    fetchControllerRef.current?.abort()
+    const ctl = new AbortController()
+    fetchControllerRef.current = ctl
+    // Chain caller's signal (e.g. effect cleanup) so it propagates to our controller
+    if (signal) signal.addEventListener('abort', () => ctl.abort(), { once: true })
+    try {
+      const url = buildEventsUrl(viewMode, rangeStart, sync)
+      const res = await fetch(url, { credentials: 'include', signal: ctl.signal })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data: EventsResponse = await res.json()
+      setEvents(data.events ?? [])
+      // sync_errors only appears on sync requests; clear on any fetch so the
+      // chip vanishes after a successful sync or a plain reload.
+      setSyncErrors(sync ? (data.sync_errors ?? []) : [])
+      setError(null)
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      setError(t('calendar.errors.failedToLoad'))
+      console.error('Failed to load calendar events:', err)
+    } finally {
+      if (!ctl.signal.aborted) setLoading(false)
+    }
+  }, [user, rangeStart, viewMode, t])
+
+  // Fetch events whenever rangeStart, viewMode, or user changes (fetchEvents
+  // identity already depends on all three).
+  useEffect(() => {
+    if (!user) return
+    const controller = new AbortController()
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- setState calls in fetchEvents are all async (after await)
+    void fetchEvents(false, controller.signal)
+    return () => controller.abort()
+  }, [fetchEvents])
+
+  const refetch = useCallback((sync = false) => fetchEvents(sync), [fetchEvents])
+
+  return { events, loading, error, syncErrors, refetch }
+}

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -68,6 +68,7 @@ export default function CalendarPage() {
         if (cals.length > 0 && !cals.some(c => c.selected)) {
           cals = cals.map(c => ({ ...c, selected: c.primary }))
         }
+        setCalendarsError(null)
         setCalendars(cals)
         setConnected(data.connected ?? false)
       })

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -1,76 +1,23 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RefreshCw, ChevronLeft, ChevronRight, Filter, CalendarDays, List, LayoutGrid, Columns3, Calendar, AlertTriangle } from 'lucide-react'
 import { useAuth } from '../auth'
 import { formatDate } from '../utils/formatDate'
 import {
-  type CalendarEvent,
   type CalendarInfo,
   type ViewMode,
   startOfDay,
-  endOfDay,
   addDays,
   startOfWeekMonday,
 } from '../components/calendar/types'
+import { useCalendarEvents } from '../hooks/useCalendarEvents'
+import { AGENDA_DAYS } from '../hooks/calendarUrl'
 import MonthView from '../components/calendar/MonthView'
 import WeekView from '../components/calendar/WeekView'
 import DayView from '../components/calendar/DayView'
 import AgendaView from '../components/calendar/AgendaView'
 
-const AGENDA_DAYS = 14
 const STORAGE_KEY = 'hytte-calendar-view'
-
-interface SyncError {
-  calendar_id: string
-  message: string
-}
-
-interface EventsResponse {
-  events?: CalendarEvent[]
-  sync_errors?: SyncError[]
-}
-
-/** Format a Date as RFC3339 without fractional seconds. */
-function toRFC3339(date: Date): string {
-  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
-}
-
-function getStartOfMonth(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), 1)
-}
-
-/** Calculate the date range to fetch based on view mode and rangeStart */
-function getViewRange(view: ViewMode, rangeStart: Date): { start: Date; end: Date } {
-  switch (view) {
-    case 'month': {
-      // Fetch from start of first visible week to end of last visible week
-      const firstOfMonth = getStartOfMonth(rangeStart)
-      const lastOfMonth = new Date(rangeStart.getFullYear(), rangeStart.getMonth() + 1, 0)
-      const gridStart = startOfWeekMonday(firstOfMonth)
-      const gridEnd = endOfDay(addDays(startOfWeekMonday(addDays(lastOfMonth, 7)), -1))
-      // Extend end to cover full 6th row if needed, using date-based arithmetic
-      // to avoid DST-sensitive millisecond day calculations.
-      const sixWeekEnd = endOfDay(addDays(gridStart, 41))
-      const endDate = gridEnd.getTime() < sixWeekEnd.getTime() ? sixWeekEnd : gridEnd
-      return { start: gridStart, end: endDate }
-    }
-    case 'week': {
-      const ws = startOfWeekMonday(rangeStart)
-      return { start: ws, end: endOfDay(addDays(ws, 6)) }
-    }
-    case 'day':
-      return { start: startOfDay(rangeStart), end: endOfDay(rangeStart) }
-    case 'agenda':
-    default:
-      return { start: startOfDay(rangeStart), end: endOfDay(addDays(rangeStart, AGENDA_DAYS - 1)) }
-  }
-}
-
-/** Build the events fetch URL for a given view mode and range start. */
-function buildEventsUrl(view: ViewMode, rangeStart: Date, sync = false): string {
-  const { start, end } = getViewRange(view, rangeStart)
-  return `/api/calendar/events?start=${encodeURIComponent(toRFC3339(start))}&end=${encodeURIComponent(toRFC3339(end))}${sync ? '&sync=true' : ''}`
-}
 
 function loadViewMode(): ViewMode {
   try {
@@ -87,55 +34,25 @@ export default function CalendarPage() {
   const { user } = useAuth()
   const locale = i18n.language
 
-  const [events, setEvents] = useState<CalendarEvent[]>([])
   const [calendars, setCalendars] = useState<CalendarInfo[]>([])
   const [connected, setConnected] = useState<boolean | null>(null)
   const [calendarsLoading, setCalendarsLoading] = useState(true)
-  const [loading, setLoading] = useState(true)
+  const [calendarsError, setCalendarsError] = useState<string | null>(null)
   const [syncing, setSyncing] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [syncErrors, setSyncErrors] = useState<SyncError[]>([])
   const [showSelector, setShowSelector] = useState(false)
   const [savingCalendars, setSavingCalendars] = useState(false)
   const [viewMode, setViewMode] = useState<ViewMode>(loadViewMode)
   const [rangeStart, setRangeStart] = useState(() => startOfDay(new Date()))
 
+  const { events, loading, error, syncErrors, refetch } = useCalendarEvents(viewMode, rangeStart, user)
+
   const selectorRef = useRef<HTMLDivElement>(null)
-  const fetchControllerRef = useRef<AbortController | null>(null)
 
   const handleSetViewMode = (mode: ViewMode) => {
     if (mode === viewMode) return
-    setLoading(true)
     setViewMode(mode)
     try { localStorage.setItem(STORAGE_KEY, mode) } catch { /* ignore */ }
   }
-
-  const fetchEvents = useCallback(async (sync = false, signal?: AbortSignal) => {
-    if (!user) return
-    // Cancel any previous in-flight fetch so stale responses can't overwrite newer results
-    fetchControllerRef.current?.abort()
-    const ctl = new AbortController()
-    fetchControllerRef.current = ctl
-    // Chain caller's signal (e.g. effect cleanup) so it propagates to our controller
-    if (signal) signal.addEventListener('abort', () => ctl.abort(), { once: true })
-    try {
-      const url = buildEventsUrl(viewMode, rangeStart, sync)
-      const res = await fetch(url, { credentials: 'include', signal: ctl.signal })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const data: EventsResponse = await res.json()
-      setEvents(data.events ?? [])
-      // sync_errors only appears on sync requests; clear on any fetch so the
-      // chip vanishes after a successful sync or a plain reload.
-      setSyncErrors(sync ? (data.sync_errors ?? []) : [])
-      setError(null)
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') return
-      setError(t('calendar.errors.failedToLoad'))
-      console.error('Failed to load calendar events:', err)
-    } finally {
-      if (!ctl.signal.aborted) setLoading(false)
-    }
-  }, [user, rangeStart, viewMode, t])
 
   // Fetch calendars once on mount
   useEffect(() => {
@@ -156,7 +73,7 @@ export default function CalendarPage() {
       })
       .catch(err => {
         if (err instanceof DOMException && err.name === 'AbortError') return
-        setError(t('calendar.errors.failedToLoad'))
+        setCalendarsError(t('calendar.errors.failedToLoad'))
         console.error('Failed to load calendars:', err)
       })
       .finally(() => {
@@ -164,15 +81,6 @@ export default function CalendarPage() {
       })
     return () => controller.abort()
   }, [user, t])
-
-  // Fetch events whenever rangeStart or viewMode changes
-  useEffect(() => {
-    if (!user) return
-    const controller = new AbortController()
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- setState calls in fetchEvents are all async (after await)
-    void fetchEvents(false, controller.signal)
-    return () => controller.abort()
-  }, [fetchEvents])
 
   // Close calendar selector on outside click
   useEffect(() => {
@@ -189,7 +97,7 @@ export default function CalendarPage() {
 
   const handleSync = async () => {
     setSyncing(true)
-    await fetchEvents(true)
+    await refetch(true)
     setSyncing(false)
   }
 
@@ -215,7 +123,7 @@ export default function CalendarPage() {
         body: JSON.stringify({ calendar_ids: selectedIds }),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      await fetchEvents(false)
+      await refetch(false)
     } catch (err) {
       setCalendars(prevCalendars)
       console.error('Failed to save calendar settings:', err)
@@ -224,10 +132,9 @@ export default function CalendarPage() {
     }
   }
 
-  const goToday = () => { setLoading(true); setRangeStart(startOfDay(new Date())) }
+  const goToday = () => { setRangeStart(startOfDay(new Date())) }
 
   const goPrev = () => {
-    setLoading(true)
     setRangeStart(prev => {
       switch (viewMode) {
         case 'month': return new Date(prev.getFullYear(), prev.getMonth() - 1, 1)
@@ -239,7 +146,6 @@ export default function CalendarPage() {
   }
 
   const goNext = () => {
-    setLoading(true)
     setRangeStart(prev => {
       switch (viewMode) {
         case 'month': return new Date(prev.getFullYear(), prev.getMonth() + 1, 1)
@@ -253,7 +159,6 @@ export default function CalendarPage() {
   /** Navigate to a specific day — switches to day view */
   const handleNavigateToDay = (date: Date) => {
     handleSetViewMode('day')
-    setLoading(true)
     setRangeStart(startOfDay(date))
   }
 
@@ -462,9 +367,9 @@ export default function CalendarPage() {
       )}
 
       {/* Error state */}
-      {error && (
+      {(error || calendarsError) && (
         <div role="alert" className="rounded-lg bg-red-900/30 border border-red-800 p-4 mb-4 text-red-300 text-sm">
-          {error}
+          {error || calendarsError}
         </div>
       )}
 


### PR DESCRIPTION
## Reviewer's approval notes

Could not parse structured verdict; defaulting to approve for human review

## Original Issue (feature): Extract event fetching and abort plumbing into a useCalendarEvents hook

### Scope
This plan extracts the calendar data-fetching layer out of `CalendarPage` into a dedicated `useCalendarEvents` hook. The hook owns the `AbortController` lifecycle, signal chaining, URL building (`buildEventsUrl`), range derivation (`getViewRange`), and the `events`/`loading`/`error` state. The page component is reduced to view-mode UI state, user input handling, and rendering. Behavior is preserved exactly; this is a pure refactor with added unit-test coverage for the abort/race logic. No backend changes.

### Files to touch
- `web/src/pages/CalendarPage.tsx` — remove fetch state, AbortController ref, and the `buildEventsUrl`/`getViewRange` helpers; consume the new hook.
- `web/src/hooks/useCalendarEvents.ts` (new) — hook returning `{events, loading, error, refetch}`; houses abort plumbing, signal chaining, URL/range helpers.
- `web/src/hooks/useCalendarEvents.test.ts` (new) — unit tests for fetch lifecycle, abort-on-unmount, race cancellation when inputs change, and `refetch`.
- `web/src/hooks/calendarUrl.ts` (new, optional) — only if `buildEventsUrl`/`getViewRange` are cleaner as standalone exported pure functions for direct testing; otherwise keep them inside the hook module.

### Acceptance criteria
- `CalendarPage.tsx` no longer references `AbortController`, fetch URLs, or `events`/`loading`/`error` `useState` directly — all come from `useCalendarEvents`.
- Calendar page renders, switches view modes, navigates ranges, and displays sync errors identically to before (no user-visible change).
- The hook accepts `(viewMode, rangeStart, user)` and returns `{events, loading, error, refetch}`; changing any input triggers a refetch and aborts the in-flight request.
- Rapidly changing inputs never applies a stale response over a newer one (race-safe), and unmounting aborts the pending request.
- `refetch()` re-runs the current query without changing inputs.
- New unit tests cover: successful fetch, error path, abort-on-input-change, abort-on-unmount, and `refetch`; all pass via the existing frontend test runner.
- `npm run lint` and `npm run build` pass; `go build`/`go vet`/`go test` unaffected.
- All existing calendar i18n keys (under `calendar.*` in `common.json`) remain wired; no strings hardcoded or removed.

### Non-goals
- No backend/API changes in `internal/calendar/handlers.go` or response shapes.
- No new features: no caching, prefetching, or persistence (the hook only creates the seam for them).
- No visual, layout, or styling changes to the calendar UI.
- No changes to authentication, feature gating, or the `calendar` flag.
- No broader refactor of unrelated `CalendarPage` view/UI state beyond what the extraction requires.

## Source

Created from Suggestions page (suggestion id 118, page slug "calendar", source=claude).

## Original suggestion

`CalendarPage` currently mixes view-mode UI state with fetch lifecycle: an `AbortController` ref, signal chaining, the `buildEventsUrl`/`getViewRange` helpers, and the `events`/`loading`/`error` triple all live alongside the layout JSX. Pull the data layer into `useCalendarEvents(viewMode, rangeStart, user)` returning `{events, loading, error, refetch}` so the page component only deals with rendering and user input. This shrinks the page file, makes the abort/race logic unit-testable, and creates a clean seam for future improvements like caching or prefetching.


---
Bead: Hytte-flmg | Branch: forge/Hytte-flmg
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->