### PR TITLE
Replace 5s grocery polling with SSE for instant shared-list updates (Hytte-z5po)

### DIFF
--- a/changelog.d/Hytte-z5po.md
+++ b/changelog.d/Hytte-z5po.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Real-time grocery list updates** - The shared grocery list now streams changes over server-sent events, so adds, check-offs, reorders, and clears appear on other open sessions within about a second. This replaces the 5-second polling loop, stops idle tabs from repeatedly refetching the list, and keeps optimistic check/uncheck state from being overwritten by background fetches. (Hytte-z5po)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -884,6 +884,7 @@ func NewRouter(db *sql.DB) http.Handler {
 			r.Group(func(r chi.Router) {
 				r.Use(auth.RequireFeature(db, "grocery"))
 				r.Get("/grocery/items", grocery.HandleList(db))
+				r.Get("/grocery/events", grocery.HandleEvents(db))
 				r.Post("/grocery/items", grocery.HandleAdd(db))
 				r.Patch("/grocery/items/{id}/check", grocery.HandleCheck(db))
 				r.Patch("/grocery/items/{id}/reorder", grocery.HandleReorder(db))

--- a/internal/grocery/events.go
+++ b/internal/grocery/events.go
@@ -12,8 +12,10 @@ const (
 
 // GroceryEvent is a single mutation pushed to subscribers of a household's list.
 // Payload carries the minimal data the client needs to patch local state:
-//   - item_added / item_changed / item_reordered: the affected GroceryItem
-//   - item_removed: a struct with the removed item's ID(s)
+//   - item_added: the full GroceryItem
+//   - item_changed: {"id": <int>, "checked": <bool>}
+//   - item_reordered: {"id": <int>, "sort_order": <int>}
+//   - item_removed: {"ids": [<int>, ...]}
 type GroceryEvent struct {
 	Type    string `json:"type"`
 	Payload any    `json:"payload"`

--- a/internal/grocery/events.go
+++ b/internal/grocery/events.go
@@ -1,0 +1,89 @@
+package grocery
+
+import "sync"
+
+// Event type constants for grocery list mutations pushed over SSE.
+const (
+	EventItemAdded     = "item_added"
+	EventItemChanged   = "item_changed"
+	EventItemRemoved   = "item_removed"
+	EventItemReordered = "item_reordered"
+)
+
+// GroceryEvent is a single mutation pushed to subscribers of a household's list.
+// Payload carries the minimal data the client needs to patch local state:
+//   - item_added / item_changed / item_reordered: the affected GroceryItem
+//   - item_removed: a struct with the removed item's ID(s)
+type GroceryEvent struct {
+	Type    string `json:"type"`
+	Payload any    `json:"payload"`
+}
+
+// Broker is an in-process, per-household pub/sub registry for grocery events.
+// It fans out events to all connected SSE subscribers of a household. Sends are
+// non-blocking: a subscriber whose buffer is full is skipped (slow-consumer
+// drop) rather than blocking the publisher. There is no cross-process fan-out —
+// this is intentionally scoped to a single Hytte process.
+type Broker struct {
+	mu          sync.Mutex
+	subscribers map[int64]map[chan GroceryEvent]struct{}
+}
+
+// NewBroker creates an empty Broker.
+func NewBroker() *Broker {
+	return &Broker{subscribers: make(map[int64]map[chan GroceryEvent]struct{})}
+}
+
+// DefaultBroker is the package-level broker shared by the grocery handlers.
+var DefaultBroker = NewBroker()
+
+// Subscribe registers a new subscriber for the given household and returns a
+// receive-only channel plus an unsubscribe function. The channel is buffered so
+// brief bursts don't drop events; the caller must invoke the returned function
+// (e.g. via defer) to release the subscription and avoid leaks.
+func (b *Broker) Subscribe(householdID int64) (<-chan GroceryEvent, func()) {
+	ch := make(chan GroceryEvent, 16)
+
+	b.mu.Lock()
+	subs := b.subscribers[householdID]
+	if subs == nil {
+		subs = make(map[chan GroceryEvent]struct{})
+		b.subscribers[householdID] = subs
+	}
+	subs[ch] = struct{}{}
+	b.mu.Unlock()
+
+	var once sync.Once
+	unsubscribe := func() {
+		once.Do(func() {
+			b.mu.Lock()
+			if subs := b.subscribers[householdID]; subs != nil {
+				delete(subs, ch)
+				if len(subs) == 0 {
+					delete(b.subscribers, householdID)
+				}
+			}
+			b.mu.Unlock()
+			close(ch)
+		})
+	}
+	return ch, unsubscribe
+}
+
+// Publish fans an event out to every subscriber of the household. Delivery is
+// non-blocking: subscribers whose buffers are full are skipped so a slow or
+// stalled client can never block a write handler. Sends happen under the lock —
+// the send itself never blocks (select/default), and holding the lock serialises
+// against unsubscribe so we never send on a channel that is being closed.
+func (b *Broker) Publish(householdID int64, event GroceryEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subscribers[householdID] {
+		select {
+		case ch <- event:
+		default:
+			// Slow consumer: drop the event for this subscriber. The client's
+			// reconnect/refetch path resyncs missed state.
+		}
+	}
+}

--- a/internal/grocery/events_test.go
+++ b/internal/grocery/events_test.go
@@ -1,0 +1,103 @@
+package grocery
+
+import (
+	"testing"
+	"time"
+)
+
+func recv(t *testing.T, ch <-chan GroceryEvent) (GroceryEvent, bool) {
+	t.Helper()
+	select {
+	case ev, ok := <-ch:
+		return ev, ok
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+		return GroceryEvent{}, false
+	}
+}
+
+func TestBrokerFanOut(t *testing.T) {
+	b := NewBroker()
+	a, unsubA := b.Subscribe(1)
+	defer unsubA()
+	c, unsubC := b.Subscribe(1)
+	defer unsubC()
+
+	b.Publish(1, GroceryEvent{Type: EventItemAdded, Payload: "x"})
+
+	for _, ch := range []<-chan GroceryEvent{a, c} {
+		ev, ok := recv(t, ch)
+		if !ok {
+			t.Fatal("channel closed unexpectedly")
+		}
+		if ev.Type != EventItemAdded {
+			t.Errorf("got type %q, want %q", ev.Type, EventItemAdded)
+		}
+	}
+}
+
+func TestBrokerHouseholdIsolation(t *testing.T) {
+	b := NewBroker()
+	h1, unsub1 := b.Subscribe(1)
+	defer unsub1()
+	h2, unsub2 := b.Subscribe(2)
+	defer unsub2()
+
+	b.Publish(1, GroceryEvent{Type: EventItemChanged})
+
+	if ev, _ := recv(t, h1); ev.Type != EventItemChanged {
+		t.Errorf("household 1 got type %q, want %q", ev.Type, EventItemChanged)
+	}
+
+	select {
+	case ev := <-h2:
+		t.Fatalf("household 2 received unexpected event: %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no cross-household delivery.
+	}
+}
+
+func TestBrokerUnsubscribeStopsDelivery(t *testing.T) {
+	b := NewBroker()
+	ch, unsub := b.Subscribe(1)
+	unsub()
+
+	// The channel must be closed by unsubscribe.
+	if _, ok := <-ch; ok {
+		t.Fatal("expected channel to be closed after unsubscribe")
+	}
+
+	// Publishing after unsubscribe must not panic and reaches no one.
+	b.Publish(1, GroceryEvent{Type: EventItemAdded})
+
+	// Unsubscribing twice must be safe (idempotent).
+	unsub()
+}
+
+func TestBrokerSlowConsumerDoesNotBlock(t *testing.T) {
+	b := NewBroker()
+	ch, unsub := b.Subscribe(1)
+	defer unsub()
+
+	// Flood far past the buffer capacity. A full subscriber must be skipped,
+	// never block Publish.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			b.Publish(1, GroceryEvent{Type: EventItemAdded, Payload: i})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Publish never blocked despite the unread channel.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish blocked on a slow consumer")
+	}
+
+	// The buffered events that did fit are still readable.
+	if _, ok := recv(t, ch); !ok {
+		t.Fatal("expected at least one buffered event")
+	}
+}

--- a/internal/grocery/handlers.go
+++ b/internal/grocery/handlers.go
@@ -240,6 +240,10 @@ func HandleClearCompleted(db *sql.DB) http.HandlerFunc {
 // close the idle connection. The subscription is released when the client
 // disconnects (r.Context().Done()), preventing goroutine/connection leaks.
 func HandleEvents(db *sql.DB) http.HandlerFunc {
+	return handleEventsWithBroker(db, DefaultBroker)
+}
+
+func handleEventsWithBroker(db *sql.DB, broker *Broker) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
 
@@ -249,7 +253,7 @@ func HandleEvents(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		events, unsubscribe := DefaultBroker.Subscribe(user.ID)
+		events, unsubscribe := broker.Subscribe(user.ID)
 		defer unsubscribe()
 
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/grocery/handlers.go
+++ b/internal/grocery/handlers.go
@@ -3,16 +3,22 @@ package grocery
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/Robin831/Hytte/internal/training"
 	"github.com/go-chi/chi/v5"
 )
+
+// sseHeartbeatInterval is how often the events stream emits a comment line to
+// keep the connection alive through proxies that close idle connections.
+const sseHeartbeatInterval = 25 * time.Second
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
@@ -73,6 +79,7 @@ func HandleAdd(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to add item"})
 			return
 		}
+		DefaultBroker.Publish(user.ID, GroceryEvent{Type: EventItemAdded, Payload: created})
 		writeJSON(w, http.StatusCreated, map[string]any{"item": created})
 	}
 }
@@ -103,6 +110,10 @@ func HandleCheck(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update item"})
 			return
 		}
+		DefaultBroker.Publish(user.ID, GroceryEvent{
+			Type:    EventItemChanged,
+			Payload: map[string]any{"id": id, "checked": body.Checked},
+		})
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	}
 }
@@ -133,6 +144,10 @@ func HandleReorder(db *sql.DB) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to reorder item"})
 			return
 		}
+		DefaultBroker.Publish(user.ID, GroceryEvent{
+			Type:    EventItemReordered,
+			Payload: map[string]any{"id": id, "sort_order": body.SortOrder},
+		})
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	}
 }
@@ -195,12 +210,82 @@ func HandleClearCompleted(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
 
+		// Capture the IDs before deletion so subscribers can patch them out.
+		ids, err := CompletedIDs(db, user.ID)
+		if err != nil {
+			log.Printf("Failed to list completed grocery items: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to clear completed items"})
+			return
+		}
+
 		deleted, err := DeleteCompleted(db, user.ID)
 		if err != nil {
 			log.Printf("Failed to clear completed grocery items: %v", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to clear completed items"})
 			return
 		}
+		if len(ids) > 0 {
+			DefaultBroker.Publish(user.ID, GroceryEvent{
+				Type:    EventItemRemoved,
+				Payload: map[string]any{"ids": ids},
+			})
+		}
 		writeJSON(w, http.StatusOK, map[string]any{"deleted": deleted})
+	}
+}
+
+// HandleEvents streams grocery list mutations for the authenticated user's
+// household as server-sent events. It holds the connection open, pushing one
+// SSE frame per event, and emits periodic heartbeat comments so proxies don't
+// close the idle connection. The subscription is released when the client
+// disconnects (r.Context().Done()), preventing goroutine/connection leaks.
+func HandleEvents(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "streaming not supported"})
+			return
+		}
+
+		events, unsubscribe := DefaultBroker.Subscribe(user.ID)
+		defer unsubscribe()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		heartbeat := time.NewTicker(sseHeartbeatInterval)
+		defer heartbeat.Stop()
+
+		ctx := r.Context()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-heartbeat.C:
+				if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
+					return
+				}
+				flusher.Flush()
+			case event, ok := <-events:
+				if !ok {
+					return
+				}
+				data, err := json.Marshal(event.Payload)
+				if err != nil {
+					log.Printf("grocery: marshal sse event %q: %v", event.Type, err)
+					continue
+				}
+				if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.Type, data); err != nil {
+					return
+				}
+				flusher.Flush()
+			}
+		}
 	}
 }

--- a/internal/grocery/handlers_test.go
+++ b/internal/grocery/handlers_test.go
@@ -1,13 +1,16 @@
 package grocery
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
 	"github.com/go-chi/chi/v5"
@@ -137,5 +140,147 @@ func TestHandleClearCompleted(t *testing.T) {
 	}
 	if len(items) != 0 {
 		t.Errorf("got %d items after clear, want 0", len(items))
+	}
+}
+
+func waitForSubscriber(t *testing.T, broker *Broker, householdID int64) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		broker.mu.Lock()
+		n := len(broker.subscribers[householdID])
+		broker.mu.Unlock()
+		if n > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for subscriber")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+func TestHandleEventsHeaders(t *testing.T) {
+	db := setupTestDB(t)
+	user := &auth.User{ID: 1, Email: "test@example.com", Name: "Test"}
+	broker := NewBroker()
+
+	handler := handleEventsWithBroker(db, broker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/grocery/events", nil).WithContext(ctx)
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	waitForSubscriber(t, broker, user.ID)
+	broker.Publish(user.ID, GroceryEvent{Type: EventItemAdded, Payload: map[string]any{"id": 1}})
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want %q", ct, "text/event-stream")
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "no-cache")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestHandleEventsBodyFormat(t *testing.T) {
+	db := setupTestDB(t)
+	user := &auth.User{ID: 1, Email: "test@example.com", Name: "Test"}
+	broker := NewBroker()
+
+	handler := handleEventsWithBroker(db, broker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/grocery/events", nil).WithContext(ctx)
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	waitForSubscriber(t, broker, user.ID)
+	broker.Publish(user.ID, GroceryEvent{
+		Type:    EventItemAdded,
+		Payload: map[string]any{"id": float64(42), "content": "Milk"},
+	})
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := w.Body.String()
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	var eventLine, dataLine string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "event: ") {
+			eventLine = line
+		}
+		if strings.HasPrefix(line, "data: ") {
+			dataLine = line
+		}
+	}
+	if eventLine != "event: item_added" {
+		t.Errorf("event line = %q, want %q", eventLine, "event: item_added")
+	}
+	if dataLine == "" {
+		t.Fatal("no data line found in SSE body")
+	}
+	payload := strings.TrimPrefix(dataLine, "data: ")
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+		t.Fatalf("data line is not valid JSON: %v", err)
+	}
+	if parsed["content"] != "Milk" {
+		t.Errorf("payload content = %v, want %q", parsed["content"], "Milk")
+	}
+}
+
+func TestHandleEventsDisconnectUnsubscribes(t *testing.T) {
+	db := setupTestDB(t)
+	user := &auth.User{ID: 1, Email: "test@example.com", Name: "Test"}
+	broker := NewBroker()
+
+	handler := handleEventsWithBroker(db, broker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/api/grocery/events", nil).WithContext(ctx)
+	req = withUser(req, user)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	waitForSubscriber(t, broker, user.ID)
+
+	cancel()
+	<-done
+
+	broker.mu.Lock()
+	subsAfter := len(broker.subscribers[user.ID])
+	broker.mu.Unlock()
+	if subsAfter != 0 {
+		t.Errorf("subscribers after disconnect = %d, want 0", subsAfter)
 	}
 }

--- a/internal/grocery/store.go
+++ b/internal/grocery/store.go
@@ -134,6 +134,29 @@ func UpdateSortOrder(db *sql.DB, id int64, householdID int64, order int) error {
 	return nil
 }
 
+// CompletedIDs returns the IDs of all checked items for the given household.
+// Used to tell SSE subscribers exactly which items a clear-completed removed.
+func CompletedIDs(db *sql.DB, householdID int64) ([]int64, error) {
+	rows, err := db.Query("SELECT id FROM grocery_items WHERE household_id = ? AND checked = 1", householdID)
+	if err != nil {
+		return nil, fmt.Errorf("query completed ids: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan completed id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
 // DeleteCompleted removes all checked items for the given household.
 func DeleteCompleted(db *sql.DB, householdID int64) (int64, error) {
 	res, err := db.Exec("DELETE FROM grocery_items WHERE household_id = ? AND checked = 1", householdID)

--- a/web/src/pages/GroceryPage.test.tsx
+++ b/web/src/pages/GroceryPage.test.tsx
@@ -25,6 +25,7 @@ const TRANSLATIONS: Record<string, string> = {
   'errors.failedToUpdate': 'Failed to update item',
   'errors.failedToClear': 'Failed to clear completed items',
   'errors.failedToTranslate': 'Failed to translate voice input',
+  'errors.failedToStartRecording': 'Failed to start recording',
   'common:actions.close': 'Close',
 }
 
@@ -48,6 +49,27 @@ const authState: { user: object | null } = { user: null }
 vi.mock('../auth', () => ({
   useAuth: () => authState,
 }))
+
+// ── EventSource mock ─────────────────────────────────────────────────────
+// The SSE subscription effect creates an EventSource; happy-dom doesn't
+// provide one. Re-stubbed in beforeEach because afterEach calls
+// vi.unstubAllGlobals().
+
+class MockEventSource {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSED = 2
+  readonly CONNECTING = 0
+  readonly OPEN = 1
+  readonly CLOSED = 2
+  readyState = MockEventSource.OPEN
+  onopen: (() => void) | null = null
+  onerror: (() => void) | null = null
+  close = vi.fn(() => { this.readyState = MockEventSource.CLOSED })
+  addEventListener = vi.fn()
+}
+
+beforeEach(() => { vi.stubGlobal('EventSource', MockEventSource) })
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -332,7 +354,7 @@ describe('GroceryPage – voice input', () => {
     })
   })
 
-  it('shows errors.failedToTranslate and stays not-recording when start() throws', async () => {
+  it('shows errors.failedToStartRecording and stays not-recording when start() throws', async () => {
     authState.user = { id: 1 }
     const MockRecognition = makeMockRecognitionClass(() => { throw new Error('permission denied') })
     vi.stubGlobal('SpeechRecognition', MockRecognition)
@@ -344,7 +366,7 @@ describe('GroceryPage – voice input', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Start voice input' }))
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Failed to translate voice input')
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to start recording')
     })
     // Button should be back to start state (not recording)
     expect(screen.getByRole('button', { name: 'Start voice input' })).toBeInTheDocument()

--- a/web/src/pages/GroceryPage.tsx
+++ b/web/src/pages/GroceryPage.tsx
@@ -91,7 +91,9 @@ export default function GroceryPage() {
 
     const resync = () => {
       fetchItems()
-        .then(fetched => setItems(fetched))
+        .then(fetched => {
+          if (source.readyState !== EventSource.CLOSED) setItems(fetched)
+        })
         .catch(() => { /* a failed resync is retried on the next reconnect */ })
     }
 
@@ -104,7 +106,13 @@ export default function GroceryPage() {
     }
 
     const on = (name: string, handler: (data: unknown) => void) =>
-      source.addEventListener(name, e => handler(JSON.parse((e as MessageEvent).data)))
+      source.addEventListener(name, e => {
+        try {
+          handler(JSON.parse((e as MessageEvent).data))
+        } catch {
+          // Malformed payload — ignore; the next reconnect resyncs full state.
+        }
+      })
 
     on('item_added', data => {
       const item = data as GroceryItem

--- a/web/src/pages/GroceryPage.tsx
+++ b/web/src/pages/GroceryPage.tsx
@@ -21,6 +21,16 @@ interface TranslatedItem {
   language: string
 }
 
+// Mirror the backend ordering (checked ASC, sort_order ASC, created_at ASC) so
+// incremental SSE patches keep the same visual order as a full fetch.
+function sortItems(items: GroceryItem[]): GroceryItem[] {
+  return [...items].sort((a, b) => {
+    if (a.checked !== b.checked) return a.checked ? 1 : -1
+    if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order
+    return a.created_at.localeCompare(b.created_at)
+  })
+}
+
 type SpeechRecognitionType = typeof window extends { SpeechRecognition: infer T } ? T : unknown
 
 function getSpeechRecognitionCtor(): (new () => SpeechRecognitionType) | undefined {
@@ -66,24 +76,58 @@ export default function GroceryPage() {
     return () => { controller.abort() }
   }, [user, fetchItems, t])
 
-  // Poll every 5 seconds
+  // Subscribe to the household's SSE stream for instant shared-list updates.
+  // Incremental events patch local state so optimistic check/uncheck is never
+  // clobbered; a single refetch on (re)connect resyncs anything missed while
+  // disconnected. The 5-second polling interval this replaces is gone, so an
+  // idle tab issues no recurring /grocery/items requests.
   useEffect(() => {
     if (!user) return
-    let currentController: AbortController | null = null
-    const poll = async () => {
-      if (document.hidden) return
-      currentController?.abort()
-      const controller = new AbortController()
-      currentController = controller
-      try {
-        const fetched = await fetchItems(controller.signal)
-        if (!controller.signal.aborted) setItems(fetched)
-      } catch {
-        // silently ignore polling errors
-      }
+
+    const source = new EventSource('/api/grocery/events', { withCredentials: true })
+    // The initial load effect already populates the list, so skip the refetch
+    // on the very first open and only resync on subsequent reconnects.
+    let firstOpen = true
+
+    const resync = () => {
+      fetchItems()
+        .then(fetched => setItems(fetched))
+        .catch(() => { /* a failed resync is retried on the next reconnect */ })
     }
-    const intervalId = setInterval(poll, 5000)
-    return () => { clearInterval(intervalId); currentController?.abort() }
+
+    source.onopen = () => {
+      if (firstOpen) {
+        firstOpen = false
+        return
+      }
+      resync()
+    }
+
+    const on = (name: string, handler: (data: unknown) => void) =>
+      source.addEventListener(name, e => handler(JSON.parse((e as MessageEvent).data)))
+
+    on('item_added', data => {
+      const item = data as GroceryItem
+      setItems(prev => (prev.some(i => i.id === item.id) ? prev : sortItems([...prev, item])))
+    })
+
+    on('item_changed', data => {
+      const { id, checked } = data as { id: number; checked: boolean }
+      setItems(prev => sortItems(prev.map(i => (i.id === id ? { ...i, checked } : i))))
+    })
+
+    on('item_reordered', data => {
+      const { id, sort_order } = data as { id: number; sort_order: number }
+      setItems(prev => sortItems(prev.map(i => (i.id === id ? { ...i, sort_order } : i))))
+    })
+
+    on('item_removed', data => {
+      const { ids } = data as { ids: number[] }
+      const removed = new Set(ids)
+      setItems(prev => prev.filter(i => !removed.has(i.id)))
+    })
+
+    return () => { source.close() }
   }, [user, fetchItems])
 
   // Unmount cleanup: abort any in-flight translation and stop any active recognition


### PR DESCRIPTION
## Changes

- **Real-time grocery list updates** - The shared grocery list now streams changes over server-sent events, so adds, check-offs, reorders, and clears appear on other open sessions within about a second. This replaces the 5-second polling loop, stops idle tabs from repeatedly refetching the list, and keeps optimistic check/uncheck state from being overwritten by background fetches. (Hytte-z5po)

## Original Issue (feature): Replace 5s grocery polling with SSE for instant shared-list updates

### Scope
Replace the 5-second full-list polling in `GroceryPage.tsx` with a server-sent events stream scoped to the user's household. A new `GET /api/grocery/events` endpoint holds the connection open and pushes incremental events (`item_added`, `item_changed`, `item_removed`, `item_reordered`) whenever a grocery write handler mutates that household's list. The frontend subscribes via `EventSource`, applies patches to local state, and does a single fallback refetch on (re)connect. Reuses the SSE conventions established in commit d359d37 (chat streaming).

### Files to touch
- `internal/grocery/events.go` (new) — in-process per-household subscriber registry (broker): subscribe/unsubscribe channels keyed by `household_id`, `Publish(householdID, event)` fan-out, non-blocking sends with slow-consumer drop.
- `internal/grocery/handlers.go` — add `HandleEvents(db)` SSE handler (resolve household, set SSE headers, flush, heartbeat ticker, exit on `r.Context().Done()`); call broker `Publish` from `HandleAdd`, `HandleCheck`, `HandleReorder`, `HandleClearCompleted` after a successful write.
- `internal/api/router.go` — register `r.Get("/grocery/events", grocery.HandleEvents(db))` inside the existing `grocery` feature group.
- `web/src/pages/GroceryPage.tsx` — remove the 5s polling `useEffect`; add an `EventSource` subscription that applies events to `items`; refetch once on open/reconnect; keep initial load.
- `internal/grocery/events_test.go` (new) — broker fan-out / unsubscribe / slow-consumer tests.
- `changelog.d/*.md` (new) — `Changed` fragment.

### Acceptance criteria
- `GET /api/grocery/events` streams `text/event-stream`, requires auth + `grocery` feature, and only delivers events for the caller's household.
- Adding, checking/unchecking, reordering, or clearing completed items on one session is reflected on another open session within ~1s without a manual refresh.
- The 5-second `setInterval` poll is gone; an idle tab issues no recurring `/grocery/items` requests (verifiable in network tab).
- Optimistic check/uncheck state is no longer clobbered by background fetches.
- On EventSource error/reconnect, the client performs exactly one `/grocery/items` refetch to resync, then resumes streaming.
- Server cleans up subscribers when the client disconnects (no goroutine/connection leak); heartbeats keep the connection alive through proxies.
- `go build`, `go vet`, `go test`, `npm run lint`, `npm run build` all pass.

### Non-goals
- No cross-process/Redis pub-sub or multi-instance fan-out (single Hytte process only).
- No changes to item data model, translation, or speech-input features.
- No WebSocket migration; SSE only, with the existing `/grocery/items` GET retained as the reconnect/fallback path.
- No reworking of household membership or feature-gating logic.

## Source

Created from Suggestions page (suggestion id 165, page slug "grocery", source=claude).

## Original suggestion

The page currently re-fetches the entire list every 5 seconds (GroceryPage.tsx:70-86), which means shared-household updates lag by up to 5s, every tab burns bandwidth even when nothing changed, and any in-flight poll can clobber an optimistic check/uncheck that hasn't been persisted yet. Add a `GET /api/grocery/events` SSE endpoint that pushes `item_added`/`item_changed`/`item_removed`/`item_reordered` events whenever a write handler mutates the household's list, and have the frontend subscribe via `EventSource` and apply incremental patches instead of replacing state wholesale. Keep a single fallback refetch on reconnect, but drop the interval. The codebase already has the SSE pattern from the recent assistant streaming work (commit d359d37), so this reuses an established approach. Result: both partners see check-offs and additions in real time, optimistic state stops getting overwritten, and idle tabs stop hammering the API.


---
Bead: Hytte-z5po | Branch: forge/Hytte-z5po
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->