### PR TITLE
Replace StridePage's local format helpers with the shared locale-aware ones (Hytte-vc1j)

### DIFF
--- a/changelog.d/Hytte-vc1j.md
+++ b/changelog.d/Hytte-vc1j.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Locale-aware distances and durations on Stride** - The Stride page now formats race distances and durations through the shared locale-aware helpers, so Norwegian and Thai users see the correct decimal separator and translated unit suffixes instead of a hardcoded `.` and literal `km`/`m`. (Hytte-vc1j)

--- a/web/src/pages/StridePage.tsx
+++ b/web/src/pages/StridePage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Trash2, Plus, Trophy, Zap, ChevronRight, RefreshCw, History, Pencil, Loader2 } from 'lucide-react'
 import { formatDate, formatDateTime, formatNumber } from '../utils/formatDate'
+import { formatDistance, formatDuration } from '../utils/training'
 import type { StrideEvaluationRecord, StridePlan, WeekSummary } from '../types/stride'
 import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
 import { TrainingBlockTimeline } from '../components/stride/TrainingBlockTimeline'
@@ -38,22 +39,6 @@ interface Note {
   created_at: string
 }
 
-
-function formatDistance(meters: number): string {
-  if (meters >= 1000) {
-    return `${(meters / 1000).toFixed(1)} km`
-  }
-  return `${meters} m`
-}
-
-function formatDuration(seconds: number | null): string {
-  if (seconds === null) return '—'
-  const h = Math.floor(seconds / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  const s = seconds % 60
-  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-  return `${m}:${String(s).padStart(2, '0')}`
-}
 
 function priorityLabel(priority: string): { label: string; class: string } {
   switch (priority) {
@@ -552,6 +537,9 @@ function EditNoteDialog({
 
 export default function StridePage() {
   const { t } = useTranslation('stride')
+  // Bound to the `training` namespace so the shared distance/duration helpers
+  // resolve their `units.*` keys (the page's own strings use the `stride` ns).
+  const { t: tTraining } = useTranslation('training')
 
   const [races, setRaces] = useState<Race[]>([])
   const [notes, setNotes] = useState<Note[]>([])
@@ -1338,9 +1326,9 @@ export default function StridePage() {
                     <p className="text-xs text-gray-400">
                       {formatDate(`${race.date}T00:00:00`, { dateStyle: 'medium' })}
                       {' · '}
-                      {formatDistance(race.distance_m)}
-                      {race.target_time != null && ` · ${t('races.target')}: ${formatDuration(race.target_time)}`}
-                      {race.result_time != null && ` · ${t('races.result')}: ${formatDuration(race.result_time)}`}
+                      {formatDistance(race.distance_m, tTraining, { fractionDigits: 1 })}
+                      {race.target_time != null && ` · ${t('races.target')}: ${formatDuration(race.target_time, tTraining)}`}
+                      {race.result_time != null && ` · ${t('races.result')}: ${formatDuration(race.result_time, tTraining)}`}
                       {weeks > 0 && ` · ${t('races.weeksAway', { count: weeks })}`}
                     </p>
                   </div>
@@ -1373,9 +1361,9 @@ export default function StridePage() {
                       <p className="text-xs text-gray-400">
                         {formatDate(`${race.date}T00:00:00`, { dateStyle: 'medium' })}
                         {' · '}
-                        {formatDistance(race.distance_m)}
-                        {race.target_time != null && ` · ${t('races.target')}: ${formatDuration(race.target_time)}`}
-                        {race.result_time != null && ` · ${t('races.result')}: ${formatDuration(race.result_time)}`}
+                        {formatDistance(race.distance_m, tTraining, { fractionDigits: 1 })}
+                        {race.target_time != null && ` · ${t('races.target')}: ${formatDuration(race.target_time, tTraining)}`}
+                        {race.result_time != null && ` · ${t('races.result')}: ${formatDuration(race.result_time, tTraining)}`}
                       </p>
                     </div>
                     <button


### PR DESCRIPTION
## Changes

- **Locale-aware distances and durations on Stride** - The Stride page now formats race distances and durations through the shared locale-aware helpers, so Norwegian and Thai users see the correct decimal separator and translated unit suffixes instead of a hardcoded `.` and literal `km`/`m`. (Hytte-vc1j)

## Original Issue (feature): Replace StridePage's local format helpers with the shared locale-aware ones

### Scope
StridePage.tsx defines local `formatDistance` (line 42) and `formatDuration` (line 49) that duplicate logic centralized in `web/src/utils/training.ts` (commit afbbacb) and bypass locale formatting (hardcoded `.toFixed(1)`, literal `km`/`m`). This plan replaces both local helpers with imports from the shared module and deletes the duplicates, so distances/durations render with locale-aware separators and units across en/nb/th. Scope is StridePage-only; the shared helpers are not modified.

### Files to touch
- `web/src/pages/StridePage.tsx` — import shared `formatDistance`/`formatDuration`, delete local copies, update the 8 call sites.
- `changelog.d/Hytte-xxxx.md` (new) — `Fixed` fragment noting locale-aware distance/duration on Stride.

### Key signature differences to reconcile
- Shared helpers take a `t: TFunction<'training'>` argument (not `i18n.language`). StridePage must supply a `t` bound to the `training` namespace (e.g. add `useTranslation('training')` or call its `t`), since the helpers reference `units.m`/`units.km`/`units.hours` keys.
- Shared `formatDistance` defaults to 2 fraction digits vs. the local copy's 1 — pass `{ fractionDigits: 1 }` only if preserving the current single-decimal look matters; otherwise accept the shared 2-digit default.
- Shared `formatDuration(seconds: number, ...)` does NOT accept `null` (local returned `—`). Guard null at each call site or render `—` before calling.

### Acceptance criteria
- StridePage no longer declares local `formatDistance` or `formatDuration`; both are imported from `web/src/utils/training.ts`.
- All 8 existing call sites compile and render distances/durations with the same information as before, with `null` durations still showing `—`.
- Under nb/th locales, distances show the locale decimal separator and translated unit suffixes (no hardcoded `.` or literal `km`/`m`).
- `npm run lint`, `npm run build`, and `go build` pass; no unused imports remain.
- Changelog fragment present in `changelog.d/` referencing the bead ID.

### Non-goals
- No changes to the shared helpers in `training.ts` or their tests.
- No backend changes (`internal/stride/handlers.go` untouched).
- No refactor of `formatPace` usage, `priorityLabel`, or other StridePage formatting not currently duplicated.
- No new translation namespace; reuse existing `training` `units.*` keys (add missing keys only if a referenced one is absent).

## Source

Created from Suggestions page (suggestion id 193, page slug "stride", source=claude).

## Original suggestion

StridePage.tsx redefines its own formatDistance and formatDuration, duplicating logic that was just centralized into shared helpers in afbbacb. The local copies also bypass locale formatting — formatDistance uses (meters/1000).toFixed(1) with a hardcoded decimal point and literal 'km'/'m' units, so Norwegian and Thai users see the wrong decimal separator instead of the i18n-aware output CLAUDE.md mandates. Import and use the shared helpers (passing i18n.language) and delete the local duplicates. This removes drift risk between pages and makes distances/durations render correctly across all three locales.


---
Bead: Hytte-vc1j | Branch: forge/Hytte-vc1j
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->