### PR TITLE
Encode credit_card_id and month query params in transactions fetch (Hytte-4vqi)

### DIFF
--- a/changelog.d/Hytte-4vqi.md
+++ b/changelog.d/Hytte-4vqi.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Encode credit-card query params** - Wrapped `credit_card_id`, `month`, and `account_id` query-string values in `encodeURIComponent` across all credit-card fetch sites so identifiers or months containing spaces, `&`, or `+` no longer produce malformed URLs that silently return no rows. (Hytte-4vqi)

--- a/web/src/pages/BudgetCreditCards.tsx
+++ b/web/src/pages/BudgetCreditCards.tsx
@@ -713,7 +713,7 @@ export default function BudgetCreditCards() {
     setLoadingSummary(true)
     setSummary(null)
     setError(null)
-    fetch(`/api/budget/credit/summary?account_id=${accountId}&month=${m}`, {
+    fetch(`/api/budget/credit/summary?account_id=${encodeURIComponent(accountId)}&month=${encodeURIComponent(m)}`, {
       credentials: 'include',
       signal: ctrl.signal,
     })
@@ -741,7 +741,7 @@ export default function BudgetCreditCards() {
     setOpeningBalance(0)
     setOpeningBalanceInput('')
     const cardId = String(accountId)
-    fetch(`/api/credit-card/transactions?credit_card_id=${encodeURIComponent(cardId)}&month=${m}`, {
+    fetch(`/api/credit-card/transactions?credit_card_id=${encodeURIComponent(cardId)}&month=${encodeURIComponent(m)}`, {
       credentials: 'include',
       signal: ctrl.signal,
     })
@@ -918,7 +918,7 @@ export default function BudgetCreditCards() {
     const cardId = String(selectedId)
     setSavingOpeningBalance(true)
     try {
-      const r = await fetch(`/api/credit-card/opening-balance?credit_card_id=${encodeURIComponent(cardId)}&month=${month}`, {
+      const r = await fetch(`/api/credit-card/opening-balance?credit_card_id=${encodeURIComponent(cardId)}&month=${encodeURIComponent(month)}`, {
         method: 'PUT',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
@@ -1423,7 +1423,7 @@ export default function BudgetCreditCards() {
                 <button
                   onClick={async () => {
                     try {
-                      const r = await fetch(`/api/credit-card/sync-variable?credit_card_id=${encodeURIComponent(String(selectedAccount.id))}&month=${month}`, {
+                      const r = await fetch(`/api/credit-card/sync-variable?credit_card_id=${encodeURIComponent(String(selectedAccount.id))}&month=${encodeURIComponent(month)}`, {
                         method: 'POST',
                         credentials: 'include',
                       })


### PR DESCRIPTION
## Changes

- **Encode credit-card query params** - Wrapped `credit_card_id`, `month`, and `account_id` query-string values in `encodeURIComponent` across all credit-card fetch sites so identifiers or months containing spaces, `&`, or `+` no longer produce malformed URLs that silently return no rows. (Hytte-4vqi)

## Original Issue (feature): Encode credit_card_id and month query params in transactions fetch

I have what I need to ground the plan.

### Scope
Wrap every query-string value sent to the credit-card endpoints from `BudgetCreditCards.tsx` in `encodeURIComponent`. Several call sites already encode `credit_card_id` but pass `month` (and `account_id`) as raw interpolations, so the fix is mainly closing the `month`/`account_id` gaps and making encoding uniform across all fetch sites, so unusual or future user-chosen identifiers can't produce a malformed URL that silently returns no rows. Note: the live routes are `/api/credit-card/*` (singular), not `/api/credit-cards/*` as worded in the suggestion.

### Files to touch
- `web/src/pages/BudgetCreditCards.tsx`
- `changelog.d/<id>-encode-credit-card-query-params.md` (new)

### Acceptance criteria
- In every GET fetch that builds a query string, both the card identifier and the month (and `account_id`) values are passed through `encodeURIComponent`. Concretely the sites at the `/api/credit-card/transactions`, `/api/credit-card/monthly-history`, `/api/credit-card/opening-balance`, `/api/credit-card/sync-variable`, and `/api/budget/credit/summary` calls all encode their dynamic values.
- The multipart import (`/api/credit-card/import/preview`) and JSON-body calls (`import/confirm`, `bulk-assign`, `reapply-rules`) are reviewed; values sent via `FormData.append` or JSON body are left unencoded (correct — encoding only applies to URL query/path segments).
- A card id or month containing a space, `&`, or `+` produces a correctly-escaped URL and the transactions listing still loads its rows.
- `npm run lint` and `npm run build` pass; no behavioral change for normal numeric ids.
- A changelog fragment exists under `changelog.d/` in the `Fixed` category.

### Non-goals
- No backend changes in `internal/creditcard/*` — server-side parsing/decoding is already handled by the stdlib and is out of scope.
- No renaming of routes or changing `credit-card` (singular) to `credit-cards`.
- No new feature to let users pick custom card names; this only makes the client robust to such values.
- No added unit/E2E test harness if none exists for this page; manual verification of the escaped URL suffices.

## Source

Created from Suggestions page (suggestion id 134, page slug "budget-credit-cards", source=claude).

## Original suggestion

The frontend likely concatenates credit_card_id and month directly into the /api/credit-cards/transactions query string. If a card identifier ever contains a space, ampersand, or plus sign, the request will be malformed and the page will silently show no rows. Wrap both values in encodeURIComponent at every fetch site (transactions, history, summary, import) so unusual identifiers and future user-chosen card names can't break the listing.


---
Bead: Hytte-4vqi | Branch: forge/Hytte-4vqi
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->