### PR TITLE
Colorblind (Hytte-z4d3)

### DIFF
--- a/changelog.d/Hytte-z4d3.md
+++ b/changelog.d/Hytte-z4d3.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Colorblind-friendly news vote buttons** - The thumbs up/down buttons on news cards now show a selected vote with a filled icon, a solid background pill, and an inset ring in addition to color, so the active choice is distinguishable without relying on hue. (Hytte-z4d3)

--- a/web/src/components/news/NewsCard.tsx
+++ b/web/src/components/news/NewsCard.tsx
@@ -26,6 +26,8 @@ export default function NewsCard({
   const { t: tc } = useTranslation('common')
 
   const horizontal = variant === 'timeline'
+  const upSelected = article.feedback === 1
+  const downSelected = article.feedback === -1
 
   return (
     <article
@@ -106,24 +108,28 @@ export default function NewsCard({
           <button
             type="button"
             onClick={() => onVote(article, 1)}
-            aria-pressed={article.feedback === 1}
+            aria-pressed={upSelected}
             title={t('card.more')}
-            className={`p-1.5 rounded-md transition-colors cursor-pointer hover:bg-gray-800 ${
-              article.feedback === 1 ? 'text-emerald-400' : 'text-gray-500 hover:text-gray-300'
+            className={`p-1.5 rounded-md transition-colors cursor-pointer ${
+              upSelected
+                ? 'bg-emerald-500/20 text-emerald-400 ring-1 ring-inset ring-emerald-400/70'
+                : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800'
             }`}
           >
-            <ThumbsUp size={16} />
+            <ThumbsUp size={16} fill={upSelected ? 'currentColor' : 'none'} />
           </button>
           <button
             type="button"
             onClick={() => onVote(article, -1)}
-            aria-pressed={article.feedback === -1}
+            aria-pressed={downSelected}
             title={t('card.less')}
-            className={`p-1.5 rounded-md transition-colors cursor-pointer hover:bg-gray-800 ${
-              article.feedback === -1 ? 'text-red-400' : 'text-gray-500 hover:text-gray-300'
+            className={`p-1.5 rounded-md transition-colors cursor-pointer ${
+              downSelected
+                ? 'bg-red-500/20 text-red-400 ring-1 ring-inset ring-red-400/70'
+                : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800'
             }`}
           >
-            <ThumbsDown size={16} />
+            <ThumbsDown size={16} fill={downSelected ? 'currentColor' : 'none'} />
           </button>
           <button
             type="button"

--- a/web/src/components/news/NewsCard.tsx
+++ b/web/src/components/news/NewsCard.tsx
@@ -112,7 +112,7 @@ export default function NewsCard({
             title={t('card.more')}
             className={`p-1.5 rounded-md transition-colors cursor-pointer ${
               upSelected
-                ? 'bg-emerald-500/20 text-emerald-400 ring-1 ring-inset ring-emerald-400/70'
+                ? 'bg-emerald-500/20 text-emerald-400 ring-1 ring-inset ring-emerald-400/70 hover:bg-emerald-500/30'
                 : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800'
             }`}
           >
@@ -125,7 +125,7 @@ export default function NewsCard({
             title={t('card.less')}
             className={`p-1.5 rounded-md transition-colors cursor-pointer ${
               downSelected
-                ? 'bg-red-500/20 text-red-400 ring-1 ring-inset ring-red-400/70'
+                ? 'bg-red-500/20 text-red-400 ring-1 ring-inset ring-red-400/70 hover:bg-red-500/30'
                 : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800'
             }`}
           >


### PR DESCRIPTION
## Changes

- **Colorblind-friendly news vote buttons** - The thumbs up/down buttons on news cards now show a selected vote with a filled icon, a solid background pill, and an inset ring in addition to color, so the active choice is distinguishable without relying on hue. (Hytte-z4d3)

## Original Issue (feature): Colorblind

### Scope
The thumbs up/down buttons in `NewsCard.tsx` signal a selected vote only by changing icon text color (emerald for up, red for down) against the unselected gray. This is invisible to colorblind users. This plan adds redundant, non-color cues to the selected (`article.feedback === 1` / `=== -1`) state so the active choice is distinguishable without relying on hue — using a filled icon, a solid background "pill", and a visible ring/border. The save bookmark already swaps to a filled `BookmarkCheck` icon, so it is out of scope.

### Files to touch
- `web/src/components/news/NewsCard.tsx` — strengthen the selected state of both vote buttons with non-color indicators.
- `web/public/locales/en/news.json`, `web/public/locales/nb/news.json`, `web/public/locales/th/news.json` — only if new/updated `title`/`aria` strings are introduced (e.g. an active-state label).

### Acceptance criteria
- When a thumbs up or thumbs down is selected, it is visually distinct from the unselected button in at least two ways that do not depend on color: e.g. a solid/filled background pill **and** the Lucide icon rendered filled (`fill="currentColor"`) and/or a visible ring/border.
- The distinction is clearly perceptible in a grayscale rendering of the button row (verifiable by desaturating a screenshot).
- Selecting up then down (or clicking again to clear) updates the indicators correctly; only the active choice shows the selected styling, and clearing returns both to the neutral state.
- `aria-pressed` remains correctly bound to `article.feedback` for each button (accessibility cue preserved/retained).
- Buttons keep their existing hover, focus, and tap-target behavior; layout does not shift or overflow at 375px width.
- All three `news.json` locale files stay in sync if any string is added; no hardcoded English in JSX.
- `npm run lint` and `npm run build` pass.

### Non-goals
- No changes to vote backend logic, the `vote`/`onVote` flow, `useNews.ts`, or `internal/news/*`.
- No global theme, palette, or app-wide colorblind/accessibility-mode work beyond these two buttons.
- No redesign of the save/bookmark button or other NewsCard actions.
- No new user setting or toggle for colorblind mode.
- No changes to the relevance ranking, sort, or filtering UI.

## Source

Created from Suggestions page (suggestion id 211, page slug "news", source=user).

## Original suggestion

I'm colorblind, and can't really see the difference in the thumbs up/down after I click them, I know they change color to indicate it's been clicked, but I need some other indicator for it


---
Bead: Hytte-z4d3 | Branch: forge/Hytte-z4d3
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->