### PR TITLE
Backfill messages missed during SSE buffer drops and reconnects (Hytte-g4iv)

### DIFF
--- a/changelog.d/Hytte-g4iv.md
+++ b/changelog.d/Hytte-g4iv.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Family Chat no longer drops messages after a connection blip** - The chat stream now accepts a resume point (the standard `Last-Event-ID` header or a `since_message_id` query param) and replays every message, edit, and delete missed while a client was disconnected or its event buffer overflowed, before resuming the live feed. Each message event carries an SSE `id:` line so reconnects pick up exactly where they left off, and replayed events are applied idempotently with no duplicate or resurrected messages. (Hytte-g4iv)

--- a/internal/familychat/calls_test.go
+++ b/internal/familychat/calls_test.go
@@ -543,7 +543,7 @@ func TestCallSSE_RoundTripOverWire(t *testing.T) {
 				next.ServeHTTP(w, req.WithContext(ctx))
 			})
 		})
-		r.Get("/api/familychat/conversations/{id}/stream", StreamHandler(hub, mem.fn()))
+		r.Get("/api/familychat/conversations/{id}/stream", StreamHandler(hub, mem.fn(), nil))
 	})
 	r.Group(func(r chi.Router) {
 		r.Use(func(next http.Handler) http.Handler {

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -321,7 +321,7 @@ func postMessageHandler(db *sql.DB, hub *Hub, sender PushSenderFunc, notifySync 
 		// Publish to any live SSE subscribers first so they see the message
 		// without waiting for the webpush round trip.
 		if hub != nil {
-			hub.Publish(convID, Event{Type: EventMessageNew, Data: map[string]any{"message": msg}})
+			hub.Publish(convID, Event{Type: EventMessageNew, ID: msg.ID, Data: map[string]any{"message": msg}})
 		}
 
 		// Fan webpush out to recipients who are not currently on SSE. Done
@@ -407,6 +407,7 @@ func editMessageHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
 			}
 			hub.Publish(convID, Event{
 				Type: EventMessageEdited,
+				ID:   msgID,
 				Data: map[string]any{
 					"message_id":      msgID,
 					"conversation_id": convID,
@@ -472,6 +473,7 @@ func deleteMessageHandler(db *sql.DB, hub *Hub) http.HandlerFunc {
 		if hub != nil {
 			hub.Publish(convID, Event{
 				Type: EventMessageDeleted,
+				ID:   msgID,
 				Data: map[string]any{
 					"message_id":      msgID,
 					"conversation_id": convID,

--- a/internal/familychat/hub.go
+++ b/internal/familychat/hub.go
@@ -15,8 +15,15 @@ import (
 // Type is the SSE `event:` line value (e.g. "message_new"); Data is the JSON
 // payload sent on the `data:` line. Data is marshaled lazily by the SSE
 // handler so non-streaming callers do not pay the JSON cost.
+//
+// ID is the resume point for the event: the message id the SSE handler writes
+// on the `id:` line so a reconnecting browser resends it as Last-Event-ID.
+// Only message-bearing events (new/edited/deleted) set it; ephemeral events
+// (typing, read receipts, call signalling) leave it zero so they never become
+// a resume point.
 type Event struct {
 	Type string
+	ID   int64
 	Data any
 }
 

--- a/internal/familychat/reactions_test.go
+++ b/internal/familychat/reactions_test.go
@@ -396,7 +396,7 @@ func TestReactionHandler_PublishesSSEEventOverHTTP(t *testing.T) {
 
 	r := chi.NewRouter()
 	r.Get("/api/familychat/conversations/{id}/stream",
-		withCtxUser(2, StreamHandler(hub, mem.fn())))
+		withCtxUser(2, StreamHandler(hub, mem.fn(), nil)))
 	r.Post("/api/familychat/conversations/{id}/messages/{messageID}/reactions",
 		withCtxUser(1, addReactionHandler(db, hub)))
 

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -20,6 +20,13 @@ import (
 // An (id) tie-breaker in ORDER BY clauses handles same-millisecond writes.
 const timeFormat = "2006-01-02T15:04:05.000Z07:00"
 
+// maxBackfillLimit caps how many catch-up events EventsSince returns for a
+// single reconnect. A reconnect after a brief blip replays only a handful of
+// rows; this ceiling is a safety net for a client that resumes from a very old
+// id (it still gets the oldest portion of the gap and can refresh for the rest,
+// matching ListMessages' own cap).
+const maxBackfillLimit = 500
+
 // Conversation is a single family chat conversation as returned to the client.
 type Conversation struct {
 	ID                  int64   `json:"id"`
@@ -309,7 +316,7 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 	)
 	if since > 0 {
 		rows, queryErr = db.Query(
-			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at, edited_at, deleted_at, deleted_by, meta_json
+			messageSelectColumns+`
 			 FROM family_chat_messages
 			 WHERE conversation_id = ? AND id > ?
 			 ORDER BY id DESC
@@ -318,7 +325,7 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 		)
 	} else {
 		rows, queryErr = db.Query(
-			`SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at, edited_at, deleted_at, deleted_by, meta_json
+			messageSelectColumns+`
 			 FROM family_chat_messages
 			 WHERE conversation_id = ?
 			 ORDER BY id DESC
@@ -331,6 +338,28 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 	}
 	defer rows.Close()
 
+	out, err := scanMessageRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	if err := attachReactions(db, out, userID); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// messageSelectColumns is the shared column list (in scan order) for queries
+// that hydrate a Message via scanMessageRows. Kept as a single constant so the
+// SELECT projection and the Scan call below can never drift apart.
+const messageSelectColumns = `SELECT id, conversation_id, sender_user_id, body, attachment_path, attachment_mime, created_at, edited_at, deleted_at, deleted_by, meta_json`
+
+// scanMessageRows scans rows produced by a messageSelectColumns query into
+// []Message, decrypting body/attachment/meta_json and applying the tombstone
+// contract (a soft-deleted row never surfaces its original body, attachment,
+// or edit history). Reactions are NOT attached — callers that need them call
+// attachReactions afterward. The returned slice is non-nil (possibly empty) so
+// JSON callers get [] rather than null.
+func scanMessageRows(rows *sql.Rows) ([]Message, error) {
 	out := []Message{}
 	for rows.Next() {
 		var m Message
@@ -339,6 +368,7 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 		if err := rows.Scan(&m.ID, &m.ConversationID, &m.SenderUserID, &m.Body, &m.AttachmentPath, &m.AttachmentMime, &m.CreatedAt, &editedAt, &deletedAt, &deletedBy, &metaJSON); err != nil {
 			return nil, err
 		}
+		var err error
 		if m.Body, err = encryption.DecryptField(m.Body); err != nil {
 			return nil, fmt.Errorf("decrypt body: %w", err)
 		}
@@ -377,23 +407,104 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	return out, nil
+}
 
-	if len(out) > 0 {
-		ids := make([]int64, len(out))
-		for i := range out {
-			ids[i] = out[i].ID
+// attachReactions populates the Reactions field on every message in msgs with
+// the per-emoji summary (including the requesting user's `me` flag) in a single
+// batched query. Each message ends up with a non-nil map so the JSON shape is
+// stable.
+func attachReactions(db *sql.DB, msgs []Message, userID int64) error {
+	if len(msgs) == 0 {
+		return nil
+	}
+	ids := make([]int64, len(msgs))
+	for i := range msgs {
+		ids[i] = msgs[i].ID
+	}
+	reactions, err := batchReactions(db, ids, userID)
+	if err != nil {
+		return fmt.Errorf("load reactions: %w", err)
+	}
+	for i := range msgs {
+		byEmoji := reactions[msgs[i].ID]
+		if byEmoji == nil {
+			byEmoji = map[string]*ReactionSummary{}
 		}
-		reactions, err := batchReactions(db, ids, userID)
-		if err != nil {
-			return nil, fmt.Errorf("load reactions: %w", err)
+		msgs[i].Reactions = byEmoji
+	}
+	return nil
+}
+
+// EventsSince returns the messages a reconnecting (or buffer-overflowed) SSE
+// client needs to replay to catch up to the live feed, given the highest
+// message id it has already seen (sinceID). The result combines two effects
+// that a naive `id > sinceID` query would miss:
+//
+//   - New messages: every message with id > sinceID (the client never saw these).
+//   - Edits and deletes of OLDER messages: a message with id <= sinceID whose
+//     edited_at/deleted_at is newer than the client's resume point. The resume
+//     point is approximated by created_at of message sinceID — the moment the
+//     client was last provably caught up — so any modification stamped after it
+//     is replayed (modifications stamped before it were delivered live).
+//
+// Messages are returned in ascending id order so the caller emits new messages
+// in chronological order; edits/deletes of older messages are idempotent on the
+// client so their relative order does not matter. Each returned Message carries
+// its current on-disk state (a tombstone for deletes, the new body for edits),
+// which the stream handler maps to the matching SSE event. Reactions are
+// attached so backfilled new-message events render identically to live ones.
+//
+// Membership is NOT re-checked here — the stream handler verifies it before
+// calling this. When sinceID <= 0, or the resume id is unknown to this
+// conversation, the edit/delete predicates are skipped and only new messages
+// (if any) are returned, so an absent or stale resume id degrades to "new
+// messages only" rather than replaying the entire history.
+func EventsSince(db *sql.DB, convID, userID, sinceID int64, limit int) ([]Message, error) {
+	if limit <= 0 {
+		limit = maxBackfillLimit
+	}
+	if limit > maxBackfillLimit {
+		limit = maxBackfillLimit
+	}
+
+	// Look up the resume point's timestamp. If the id is unknown (different
+	// conversation, reset DB), watermark stays empty and we replay new messages
+	// only — comparing against '' would otherwise match every edited/deleted row.
+	var watermark string
+	if sinceID > 0 {
+		err := db.QueryRow(
+			`SELECT created_at FROM family_chat_messages WHERE id = ? AND conversation_id = ?`,
+			sinceID, convID,
+		).Scan(&watermark)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
 		}
-		for i := range out {
-			byEmoji := reactions[out[i].ID]
-			if byEmoji == nil {
-				byEmoji = map[string]*ReactionSummary{}
-			}
-			out[i].Reactions = byEmoji
-		}
+	}
+
+	query := messageSelectColumns + ` FROM family_chat_messages WHERE conversation_id = ? AND (id > ?`
+	args := []any{convID, sinceID}
+	if watermark != "" {
+		// A delete supersedes an edit, so a deleted row is matched purely on
+		// deleted_at; an edited (but not deleted) row on edited_at.
+		query += ` OR (deleted_at IS NOT NULL AND deleted_at > ?) OR (deleted_at IS NULL AND edited_at IS NOT NULL AND edited_at > ?)`
+		args = append(args, watermark, watermark)
+	}
+	query += `) ORDER BY id ASC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out, err := scanMessageRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	if err := attachReactions(db, out, userID); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/internal/familychat/store_test.go
+++ b/internal/familychat/store_test.go
@@ -1,6 +1,7 @@
 package familychat
 
 import (
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
@@ -343,5 +344,149 @@ func TestStoreListConversations_LastMessagePreview(t *testing.T) {
 	}
 	if convos[0].LastMessagePreview == "" {
 		t.Errorf("attachment-only message should have a placeholder preview, got empty")
+	}
+}
+
+// overrideMsgTimes rewrites the created_at (and optionally edited_at/deleted_at)
+// of a message so backfill watermark logic can be tested deterministically,
+// independent of the wall clock. Empty edited/deleted strings leave that column
+// untouched.
+func overrideMsgTimes(t *testing.T, db *sql.DB, msgID int64, created, edited, deleted string) {
+	t.Helper()
+	if _, err := db.Exec(`UPDATE family_chat_messages SET created_at = ? WHERE id = ?`, created, msgID); err != nil {
+		t.Fatalf("override created_at for %d: %v", msgID, err)
+	}
+	if edited != "" {
+		if _, err := db.Exec(`UPDATE family_chat_messages SET edited_at = ? WHERE id = ?`, edited, msgID); err != nil {
+			t.Fatalf("override edited_at for %d: %v", msgID, err)
+		}
+	}
+	if deleted != "" {
+		if _, err := db.Exec(`UPDATE family_chat_messages SET deleted_at = ? WHERE id = ?`, deleted, msgID); err != nil {
+			t.Fatalf("override deleted_at for %d: %v", msgID, err)
+		}
+	}
+}
+
+func TestEventsSince_NewMessagesOnly(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "a@example.com")
+	makeUser(t, db, 2, "b@example.com")
+	conv := seedConversation(t, db, 1, "c", 2)
+
+	m1, err := CreateMessage(db, conv, 1, "one", "", "")
+	if err != nil {
+		t.Fatalf("create m1: %v", err)
+	}
+	m2, err := CreateMessage(db, conv, 2, "two", "", "")
+	if err != nil {
+		t.Fatalf("create m2: %v", err)
+	}
+	m3, err := CreateMessage(db, conv, 1, "three", "", "")
+	if err != nil {
+		t.Fatalf("create m3: %v", err)
+	}
+
+	got, err := EventsSince(db, conv, 1, m1.ID, 100)
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 backfill messages, got %d", len(got))
+	}
+	// Ascending id order so the client replays in chronological order.
+	if got[0].ID != m2.ID || got[1].ID != m3.ID {
+		t.Fatalf("expected ids [%d %d], got [%d %d]", m2.ID, m3.ID, got[0].ID, got[1].ID)
+	}
+	if got[0].Body != "two" || got[1].Body != "three" {
+		t.Fatalf("bodies not decrypted: %q %q", got[0].Body, got[1].Body)
+	}
+	if got[0].Reactions == nil {
+		t.Errorf("expected non-nil reactions map on backfilled message")
+	}
+}
+
+func TestEventsSince_ReplaysEditAndDeleteOfOlderMessages(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "a@example.com")
+	makeUser(t, db, 2, "b@example.com")
+	conv := seedConversation(t, db, 1, "c", 2)
+
+	m1, _ := CreateMessage(db, conv, 1, "one", "", "")
+	m2, _ := CreateMessage(db, conv, 2, "two", "", "")
+	m3, _ := CreateMessage(db, conv, 1, "three", "", "")
+	m4, _ := CreateMessage(db, conv, 2, "four", "", "")
+
+	// Deterministic ordering of creation timestamps.
+	overrideMsgTimes(t, db, m1.ID, "2026-01-01T00:00:01.000Z", "", "")
+	overrideMsgTimes(t, db, m2.ID, "2026-01-01T00:00:02.000Z", "", "")
+	overrideMsgTimes(t, db, m3.ID, "2026-01-01T00:00:03.000Z", "", "")
+	overrideMsgTimes(t, db, m4.ID, "2026-01-01T00:00:04.000Z", "", "")
+
+	// Edit m1 (after the watermark) and m2 (before the watermark); delete m3
+	// (after the watermark). The resume point is m4, so its created_at (:04) is
+	// the watermark.
+	if _, err := EditMessage(db, conv, m1.ID, 1, "one-edited"); err != nil {
+		t.Fatalf("edit m1: %v", err)
+	}
+	overrideMsgTimes(t, db, m1.ID, "2026-01-01T00:00:01.000Z", "2026-01-01T00:00:10.000Z", "")
+	if _, err := EditMessage(db, conv, m2.ID, 2, "two-edited"); err != nil {
+		t.Fatalf("edit m2: %v", err)
+	}
+	overrideMsgTimes(t, db, m2.ID, "2026-01-01T00:00:02.000Z", "2026-01-01T00:00:02.500Z", "")
+	if _, err := SoftDeleteMessage(db, conv, m3.ID, 1); err != nil {
+		t.Fatalf("delete m3: %v", err)
+	}
+	overrideMsgTimes(t, db, m3.ID, "2026-01-01T00:00:03.000Z", "", "2026-01-01T00:00:11.000Z")
+
+	got, err := EventsSince(db, conv, 1, m4.ID, 100)
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+	// Expect m1 (edited after watermark) and m3 (deleted after watermark) only —
+	// m2's edit predates the watermark and is excluded, and there are no newer
+	// messages than m4.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 backfill messages, got %d: %+v", len(got), got)
+	}
+	if got[0].ID != m1.ID || got[1].ID != m3.ID {
+		t.Fatalf("expected ids [%d %d], got [%d %d]", m1.ID, m3.ID, got[0].ID, got[1].ID)
+	}
+	if got[0].Body != "one-edited" {
+		t.Errorf("expected edited body for m1, got %q", got[0].Body)
+	}
+	if got[0].EditedAt == nil {
+		t.Errorf("expected edited_at set for m1")
+	}
+	// m3 is a tombstone: deleted_at set, body cleared.
+	if got[1].DeletedAt == nil {
+		t.Errorf("expected deleted_at set for m3")
+	}
+	if got[1].Body != "" {
+		t.Errorf("expected cleared body for tombstone m3, got %q", got[1].Body)
+	}
+}
+
+func TestEventsSince_UnknownResumeIDReturnsOnlyNewer(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "a@example.com")
+	makeUser(t, db, 2, "b@example.com")
+	conv := seedConversation(t, db, 1, "c", 2)
+
+	m1, _ := CreateMessage(db, conv, 1, "one", "", "")
+	// Edit m1 so an edited row exists; a stale/unknown resume id must NOT pull it
+	// in (no watermark → edit predicate skipped).
+	if _, err := EditMessage(db, conv, m1.ID, 1, "one-edited"); err != nil {
+		t.Fatalf("edit m1: %v", err)
+	}
+
+	// Resume from an id larger than any message: unknown row → no watermark, and
+	// id > since matches nothing.
+	got, err := EventsSince(db, conv, 1, m1.ID+9999, 100)
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty backfill for unknown resume id, got %d", len(got))
 	}
 }

--- a/internal/familychat/stream.go
+++ b/internal/familychat/stream.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -18,18 +19,40 @@ import (
 // connection.
 const heartbeatInterval = 30 * time.Second
 
+// BackfillFn returns the catch-up messages a reconnecting client missed, given
+// the highest message id it has already seen (sinceID). It is backed by
+// EventsSince in production; tests inject a fake. A nil BackfillFn (or a
+// sinceID <= 0) disables replay so the stream behaves as a plain live feed.
+type BackfillFn func(convID, userID, sinceID int64) ([]Message, error)
+
 // StreamHandler returns an SSE handler at
 // GET /api/familychat/conversations/{id}/stream that pushes message_new,
-// message_deleted, and read_receipt events as they are published into hub.
+// message_edited, message_deleted, read_receipt, typing, and call signalling
+// events as they are published into hub.
+//
+// Resume: a reconnecting client supplies the id of the last message it saw via
+// the standard Last-Event-ID header (set automatically by the browser's native
+// EventSource) or a since_message_id query param. When present and valid, the
+// handler replays every newer message plus any edit/delete of an older message
+// (via backfill) before attaching to the live feed, so a client whose buffer
+// overflowed or who dropped offline converges to the same state as one that
+// never disconnected. An absent/invalid id is not an error — the stream simply
+// starts at the live feed, exactly as before.
+//
+// Each message-bearing event (new/edited/deleted), live or replayed, is written
+// with an `id:` line carrying the message id so the browser resends the correct
+// Last-Event-ID on auto-reconnect. Ephemeral events (typing, read receipts,
+// call signalling) carry no `id:` line and never become a resume point.
 //
 // Membership is re-verified at subscribe time; non-members get 404 (to avoid
 // leaking conversation existence).
 //
-// hub is the pub/sub the handler subscribes to (callers wiring this into a
-// router should pass DefaultHub() so it shares state with the message and
-// read-receipt handlers). membership is the function used to confirm the
-// requester belongs to the conversation.
-func StreamHandler(hub *Hub, membership MembershipFn) http.HandlerFunc {
+// Ordering guarantee: the handler subscribes to the live hub BEFORE running the
+// backfill, so any event published while the backfill query runs lands in the
+// subscriber buffer rather than being lost. The cost is that such an event may
+// be delivered twice (once via backfill, once live); the frontend applies all
+// replayed events idempotently, so a duplicate is a no-op.
+func StreamHandler(hub *Hub, membership MembershipFn, backfill BackfillFn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
 		if user == nil {
@@ -66,8 +89,35 @@ func StreamHandler(hub *Hub, membership MembershipFn) http.HandlerFunc {
 		w.Header().Set("X-Accel-Buffering", "no")
 		flusher.Flush()
 
+		// Subscribe before backfilling so events published during the backfill
+		// query are buffered, not dropped (see the ordering note in the doc).
 		sub := hub.Subscribe(user.ID, convID)
 		defer hub.Unsubscribe(convID, sub)
+
+		// Replay anything the client missed before streaming live events. An
+		// invalid or absent resume id yields sinceID == 0, which disables replay.
+		sinceID := resumeID(r)
+		if backfill != nil && sinceID > 0 {
+			msgs, err := backfill(convID, user.ID, sinceID)
+			if err != nil {
+				// A backfill failure must not abort the stream — fall through to
+				// the live feed so the client still receives new events (and can
+				// recover the gap via a manual refresh).
+				log.Printf("familychat: backfill conv=%d user=%d since=%d: %v", convID, user.ID, sinceID, err)
+			} else {
+				for _, m := range msgs {
+					if r.Context().Err() != nil {
+						return
+					}
+					if err := writeEvent(w, backfillEvent(m, sinceID)); err != nil {
+						return
+					}
+				}
+				if len(msgs) > 0 {
+					flusher.Flush()
+				}
+			}
+		}
 
 		ticker := time.NewTicker(heartbeatInterval)
 		defer ticker.Stop()
@@ -86,13 +136,12 @@ func StreamHandler(hub *Hub, membership MembershipFn) http.HandlerFunc {
 				if !open {
 					return
 				}
-				data, err := json.Marshal(evt.Data)
-				if err != nil {
+				if err := writeEvent(w, evt); err != nil {
+					if err != errMarshal {
+						return
+					}
 					log.Printf("familychat: marshal event %s for conv %d: %v", evt.Type, convID, err)
 					continue
-				}
-				if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", evt.Type, data); err != nil {
-					return
 				}
 				flusher.Flush()
 			}
@@ -100,9 +149,94 @@ func StreamHandler(hub *Hub, membership MembershipFn) http.HandlerFunc {
 	}
 }
 
+// errMarshal is returned by writeEvent when the event payload cannot be
+// JSON-encoded, distinguishing a (recoverable) bad payload from an I/O failure
+// on the connection (which should tear the stream down).
+var errMarshal = fmt.Errorf("familychat: event payload not marshalable")
+
+// writeEvent serializes one SSE event. Message-bearing events (those with a
+// non-zero ID) get an `id:` line so the browser tracks Last-Event-ID; ephemeral
+// events omit it. Returns errMarshal if the payload can't be encoded, or the
+// underlying write error otherwise.
+func writeEvent(w io.Writer, evt Event) error {
+	data, err := json.Marshal(evt.Data)
+	if err != nil {
+		return errMarshal
+	}
+	if evt.ID > 0 {
+		if _, err := fmt.Fprintf(w, "id: %d\n", evt.ID); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", evt.Type, data); err != nil {
+		return err
+	}
+	return nil
+}
+
+// resumeID extracts the last-seen message id from the request, preferring the
+// standard Last-Event-ID header (which native EventSource resends on
+// auto-reconnect) and falling back to the since_message_id query param (used by
+// the fetch-based reader, which can't set the header). A missing or unparseable
+// value yields 0, which disables replay — i.e. behaves as a fresh live feed.
+func resumeID(r *http.Request) int64 {
+	raw := r.Header.Get("Last-Event-ID")
+	if raw == "" {
+		raw = r.URL.Query().Get("since_message_id")
+	}
+	if raw == "" {
+		return 0
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id < 0 {
+		return 0
+	}
+	return id
+}
+
+// backfillEvent maps a catch-up Message (current on-disk state) to the SSE event
+// the client expects, matching the shapes the live handlers publish:
+//
+//   - id > sinceID: the client never saw this message, so deliver the whole row
+//     as message_new. The row already reflects any later edit (new body) or
+//     delete (tombstone), so a single event converges the client correctly.
+//   - id <= sinceID, deleted: a delete of a message the client already has →
+//     message_deleted.
+//   - id <= sinceID, edited: an edit of a message the client already has →
+//     message_edited.
+func backfillEvent(m Message, sinceID int64) Event {
+	switch {
+	case m.ID > sinceID:
+		return Event{Type: EventMessageNew, ID: m.ID, Data: map[string]any{"message": m}}
+	case m.DeletedAt != nil:
+		var deletedBy int64
+		if m.DeletedBy != nil {
+			deletedBy = *m.DeletedBy
+		}
+		return Event{Type: EventMessageDeleted, ID: m.ID, Data: map[string]any{
+			"message_id":      m.ID,
+			"conversation_id": m.ConversationID,
+			"deleted_by":      deletedBy,
+		}}
+	default:
+		var editedAt string
+		if m.EditedAt != nil {
+			editedAt = *m.EditedAt
+		}
+		return Event{Type: EventMessageEdited, ID: m.ID, Data: map[string]any{
+			"message_id":      m.ID,
+			"conversation_id": m.ConversationID,
+			"body":            m.Body,
+			"edited_at":       editedAt,
+		}}
+	}
+}
+
 // StreamHandlerWithDB is a convenience wrapper that pairs DefaultHub with a
-// DB-backed membership checker. Use this from router.go; tests should call
-// StreamHandler directly with a fake MembershipFn.
+// DB-backed membership checker and backfill. Use this from router.go; tests
+// should call StreamHandler directly with fakes.
 func StreamHandlerWithDB(db *sql.DB) http.HandlerFunc {
-	return StreamHandler(DefaultHub(), DefaultMembership(db))
+	return StreamHandler(DefaultHub(), DefaultMembership(db), func(convID, userID, sinceID int64) ([]Message, error) {
+		return EventsSince(db, convID, userID, sinceID, maxBackfillLimit)
+	})
 }

--- a/internal/familychat/stream.go
+++ b/internal/familychat/stream.go
@@ -110,7 +110,11 @@ func StreamHandler(hub *Hub, membership MembershipFn, backfill BackfillFn) http.
 						return
 					}
 					if err := writeEvent(w, backfillEvent(m, sinceID)); err != nil {
-						return
+						if err != errMarshal {
+							return
+						}
+						log.Printf("familychat: backfill marshal event for msg %d conv %d: %v", m.ID, convID, err)
+						continue
 					}
 				}
 				if len(msgs) > 0 {

--- a/internal/familychat/stream_test.go
+++ b/internal/familychat/stream_test.go
@@ -501,7 +501,7 @@ func TestStreamHandler_ReceivesEventViaPublishRoute(t *testing.T) {
 	r.Get("/api/familychat/conversations/{id}/stream", StreamHandler(hub, mem.fn(), nil))
 	// Stub that publishes an event, standing in for a real POST /messages handler.
 	r.Post("/api/familychat/conversations/{id}/publish", func(w http.ResponseWriter, req *http.Request) {
-		hub.Publish(convID, Event{Type: EventMessageNew, Data: map[string]any{"body": "via-post"}})
+		hub.Publish(convID, Event{Type: EventMessageNew, ID: 1, Data: map[string]any{"body": "via-post"}})
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/internal/familychat/stream_test.go
+++ b/internal/familychat/stream_test.go
@@ -5,16 +5,274 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/go-chi/chi/v5"
 )
+
+// sseFrame is one parsed SSE event: the optional id: line plus event/data.
+type sseFrame struct {
+	id    string
+	event string
+	data  string
+}
+
+// sseFrameChannel parses complete SSE frames off r and delivers them in order.
+// The channel closes when the stream ends. Heartbeat comment lines (": ...")
+// are skipped. id/event/data are trimmed of the single optional leading space.
+func sseFrameChannel(r io.Reader) <-chan sseFrame {
+	ch := make(chan sseFrame)
+	go func() {
+		defer close(ch)
+		scanner := bufio.NewScanner(r)
+		var cur sseFrame
+		var have bool
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, ":"):
+				// heartbeat / comment — ignore
+			case strings.HasPrefix(line, "id:"):
+				cur.id = strings.TrimSpace(line[len("id:"):])
+				have = true
+			case strings.HasPrefix(line, "event:"):
+				cur.event = strings.TrimSpace(line[len("event:"):])
+				have = true
+			case strings.HasPrefix(line, "data:"):
+				cur.data = strings.TrimSpace(line[len("data:"):])
+				have = true
+			case line == "":
+				if have && cur.event != "" {
+					ch <- cur
+				}
+				cur = sseFrame{}
+				have = false
+			}
+		}
+	}()
+	return ch
+}
+
+// nextFrame waits up to d for the next SSE frame, failing the test on timeout
+// or premature close.
+func nextFrame(t *testing.T, ch <-chan sseFrame, d time.Duration) sseFrame {
+	t.Helper()
+	select {
+	case f, ok := <-ch:
+		if !ok {
+			t.Fatal("SSE stream closed before a frame arrived")
+		}
+		return f
+	case <-time.After(d):
+		t.Fatal("timed out waiting for SSE frame")
+	}
+	return sseFrame{}
+}
+
+func TestStreamHandler_ReplaysBacklogBeforeLiveEvents(t *testing.T) {
+	hub := NewHub()
+	const convID int64 = 400
+	mem := newMembershipSet([2]int64{1, convID})
+	user := &auth.User{ID: 1, Email: "a@example.com", Name: "A"}
+
+	edited := "2026-01-01T00:00:00.000Z"
+	backfill := BackfillFn(func(cid, uid, since int64) ([]Message, error) {
+		if cid != convID || uid != 1 || since != 3 {
+			t.Errorf("backfill args: conv=%d user=%d since=%d", cid, uid, since)
+		}
+		return []Message{
+			{ID: 5, ConversationID: convID, SenderUserID: 2, Body: "after gap", CreatedAt: edited, Reactions: map[string]*ReactionSummary{}},
+			{ID: 2, ConversationID: convID, SenderUserID: 1, Body: "edited body", CreatedAt: edited, EditedAt: &edited, Reactions: map[string]*ReactionSummary{}},
+		}, nil
+	})
+
+	srv := httptest.NewServer(newBackfillRouter(t, hub, mem.fn(), backfill, user))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/familychat/conversations/400/stream?since_message_id=3", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	frames := sseFrameChannel(resp.Body)
+
+	// Backlog first: a never-seen message (id 5) becomes message_new; an edit of
+	// an older message (id 2) becomes message_edited. Both carry id: lines.
+	f1 := nextFrame(t, frames, 3*time.Second)
+	if f1.event != EventMessageNew || f1.id != "5" {
+		t.Fatalf("frame 1 = {event:%q id:%q}, want message_new/5", f1.event, f1.id)
+	}
+	if !strings.Contains(f1.data, `"after gap"`) {
+		t.Fatalf("frame 1 data missing body: %q", f1.data)
+	}
+	f2 := nextFrame(t, frames, 3*time.Second)
+	if f2.event != EventMessageEdited || f2.id != "2" {
+		t.Fatalf("frame 2 = {event:%q id:%q}, want message_edited/2", f2.event, f2.id)
+	}
+
+	// Now a live event arrives after the backlog has been flushed.
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.subscriberCount(convID) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("subscriber never registered")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	hub.Publish(convID, Event{Type: EventMessageNew, ID: 6, Data: map[string]any{"message": map[string]any{"id": 6, "body": "live"}}})
+	f3 := nextFrame(t, frames, 3*time.Second)
+	if f3.event != EventMessageNew || f3.id != "6" {
+		t.Fatalf("frame 3 = {event:%q id:%q}, want message_new/6", f3.event, f3.id)
+	}
+}
+
+func TestStreamHandler_NoResumeIDSkipsBackfill(t *testing.T) {
+	hub := NewHub()
+	const convID int64 = 410
+	mem := newMembershipSet([2]int64{1, convID})
+	user := &auth.User{ID: 1, Email: "a@example.com", Name: "A"}
+
+	var calls int32
+	backfill := BackfillFn(func(cid, uid, since int64) ([]Message, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, nil
+	})
+
+	srv := httptest.NewServer(newBackfillRouter(t, hub, mem.fn(), backfill, user))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// No since_message_id and no Last-Event-ID header → behave as a live feed.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/familychat/conversations/410/stream", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (membership verified), got %d", resp.StatusCode)
+	}
+
+	frames := sseFrameChannel(resp.Body)
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.subscriberCount(convID) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("subscriber never registered")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	hub.Publish(convID, Event{Type: EventMessageNew, ID: 9, Data: map[string]any{"message": map[string]any{"id": 9}}})
+	f := nextFrame(t, frames, 3*time.Second)
+	if f.event != EventMessageNew || f.id != "9" {
+		t.Fatalf("live frame = {event:%q id:%q}, want message_new/9", f.event, f.id)
+	}
+	if n := atomic.LoadInt32(&calls); n != 0 {
+		t.Fatalf("backfill should not run without a resume id, called %d times", n)
+	}
+}
+
+func TestStreamHandler_InvalidResumeIDSkipsBackfill(t *testing.T) {
+	hub := NewHub()
+	const convID int64 = 420
+	mem := newMembershipSet([2]int64{1, convID})
+	user := &auth.User{ID: 1, Email: "a@example.com", Name: "A"}
+
+	var calls int32
+	backfill := BackfillFn(func(cid, uid, since int64) ([]Message, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, nil
+	})
+
+	srv := httptest.NewServer(newBackfillRouter(t, hub, mem.fn(), backfill, user))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/familychat/conversations/420/stream?since_message_id=not-a-number", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for invalid resume id, got %d", resp.StatusCode)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.subscriberCount(convID) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("subscriber never registered")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if n := atomic.LoadInt32(&calls); n != 0 {
+		t.Fatalf("backfill should not run for an unparseable resume id, called %d times", n)
+	}
+}
+
+func TestStreamHandler_EphemeralEventHasNoIDLine(t *testing.T) {
+	hub := NewHub()
+	const convID int64 = 430
+	mem := newMembershipSet([2]int64{1, convID})
+	user := &auth.User{ID: 1, Email: "a@example.com", Name: "A"}
+
+	srv := httptest.NewServer(newBackfillRouter(t, hub, mem.fn(), nil, user))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/familychat/conversations/430/stream", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	frames := sseFrameChannel(resp.Body)
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.subscriberCount(convID) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("subscriber never registered")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Typing is ephemeral: ID left zero → no id: line, so it never becomes a
+	// resume point for a reconnecting browser.
+	hub.Publish(convID, Event{Type: EventTyping, Data: map[string]any{"conversation_id": convID, "user_id": int64(2)}})
+	f := nextFrame(t, frames, 3*time.Second)
+	if f.event != EventTyping {
+		t.Fatalf("expected typing event, got %q", f.event)
+	}
+	if f.id != "" {
+		t.Fatalf("ephemeral event must not carry an id: line, got id=%q", f.id)
+	}
+}
 
 // fakeMembership returns a MembershipFn that consults a closed-over set.
 type membershipSet struct {
@@ -50,7 +308,22 @@ func newAuthRouter(t *testing.T, hub *Hub, membership MembershipFn, user *auth.U
 			next.ServeHTTP(w, req.WithContext(ctx))
 		})
 	})
-	r.Get("/api/familychat/conversations/{id}/stream", StreamHandler(hub, membership))
+	r.Get("/api/familychat/conversations/{id}/stream", StreamHandler(hub, membership, nil))
+	return r
+}
+
+// newBackfillRouter is like newAuthRouter but wires a backfill function so the
+// resume/replay path can be exercised end-to-end over the wire.
+func newBackfillRouter(t *testing.T, hub *Hub, membership MembershipFn, backfill BackfillFn, user *auth.User) http.Handler {
+	t.Helper()
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := auth.ContextWithUser(req.Context(), user)
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	r.Get("/api/familychat/conversations/{id}/stream", StreamHandler(hub, membership, backfill))
 	return r
 }
 
@@ -225,7 +498,7 @@ func TestStreamHandler_ReceivesEventViaPublishRoute(t *testing.T) {
 			next.ServeHTTP(w, req.WithContext(ctx))
 		})
 	})
-	r.Get("/api/familychat/conversations/{id}/stream", StreamHandler(hub, mem.fn()))
+	r.Get("/api/familychat/conversations/{id}/stream", StreamHandler(hub, mem.fn(), nil))
 	// Stub that publishes an event, standing in for a real POST /messages handler.
 	r.Post("/api/familychat/conversations/{id}/publish", func(w http.ResponseWriter, req *http.Request) {
 		hub.Publish(convID, Event{Type: EventMessageNew, Data: map[string]any{"body": "via-post"}})

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -504,6 +504,13 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
 
     const connect = async (firstConnect: boolean) => {
       if (controller.signal.aborted) return
+      // Capture the resume point BEFORE fillGap runs. fillGap appends any new
+      // messages and bumps lastId; if we passed the post-fillGap lastId to the
+      // stream, the backfill watermark would advance past edits/deletes that
+      // happened mid-gap (older than the newest message but newer than where we
+      // actually left off), silently dropping them. The pre-gap id is the true
+      // "last seen while connected" point.
+      const resumeId = lastId
       // Skip the gap-fill on the very first connect: the initial /messages
       // fetch already covered everything up to lastId. On reconnects we
       // re-issue it so a disconnect window can't lose messages.
@@ -511,8 +518,19 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       if (controller.signal.aborted) return
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
       try {
+        // On reconnect, pass the last-seen message id as since_message_id so the
+        // stream replays anything missed while we were gone — not just new
+        // messages (which fillGap above already covers) but edits and deletes of
+        // older messages too, which a plain id>since fetch can't see. A native
+        // EventSource would resend this via Last-Event-ID automatically; this
+        // fetch-based reader can't set that header, so the query param carries
+        // the resume point instead. All replayed events are applied idempotently
+        // below, so overlap with fillGap (or a never-dropped event) is a no-op.
+        const streamUrl = !firstConnect && resumeId > 0
+          ? `/api/familychat/conversations/${conversationId}/stream?since_message_id=${resumeId}`
+          : `/api/familychat/conversations/${conversationId}/stream`
         const res = await fetch(
-          `/api/familychat/conversations/${conversationId}/stream`,
+          streamUrl,
           { credentials: 'include', signal: controller.signal },
         )
         if (!res.ok || !res.body) {


### PR DESCRIPTION
## Changes

- **Family Chat no longer drops messages after a connection blip** - The chat stream now accepts a resume point (the standard `Last-Event-ID` header or a `since_message_id` query param) and replays every message, edit, and delete missed while a client was disconnected or its event buffer overflowed, before resuming the live feed. Each message event carries an SSE `id:` line so reconnects pick up exactly where they left off, and replayed events are applied idempotently with no duplicate or resurrected messages. (Hytte-g4iv)

## Original Issue (feature): Backfill messages missed during SSE buffer drops and reconnects

### Scope
Close the two gaps where Family Chat clients silently lose events: (1) the hub drops a publish when a subscriber's 16-slot buffer is full, and (2) a client that reconnects after a network blip never replays what it missed. The fix gives the SSE stream a resume point: clients send their last-seen message id (via the standard `Last-Event-ID` header or a `since_message_id` query param), the stream handler replays everything newer — including edits and deletes — from the DB before attaching to the live feed, and each message-bearing SSE event carries an `id:` line so the browser's native `EventSource` auto-reconnect supplies `Last-Event-ID` for free.

### Files to touch
- `internal/familychat/stream.go` — read `Last-Event-ID`/`since_message_id` on subscribe; replay backlog before live loop; write `id:` lines on message events.
- `internal/familychat/store.go` — add a query for events newer than a given message id, covering new messages **and** edits/deletes of older messages (needs an `updated_at`/tombstone-aware fetch, not just `id > since`).
- `internal/familychat/handlers.go` — confirm `ListMessages`/`since` semantics align with replay; reuse rather than duplicate.
- `web/src/pages/FamilyChat.tsx` — track last-seen message id, pass it on (re)connect, and reconcile backfilled new/edited/deleted messages into local state idempotently.
- `internal/familychat/stream_test.go` (new) — backfill + reconnect coverage.
- `changelog.d/<id>-familychat-sse-backfill.md` (new).

### Acceptance criteria
- Connecting to the stream with `Last-Event-ID: N` (or `?since_message_id=N`) replays every new message, edit, and delete with id/effect after `N` before any live event arrives, in order.
- Each message-bearing SSE event includes an `id:` line so a browser reconnect resends the correct `Last-Event-ID` automatically; ephemeral events (typing, call signalling) are excluded from resume.
- A client whose buffer overflowed or who dropped offline and reconnected ends up with the same messages, edits, and deletes as a never-disconnected client, with no manual refresh.
- Replayed events are applied idempotently on the frontend (no duplicate bubbles, no resurrected deleted messages).
- An invalid/absent resume id behaves as today (full live feed, no error); membership is still re-verified.
- New backend tests cover replay-from-id, edit/delete replay, and the no-id path; `go test`, `go vet`, `npm run lint`, `npm run build` pass.

### Non-goals
- No persistent server-side per-subscriber outbox/queue or delivery acks; replay is DB-derived, not buffered.
- No change to webpush fan-out, typing, reactions transport, or WebRTC call signalling.
- No increase to `SubscriberBufferSize` as the primary fix (may note, but resume is the mechanism).
- No new schema beyond what edit/delete replay strictly requires; no cross-conversation or multi-device sync semantics.

## Source

Created from Suggestions page (suggestion id 188, page slug "family-chat", source=claude).

## Original suggestion

The hub's `Publish` silently drops an event when a subscriber's 16-slot buffer is full, and a subscriber that reconnects after a network blip gets no replay of events sent while it was gone — so messages, edits, and deletes can vanish from a client until a manual refresh. Add a `Last-Event-ID`/`since_message_id` parameter to the SSE stream (and the message list endpoint) so a reconnecting or backlogged client fetches everything newer than its last seen message before resuming the live feed. Users would stop seeing gaps in conversations after spotty connectivity without noticing they missed anything.


---
Bead: Hytte-g4iv | Branch: forge/Hytte-g4iv
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->