### PR TITLE
Show a live connection status indicator when the SSE stream drops (Hytte-pe6v)

### DIFF
--- a/changelog.d/Hytte-pe6v.md
+++ b/changelog.d/Hytte-pe6v.md
@@ -1,0 +1,2 @@
+category: Added
+- **Live connection status in Family Chat** - The chat view now shows a "Reconnecting…" badge when the message stream drops and briefly confirms "Connected" once it recovers, re-fetching recent messages so no gap is left on a stale view. (Hytte-pe6v)

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -33,8 +33,7 @@
     "lightboxClose": "Close preview",
     "connection": {
       "live": "Connected",
-      "reconnecting": "Reconnecting…",
-      "ariaLabel": "Connection status"
+      "reconnecting": "Reconnecting…"
     },
     "typing": {
       "single": "{{name}} is typing…",

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -32,7 +32,9 @@
     "lightboxTitle": "Image preview",
     "lightboxClose": "Close preview",
     "connection": {
-      "reconnecting": "Reconnecting…"
+      "live": "Connected",
+      "reconnecting": "Reconnecting…",
+      "ariaLabel": "Connection status"
     },
     "typing": {
       "single": "{{name}} is typing…",

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -33,8 +33,7 @@
     "lightboxClose": "Lukk forhåndsvisning",
     "connection": {
       "live": "Tilkoblet",
-      "reconnecting": "Kobler til på nytt…",
-      "ariaLabel": "Tilkoblingsstatus"
+      "reconnecting": "Kobler til på nytt…"
     },
     "typing": {
       "single": "{{name}} skriver…",

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -32,7 +32,9 @@
     "lightboxTitle": "Forhåndsvisning av bilde",
     "lightboxClose": "Lukk forhåndsvisning",
     "connection": {
-      "reconnecting": "Kobler til på nytt…"
+      "live": "Tilkoblet",
+      "reconnecting": "Kobler til på nytt…",
+      "ariaLabel": "Tilkoblingsstatus"
     },
     "typing": {
       "single": "{{name}} skriver…",

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -33,8 +33,7 @@
     "lightboxClose": "ปิดการดูตัวอย่าง",
     "connection": {
       "live": "เชื่อมต่อแล้ว",
-      "reconnecting": "กำลังเชื่อมต่อใหม่…",
-      "ariaLabel": "สถานะการเชื่อมต่อ"
+      "reconnecting": "กำลังเชื่อมต่อใหม่…"
     },
     "typing": {
       "single": "{{name}} กำลังพิมพ์…",

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -32,7 +32,9 @@
     "lightboxTitle": "ดูตัวอย่างรูปภาพ",
     "lightboxClose": "ปิดการดูตัวอย่าง",
     "connection": {
-      "reconnecting": "กำลังเชื่อมต่อใหม่…"
+      "live": "เชื่อมต่อแล้ว",
+      "reconnecting": "กำลังเชื่อมต่อใหม่…",
+      "ariaLabel": "สถานะการเชื่อมต่อ"
     },
     "typing": {
       "single": "{{name}} กำลังพิมพ์…",

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -51,7 +51,6 @@ const TRANSLATIONS: Record<string, string> = {
   'chat.lightboxClose': 'Close preview',
   'chat.connection.live': 'Connected',
   'chat.connection.reconnecting': 'Reconnecting…',
-  'chat.connection.ariaLabel': 'Connection status',
   'newModal.parent': 'Parent',
   'reactions.pickerLabel': 'Add reaction',
   'reactions.add': 'React with {{emoji}}',

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -49,7 +49,9 @@ const TRANSLATIONS: Record<string, string> = {
   'chat.attachmentFileLabel': 'Download attachment ({{mime}})',
   'chat.lightboxTitle': 'Image preview',
   'chat.lightboxClose': 'Close preview',
+  'chat.connection.live': 'Connected',
   'chat.connection.reconnecting': 'Reconnecting…',
+  'chat.connection.ariaLabel': 'Connection status',
   'newModal.parent': 'Parent',
   'reactions.pickerLabel': 'Add reaction',
   'reactions.add': 'React with {{emoji}}',
@@ -567,6 +569,85 @@ describe('ChatView – reconnect gap-fill', () => {
     await waitFor(() => {
       expect(screen.getByTestId('family-chat-reconnecting')).toBeInTheDocument()
     })
+  }, 15000)
+
+  it('returns to a live indicator and re-fetches recent messages on successful reconnect', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    let closeStream: (() => void) | null = null
+    const firstStream = new ReadableStream<Uint8Array>({
+      start(c) { closeStream = () => c.close() },
+    })
+
+    const initialMsg = makeMessage({ id: 10, body: 'Before disconnect', conversation_id: 1 })
+    const gapMsg = makeMessage({ id: 11, body: 'Filled on reconnect', conversation_id: 1, created_at: '2026-05-01T10:11:00Z' })
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([initialMsg]))
+      .mockResolvedValueOnce({ ok: true, body: firstStream })
+      .mockResolvedValueOnce(msgsOk([gapMsg]))   // gap-fill on reconnect
+      .mockResolvedValueOnce(streamOk())          // reconnect stream opens cleanly
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderChatView()
+    await waitFor(() => expect(screen.getByText('Before disconnect')).toBeInTheDocument())
+
+    // Drop the stream → the Reconnecting badge appears.
+    await act(async () => {
+      closeStream!()
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('family-chat-reconnecting')).toBeInTheDocument()
+    })
+
+    // Fast-forward past the backoff so the reconnect lands.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+
+    // The Reconnecting badge clears, a brief "Connected" confirmation shows,
+    // and the gap-fill backfilled the message that arrived during the drop.
+    await waitFor(() => {
+      expect(screen.queryByTestId('family-chat-reconnecting')).not.toBeInTheDocument()
+      expect(screen.getByTestId('family-chat-connected')).toBeInTheDocument()
+      expect(screen.getByText('Filled on reconnect')).toBeInTheDocument()
+    })
+    const fetchedUrls = fetchMock.mock.calls.map(([url]) => url as string)
+    expect(fetchedUrls.some(url => url.includes('/messages?since=10'))).toBe(true)
+  }, 15000)
+
+  it('clears the reconnecting indicator when the view unmounts mid-backoff', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    let closeStream: (() => void) | null = null
+    const firstStream = new ReadableStream<Uint8Array>({
+      start(c) { closeStream = () => c.close() },
+    })
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce({ ok: true, body: firstStream })
+      .mockResolvedValue(streamOk())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { unmount } = renderChatView()
+    await waitFor(() => screen.getByText('No messages yet. Say hello!'))
+
+    await act(async () => {
+      closeStream!()
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('family-chat-reconnecting')).toBeInTheDocument()
+    })
+
+    // Unmounting while the backoff is pending must tear down cleanly without
+    // leaving the indicator stuck.
+    unmount()
+    expect(screen.queryByTestId('family-chat-reconnecting')).not.toBeInTheDocument()
   }, 15000)
 
   it('gap-fills without a since param when the initial message list is empty', async () => {

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -5,6 +5,7 @@ import {
   MessageSquare,
   Download,
   X,
+  Wifi,
   WifiOff,
   Smile,
   MoreVertical,
@@ -122,11 +123,18 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const [error, setError] = useState('')
   const [memberLookup, setMemberLookup] = useState<Map<number, MemberInfo>>(new Map())
   const [lightbox, setLightbox] = useState<{ url: string; alt: string } | null>(null)
-  // streamDropped flips to true while the SSE reconnect backoff is in flight.
-  // It only ever shows the indicator after we've successfully connected once,
-  // so the initial-load skeleton isn't shadowed by a "Reconnecting" badge.
-  const [streamDropped, setStreamDropped] = useState(false)
-  const [hasConnected, setHasConnected] = useState(false)
+  // connStatus tracks the live state of the SSE stream so the header can show
+  // honest connectivity feedback:
+  //   'connecting'   — initial load, before the stream has ever opened
+  //   'live'         — stream is open and messages arrive in real time
+  //   'reconnecting' — the stream dropped after being live and a backoff retry
+  //                    is in flight
+  // The 'connecting' → 'reconnecting' distinction keeps the initial-load
+  // skeleton from being shadowed by a false "Reconnecting" badge.
+  const [connStatus, setConnStatus] = useState<'connecting' | 'live' | 'reconnecting'>('connecting')
+  // justReconnected briefly flips true right after the stream recovers from a
+  // drop so the header can flash a "Connected" confirmation, then auto-clears.
+  const [justReconnected, setJustReconnected] = useState(false)
   // pickerForMsgId is the id of the bubble whose reaction picker is open, or
   // null when nothing is open. We only show one picker at a time.
   const [pickerForMsgId, setPickerForMsgId] = useState<number | null>(null)
@@ -354,6 +362,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     // updated by initial load, SSE events, and gap-fill responses.
     let lastId = 0
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    // recoveredTimer clears the brief "Connected" confirmation after a drop.
+    let recoveredTimer: ReturnType<typeof setTimeout> | null = null
     let reconnectAttempts = 0
     let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null
 
@@ -368,8 +378,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     setError('')
     setMessages([])
     setConversation(null)
-    setStreamDropped(false)
-    setHasConnected(false)
+    setConnStatus('connecting')
+    setJustReconnected(false)
     setMissedCalls([])
     setEndedCallSummary(null)
     setTypingUsers(new Map())
@@ -490,7 +500,10 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
 
     const scheduleReconnect = () => {
       if (controller.signal.aborted) return
-      setStreamDropped(true)
+      // Only surface the "Reconnecting" badge once we've actually been live —
+      // a failure on the very first connect keeps us in 'connecting' so the
+      // initial load never flashes a false "offline".
+      setConnStatus(prev => (prev === 'connecting' ? 'connecting' : 'reconnecting'))
       reconnectAttempts += 1
       // Exponential backoff capped at 30s to keep a server outage from
       // hammering the endpoint while still recovering quickly from a
@@ -522,8 +535,19 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         reconnectAttempts = 0
         reader = res.body.getReader()
         activeReader = reader
-        setStreamDropped(false)
-        setHasConnected(true)
+        // A non-first connect means the stream just recovered from a drop. The
+        // gap-fill above already backfilled any messages missed during the
+        // outage; flash a brief "Connected" confirmation so the user gets a
+        // visible signal that messages are arriving live again.
+        if (!firstConnect) {
+          setJustReconnected(true)
+          if (recoveredTimer !== null) clearTimeout(recoveredTimer)
+          recoveredTimer = setTimeout(() => {
+            recoveredTimer = null
+            setJustReconnected(false)
+          }, 3000)
+        }
+        setConnStatus('live')
         const decoder = new TextDecoder()
         let buffer = ''
         let eventName = 'message'
@@ -686,6 +710,10 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         clearTimeout(reconnectTimer)
         reconnectTimer = null
       }
+      if (recoveredTimer !== null) {
+        clearTimeout(recoveredTimer)
+        recoveredTimer = null
+      }
       // Cancel the reader so the read loop exits even when the fetch mock
       // doesn't propagate abort to the body (notably in tests). The catch is
       // intentional — cancel can throw if the reader is already detached.
@@ -704,6 +732,10 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       setMessages([])
       setError('')
       setLoading(false)
+      // Reset connection state so the indicator never stays stuck in
+      // 'reconnecting' after the view unmounts or switches conversation.
+      setConnStatus('connecting')
+      setJustReconnected(false)
       setMissedCalls([])
       setEndedCallSummary(null)
       setTypingUsers(new Map())
@@ -1182,16 +1214,30 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
             </ul>
           )}
         </div>
-        {hasConnected && streamDropped && (
+        {connStatus === 'reconnecting' && (
           <span
             className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-amber-500/15 border border-amber-500/40 text-amber-200 shrink-0"
             role="status"
             aria-live="polite"
+            aria-label={t('chat.connection.ariaLabel')}
             title={t('chat.connection.reconnecting')}
             data-testid="family-chat-reconnecting"
           >
             <WifiOff size={12} aria-hidden="true" />
             <span className="truncate max-w-[8rem] sm:max-w-none">{t('chat.connection.reconnecting')}</span>
+          </span>
+        )}
+        {connStatus === 'live' && justReconnected && (
+          <span
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-green-500/15 border border-green-500/40 text-green-200 shrink-0"
+            role="status"
+            aria-live="polite"
+            aria-label={t('chat.connection.ariaLabel')}
+            title={t('chat.connection.live')}
+            data-testid="family-chat-connected"
+          >
+            <Wifi size={12} aria-hidden="true" />
+            <span className="truncate max-w-[8rem] sm:max-w-none">{t('chat.connection.live')}</span>
           </span>
         )}
         {canCall && (

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -1219,7 +1219,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
             className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-amber-500/15 border border-amber-500/40 text-amber-200 shrink-0"
             role="status"
             aria-live="polite"
-            aria-label={t('chat.connection.ariaLabel')}
             title={t('chat.connection.reconnecting')}
             data-testid="family-chat-reconnecting"
           >
@@ -1232,7 +1231,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
             className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-green-500/15 border border-green-500/40 text-green-200 shrink-0"
             role="status"
             aria-live="polite"
-            aria-label={t('chat.connection.ariaLabel')}
             title={t('chat.connection.live')}
             data-testid="family-chat-connected"
           >


### PR DESCRIPTION
## Changes

- **Live connection status in Family Chat** - The chat view now shows a "Reconnecting…" badge when the message stream drops and briefly confirms "Connected" once it recovers, re-fetching recent messages so no gap is left on a stale view. (Hytte-pe6v)

## Original Issue (feature): Show a live connection status indicator when the SSE stream drops

### Scope
Add a live connection-status indicator to the Family Chat stream. `ChatView.tsx` already maintains a manual fetch-based SSE loop with a `scheduleReconnect()` retry path; this plan threads a connection state ("live" / "reconnecting") out of that loop into a small visible indicator, and re-fetches recent messages on recovery so the user isn't left on a stale view. No backend changes are required.

### Files to touch
- `web/src/pages/familychat/ChatView.tsx` — add `connStatus` state set to "connecting"/"live"/"reconnecting"; update it where the stream opens successfully, where `scheduleReconnect()` fires, and on abort/unmount; trigger a message re-fetch when transitioning back to "live" after a drop; render the indicator.
- `web/src/pages/familychat/ChatView.test.tsx` — cover status transitions: shows reconnecting after stream error, returns to live and re-fetches on recovery.
- `web/public/locales/en/familyChat.json` — add `connection.live` / `connection.reconnecting` (and any aria-label) keys.
- `web/public/locales/nb/familyChat.json` — same keys, Norwegian.
- `web/public/locales/th/familyChat.json` — same keys, Thai.

### Acceptance criteria
- When the SSE stream is healthy, the indicator shows a connected state (or is unobtrusive/hidden) — no false "offline" on normal operation.
- When the stream errors and `scheduleReconnect()` is pending, a visible "reconnecting" dot/banner appears in `ChatView`, driven by the actual stream state (not a timer guess).
- On successful reconnect, the indicator returns to "live" and the view re-fetches recent messages so any gap is filled.
- All indicator strings use `t('familyChat:...')` and exist in `en`, `nb`, and `th` locale files (no hardcoded English).
- The indicator renders correctly at 375px width and does not obscure message content or the composer.
- Unmount/navigation aborts cleanly without leaving the indicator stuck in "reconnecting".
- A changelog fragment is added under `changelog.d/`.

### Non-goals
- No changes to the backend stream, hub, or reconnect/backoff strategy in `internal/familychat/`.
- No offline message queueing, send-retry, or optimistic delivery guarantees.
- No global/app-wide connectivity indicator — scope is the Family Chat view only.
- No changes to voice-call signaling or reaction streams beyond the shared connection state.
- No new EventSource migration; keep the existing fetch-based stream loop.

## Source

Created from Suggestions page (suggestion id 189, page slug "family-chat", source=claude).

## Original suggestion

Real-time delivery depends on the SSE subscription, but there is no UI signal when that connection is down — a user can sit on a stale conversation believing they're up to date while their stream is disconnected. Surface a small "reconnecting" / offline banner or dot in ChatView driven by the EventSource readyState, and re-fetch on recovery. This gives users honest feedback about whether messages are arriving live and sets expectations during flaky connectivity instead of silently appearing frozen.


---
Bead: Hytte-pe6v | Branch: forge/Hytte-pe6v
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->