### PR TITLE
Add a per-conversation model selector to the chat header (Hytte-l40r)

### DIFF
--- a/changelog.d/Hytte-l40r.md
+++ b/changelog.d/Hytte-l40r.md
@@ -1,0 +1,2 @@
+category: Added
+- **Per-conversation model selector in chat** - Added a model dropdown to the chat header so you can pick Opus, Sonnet, or Haiku for each conversation. The choice applies to new conversations and persists on existing ones via `PUT /api/chat/conversations/{id}`. (Hytte-l40r)

--- a/internal/chat/handlers.go
+++ b/internal/chat/handlers.go
@@ -79,10 +79,11 @@ func CreateHandler(db *sql.DB) http.HandlerFunc {
 
 		model := strings.TrimSpace(body.Model)
 		if model == "" {
-			// Fall back to user's configured Claude model.
+			// Fall back to user's configured Claude model, validated against
+			// the allowlist so an unsupported config value can't slip through.
 			cfg, err := training.LoadClaudeConfig(db, user.ID)
-			if err == nil && cfg.Model != "" {
-				model = cfg.Model
+			if err == nil && SupportedModels[strings.TrimSpace(cfg.Model)] {
+				model = strings.TrimSpace(cfg.Model)
 			} else {
 				model = "claude-sonnet-4-6"
 			}

--- a/internal/chat/handlers.go
+++ b/internal/chat/handlers.go
@@ -293,8 +293,8 @@ func SendMessageHandler(db *sql.DB) http.HandlerFunc {
 }
 
 // RenameHandler updates a conversation's title and/or model. Both fields are
-// optional; at least one must be supplied. Title-only requests behave exactly
-// as before. A supplied model is validated against SupportedModels.
+// optional; at least one must be supplied. A supplied model is validated
+// against SupportedModels.
 // PUT /api/chat/conversations/{id}
 // Body: {"title": "New Title"} and/or {"model": "claude-opus-4-8"}
 func RenameHandler(db *sql.DB) http.HandlerFunc {

--- a/internal/chat/handlers.go
+++ b/internal/chat/handlers.go
@@ -16,6 +16,17 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// SupportedModels is the allowlist of Claude model IDs a conversation may use.
+// Keep this in sync with the model options offered in the chat header dropdown
+// (web/src/pages/Chat.tsx) and the Settings page (web/src/pages/Settings.tsx).
+var SupportedModels = map[string]bool{
+	"claude-opus-4-8":   true,
+	"claude-opus-4-7":   true,
+	"claude-opus-4-6":   true,
+	"claude-sonnet-4-6": true,
+	"claude-haiku-4-5":  true,
+}
+
 // runPromptFn is the function used to invoke Claude (for auto-title generation).
 var runPromptFn = training.RunPrompt
 
@@ -75,6 +86,9 @@ func CreateHandler(db *sql.DB) http.HandlerFunc {
 			} else {
 				model = "claude-sonnet-4-6"
 			}
+		} else if !SupportedModels[model] {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unsupported model"})
+			return
 		}
 
 		convo, err := CreateConversation(db, user.ID, "", model)
@@ -277,9 +291,11 @@ func SendMessageHandler(db *sql.DB) http.HandlerFunc {
 	}
 }
 
-// RenameHandler updates a conversation's title.
+// RenameHandler updates a conversation's title and/or model. Both fields are
+// optional; at least one must be supplied. Title-only requests behave exactly
+// as before. A supplied model is validated against SupportedModels.
 // PUT /api/chat/conversations/{id}
-// Body: {"title": "New Title"}
+// Body: {"title": "New Title"} and/or {"model": "claude-opus-4-8"}
 func RenameHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
@@ -291,27 +307,47 @@ func RenameHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		var body struct {
-			Title string `json:"title"`
+			Title *string `json:"title"`
+			Model *string `json:"model"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
 			return
 		}
 
-		title := strings.TrimSpace(body.Title)
-		if title == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "title is required"})
+		var titlePtr *string
+		if body.Title != nil {
+			title := strings.TrimSpace(*body.Title)
+			if title == "" {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "title is required"})
+				return
+			}
+			titlePtr = &title
+		}
+
+		var modelPtr *string
+		if body.Model != nil {
+			model := strings.TrimSpace(*body.Model)
+			if !SupportedModels[model] {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unsupported model"})
+				return
+			}
+			modelPtr = &model
+		}
+
+		if titlePtr == nil && modelPtr == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "title or model is required"})
 			return
 		}
 
-		convo, err := RenameConversation(db, id, user.ID, title)
+		convo, err := UpdateConversation(db, id, user.ID, titlePtr, modelPtr)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				writeJSON(w, http.StatusNotFound, map[string]string{"error": "conversation not found"})
 				return
 			}
-			log.Printf("Failed to rename conversation: %v", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to rename conversation"})
+			log.Printf("Failed to update conversation: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update conversation"})
 			return
 		}
 

--- a/internal/chat/handlers_test.go
+++ b/internal/chat/handlers_test.go
@@ -204,6 +204,119 @@ func TestRenameHandler_EmptyTitle(t *testing.T) {
 	}
 }
 
+func TestRenameHandler_UpdateModel(t *testing.T) {
+	db := setupTestDB(t)
+
+	convo, _ := CreateConversation(db, 1, "Keep Title", "claude-sonnet-4-6")
+
+	body := `{"model": "claude-opus-4-8"}`
+	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
+	req = withUser(req)
+	req = withURLParam(req, "id", strconv.FormatInt(convo.ID, 10))
+	rec := httptest.NewRecorder()
+
+	RenameHandler(db)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]*Conversation
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["conversation"].Model != "claude-opus-4-8" {
+		t.Fatalf("expected model 'claude-opus-4-8', got %q", resp["conversation"].Model)
+	}
+	// Title must be left untouched when only the model is supplied.
+	if resp["conversation"].Title != "Keep Title" {
+		t.Fatalf("expected title preserved as 'Keep Title', got %q", resp["conversation"].Title)
+	}
+
+	// Verify persistence.
+	after, err := GetConversation(db, convo.ID, 1)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if after.Model != "claude-opus-4-8" {
+		t.Fatalf("expected persisted model 'claude-opus-4-8', got %q", after.Model)
+	}
+}
+
+func TestRenameHandler_InvalidModel(t *testing.T) {
+	db := setupTestDB(t)
+
+	convo, _ := CreateConversation(db, 1, "Original", "claude-sonnet-4-6")
+
+	body := `{"model": "gpt-4"}`
+	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
+	req = withUser(req)
+	req = withURLParam(req, "id", strconv.FormatInt(convo.ID, 10))
+	rec := httptest.NewRecorder()
+
+	RenameHandler(db)(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+
+	// Model must be left untouched on rejection.
+	after, err := GetConversation(db, convo.ID, 1)
+	if err != nil {
+		t.Fatalf("get conversation: %v", err)
+	}
+	if after.Model != "claude-sonnet-4-6" {
+		t.Fatalf("expected model unchanged 'claude-sonnet-4-6', got %q", after.Model)
+	}
+}
+
+func TestRenameHandler_TitleAndModel(t *testing.T) {
+	db := setupTestDB(t)
+
+	convo, _ := CreateConversation(db, 1, "", "claude-sonnet-4-6")
+
+	body := `{"title": "New Title", "model": "claude-haiku-4-5"}`
+	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
+	req = withUser(req)
+	req = withURLParam(req, "id", strconv.FormatInt(convo.ID, 10))
+	rec := httptest.NewRecorder()
+
+	RenameHandler(db)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]*Conversation
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["conversation"].Title != "New Title" {
+		t.Fatalf("expected title 'New Title', got %q", resp["conversation"].Title)
+	}
+	if resp["conversation"].Model != "claude-haiku-4-5" {
+		t.Fatalf("expected model 'claude-haiku-4-5', got %q", resp["conversation"].Model)
+	}
+}
+
+func TestRenameHandler_NoFields(t *testing.T) {
+	db := setupTestDB(t)
+
+	convo, _ := CreateConversation(db, 1, "Original", "claude-sonnet-4-6")
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(body))
+	req = withUser(req)
+	req = withURLParam(req, "id", strconv.FormatInt(convo.ID, 10))
+	rec := httptest.NewRecorder()
+
+	RenameHandler(db)(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when neither title nor model supplied, got %d", rec.Code)
+	}
+}
+
 func TestRenameHandler_NotFound(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/internal/chat/handlers_test.go
+++ b/internal/chat/handlers_test.go
@@ -79,6 +79,30 @@ func TestCreateHandler(t *testing.T) {
 	}
 }
 
+func TestCreateHandler_InvalidModel(t *testing.T) {
+	db := setupTestDB(t)
+
+	body := `{"model": "gpt-4"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/conversations", bytes.NewBufferString(body))
+	req = withUser(req)
+	rec := httptest.NewRecorder()
+
+	CreateHandler(db)(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify no conversation was created.
+	convos, err := ListConversations(db, 1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(convos) != 0 {
+		t.Fatalf("expected no conversations after invalid model rejection, got %d", len(convos))
+	}
+}
+
 func TestGetHandler(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"database/sql"
+	"strings"
 	"time"
 )
 
@@ -121,6 +122,39 @@ func RenameConversation(db *sql.DB, id, userID int64, title string) (*Conversati
 		`UPDATE chat_conversations SET title = ?, updated_at = ? WHERE id = ? AND user_id = ?`,
 		title, now, id, userID,
 	)
+	if err != nil {
+		return nil, err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	if n == 0 {
+		return nil, sql.ErrNoRows
+	}
+	return GetConversation(db, id, userID)
+}
+
+// UpdateConversation updates the title and/or model of a conversation owned by
+// the given user. Only the non-nil fields are written; updated_at is always
+// touched. Passing both nil touches only updated_at. Returns sql.ErrNoRows if
+// the conversation doesn't exist or isn't owned by the user.
+func UpdateConversation(db *sql.DB, id, userID int64, title, model *string) (*Conversation, error) {
+	now := time.Now().UTC().Format(timeFormat)
+	sets := []string{"updated_at = ?"}
+	args := []any{now}
+	if title != nil {
+		sets = append(sets, "title = ?")
+		args = append(args, *title)
+	}
+	if model != nil {
+		sets = append(sets, "model = ?")
+		args = append(args, *model)
+	}
+	args = append(args, id, userID)
+
+	query := "UPDATE chat_conversations SET " + strings.Join(sets, ", ") + " WHERE id = ? AND user_id = ?"
+	result, err := db.Exec(query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/web/public/locales/en/chat.json
+++ b/web/public/locales/en/chat.json
@@ -16,7 +16,13 @@
     "backLabel": "Back to conversations"
   },
   "header": {
-    "selectOrStart": "Select or start a conversation"
+    "selectOrStart": "Select or start a conversation",
+    "modelLabel": "Model"
+  },
+  "models": {
+    "opus": "Opus",
+    "sonnet": "Sonnet",
+    "haiku": "Haiku"
   },
   "welcome": {
     "title": "Hytte Chat",
@@ -38,6 +44,7 @@
     "failedToCreate": "Failed to create conversation",
     "failedToDelete": "Failed to delete conversation",
     "failedToRename": "Failed to rename conversation",
+    "failedToUpdateModel": "Failed to update model",
     "failedToSend": "Failed to send message",
     "streamError": "The response stream was interrupted. Please try again."
   }

--- a/web/public/locales/nb/chat.json
+++ b/web/public/locales/nb/chat.json
@@ -16,7 +16,13 @@
     "backLabel": "Tilbake til samtaler"
   },
   "header": {
-    "selectOrStart": "Velg eller start en samtale"
+    "selectOrStart": "Velg eller start en samtale",
+    "modelLabel": "Modell"
+  },
+  "models": {
+    "opus": "Opus",
+    "sonnet": "Sonnet",
+    "haiku": "Haiku"
   },
   "welcome": {
     "title": "Hytte Chat",
@@ -38,6 +44,7 @@
     "failedToCreate": "Kunne ikke opprette samtale",
     "failedToDelete": "Kunne ikke slette samtale",
     "failedToRename": "Kunne ikke gi samtalen nytt navn",
+    "failedToUpdateModel": "Kunne ikke oppdatere modell",
     "failedToSend": "Kunne ikke sende melding",
     "streamError": "Strømmen ble avbrutt. Prøv igjen."
   }

--- a/web/public/locales/th/chat.json
+++ b/web/public/locales/th/chat.json
@@ -16,7 +16,13 @@
     "backLabel": "กลับสู่รายการสนทนา"
   },
   "header": {
-    "selectOrStart": "เลือกหรือเริ่มการสนทนา"
+    "selectOrStart": "เลือกหรือเริ่มการสนทนา",
+    "modelLabel": "โมเดล"
+  },
+  "models": {
+    "opus": "Opus",
+    "sonnet": "Sonnet",
+    "haiku": "Haiku"
   },
   "welcome": {
     "title": "Hytte Chat",
@@ -38,6 +44,7 @@
     "failedToCreate": "สร้างการสนทนาไม่สำเร็จ",
     "failedToDelete": "ลบการสนทนาไม่สำเร็จ",
     "failedToRename": "เปลี่ยนชื่อการสนทนาไม่สำเร็จ",
+    "failedToUpdateModel": "อัปเดตโมเดลไม่สำเร็จ",
     "failedToSend": "ส่งข้อความไม่สำเร็จ",
     "streamError": "การสตรีมตอบกลับถูกขัดจังหวะ โปรดลองอีกครั้ง"
   }

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -23,6 +23,10 @@ const TRANSLATIONS: Record<string, string> = {
   'conversation.confirmDelete': 'Delete?',
   'conversation.backLabel': 'Back to conversations',
   'header.selectOrStart': 'Select or start a conversation',
+  'header.modelLabel': 'Model',
+  'models.opus': 'Opus',
+  'models.sonnet': 'Sonnet',
+  'models.haiku': 'Haiku',
   'welcome.title': 'Hytte Chat',
   'welcome.subtitle': 'Start a new conversation or pick one from the sidebar',
   'input.placeholder': 'Type a message...',
@@ -35,6 +39,7 @@ const TRANSLATIONS: Record<string, string> = {
   'errors.failedToCreate': 'Failed to create conversation',
   'errors.failedToDelete': 'Failed to delete conversation',
   'errors.failedToRename': 'Failed to rename conversation',
+  'errors.failedToUpdateModel': 'Failed to update model',
   'errors.failedToSend': 'Failed to send message',
   'errors.streamError': 'The response stream was interrupted. Please try again.',
 }
@@ -404,5 +409,118 @@ describe('Chat – streaming send', () => {
       expect(screen.getByText('Send a message to start the conversation')).toBeInTheDocument()
     })
     expect(screen.queryByText('Streaming A reply')).not.toBeInTheDocument()
+  })
+})
+
+describe('Chat – model selector', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('renders the model dropdown listing the three supported models', async () => {
+    const { convListRes, convDetailRes } = await selectExistingConversation([])
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(convListRes)
+      .mockResolvedValueOnce(convDetailRes)
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderChat()
+
+    await waitFor(() => screen.getByText('Existing chat'))
+    fireEvent.click(screen.getByText('Existing chat'))
+    await waitFor(() => screen.getByPlaceholderText('Type a message...'))
+
+    const select = screen.getByLabelText('Model') as HTMLSelectElement
+    expect(select).toBeInTheDocument()
+    // The active conversation's model is reflected as the selected value.
+    expect(select.value).toBe('claude-sonnet-4-6')
+
+    const optionValues = Array.from(select.options).map(o => o.value)
+    expect(optionValues).toContain('claude-opus-4-8')
+    expect(optionValues).toContain('claude-sonnet-4-6')
+    expect(optionValues).toContain('claude-haiku-4-5')
+    expect(optionValues).toHaveLength(3)
+  })
+
+  it('selecting a model on an existing conversation issues a PUT with the model', async () => {
+    const { conv, convListRes, convDetailRes } = await selectExistingConversation([])
+    const putRes = {
+      ok: true,
+      json: () => Promise.resolve({ conversation: { ...conv, model: 'claude-opus-4-8' } }),
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(convListRes)
+      .mockResolvedValueOnce(convDetailRes)
+      .mockResolvedValueOnce(putRes)
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderChat()
+
+    await waitFor(() => screen.getByText('Existing chat'))
+    fireEvent.click(screen.getByText('Existing chat'))
+    await waitFor(() => screen.getByPlaceholderText('Type a message...'))
+
+    const select = screen.getByLabelText('Model') as HTMLSelectElement
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'claude-opus-4-8' } })
+    })
+
+    await waitFor(() => {
+      const putCall = fetchMock.mock.calls.find(
+        ([url, init]) => url === `/api/chat/conversations/${conv.id}` && init?.method === 'PUT',
+      )
+      expect(putCall).toBeDefined()
+      expect(JSON.parse((putCall![1] as RequestInit).body as string)).toEqual({
+        model: 'claude-opus-4-8',
+      })
+    })
+    expect((screen.getByLabelText('Model') as HTMLSelectElement).value).toBe('claude-opus-4-8')
+  })
+
+  it('selecting a model before creating a conversation passes it in the POST body', async () => {
+    const created = makeConv({ id: 5, title: '', model: 'claude-haiku-4-5' })
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/chat/conversations' && init?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ conversation: created }) })
+      }
+      if (url === '/api/chat/conversations') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ conversations: [] }) })
+      }
+      if (url === `/api/chat/conversations/${created.id}`) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ conversation: created, messages: [] }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderChat()
+
+    // With no active conversation, the dropdown selects the next model.
+    await waitFor(() => screen.getByLabelText('Model'))
+    const select = screen.getByLabelText('Model') as HTMLSelectElement
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'claude-haiku-4-5' } })
+    })
+
+    // Start a new conversation via the sidebar button.
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('New chat'))
+    })
+
+    await waitFor(() => {
+      const postCall = fetchMock.mock.calls.find(
+        ([url, init]) => url === '/api/chat/conversations' && init?.method === 'POST',
+      )
+      expect(postCall).toBeDefined()
+      expect(JSON.parse((postCall![1] as RequestInit).body as string)).toEqual({
+        model: 'claude-haiku-4-5',
+      })
+    })
   })
 })

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -291,7 +291,7 @@ export default function Chat() {
   }
 
   async function updateModel(id: number, model: string) {
-    setError('')
+    setLocalError('')
     const prevModel = activeConversation?.model
     if (model === prevModel) return
     const seq = ++modelUpdateSeqRef.current
@@ -316,7 +316,7 @@ export default function Chat() {
         setActiveConversation(current => (current && current.id === id ? { ...current, model: prevModel } : current))
         setConversations(prev => prev.map(c => (c.id === id ? { ...c, model: prevModel } : c)))
       }
-      if (err instanceof Error) setError(err.message)
+      if (err instanceof Error) setLocalError(err.message)
     }
   }
 

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -30,9 +30,10 @@ import type { Conversation, Message } from '../hooks/useChatStream'
 // Past this, the user has scrolled up to read history and we leave them be.
 const PIN_THRESHOLD = 80
 
-// MODEL_OPTIONS is the fixed allowlist of Claude models offered in the header
-// dropdown. Keep in sync with the backend allowlist (internal/chat/handlers.go
-// SupportedModels). The default for new conversations is Sonnet.
+// MODEL_OPTIONS is a curated subset of the models the backend allows
+// (internal/chat/handlers.go SupportedModels). The backend may accept
+// additional model IDs (e.g. older Opus variants) that we intentionally
+// omit from the UI dropdown.
 const MODEL_OPTIONS = ['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5'] as const
 const DEFAULT_MODEL = 'claude-sonnet-4-6'
 
@@ -62,7 +63,8 @@ export default function Chat() {
   const [renamingId, setRenamingId] = useState<number | null>(null)
   const [renameTitle, setRenameTitle] = useState('')
   // Model chosen for the next new conversation (used when none is active).
-  const [newConversationModel, setNewConversationModel] = useState<string>(DEFAULT_MODEL)
+  // Empty means "let the backend pick" (falls back to user's configured model).
+  const [newConversationModel, setNewConversationModel] = useState<string>('')
   const [deletingId, setDeletingId] = useState<number | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -84,7 +86,7 @@ export default function Chat() {
   // Track locally deleted conversation IDs so we don't resurrect them if a
   // send response arrives after the user deleted the conversation mid-flight.
   const deletedConversationIds = useRef<Set<number>>(new Set())
-  const modelUpdateSeqRef = useRef(0)
+  const modelUpdateSeqRef = useRef<Map<number, number>>(new Map())
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     messagesEndRef.current?.scrollIntoView({ behavior })
@@ -272,7 +274,7 @@ export default function Chat() {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: newConversationModel }),
+        body: JSON.stringify(newConversationModel ? { model: newConversationModel } : {}),
       })
       if (!res.ok) {
         const data = await res.json().catch(() => null)
@@ -294,8 +296,9 @@ export default function Chat() {
     setLocalError('')
     const prevModel = activeConversation?.model
     if (model === prevModel) return
-    const seq = ++modelUpdateSeqRef.current
-    // Optimistically reflect the choice so the dropdown updates immediately.
+    const seqMap = modelUpdateSeqRef.current
+    const seq = (seqMap.get(id) ?? 0) + 1
+    seqMap.set(id, seq)
     setActiveConversation(current => (current && current.id === id ? { ...current, model } : current))
     setConversations(prev => prev.map(c => (c.id === id ? { ...c, model } : c)))
     try {
@@ -308,11 +311,11 @@ export default function Chat() {
       if (!res.ok) throw new Error(t('errors.failedToUpdateModel'))
       const data = await res.json()
       const updated = data.conversation as Conversation
-      if (modelUpdateSeqRef.current !== seq) return
+      if (seqMap.get(id) !== seq) return
       setConversations(prev => prev.map(c => (c.id === id ? updated : c)))
       setActiveConversation(current => (current?.id === id ? updated : current))
     } catch (err) {
-      if (modelUpdateSeqRef.current === seq && prevModel !== undefined) {
+      if (seqMap.get(id) === seq && prevModel !== undefined) {
         setActiveConversation(current => (current && current.id === id ? { ...current, model: prevModel } : current))
         setConversations(prev => prev.map(c => (c.id === id ? { ...c, model: prevModel } : c)))
       }
@@ -422,7 +425,7 @@ export default function Chat() {
     return key ? t(key) : model
   }
 
-  const selectedModel = activeConversation ? activeConversation.model : newConversationModel
+  const selectedModel = activeConversation ? activeConversation.model : (newConversationModel || DEFAULT_MODEL)
   const modelSelectDisabled =
     activeConversation != null && sendingConversationIds.has(activeConversation.id)
   const onModelChange = (model: string) => {

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -84,9 +84,6 @@ export default function Chat() {
   // Track locally deleted conversation IDs so we don't resurrect them if a
   // send response arrives after the user deleted the conversation mid-flight.
   const deletedConversationIds = useRef<Set<number>>(new Set())
-  // Tracks the active streaming request so the user can cancel mid-send and
-  // so a conversation switch can abort the in-flight stream.
-  const streamAbortRef = useRef<AbortController | null>(null)
   const modelUpdateSeqRef = useRef(0)
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -38,7 +38,7 @@ const DEFAULT_MODEL = 'claude-sonnet-4-6'
 
 // modelLabelKey maps a model ID to its i18n label key by family so any
 // supported variant (e.g. an older Opus) still shows a friendly name.
-function modelLabelKey(model: string): string {
+function modelLabelKey(model: string): 'models.opus' | 'models.sonnet' | 'models.haiku' | '' {
   if (model.startsWith('claude-opus')) return 'models.opus'
   if (model.startsWith('claude-sonnet')) return 'models.sonnet'
   if (model.startsWith('claude-haiku')) return 'models.haiku'

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -84,6 +84,10 @@ export default function Chat() {
   // Track locally deleted conversation IDs so we don't resurrect them if a
   // send response arrives after the user deleted the conversation mid-flight.
   const deletedConversationIds = useRef<Set<number>>(new Set())
+  // Tracks the active streaming request so the user can cancel mid-send and
+  // so a conversation switch can abort the in-flight stream.
+  const streamAbortRef = useRef<AbortController | null>(null)
+  const modelUpdateSeqRef = useRef(0)
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     messagesEndRef.current?.scrollIntoView({ behavior })
@@ -293,6 +297,7 @@ export default function Chat() {
     setError('')
     const prevModel = activeConversation?.model
     if (model === prevModel) return
+    const seq = ++modelUpdateSeqRef.current
     // Optimistically reflect the choice so the dropdown updates immediately.
     setActiveConversation(current => (current && current.id === id ? { ...current, model } : current))
     setConversations(prev => prev.map(c => (c.id === id ? { ...c, model } : c)))
@@ -306,11 +311,11 @@ export default function Chat() {
       if (!res.ok) throw new Error(t('errors.failedToUpdateModel'))
       const data = await res.json()
       const updated = data.conversation as Conversation
+      if (modelUpdateSeqRef.current !== seq) return
       setConversations(prev => prev.map(c => (c.id === id ? updated : c)))
       setActiveConversation(current => (current?.id === id ? updated : current))
     } catch (err) {
-      // Revert the optimistic update on failure.
-      if (prevModel !== undefined) {
+      if (modelUpdateSeqRef.current === seq && prevModel !== undefined) {
         setActiveConversation(current => (current && current.id === id ? { ...current, model: prevModel } : current))
         setConversations(prev => prev.map(c => (c.id === id ? { ...c, model: prevModel } : c)))
       }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -30,6 +30,21 @@ import type { Conversation, Message } from '../hooks/useChatStream'
 // Past this, the user has scrolled up to read history and we leave them be.
 const PIN_THRESHOLD = 80
 
+// MODEL_OPTIONS is the fixed allowlist of Claude models offered in the header
+// dropdown. Keep in sync with the backend allowlist (internal/chat/handlers.go
+// SupportedModels). The default for new conversations is Sonnet.
+const MODEL_OPTIONS = ['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5'] as const
+const DEFAULT_MODEL = 'claude-sonnet-4-6'
+
+// modelLabelKey maps a model ID to its i18n label key by family so any
+// supported variant (e.g. an older Opus) still shows a friendly name.
+function modelLabelKey(model: string): string {
+  if (model.startsWith('claude-opus')) return 'models.opus'
+  if (model.startsWith('claude-sonnet')) return 'models.sonnet'
+  if (model.startsWith('claude-haiku')) return 'models.haiku'
+  return ''
+}
+
 export default function Chat() {
   const { t } = useTranslation('chat')
   const [conversations, setConversations] = useState<Conversation[]>([])
@@ -46,6 +61,8 @@ export default function Chat() {
   const [showSidebar, setShowSidebar] = useState(true)
   const [renamingId, setRenamingId] = useState<number | null>(null)
   const [renameTitle, setRenameTitle] = useState('')
+  // Model chosen for the next new conversation (used when none is active).
+  const [newConversationModel, setNewConversationModel] = useState<string>(DEFAULT_MODEL)
   const [deletingId, setDeletingId] = useState<number | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -254,7 +271,7 @@ export default function Chat() {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ model: newConversationModel }),
       })
       if (!res.ok) {
         const data = await res.json().catch(() => null)
@@ -269,6 +286,35 @@ export default function Chat() {
       inputRef.current?.focus()
     } catch (err) {
       if (err instanceof Error) setLocalError(err.message)
+    }
+  }
+
+  async function updateModel(id: number, model: string) {
+    setError('')
+    const prevModel = activeConversation?.model
+    if (model === prevModel) return
+    // Optimistically reflect the choice so the dropdown updates immediately.
+    setActiveConversation(current => (current && current.id === id ? { ...current, model } : current))
+    setConversations(prev => prev.map(c => (c.id === id ? { ...c, model } : c)))
+    try {
+      const res = await fetch(`/api/chat/conversations/${id}`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model }),
+      })
+      if (!res.ok) throw new Error(t('errors.failedToUpdateModel'))
+      const data = await res.json()
+      const updated = data.conversation as Conversation
+      setConversations(prev => prev.map(c => (c.id === id ? updated : c)))
+      setActiveConversation(current => (current?.id === id ? updated : current))
+    } catch (err) {
+      // Revert the optimistic update on failure.
+      if (prevModel !== undefined) {
+        setActiveConversation(current => (current && current.id === id ? { ...current, model: prevModel } : current))
+        setConversations(prev => prev.map(c => (c.id === id ? { ...c, model: prevModel } : c)))
+      }
+      if (err instanceof Error) setError(err.message)
     }
   }
 
@@ -360,6 +406,47 @@ export default function Chat() {
   }
 
   const conversationTitle = (conv: Conversation) => conv.title || t('newConversation')
+
+  // Options for the header model dropdown. If the current selection isn't one
+  // of the fixed options (e.g. an existing conversation on an older variant),
+  // prepend it so the select still reflects the real value.
+  const modelOptionsFor = (current: string): string[] =>
+    MODEL_OPTIONS.includes(current as (typeof MODEL_OPTIONS)[number])
+      ? [...MODEL_OPTIONS]
+      : [current, ...MODEL_OPTIONS]
+
+  const modelLabel = (model: string): string => {
+    const key = modelLabelKey(model)
+    return key ? t(key) : model
+  }
+
+  const selectedModel = activeConversation ? activeConversation.model : newConversationModel
+  const modelSelectDisabled =
+    activeConversation != null && sendingConversationIds.has(activeConversation.id)
+  const onModelChange = (model: string) => {
+    if (activeConversation) {
+      updateModel(activeConversation.id, model)
+    } else {
+      setNewConversationModel(model)
+    }
+  }
+
+  const modelSelector = (
+    <select
+      value={selectedModel}
+      onChange={e => onModelChange(e.target.value)}
+      disabled={modelSelectDisabled}
+      aria-label={t('header.modelLabel')}
+      title={t('header.modelLabel')}
+      className="shrink-0 bg-gray-800 border border-gray-600 rounded-lg px-2 py-1 text-xs text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+    >
+      {modelOptionsFor(selectedModel).map(m => (
+        <option key={m} value={m}>
+          {modelLabel(m)}
+        </option>
+      ))}
+    </select>
+  )
 
   // Conversation sidebar panel
   const sidebarContent = (
@@ -531,16 +618,16 @@ export default function Chat() {
           >
             <ChevronLeft size={20} />
           </button>
-          {activeConversation ? (
-            <div className="min-w-0">
+          <div className="min-w-0 flex-1">
+            {activeConversation ? (
               <h2 className="text-sm font-medium truncate">
                 {conversationTitle(activeConversation)}
               </h2>
-              <p className="text-xs text-gray-500">{activeConversation.model}</p>
-            </div>
-          ) : (
-            <h2 className="text-sm font-medium text-gray-400">{t('header.selectOrStart')}</h2>
-          )}
+            ) : (
+              <h2 className="text-sm font-medium text-gray-400 truncate">{t('header.selectOrStart')}</h2>
+            )}
+          </div>
+          {modelSelector}
         </div>
 
         {/* Messages area */}


### PR DESCRIPTION
## Changes

- **Per-conversation model selector in chat** - Added a model dropdown to the chat header so you can pick Opus, Sonnet, or Haiku for each conversation. The choice applies to new conversations and persists on existing ones via `PUT /api/chat/conversations/{id}`. (Hytte-l40r)

## Original Issue (feature): Add a per-conversation model selector to the chat header

### Scope
Add a model selector dropdown to the chat header so users can pick Opus / Sonnet / Haiku per conversation. The dropdown sets the model when creating a new conversation and updates it on existing conversations, persisting via the existing `PUT /api/chat/conversations/{id}` endpoint (currently rename-only, extended to accept an optional `model` field). The header already renders `activeConversation.model`; this replaces that static text with an interactive control.

### Files to touch
- `internal/chat/handlers.go` — extend `RenameHandler` (PUT) to accept an optional `model` field; validate against an allowlist of known model IDs; keep title-only behaviour working.
- `internal/chat/store.go` — add/extend a store function to update `model` (alongside `RenameConversation`), or a combined update.
- `internal/chat/handlers_test.go` — cover PUT with model, invalid model rejected, title-only still works.
- `web/src/pages/Chat.tsx` — add a model dropdown in the header next to the title; wire to `createConversation()` (send chosen model in POST body) and to a new `updateModel()` calling PUT; update local state on success.
- `web/public/locales/{en,nb,th}/chat.json` (or `common.json` if chat keys live there) — add label/option strings.
- `web/src/pages/Chat.test.tsx` — assert dropdown renders, lists models, and triggers the PUT/POST.
- `changelog.d/<fragment>` (new) — `Added` entry.

### Acceptance criteria
- A dropdown in the chat header shows the active conversation's current model (friendly label: Opus / Sonnet / Haiku) and lists the three supported models.
- Selecting a model on an existing conversation issues `PUT /api/chat/conversations/{id}` with `{"model": "..."}`, persists, and the header reflects it after reload.
- When no conversation is active, the dropdown sets the model used for the next new conversation (sent in the POST body).
- The PUT endpoint accepts `model` (optional), rejects unknown model IDs with 400, and still handles title-only requests unchanged.
- Backend tests cover update-model, invalid-model, and title-only paths; all pass with `make test`.
- All new user-facing strings are in en/nb/th via `react-i18next`; layout works at 375px width.
- A changelog fragment exists referencing the suggestion ID.

### Non-goals
- No per-message model switching mid-conversation or retroactive re-runs of past messages.
- No changes to streaming/CLI invocation logic beyond reading the stored model.
- No user-level default-model preference UI (that lives in Settings/Claude config already).
- No pricing/cost display or token accounting.
- No dynamic discovery of available models — use a fixed allowlist matching the supported Claude models.

## Source

Created from Suggestions page (suggestion id 161, page slug "chat", source=claude).

## Original suggestion

The backend `CreateConversation` and `Conversation.model` field already support arbitrary Claude models and the header even displays `activeConversation.model`, but there is no UI to choose one — every new chat silently inherits the user's default Claude config or falls back to `claude-sonnet-4-6`. Add a small dropdown next to the title showing the current model (Opus 4.7 / Sonnet 4.6 / Haiku 4.5) for both the new-conversation flow and existing conversations, persisting the choice via a new `PUT /api/chat/conversations/{id}` field. Users can then pick Haiku for cheap quick questions or Opus for harder ones without leaving the page, which is the single most-requested capability for any chat UI.


---
Bead: Hytte-l40r | Branch: forge/Hytte-l40r
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->