### PR TITLE
Fix transaction list ordering when carry-overs span months (Hytte-gvfu)

### DIFF
--- a/changelog.d/Hytte-gvfu.md
+++ b/changelog.d/Hytte-gvfu.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Credit-card carry-overs sort to the top** - Transactions deferred from the previous month now appear at the top of their group in the credit-card statement instead of sinking below every in-period row, keeping the rows that belong to the viewed statement together. (Hytte-gvfu)

--- a/internal/creditcard/transactions.go
+++ b/internal/creditcard/transactions.go
@@ -91,8 +91,8 @@ func TransactionsListHandler(db *sql.DB) http.HandlerFunc {
 			      (t.transaksjonsdato >= ? AND t.transaksjonsdato < ?
 			       AND t.deferred_to_next_month = 1 AND t.is_pending = 0)
 			  )
-			ORDER BY t.transaksjonsdato DESC, t.id DESC
-		`, user.ID, creditCardID, startStr, endStr, prevStartStr, startStr)
+			ORDER BY (t.transaksjonsdato < ?) DESC, t.transaksjonsdato DESC, t.id DESC
+		`, user.ID, creditCardID, startStr, endStr, prevStartStr, startStr, startStr)
 		if err != nil {
 			log.Printf("creditcard: transactions list query: %v", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list transactions"})

--- a/internal/creditcard/transactions_test.go
+++ b/internal/creditcard/transactions_test.go
@@ -240,6 +240,91 @@ func TestTransactionsListHandler_DeferredCarryoverShownInTargetMonth(t *testing.
 	}
 }
 
+func TestTransactionsListHandler_CarryoversSortedFirst(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Two deferred March carry-overs plus several in-period April rows with
+	// varied dates and ids. The carry-overs are dated before the period start,
+	// so by date alone they would sink below every April row.
+	descs := map[string]string{}
+	for _, name := range []string{
+		"Carryover Feb 28", "Carryover Mar 30",
+		"April 02", "April 18", "April 18 second",
+	} {
+		enc, err := encryption.EncryptField(name)
+		if err != nil {
+			t.Fatalf("encrypt %q: %v", name, err)
+		}
+		descs[name] = enc
+	}
+
+	// Insert in a deliberately scrambled order so the ORDER BY clause is what
+	// determines the response order, not insertion order.
+	if _, err := db.Exec(`
+		INSERT INTO credit_card_transactions
+			(user_id, credit_card_id, transaksjonsdato, beskrivelse, belop, belop_i_valuta, is_pending, is_innbetaling, deferred_to_next_month)
+		VALUES
+			(1, '1', '2026-04-18', ?, -100, -100, 0, 0, 0),
+			(1, '1', '2026-02-28', ?, -300, -300, 0, 0, 1),
+			(1, '1', '2026-04-02', ?, -100, -100, 0, 0, 0),
+			(1, '1', '2026-03-30', ?, -300, -300, 0, 0, 1),
+			(1, '1', '2026-04-18', ?, -100, -100, 0, 0, 0)
+	`, descs["April 18"], descs["Carryover Feb 28"], descs["April 02"], descs["Carryover Mar 30"], descs["April 18 second"]); err != nil {
+		t.Fatalf("insert transactions: %v", err)
+	}
+
+	handler := TransactionsListHandler(db)
+	req := httptest.NewRequest(http.MethodGet, "/api/credit-card/transactions?credit_card_id=1&month=2026-04", nil)
+	req = withUser(req, 1)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp TransactionsListResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Transactions) != 5 {
+		t.Fatalf("expected 5 transactions, got %d", len(resp.Transactions))
+	}
+
+	// All carry-over rows must precede every in-period row.
+	seenInPeriod := false
+	for i, tx := range resp.Transactions {
+		if tx.DeferredFromPreviousMonth {
+			if seenInPeriod {
+				t.Errorf("carry-over row %q at index %d appears after an in-period row", tx.Beskrivelse, i)
+			}
+		} else {
+			seenInPeriod = true
+		}
+	}
+
+	// Within each block, ordering stays transaksjonsdato DESC, id DESC:
+	// Mar 30 before Feb 28 in the carry-over block; April 18 rows before
+	// April 02 in the in-period block, with the two April 18 rows broken by
+	// descending id.
+	got := make([]string, len(resp.Transactions))
+	for i, tx := range resp.Transactions {
+		got[i] = tx.Beskrivelse
+	}
+	want := []string{
+		"Carryover Mar 30",   // carry-over block, date DESC
+		"Carryover Feb 28",   // carry-over block
+		"April 18 second",    // in-period block, date DESC then id DESC
+		"April 18",           // same date, lower id
+		"April 02",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("order[%d] = %q, want %q (full order: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestTransactionsListHandler_PendingPreviousMonthNotCarriedOver(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/internal/creditcard/transactions_test.go
+++ b/internal/creditcard/transactions_test.go
@@ -245,10 +245,12 @@ func TestTransactionsListHandler_CarryoversSortedFirst(t *testing.T) {
 
 	// Two deferred March carry-overs plus several in-period April rows with
 	// varied dates and ids. The carry-overs are dated before the period start,
-	// so by date alone they would sink below every April row.
+	// so by date alone they would sink below every April row. They live in the
+	// immediately preceding month (March) so the previous-month carry-over
+	// selection includes them.
 	descs := map[string]string{}
 	for _, name := range []string{
-		"Carryover Feb 28", "Carryover Mar 30",
+		"Carryover Mar 12", "Carryover Mar 30",
 		"April 02", "April 18", "April 18 second",
 	} {
 		enc, err := encryption.EncryptField(name)
@@ -265,11 +267,11 @@ func TestTransactionsListHandler_CarryoversSortedFirst(t *testing.T) {
 			(user_id, credit_card_id, transaksjonsdato, beskrivelse, belop, belop_i_valuta, is_pending, is_innbetaling, deferred_to_next_month)
 		VALUES
 			(1, '1', '2026-04-18', ?, -100, -100, 0, 0, 0),
-			(1, '1', '2026-02-28', ?, -300, -300, 0, 0, 1),
+			(1, '1', '2026-03-12', ?, -300, -300, 0, 0, 1),
 			(1, '1', '2026-04-02', ?, -100, -100, 0, 0, 0),
 			(1, '1', '2026-03-30', ?, -300, -300, 0, 0, 1),
 			(1, '1', '2026-04-18', ?, -100, -100, 0, 0, 0)
-	`, descs["April 18"], descs["Carryover Feb 28"], descs["April 02"], descs["Carryover Mar 30"], descs["April 18 second"]); err != nil {
+	`, descs["April 18"], descs["Carryover Mar 12"], descs["April 02"], descs["Carryover Mar 30"], descs["April 18 second"]); err != nil {
 		t.Fatalf("insert transactions: %v", err)
 	}
 
@@ -304,7 +306,7 @@ func TestTransactionsListHandler_CarryoversSortedFirst(t *testing.T) {
 	}
 
 	// Within each block, ordering stays transaksjonsdato DESC, id DESC:
-	// Mar 30 before Feb 28 in the carry-over block; April 18 rows before
+	// Mar 30 before Mar 12 in the carry-over block; April 18 rows before
 	// April 02 in the in-period block, with the two April 18 rows broken by
 	// descending id.
 	got := make([]string, len(resp.Transactions))
@@ -313,7 +315,7 @@ func TestTransactionsListHandler_CarryoversSortedFirst(t *testing.T) {
 	}
 	want := []string{
 		"Carryover Mar 30",   // carry-over block, date DESC
-		"Carryover Feb 28",   // carry-over block
+		"Carryover Mar 12",   // carry-over block
 		"April 18 second",    // in-period block, date DESC then id DESC
 		"April 18",           // same date, lower id
 		"April 02",


### PR DESCRIPTION
## Changes

- **Credit-card carry-overs sort to the top** - Transactions deferred from the previous month now appear at the top of their group in the credit-card statement instead of sinking below every in-period row, keeping the rows that belong to the viewed statement together. (Hytte-gvfu)

## Original Issue (feature): Fix transaction list ordering when carry-overs span months

### Scope
`TransactionsListHandler` returns rows ordered strictly by `transaksjonsdato DESC, id DESC`, so a carry-over deferred from the previous month (e.g. dated Feb 28, shown in the March statement) sinks below every March row. Sort carry-overs to the top of each result so the rows that belong to the viewed statement appear first. The carry-over flag (`DeferredFromPreviousMonth`) is derived in Go from the period boundary (`t.Transaksjonsdato < startStr`), so the ordering must key off that same boundary rather than an existing column. Because `GroupSection` renders rows in backend order with no secondary sort, fixing the query ordering corrects the visual grouping too.

### Files to touch
- `internal/creditcard/transactions.go` — change the `ORDER BY` in the list query to put carry-overs first, keying off the period start.
- `internal/creditcard/transactions_test.go` — add/extend a test asserting carry-over rows precede in-period rows.

### Acceptance criteria
- For a billing month with at least one deferred-from-previous-month carry-over plus several in-period rows, the list response returns all carry-over rows (where `transaksjonsdato < startStr`) before any in-period row.
- Within the carry-over block and within the in-period block, ordering remains `transaksjonsdato DESC, id DESC` (existing behavior preserved).
- The change uses the same period boundary already used to compute `DeferredFromPreviousMonth` (e.g. `ORDER BY (t.transaksjonsdato < ?) DESC, t.transaksjonsdato DESC, t.id DESC` with `startStr` bound), keeping flag and ordering consistent.
- On the `/budget/credit-cards` page, carry-over rows appear at the top of their group rather than orphaned at the bottom; the existing "deferred from previous month" badge still renders.
- A new or extended test in `transactions_test.go` verifies the ordering; `make test` passes.
- A changelog fragment is added under `changelog.d/` (category `Fixed`).

### Non-goals
- No new DB column for `deferred_from_previous_month`; ordering is derived from the period boundary in the query.
- No change to which rows are included (the WHERE clause and carry-over selection logic stay as-is).
- No change to variable-bill sync, opening balance, defer toggling, or import logic.
- No client-side re-sorting added to `GroupSection`; it continues to render in backend order.
- No changes to group totals, grouping, or `SyncCreditCardExpense`.

## Source

Created from Suggestions page (suggestion id 28, page slug "budget-credit-cards", source=claude).

## Original suggestion

TransactionsListHandler orders strictly by `transaksjonsdato DESC, id DESC`, so a deferred-from-previous-month row dated e.g. Feb 28 sinks below all March rows even though it's an active expense in the viewed period. The frontend's GroupSection also has no secondary sort, leaving carry-overs visually orphaned at the bottom of the group. Fix by sorting carry-overs to the top (e.g. `ORDER BY deferred_from_previous_month DESC, transaksjonsdato DESC, id DESC` — derived from the period boundary) so users see the rows that actually belong to the current statement first.


---
Bead: Hytte-gvfu | Branch: forge/Hytte-gvfu
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->