### PR TITLE
Extract SSE streaming and optimistic message bookkeeping into a useChatStream hook (Hytte-e86s)

### DIFF
--- a/changelog.d/Hytte-e86s.md
+++ b/changelog.d/Hytte-e86s.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Refactor chat SSE streaming into a useChatStream hook** - Extracted the chat streaming state machine, optimistic message bookkeeping, abort handling, and post-stream conversation refetch out of `Chat.tsx` into a dedicated `useChatStream` hook with unit tests. No user-visible behavior change. (Hytte-e86s)

--- a/web/src/hooks/useChatStream.test.ts
+++ b/web/src/hooks/useChatStream.test.ts
@@ -1,0 +1,329 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { Dispatch, RefObject, SetStateAction } from 'react'
+import { useChatStream } from './useChatStream'
+import type { Conversation, Message } from './useChatStream'
+
+// ── i18n mock ─────────────────────────────────────────────────────────────────
+// Return the key verbatim so error assertions are deterministic and `t` is a
+// stable reference (matching real react-i18next) so useCallback deps that
+// include `t` don't invalidate every render.
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key
+  const i18n = { language: 'en' }
+  return { useTranslation: () => ({ t, i18n }) }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+// ── SSE frame + controllable stream helpers ─────────────────────────────────────
+// Mirrors the backend wire format: `event: <name>\ndata: <json>\n\n`.
+const frame = (event: string, data: unknown) =>
+  `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+
+// A hand-driven ReadableStream-ish body: tests push SSE chunks and close it, and
+// aborting the attached signal rejects the pending read with an AbortError —
+// matching the real fetch contract the hook's read loop relies on.
+function makeSSEStream() {
+  const encoder = new TextEncoder()
+  const queue: Array<{ done: boolean; value?: Uint8Array }> = []
+  let pending: { resolve: (r: { done: boolean; value?: Uint8Array }) => void; reject: (e: unknown) => void } | null = null
+  let signal: AbortSignal | undefined
+
+  const reader = {
+    read() {
+      return new Promise<{ done: boolean; value?: Uint8Array }>((resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'))
+          return
+        }
+        const next = queue.shift()
+        if (next) {
+          resolve(next)
+          return
+        }
+        pending = { resolve, reject }
+      })
+    },
+    cancel() {},
+  }
+
+  return {
+    body: { getReader: () => reader },
+    attachSignal(s: AbortSignal | undefined) {
+      signal = s
+      s?.addEventListener(
+        'abort',
+        () => {
+          if (pending) {
+            pending.reject(new DOMException('Aborted', 'AbortError'))
+            pending = null
+          }
+        },
+        { once: true },
+      )
+    },
+    push(text: string) {
+      const value = encoder.encode(text)
+      if (pending) {
+        const p = pending
+        pending = null
+        p.resolve({ done: false, value })
+      } else {
+        queue.push({ done: false, value })
+      }
+    },
+    close() {
+      if (pending) {
+        const p = pending
+        pending = null
+        p.resolve({ done: true })
+      } else {
+        queue.push({ done: true })
+      }
+    },
+  }
+}
+
+type SSEStream = ReturnType<typeof makeSSEStream>
+
+interface FetchOpts {
+  // When set, the stream POST responds non-OK with this error body.
+  streamError?: string
+  // Conversations returned by the post-stream refetch.
+  conversations?: Conversation[]
+}
+
+function installFetch(stream: SSEStream, opts: FetchOpts = {}) {
+  const fetchMock = vi.fn((url: string, options?: { signal?: AbortSignal }) => {
+    if (url.includes('/messages/stream')) {
+      if (opts.streamError) {
+        return Promise.resolve({
+          ok: false,
+          body: null,
+          json: () => Promise.resolve({ error: opts.streamError }),
+        })
+      }
+      stream.attachSignal(options?.signal)
+      return Promise.resolve({ ok: true, body: stream.body })
+    }
+    // Post-stream conversation-list refetch.
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ conversations: opts.conversations ?? [] }),
+    })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+const CONV: Conversation = {
+  id: 1,
+  user_id: 1,
+  title: 'Chat',
+  model: 'claude',
+  created_at: '2026-06-03T00:00:00Z',
+  updated_at: '2026-06-03T00:00:00Z',
+}
+
+interface HarnessState {
+  messages: Message[]
+  conversations: Conversation[]
+  active: Conversation | null
+  input: string
+  sending: Set<number>
+  deleted: RefObject<Set<number>>
+}
+
+function makeHarness(initial?: { sending?: Set<number> }) {
+  const state: HarnessState = {
+    messages: [],
+    conversations: [],
+    active: CONV,
+    input: '',
+    sending: initial?.sending ?? new Set<number>(),
+    deleted: { current: new Set<number>() },
+  }
+
+  const setMessages: Dispatch<SetStateAction<Message[]>> = u => {
+    state.messages = typeof u === 'function' ? (u as (p: Message[]) => Message[])(state.messages) : u
+  }
+  const setConversations: Dispatch<SetStateAction<Conversation[]>> = u => {
+    state.conversations =
+      typeof u === 'function' ? (u as (p: Conversation[]) => Conversation[])(state.conversations) : u
+  }
+  const setActiveConversation: Dispatch<SetStateAction<Conversation | null>> = u => {
+    state.active =
+      typeof u === 'function' ? (u as (p: Conversation | null) => Conversation | null)(state.active) : u
+  }
+
+  const params = {
+    activeConversation: state.active,
+    setActiveConversation,
+    setMessages,
+    setConversations,
+    sendingConversationIds: state.sending,
+    addSendingConversation: (id: number) => state.sending.add(id),
+    removeSendingConversation: (id: number) => state.sending.delete(id),
+    deletedConversationIds: state.deleted,
+    setInput: (v: string) => {
+      state.input = v
+    },
+    pinToBottom: () => {},
+    focusInput: () => {},
+  }
+
+  return { state, params }
+}
+
+const userFrame = (overrides?: Partial<Message>) =>
+  frame('user_message', {
+    id: 10,
+    conversation_id: 1,
+    role: 'user',
+    content: 'hi',
+    created_at: '2026-06-03T00:00:01Z',
+    ...overrides,
+  })
+
+const doneFrame = (content: string) =>
+  frame('done', {
+    assistant_message: {
+      id: 11,
+      conversation_id: 1,
+      role: 'assistant',
+      content,
+      created_at: '2026-06-03T00:00:02Z',
+    },
+  })
+
+describe('useChatStream', () => {
+  it('success: swaps placeholders for canonical rows and streams tokens', async () => {
+    const stream = makeSSEStream()
+    installFetch(stream, { conversations: [{ ...CONV, title: 'Auto title' }] })
+    const { state, params } = makeHarness()
+    const { result } = renderHook(() => useChatStream(params))
+
+    await act(async () => {
+      const p = result.current.send('hi')
+      stream.push(userFrame())
+      stream.push(frame('token', { text: 'Hel' }))
+      stream.push(frame('token', { text: 'lo' }))
+      stream.push(doneFrame('Hello'))
+      stream.close()
+      await p
+    })
+
+    // Canonical rows (positive ids) replaced the optimistic placeholders.
+    expect(state.messages).toHaveLength(2)
+    expect(state.messages[0]).toMatchObject({ id: 10, role: 'user', content: 'hi' })
+    expect(state.messages[1]).toMatchObject({ id: 11, role: 'assistant', content: 'Hello' })
+    expect(result.current.error).toBe('')
+    expect(result.current.streamingId).toBeNull()
+    expect(state.sending.has(1)).toBe(false)
+    // Post-stream refetch updated the conversation list.
+    expect(state.conversations).toEqual([{ ...CONV, title: 'Auto title' }])
+  })
+
+  it('server error: surfaces error and keeps the persisted user message', async () => {
+    const stream = makeSSEStream()
+    installFetch(stream)
+    const { state, params } = makeHarness()
+    const { result } = renderHook(() => useChatStream(params))
+
+    await act(async () => {
+      const p = result.current.send('hi')
+      stream.push(userFrame())
+      stream.push(frame('error', { error: 'rate limited' }))
+      stream.close()
+      await p
+    })
+
+    expect(result.current.error).toBe('rate limited')
+    // The user message persisted by the backend stays visible (canonical row),
+    // the empty assistant placeholder is dropped, and the draft is restored.
+    expect(state.messages).toHaveLength(1)
+    expect(state.messages[0]).toMatchObject({ id: 10, role: 'user', content: 'hi' })
+    expect(state.input).toBe('hi')
+    expect(state.sending.has(1)).toBe(false)
+  })
+
+  it('abort before user_message: removes both optimistic placeholders', async () => {
+    const stream = makeSSEStream()
+    installFetch(stream)
+    const { state, params } = makeHarness()
+    const { result } = renderHook(() => useChatStream(params))
+
+    await act(async () => {
+      const p = result.current.send('hi')
+      // Both placeholders exist synchronously before any frame arrives.
+      expect(state.messages).toHaveLength(2)
+      result.current.stop()
+      await p
+    })
+
+    expect(state.messages).toHaveLength(0)
+    // Draft restored so the user can re-send.
+    expect(state.input).toBe('hi')
+    expect(result.current.error).toBe('')
+    expect(state.sending.has(1)).toBe(false)
+  })
+
+  it('abort after tokens: keeps the partial assistant message', async () => {
+    const stream = makeSSEStream()
+    installFetch(stream)
+    const { state, params } = makeHarness()
+    const { result } = renderHook(() => useChatStream(params))
+
+    let pending!: Promise<void>
+    await act(async () => {
+      pending = result.current.send('hi')
+      stream.push(userFrame())
+      stream.push(frame('token', { text: 'Partial' }))
+    })
+    // Guard: the token frame was consumed and applied to the placeholder before
+    // we abort — this is what distinguishes the "after tokens" branch.
+    expect(state.messages[1]).toMatchObject({ role: 'assistant', content: 'Partial' })
+
+    // The read loop is now awaiting the next read; aborting hits the
+    // sawToken branch which keeps the partial assistant text on screen.
+    await act(async () => {
+      result.current.stop()
+      await pending
+    })
+
+    expect(state.messages).toHaveLength(2)
+    // Assistant placeholder retains the partial streamed text.
+    expect(state.messages[1]).toMatchObject({ role: 'assistant', content: 'Partial' })
+    // No error and the draft is NOT restored (Stop is intentional, not a failure).
+    expect(result.current.error).toBe('')
+    expect(state.input).toBe('')
+    expect(state.sending.has(1)).toBe(false)
+  })
+
+  it('preserves a concurrent send on a different conversation', async () => {
+    const stream = makeSSEStream()
+    installFetch(stream, { conversations: [CONV] })
+    // Conversation 2 already has an in-flight send when we send in conversation 1.
+    const { state, params } = makeHarness({ sending: new Set<number>([2]) })
+    const { result } = renderHook(() => useChatStream(params))
+
+    await act(async () => {
+      const p = result.current.send('hi')
+      stream.push(userFrame())
+      stream.push(doneFrame('Hello'))
+      stream.close()
+      await p
+    })
+
+    // The send/reconcile lifecycle only touched conversation 1's membership;
+    // the concurrent send on conversation 2 is untouched.
+    expect(state.sending.has(1)).toBe(false)
+    expect(state.sending.has(2)).toBe(true)
+  })
+})

--- a/web/src/hooks/useChatStream.ts
+++ b/web/src/hooks/useChatStream.ts
@@ -48,7 +48,7 @@ export interface UseChatStream {
   streamingId: number | null
   /** Last send/stream error message, or '' when clear. */
   error: string
-  setError: Dispatch<SetStateAction<string>>
+  clearError: () => void
 }
 
 /**
@@ -73,6 +73,7 @@ export function useChatStream({
   const { t } = useTranslation('chat')
   const [error, setError] = useState('')
   const [streamingId, setStreamingId] = useState<number | null>(null)
+  const clearError = useCallback(() => setError(''), [])
   // Tracks the active streaming request so the user can cancel mid-send and so
   // a conversation switch can abort the in-flight stream.
   const streamAbortRef = useRef<AbortController | null>(null)
@@ -250,12 +251,9 @@ export function useChatStream({
           if (convRes.ok) {
             const convData = await convRes.json()
             const allConvs: Conversation[] = convData.conversations ?? []
-            setConversations(_prev => {
-              // Build a merged list: start from the server list, but drop any
-              // conversations the user explicitly deleted locally so we don't
-              // resurrect them.
-              return allConvs.filter(c => !deletedConversationIds.current.has(c.id))
-            })
+            setConversations(
+              allConvs.filter(c => !deletedConversationIds.current.has(c.id)),
+            )
             const updated = allConvs.find(c => c.id === sentConversationId)
             if (updated) {
               setActiveConversation(current =>
@@ -338,5 +336,5 @@ export function useChatStream({
     ],
   )
 
-  return { send, stop, streamingId, error, setError }
+  return { send, stop, streamingId, error, clearError }
 }

--- a/web/src/hooks/useChatStream.ts
+++ b/web/src/hooks/useChatStream.ts
@@ -1,0 +1,342 @@
+import { useCallback, useRef, useState } from 'react'
+import type { Dispatch, RefObject, SetStateAction } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export interface Conversation {
+  id: number
+  user_id: number
+  title: string
+  model: string
+  created_at: string
+  updated_at: string
+}
+
+export interface Message {
+  id: number
+  conversation_id: number
+  role: 'user' | 'assistant'
+  content: string
+  created_at: string
+}
+
+interface UseChatStreamParams {
+  /** The conversation a send targets and that the post-stream swap is gated on. */
+  activeConversation: Conversation | null
+  setActiveConversation: Dispatch<SetStateAction<Conversation | null>>
+  setMessages: Dispatch<SetStateAction<Message[]>>
+  setConversations: Dispatch<SetStateAction<Conversation[]>>
+  /** Conversations with an in-flight send, used to guard against double sends. */
+  sendingConversationIds: Set<number>
+  addSendingConversation: (id: number) => void
+  removeSendingConversation: (id: number) => void
+  /** Locally deleted conversation ids so a late response can't resurrect them. */
+  deletedConversationIds: RefObject<Set<number>>
+  /** Clears the input on send start; restores the draft on recoverable failure. */
+  setInput: (value: string) => void
+  /** Re-pins the messages view to the bottom when a send begins (UI concern). */
+  pinToBottom?: () => void
+  /** Returns focus to the input once a send settles (UI concern). */
+  focusInput?: () => void
+}
+
+export interface UseChatStream {
+  /** Starts an SSE send for `content` in the active conversation. */
+  send: (content: string) => Promise<void>
+  /** Aborts the in-flight stream (cancel button / conversation switch / unmount). */
+  stop: () => void
+  /** Id of the assistant placeholder currently streaming, or null. */
+  streamingId: number | null
+  /** Last send/stream error message, or '' when clear. */
+  error: string
+  setError: Dispatch<SetStateAction<string>>
+}
+
+/**
+ * Owns the chat SSE streaming state machine: optimistic placeholder rows, frame
+ * parsing, the three error-recovery branches, abort handling, and the
+ * post-stream conversation-list refetch. Lifted out of `Chat.tsx` so the parser
+ * and reconciliation can be unit-tested and the component keeps only UI state.
+ */
+export function useChatStream({
+  activeConversation,
+  setActiveConversation,
+  setMessages,
+  setConversations,
+  sendingConversationIds,
+  addSendingConversation,
+  removeSendingConversation,
+  deletedConversationIds,
+  setInput,
+  pinToBottom,
+  focusInput,
+}: UseChatStreamParams): UseChatStream {
+  const { t } = useTranslation('chat')
+  const [error, setError] = useState('')
+  const [streamingId, setStreamingId] = useState<number | null>(null)
+  // Tracks the active streaming request so the user can cancel mid-send and so
+  // a conversation switch can abort the in-flight stream.
+  const streamAbortRef = useRef<AbortController | null>(null)
+
+  const stop = useCallback(() => {
+    streamAbortRef.current?.abort()
+    streamAbortRef.current = null
+  }, [])
+
+  const send = useCallback(
+    async (content: string) => {
+      if (!content || !activeConversation || sendingConversationIds.has(activeConversation.id)) {
+        return
+      }
+      const sentConversationId = activeConversation.id
+      setInput('')
+      addSendingConversation(sentConversationId)
+      setError('')
+
+      // Optimistic rows: the user bubble and an empty assistant bubble that
+      // we mutate as `token` events arrive. Negative ids mark them as
+      // placeholders that will be swapped for canonical rows on `user_message`
+      // / `done`.
+      const tempUserId = -Date.now()
+      const tempAssistantId = tempUserId - 1
+      const tempUserMsg: Message = {
+        id: tempUserId,
+        conversation_id: sentConversationId,
+        role: 'user',
+        content,
+        created_at: new Date().toISOString(),
+      }
+      const tempAssistantMsg: Message = {
+        id: tempAssistantId,
+        conversation_id: sentConversationId,
+        role: 'assistant',
+        content: '',
+        created_at: new Date().toISOString(),
+      }
+      setMessages(prev => [...prev, tempUserMsg, tempAssistantMsg])
+      setStreamingId(tempAssistantId)
+      // Sending is a deliberate action: re-pin to the bottom so the user's new
+      // message and the streamed reply stay in view, even if they had scrolled up.
+      pinToBottom?.()
+
+      // Abort any earlier in-flight stream before starting this one. The
+      // conversation-switch effect in Chat also calls stop() on switches.
+      streamAbortRef.current?.abort()
+      const controller = new AbortController()
+      streamAbortRef.current = controller
+
+      // Accumulate streamed text in a local string so the placeholder row's
+      // content reflects the full assistant reply on every render, even though
+      // React batches the setState calls.
+      let accumulated = ''
+      const applyAccumulated = () => {
+        const next = accumulated
+        setMessages(prev =>
+          prev.map(m => (m.id === tempAssistantId ? { ...m, content: next } : m)),
+        )
+      }
+
+      let sawToken = false
+      // Hoisted so the catch block can reference the canonical user row when
+      // deciding whether to keep the user bubble visible after a stream error.
+      let canonicalUserMsg: Message | null = null
+
+      try {
+        const res = await fetch(`/api/chat/conversations/${sentConversationId}/messages/stream`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content }),
+          signal: controller.signal,
+        })
+        if (!res.ok || !res.body) {
+          const data = await res.json().catch(() => null)
+          throw new Error(data?.error || t('errors.failedToSend'))
+        }
+
+        const reader = res.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+        let canonicalAssistantMsg: Message | null = null
+        let serverError: string | null = null
+
+        const handleFrame = (frame: string) => {
+          let eventName = 'message'
+          const dataLines: string[] = []
+          for (const line of frame.split('\n')) {
+            if (line.startsWith('event:')) {
+              eventName = line.slice(6).trim()
+            } else if (line.startsWith('data:')) {
+              dataLines.push(line.slice(5).trim())
+            }
+          }
+          if (dataLines.length === 0) return
+          let payload: unknown
+          try {
+            payload = JSON.parse(dataLines.join('\n'))
+          } catch {
+            return
+          }
+          if (eventName === 'token') {
+            const text = (payload as { text?: string }).text ?? ''
+            if (text) {
+              sawToken = true
+              accumulated += text
+              applyAccumulated()
+            }
+          } else if (eventName === 'user_message') {
+            canonicalUserMsg = payload as Message
+          } else if (eventName === 'done') {
+            canonicalAssistantMsg = (payload as { assistant_message?: Message }).assistant_message ?? null
+          } else if (eventName === 'error') {
+            serverError = (payload as { error?: string }).error ?? t('errors.streamError')
+          }
+        }
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          const frames = buffer.split('\n\n')
+          buffer = frames.pop() ?? ''
+          for (const frame of frames) {
+            if (!frame.trim()) continue
+            handleFrame(frame)
+          }
+        }
+        // Flush the TextDecoder's internal buffer so any multi-byte UTF-8
+        // codepoint that was split across the final two chunks is completed.
+        buffer += decoder.decode()
+        // Flush any trailing frame that didn't end with the double-newline.
+        if (buffer.trim()) handleFrame(buffer)
+
+        if (serverError) {
+          throw new Error(serverError)
+        }
+
+        // Detect an unexpected server disconnect: the stream ended without
+        // a `done` or `error` event and the AbortController was not fired
+        // (AbortError from Stop/navigation reaches the catch block, not here).
+        if (!canonicalAssistantMsg && !controller.signal.aborted) {
+          throw new Error(t('errors.streamError'))
+        }
+
+        // Final swap: replace optimistic rows with the canonical ones the
+        // server returned. Skip if the user navigated away from this
+        // conversation while the stream was running.
+        setActiveConversation(current => {
+          if (current?.id !== sentConversationId) return current
+          setMessages(prev => {
+            // Drop the assistant placeholder if Claude returned an empty body
+            // and we never saw a token; otherwise replace with canonical.
+            if (!canonicalAssistantMsg && !sawToken) {
+              return prev.filter(m => m.id !== tempUserId && m.id !== tempAssistantId)
+            }
+            return prev.flatMap(m => {
+              if (m.id === tempUserId) {
+                return canonicalUserMsg ? [canonicalUserMsg] : [m]
+              }
+              if (m.id === tempAssistantId) {
+                return canonicalAssistantMsg ? [canonicalAssistantMsg] : [m]
+              }
+              return [m]
+            })
+          })
+          return current
+        })
+
+        // Refresh conversation list to pick up auto-title updates (non-fatal).
+        try {
+          const convRes = await fetch('/api/chat/conversations', { credentials: 'include' })
+          if (convRes.ok) {
+            const convData = await convRes.json()
+            const allConvs: Conversation[] = convData.conversations ?? []
+            setConversations(_prev => {
+              // Build a merged list: start from the server list, but drop any
+              // conversations the user explicitly deleted locally so we don't
+              // resurrect them.
+              return allConvs.filter(c => !deletedConversationIds.current.has(c.id))
+            })
+            const updated = allConvs.find(c => c.id === sentConversationId)
+            if (updated) {
+              setActiveConversation(current =>
+                current?.id === sentConversationId ? updated : current,
+              )
+            }
+          }
+        } catch (refreshErr) {
+          console.error('Failed to refresh conversations after sending message', refreshErr)
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          if (sawToken) {
+            // Stop semantics: keep the partial assistant text on screen at
+            // whatever was already streamed. The placeholder rows stay in
+            // place as non-persisted local entries.
+            setMessages(prev =>
+              prev.map(m =>
+                m.id === tempAssistantId
+                  ? { ...m, content: accumulated || m.content }
+                  : m,
+              ),
+            )
+          } else if (canonicalUserMsg) {
+            // Aborted before any tokens arrived but after the server persisted
+            // the user message (we received the `user_message` SSE event).
+            // Drop only the empty assistant placeholder; keep the canonical user
+            // row so the conversation history remains consistent.
+            setMessages(prev =>
+              prev
+                .filter(m => m.id !== tempAssistantId)
+                .map(m => (m.id === tempUserId ? canonicalUserMsg! : m)),
+            )
+          } else {
+            // Aborted before the `user_message` SSE event arrived — the server
+            // may not have persisted the message yet. Remove both optimistic
+            // placeholders and restore the draft so the user can re-send.
+            setMessages(prev =>
+              prev.filter(m => m.id !== tempUserId && m.id !== tempAssistantId),
+            )
+            setInput(content)
+          }
+        } else {
+          // Stream error: the backend has already persisted the user_message
+          // before running Claude, so keep it visible (swap in the canonical
+          // row if one arrived, otherwise leave the optimistic placeholder).
+          // Only remove the assistant placeholder and restore the draft input
+          // so the user can re-send without losing their message context.
+          setMessages(prev =>
+            prev
+              .filter(m => m.id !== tempAssistantId)
+              .map(m => (m.id === tempUserId && canonicalUserMsg ? canonicalUserMsg : m)),
+          )
+          setInput(content)
+          if (err instanceof Error) setError(err.message || t('errors.streamError'))
+          else setError(t('errors.streamError'))
+        }
+      } finally {
+        if (streamAbortRef.current === controller) {
+          streamAbortRef.current = null
+        }
+        setStreamingId(current => (current === tempAssistantId ? null : current))
+        removeSendingConversation(sentConversationId)
+        focusInput?.()
+      }
+    },
+    [
+      activeConversation,
+      sendingConversationIds,
+      addSendingConversation,
+      removeSendingConversation,
+      setActiveConversation,
+      setMessages,
+      setConversations,
+      deletedConversationIds,
+      setInput,
+      pinToBottom,
+      focusInput,
+      t,
+    ],
+  )
+
+  return { send, stop, streamingId, error, setError }
+}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -36,6 +36,7 @@ export default function Chat() {
   const [activeConversation, setActiveConversation] = useState<Conversation | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
   const [input, setInput] = useState('')
+  const [localError, setLocalError] = useState('')
   const [loadingConversations, setLoadingConversations] = useState(true)
   const [loadingMessages, setLoadingMessages] = useState(false)
   // Track every conversation with an in-flight send so concurrent sends in
@@ -108,7 +109,7 @@ export default function Chat() {
   // SSE streaming state machine: optimistic placeholders, frame parsing, the
   // three error-recovery branches, abort handling, and the post-stream
   // conversation-list refetch all live in the hook. Chat keeps only UI state.
-  const { send, stop, error, setError } = useChatStream({
+  const { send, stop, error, clearError } = useChatStream({
     activeConversation,
     setActiveConversation,
     setMessages,
@@ -178,14 +179,14 @@ export default function Chat() {
         setConversations(data.conversations ?? [])
       } catch (err) {
         if (err instanceof Error && err.name !== 'AbortError') {
-          setError(err.message)
+          setLocalError(err.message)
         }
       } finally {
         if (!controller.signal.aborted) setLoadingConversations(false)
       }
     })()
     return () => { controller.abort() }
-  }, [t, setError])
+  }, [t])
 
   // Load messages when conversation changes
   const activeConversationId = activeConversation?.id ?? null
@@ -193,13 +194,14 @@ export default function Chat() {
     // Cancel any in-flight streaming send when switching conversations so the
     // partial tokens do not bleed into the newly selected conversation.
     stop()
+    clearError()
 
     const controller = new AbortController()
     ;(async () => {
       if (activeConversationId === null) {
         setMessages([])
         setLoadingMessages(false)
-        setError('')
+        setLocalError('')
         return
       }
       setLoadingMessages(true)
@@ -211,17 +213,17 @@ export default function Chat() {
         if (!res.ok) throw new Error(t('errors.failedToLoadMessages'))
         const data = await res.json()
         setMessages(data.messages ?? [])
-        setError('')
+        setLocalError('')
       } catch (err) {
         if (err instanceof Error && err.name !== 'AbortError') {
-          setError(err.message)
+          setLocalError(err.message)
         }
       } finally {
         if (!controller.signal.aborted) setLoadingMessages(false)
       }
     })()
     return () => { controller.abort() }
-  }, [activeConversationId, t, stop, setError])
+  }, [activeConversationId, t, stop, clearError])
 
   // Resize textarea when input changes (including programmatic clears)
   useEffect(() => {
@@ -263,15 +265,15 @@ export default function Chat() {
       setConversations(prev => [conv, ...prev])
       setActiveConversation(conv)
       setShowSidebar(false)
-      setError('')
+      setLocalError('')
       inputRef.current?.focus()
     } catch (err) {
-      if (err instanceof Error) setError(err.message)
+      if (err instanceof Error) setLocalError(err.message)
     }
   }
 
   async function deleteConversation(id: number) {
-    setError('')
+    setLocalError('')
     try {
       const res = await fetch(`/api/chat/conversations/${id}`, {
         method: 'DELETE',
@@ -285,9 +287,9 @@ export default function Chat() {
         setMessages([])
       }
       setDeletingId(null)
-      setError('')
+      setLocalError('')
     } catch (err) {
-      if (err instanceof Error) setError(err.message)
+      if (err instanceof Error) setLocalError(err.message)
     }
   }
 
@@ -296,7 +298,7 @@ export default function Chat() {
       setRenamingId(null)
       return
     }
-    setError('')
+    setLocalError('')
     try {
       const res = await fetch(`/api/chat/conversations/${id}`, {
         method: 'PUT',
@@ -312,9 +314,9 @@ export default function Chat() {
         setActiveConversation(updated)
       }
       setRenamingId(null)
-      setError('')
+      setLocalError('')
     } catch (err) {
-      if (err instanceof Error) setError(err.message)
+      if (err instanceof Error) setLocalError(err.message)
     }
   }
 
@@ -334,7 +336,8 @@ export default function Chat() {
   function selectConversation(conv: Conversation) {
     setActiveConversation(conv)
     setShowSidebar(false)
-    setError('')
+    clearError()
+    setLocalError('')
   }
 
   function formatTime(dateStr: string): string {
@@ -613,11 +616,11 @@ export default function Chat() {
         </div>
 
         {/* Error banner */}
-        {error && (
+        {(error || localError) && (
           <div className="px-4 py-2 bg-red-900/50 border-t border-red-800 text-red-300 text-sm flex items-center justify-between">
-            <span>{error}</span>
+            <span>{error || localError}</span>
             <button
-              onClick={() => setError('')}
+              onClick={() => { clearError(); setLocalError('') }}
               className="text-red-400 hover:text-red-300 cursor-pointer"
               aria-label={t('input.dismissError')}
             >

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -22,23 +22,8 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { formatDate, formatTime as fmtTime } from '../utils/formatDate'
-
-interface Conversation {
-  id: number
-  user_id: number
-  title: string
-  model: string
-  created_at: string
-  updated_at: string
-}
-
-interface Message {
-  id: number
-  conversation_id: number
-  role: 'user' | 'assistant'
-  content: string
-  created_at: string
-}
+import { useChatStream } from '../hooks/useChatStream'
+import type { Conversation, Message } from '../hooks/useChatStream'
 
 // Distance from the bottom (px) within which the messages view is considered
 // "pinned": new streamed tokens keep the view glued to the latest message.
@@ -57,7 +42,6 @@ export default function Chat() {
   // different conversations don't clobber each other's pending state. Kept
   // immutably (a fresh Set on each update) so React re-renders fire.
   const [sendingConversationIds, setSendingConversationIds] = useState<Set<number>>(new Set())
-  const [error, setError] = useState('')
   const [showSidebar, setShowSidebar] = useState(true)
   const [renamingId, setRenamingId] = useState<number | null>(null)
   const [renameTitle, setRenameTitle] = useState('')
@@ -82,9 +66,6 @@ export default function Chat() {
   // Track locally deleted conversation IDs so we don't resurrect them if a
   // send response arrives after the user deleted the conversation mid-flight.
   const deletedConversationIds = useRef<Set<number>>(new Set())
-  // Tracks the active streaming request so the user can cancel mid-send and
-  // so a conversation switch can abort the in-flight stream.
-  const streamAbortRef = useRef<AbortController | null>(null)
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     messagesEndRef.current?.scrollIntoView({ behavior })
@@ -112,6 +93,34 @@ export default function Chat() {
       return next
     })
   }, [])
+
+  // Re-pin the messages view to the bottom — used when a send begins so the
+  // user's new message and the streamed reply stay in view.
+  const pinToBottom = useCallback(() => {
+    isPinnedRef.current = true
+    setIsPinned(true)
+  }, [])
+
+  const focusInput = useCallback(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  // SSE streaming state machine: optimistic placeholders, frame parsing, the
+  // three error-recovery branches, abort handling, and the post-stream
+  // conversation-list refetch all live in the hook. Chat keeps only UI state.
+  const { send, stop, error, setError } = useChatStream({
+    activeConversation,
+    setActiveConversation,
+    setMessages,
+    setConversations,
+    sendingConversationIds,
+    addSendingConversation,
+    removeSendingConversation,
+    deletedConversationIds,
+    setInput,
+    pinToBottom,
+    focusInput,
+  })
 
   // Keep the view glued to the latest message only while the user is pinned
   // near the bottom. If they have scrolled up to read history, leave their
@@ -176,15 +185,14 @@ export default function Chat() {
       }
     })()
     return () => { controller.abort() }
-  }, [t])
+  }, [t, setError])
 
   // Load messages when conversation changes
   const activeConversationId = activeConversation?.id ?? null
   useEffect(() => {
     // Cancel any in-flight streaming send when switching conversations so the
     // partial tokens do not bleed into the newly selected conversation.
-    streamAbortRef.current?.abort()
-    streamAbortRef.current = null
+    stop()
 
     const controller = new AbortController()
     ;(async () => {
@@ -213,7 +221,7 @@ export default function Chat() {
       }
     })()
     return () => { controller.abort() }
-  }, [activeConversationId, t])
+  }, [activeConversationId, t, stop, setError])
 
   // Resize textarea when input changes (including programmatic clears)
   useEffect(() => {
@@ -227,11 +235,8 @@ export default function Chat() {
   // Abort any in-flight streaming send when the component unmounts so the
   // background fetch does not keep running with a stale state ref.
   useEffect(() => {
-    return () => {
-      streamAbortRef.current?.abort()
-      streamAbortRef.current = null
-    }
-  }, [])
+    return () => { stop() }
+  }, [stop])
 
   // Focus rename input when entering rename mode
   useEffect(() => {
@@ -313,254 +318,16 @@ export default function Chat() {
     }
   }
 
-  async function sendMessage() {
-    if (!input.trim() || !activeConversation || sendingConversationIds.has(activeConversation.id)) return
-    const content = input.trim()
-    const sentConversationId = activeConversation.id
-    setInput('')
-    addSendingConversation(sentConversationId)
-    setError('')
-
-    // Optimistic rows: the user bubble and an empty assistant bubble that
-    // we mutate as `token` events arrive. Negative ids mark them as
-    // placeholders that will be swapped for canonical rows on `user_message`
-    // / `done`.
-    const tempUserId = -Date.now()
-    const tempAssistantId = tempUserId - 1
-    const tempUserMsg: Message = {
-      id: tempUserId,
-      conversation_id: sentConversationId,
-      role: 'user',
-      content,
-      created_at: new Date().toISOString(),
-    }
-    const tempAssistantMsg: Message = {
-      id: tempAssistantId,
-      conversation_id: sentConversationId,
-      role: 'assistant',
-      content: '',
-      created_at: new Date().toISOString(),
-    }
-    setMessages(prev => [...prev, tempUserMsg, tempAssistantMsg])
-    // Sending is a deliberate action: re-pin to the bottom so the user's new
-    // message and the streamed reply stay in view, even if they had scrolled up.
-    isPinnedRef.current = true
-    setIsPinned(true)
-
-    // Abort any earlier in-flight stream before starting this one. The
-    // useEffect on activeConversationId also calls abort on conversation
-    // switches.
-    streamAbortRef.current?.abort()
-    const controller = new AbortController()
-    streamAbortRef.current = controller
-
-    // Accumulate streamed text in a local string so the placeholder row's
-    // content reflects the full assistant reply on every render, even though
-    // React batches the setState calls.
-    let accumulated = ''
-    const applyAccumulated = () => {
-      const next = accumulated
-      setMessages(prev =>
-        prev.map(m => (m.id === tempAssistantId ? { ...m, content: next } : m)),
-      )
-    }
-
-    let sawToken = false
-    // Hoisted so the catch block can reference the canonical user row when
-    // deciding whether to keep the user bubble visible after a stream error.
-    let canonicalUserMsg: Message | null = null
-
-    try {
-      const res = await fetch(`/api/chat/conversations/${sentConversationId}/messages/stream`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content }),
-        signal: controller.signal,
-      })
-      if (!res.ok || !res.body) {
-        const data = await res.json().catch(() => null)
-        throw new Error(data?.error || t('errors.failedToSend'))
-      }
-
-      const reader = res.body.getReader()
-      const decoder = new TextDecoder()
-      let buffer = ''
-      let canonicalAssistantMsg: Message | null = null
-      let serverError: string | null = null
-
-      const handleFrame = (frame: string) => {
-        let eventName = 'message'
-        const dataLines: string[] = []
-        for (const line of frame.split('\n')) {
-          if (line.startsWith('event:')) {
-            eventName = line.slice(6).trim()
-          } else if (line.startsWith('data:')) {
-            dataLines.push(line.slice(5).trim())
-          }
-        }
-        if (dataLines.length === 0) return
-        let payload: unknown
-        try {
-          payload = JSON.parse(dataLines.join('\n'))
-        } catch {
-          return
-        }
-        if (eventName === 'token') {
-          const text = (payload as { text?: string }).text ?? ''
-          if (text) {
-            sawToken = true
-            accumulated += text
-            applyAccumulated()
-          }
-        } else if (eventName === 'user_message') {
-          canonicalUserMsg = payload as Message
-        } else if (eventName === 'done') {
-          canonicalAssistantMsg = (payload as { assistant_message?: Message }).assistant_message ?? null
-        } else if (eventName === 'error') {
-          serverError = (payload as { error?: string }).error ?? t('errors.streamError')
-        }
-      }
-
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        buffer += decoder.decode(value, { stream: true })
-        const frames = buffer.split('\n\n')
-        buffer = frames.pop() ?? ''
-        for (const frame of frames) {
-          if (!frame.trim()) continue
-          handleFrame(frame)
-        }
-      }
-      // Flush the TextDecoder's internal buffer so any multi-byte UTF-8
-      // codepoint that was split across the final two chunks is completed.
-      buffer += decoder.decode()
-      // Flush any trailing frame that didn't end with the double-newline.
-      if (buffer.trim()) handleFrame(buffer)
-
-      if (serverError) {
-        throw new Error(serverError)
-      }
-
-      // Detect an unexpected server disconnect: the stream ended without
-      // a `done` or `error` event and the AbortController was not fired
-      // (AbortError from Stop/navigation reaches the catch block, not here).
-      if (!canonicalAssistantMsg && !controller.signal.aborted) {
-        throw new Error(t('errors.streamError'))
-      }
-
-      // Final swap: replace optimistic rows with the canonical ones the
-      // server returned. Skip if the user navigated away from this
-      // conversation while the stream was running.
-      setActiveConversation(current => {
-        if (current?.id !== sentConversationId) return current
-        setMessages(prev => {
-          // Drop the assistant placeholder if Claude returned an empty body
-          // and we never saw a token; otherwise replace with canonical.
-          if (!canonicalAssistantMsg && !sawToken) {
-            return prev.filter(m => m.id !== tempUserId && m.id !== tempAssistantId)
-          }
-          return prev.flatMap(m => {
-            if (m.id === tempUserId) {
-              return canonicalUserMsg ? [canonicalUserMsg] : [m]
-            }
-            if (m.id === tempAssistantId) {
-              return canonicalAssistantMsg ? [canonicalAssistantMsg] : [m]
-            }
-            return [m]
-          })
-        })
-        return current
-      })
-
-      // Refresh conversation list to pick up auto-title updates (non-fatal).
-      try {
-        const convRes = await fetch('/api/chat/conversations', { credentials: 'include' })
-        if (convRes.ok) {
-          const convData = await convRes.json()
-          const allConvs: Conversation[] = convData.conversations ?? []
-          setConversations(_prev => {
-            // Build a merged list: start from the server list, but drop any
-            // conversations the user explicitly deleted locally so we don't
-            // resurrect them.
-            return allConvs.filter(c => !deletedConversationIds.current.has(c.id))
-          })
-          const updated = allConvs.find(c => c.id === sentConversationId)
-          if (updated) {
-            setActiveConversation(current =>
-              current?.id === sentConversationId ? updated : current,
-            )
-          }
-        }
-      } catch (refreshErr) {
-        console.error('Failed to refresh conversations after sending message', refreshErr)
-      }
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') {
-        if (sawToken) {
-          // Stop semantics: keep the partial assistant text on screen at
-          // whatever was already streamed. The placeholder rows stay in
-          // place as non-persisted local entries.
-          setMessages(prev =>
-            prev.map(m =>
-              m.id === tempAssistantId
-                ? { ...m, content: accumulated || m.content }
-                : m,
-            ),
-          )
-        } else if (canonicalUserMsg) {
-          // Aborted before any tokens arrived but after the server persisted
-          // the user message (we received the `user_message` SSE event).
-          // Drop only the empty assistant placeholder; keep the canonical user
-          // row so the conversation history remains consistent.
-          setMessages(prev =>
-            prev
-              .filter(m => m.id !== tempAssistantId)
-              .map(m => (m.id === tempUserId ? canonicalUserMsg! : m)),
-          )
-        } else {
-          // Aborted before the `user_message` SSE event arrived — the server
-          // may not have persisted the message yet. Remove both optimistic
-          // placeholders and restore the draft so the user can re-send.
-          setMessages(prev =>
-            prev.filter(m => m.id !== tempUserId && m.id !== tempAssistantId),
-          )
-          setInput(content)
-        }
-      } else {
-        // Stream error: the backend has already persisted the user_message
-        // before running Claude, so keep it visible (swap in the canonical
-        // row if one arrived, otherwise leave the optimistic placeholder).
-        // Only remove the assistant placeholder and restore the draft input
-        // so the user can re-send without losing their message context.
-        setMessages(prev =>
-          prev
-            .filter(m => m.id !== tempAssistantId)
-            .map(m => (m.id === tempUserId && canonicalUserMsg ? canonicalUserMsg : m)),
-        )
-        setInput(content)
-        if (err instanceof Error) setError(err.message || t('errors.streamError'))
-        else setError(t('errors.streamError'))
-      }
-    } finally {
-      if (streamAbortRef.current === controller) {
-        streamAbortRef.current = null
-      }
-      removeSendingConversation(sentConversationId)
-      inputRef.current?.focus()
-    }
-  }
-
-  function stopStreaming() {
-    streamAbortRef.current?.abort()
-    streamAbortRef.current = null
+  // Thin wrapper around the hook's send: the trimmed input is the message
+  // content; the hook owns the optimistic rows, streaming, and reconciliation.
+  function handleSend() {
+    send(input.trim())
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      sendMessage()
+      handleSend()
     }
   }
 
@@ -881,7 +648,7 @@ export default function Chat() {
               />
               {sendingConversationIds.has(activeConversation.id) ? (
                 <button
-                  onClick={stopStreaming}
+                  onClick={stop}
                   className="self-end p-3 rounded-xl bg-red-600 hover:bg-red-500 text-white transition-colors cursor-pointer shrink-0"
                   title={t('input.stopStreaming')}
                   aria-label={t('input.stopStreaming')}
@@ -891,7 +658,7 @@ export default function Chat() {
                 </button>
               ) : (
                 <button
-                  onClick={sendMessage}
+                  onClick={handleSend}
                   disabled={!input.trim()}
                   className="self-end p-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-white transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
                   title={t('input.sendLabel')}


### PR DESCRIPTION
## Changes

- **Refactor chat SSE streaming into a useChatStream hook** - Extracted the chat streaming state machine, optimistic message bookkeeping, abort handling, and post-stream conversation refetch out of `Chat.tsx` into a dedicated `useChatStream` hook with unit tests. No user-visible behavior change. (Hytte-e86s)

## Original Issue (feature): Extract SSE streaming and optimistic message bookkeeping into a useChatStream hook

### Scope
Extract the SSE streaming state machine currently embedded in `Chat.tsx`'s ~230-line `sendMessage` into a dedicated `useChatStream` hook. The hook owns SSE frame parsing, optimistic placeholder bookkeeping, abort handling, the three error-recovery branches, and the post-stream conversation-list refetch. `Chat.tsx` keeps only UI concerns (input, scroll/pin, sidebar, rename/delete). No user-visible behavior change. Add unit tests for the four observed stream paths.

### Files to touch
- `web/src/hooks/useChatStream.ts` (new) — exposes `{ send, stop, streamingId, error }`, accepts `messages`/`setMessages`, `setConversations` (or a refetch callback), and the sending-set updaters so optimistic rows and reconciliation live here.
- `web/src/hooks/useChatStream.test.ts` (new) — tests for success, server error, abort-before-`user_message`, abort-after-tokens, with a mocked `fetch`/SSE body.
- `web/src/pages/Chat.tsx` — remove `sendMessage` body and the stream abort ref; call `useChatStream`; wire `send`/`stop`/`streamingId`/`error` into existing buttons and effects (conversation switch must still abort via the hook).

### Acceptance criteria
- `Chat.tsx` no longer contains SSE parsing, optimistic placeholder creation, or the post-stream refetch; `sendMessage` is gone in favor of the hook's `send`.
- Conversation switch and the cancel button still abort the in-flight stream (no orphaned streams, no resurrected deleted conversations).
- All four paths covered by passing tests: (1) success swaps placeholders for canonical rows on `user_message` then streams tokens; (2) server error surfaces `error` and keeps the persisted user message; (3) abort before `user_message` removes both placeholders; (4) abort after tokens keeps the partial assistant message.
- Optimistic-row reconciliation preserves concurrent sends across different conversations (the `sendingConversationIds` set behavior is unchanged).
- `npm run lint`, `npm run build`, and the new tests pass; manual chat send/stop/switch behaves identically to before.

### Non-goals
- No backend changes to `internal/chat/handlers.go` or the SSE wire format.
- No changes to scroll/pin logic, rename/delete flows, or conversation loading effects beyond rewiring abort to the hook.
- No new UI, no streaming-protocol redesign, no i18n key changes.
- No change to encryption, auth, or feature-flag gating.

## Source

Created from Suggestions page (suggestion id 162, page slug "chat", source=claude).

## Original suggestion

`sendMessage` is ~230 lines and tangles SSE frame parsing, optimistic placeholder rows, abort handling, three distinct error-recovery branches, and a post-stream conversation-list refetch all inside one component closure. That makes it hard to unit-test the parser, hard to reason about which `setMessages` call wins, and forces every reader of `Chat.tsx` to load all of it. Pull the streaming state machine into `hooks/useChatStream.ts` exposing `{ send, stop, streamingId, error }` and let `Chat.tsx` keep only UI concerns; cover the hook with tests for the four observed paths (success, server error, abort before `user_message`, abort after tokens). No user-visible change, but it shrinks the component to something a future contributor can hold in their head.


---
Bead: Hytte-e86s | Branch: forge/Hytte-e86s
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->