### PR TITLE
Mezzanine events panel: filter the full event log, not just the in-memory window (Hytte-gvl5)

### DIFF
--- a/changelog.d/Hytte-gvl5.md
+++ b/changelog.d/Hytte-gvl5.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Mezzanine events panel filters search the full event log** - The Errors, PRs, and per-anvil filters on the Hearth events panel now query the entire event history server-side (newest first) instead of only the ~50-100 events in the live in-memory window, so older matching events are no longer hidden. The events endpoints gained `level=error` and `group=prs` query params (mirroring the old client-side heuristics), and the full Events page reuses them for a matching "Errors" / "PRs" filter. (Hytte-gvl5)

--- a/internal/forge/db.go
+++ b/internal/forge/db.go
@@ -463,15 +463,17 @@ func (d *DB) RecentlyMergedPRs(since time.Time) ([]PR, error) {
 	return prs, nil
 }
 
-// Events returns recent events, optionally filtered by type and/or anvil.
-// limit controls how many rows are returned (0 means 50).
-func (d *DB) Events(limit int, eventType, anvil string) ([]Event, error) {
-	if limit <= 0 {
-		limit = 50
-	}
-
-	var conditions []string
-	var args []any
+// appendEventFilters appends WHERE conditions (and any bind args) for the
+// shared event filters used by both Events and EventsPaginated: exact type,
+// exact anvil, the "errors" level group, and the "prs" type group.
+//
+// level=="error" mirrors the frontend classifyLevel failure heuristic, and
+// group=="prs" mirrors the frontend PR-group test, so the Mezzanine events
+// panel and the full Events page filter the entire event log identically to
+// the old client-side checks. SQLite LIKE is case-insensitive for ASCII, which
+// matches the frontend's lower-cased substring tests. Unknown level/group
+// values are ignored. See web/src/utils/forgeEventFilter.ts.
+func appendEventFilters(conditions []string, args []any, eventType, anvil, level, group string) ([]string, []any) {
 	if eventType != "" {
 		conditions = append(conditions, "type = ?")
 		args = append(args, eventType)
@@ -480,6 +482,25 @@ func (d *DB) Events(limit int, eventType, anvil string) ([]Event, error) {
 		conditions = append(conditions, "anvil = ?")
 		args = append(args, anvil)
 	}
+	if level == "error" {
+		conditions = append(conditions, "(type LIKE '%fail%' OR type LIKE '%error%' OR message LIKE '%failed%')")
+	}
+	if group == "prs" {
+		conditions = append(conditions, "(type LIKE '%pr%' OR type LIKE '%merge%' OR type LIKE '%warden%' OR type LIKE '%review%')")
+	}
+	return conditions, args
+}
+
+// Events returns recent events, optionally filtered by type, anvil, level, and
+// type group. limit controls how many rows are returned (0 means 50).
+func (d *DB) Events(limit int, eventType, anvil, level, group string) ([]Event, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	var conditions []string
+	var args []any
+	conditions, args = appendEventFilters(conditions, args, eventType, anvil, level, group)
 
 	where := ""
 	if len(conditions) > 0 {
@@ -527,8 +548,9 @@ type EventsPageResult struct {
 
 // EventsPaginated returns a paginated, filtered list of events for the full
 // events page. It supports text search across message/bead_id/type, date range
-// filtering, type and anvil filters, plus offset/limit pagination.
-func (d *DB) EventsPaginated(limit, offset int, eventType, anvil, search, from, to string) (*EventsPageResult, error) {
+// filtering, type and anvil filters, the "errors" level group and "prs" type
+// group (see appendEventFilters), plus offset/limit pagination.
+func (d *DB) EventsPaginated(limit, offset int, eventType, anvil, search, from, to, level, group string) (*EventsPageResult, error) {
 	if limit <= 0 {
 		limit = 50
 	}
@@ -538,14 +560,7 @@ func (d *DB) EventsPaginated(limit, offset int, eventType, anvil, search, from, 
 
 	var conditions []string
 	var args []any
-	if eventType != "" {
-		conditions = append(conditions, "type = ?")
-		args = append(args, eventType)
-	}
-	if anvil != "" {
-		conditions = append(conditions, "anvil = ?")
-		args = append(args, anvil)
-	}
+	conditions, args = appendEventFilters(conditions, args, eventType, anvil, level, group)
 	if search != "" {
 		conditions = append(conditions, "(message LIKE ? ESCAPE '\\' OR bead_id LIKE ? ESCAPE '\\' OR type LIKE ? ESCAPE '\\')")
 		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(search)

--- a/internal/forge/db_test.go
+++ b/internal/forge/db_test.go
@@ -225,7 +225,7 @@ func TestPRs_OpenOnly(t *testing.T) {
 
 func TestEvents_Empty(t *testing.T) {
 	fdb := setupTestDB(t)
-	events, err := fdb.Events(0, "", "")
+	events, err := fdb.Events(0, "", "", "", "")
 	if err != nil {
 		t.Fatalf("Events: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestEvents_FilterByType(t *testing.T) {
 		t.Fatalf("insert events: %v", err)
 	}
 
-	events, err := fdb.Events(10, "worker_start", "")
+	events, err := fdb.Events(10, "worker_start", "", "", "")
 	if err != nil {
 		t.Fatalf("Events: %v", err)
 	}
@@ -256,12 +256,122 @@ func TestEvents_FilterByType(t *testing.T) {
 		t.Errorf("expected 2 worker_start events, got %d", len(events))
 	}
 
-	events, err = fdb.Events(10, "worker_start", "anvil2")
+	events, err = fdb.Events(10, "worker_start", "anvil2", "", "")
 	if err != nil {
 		t.Fatalf("Events with anvil filter: %v", err)
 	}
 	if len(events) != 1 {
 		t.Errorf("expected 1 event for anvil2, got %d", len(events))
+	}
+}
+
+// seedFilterEvents inserts a representative spread of event types/messages used
+// by the level= and group= predicate tests.
+func seedFilterEvents(t *testing.T, fdb *DB) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := fdb.db.Exec(`
+		INSERT INTO events (id, timestamp, type, message, bead_id, anvil) VALUES
+		  (1, ?, 'worker_start',  'Worker started',       'b1', 'anvil1'),
+		  (2, ?, 'worker_fail',   'Worker crashed',       'b1', 'anvil1'),
+		  (3, ?, 'worker_error',  'Boom',                 'b2', 'anvil2'),
+		  (4, ?, 'ci_done',       'Build failed on main', 'b3', 'anvil1'),
+		  (5, ?, 'pr_opened',     'PR opened',            'b4', 'anvil2'),
+		  (6, ?, 'pr_merged',     'PR merged',            'b5', 'anvil1'),
+		  (7, ?, 'warden_review', 'Review requested',     'b6', 'anvil2'),
+		  (8, ?, 'dispatch',      'Dispatched',           'b7', 'anvil1')
+	`, now, now, now, now, now, now, now, now)
+	if err != nil {
+		t.Fatalf("insert events: %v", err)
+	}
+}
+
+func TestEvents_FilterByLevelError(t *testing.T) {
+	fdb := setupTestDB(t)
+	seedFilterEvents(t, fdb)
+
+	// level=error mirrors classifyLevel's failure heuristic: type contains
+	// fail/error, or message contains failed. Matches ids 2, 3, 4.
+	events, err := fdb.Events(50, "", "", "error", "")
+	if err != nil {
+		t.Fatalf("Events level=error: %v", err)
+	}
+	got := map[int]bool{}
+	for _, e := range events {
+		got[e.ID] = true
+	}
+	for _, id := range []int{2, 3, 4} {
+		if !got[id] {
+			t.Errorf("expected event %d in level=error results", id)
+		}
+	}
+	if len(events) != 3 {
+		t.Errorf("expected 3 error events, got %d: %+v", len(events), events)
+	}
+}
+
+func TestEvents_FilterByGroupPRs(t *testing.T) {
+	fdb := setupTestDB(t)
+	seedFilterEvents(t, fdb)
+
+	// group=prs mirrors the frontend PR-group test: type contains
+	// pr/merge/warden/review. Matches ids 5, 6, 7.
+	events, err := fdb.Events(50, "", "", "", "prs")
+	if err != nil {
+		t.Fatalf("Events group=prs: %v", err)
+	}
+	got := map[int]bool{}
+	for _, e := range events {
+		got[e.ID] = true
+	}
+	for _, id := range []int{5, 6, 7} {
+		if !got[id] {
+			t.Errorf("expected event %d in group=prs results", id)
+		}
+	}
+	if len(events) != 3 {
+		t.Errorf("expected 3 PR-group events, got %d: %+v", len(events), events)
+	}
+}
+
+func TestEvents_FilterByLevelAndAnvil(t *testing.T) {
+	fdb := setupTestDB(t)
+	seedFilterEvents(t, fdb)
+
+	// level=error AND anvil=anvil1 combine with AND. Of the error events
+	// (2, 3, 4), only 2 and 4 are on anvil1.
+	events, err := fdb.Events(50, "", "anvil1", "error", "")
+	if err != nil {
+		t.Fatalf("Events level=error anvil=anvil1: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %+v", len(events), events)
+	}
+	for _, e := range events {
+		if e.Anvil != "anvil1" {
+			t.Errorf("expected anvil1, got %q", e.Anvil)
+		}
+	}
+}
+
+func TestEventsPaginated_FilterByLevelAndGroup(t *testing.T) {
+	fdb := setupTestDB(t)
+	seedFilterEvents(t, fdb)
+
+	res, err := fdb.EventsPaginated(50, 0, "", "", "", "", "", "error", "")
+	if err != nil {
+		t.Fatalf("EventsPaginated level=error: %v", err)
+	}
+	if res.Total != 3 {
+		t.Errorf("expected total 3 for level=error, got %d", res.Total)
+	}
+
+	res, err = fdb.EventsPaginated(50, 0, "", "", "", "", "", "", "prs")
+	if err != nil {
+		t.Fatalf("EventsPaginated group=prs: %v", err)
+	}
+	if res.Total != 3 {
+		t.Errorf("expected total 3 for group=prs, got %d", res.Total)
 	}
 }
 
@@ -1186,7 +1296,7 @@ func TestAnvilCosts_DefaultsAndCap(t *testing.T) {
 
 func TestEventsPaginated_Empty(t *testing.T) {
 	fdb := setupTestDB(t)
-	result, err := fdb.EventsPaginated(50, 0, "", "", "", "", "")
+	result, err := fdb.EventsPaginated(50, 0, "", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated: %v", err)
 	}
@@ -1218,7 +1328,7 @@ func TestEventsPaginated_PaginationAndFilters(t *testing.T) {
 	}
 
 	// Test basic pagination: limit=2, offset=0
-	result, err := fdb.EventsPaginated(2, 0, "", "", "", "", "")
+	result, err := fdb.EventsPaginated(2, 0, "", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated: %v", err)
 	}
@@ -1234,7 +1344,7 @@ func TestEventsPaginated_PaginationAndFilters(t *testing.T) {
 	}
 
 	// Test offset: limit=2, offset=2
-	result, err = fdb.EventsPaginated(2, 2, "", "", "", "", "")
+	result, err = fdb.EventsPaginated(2, 2, "", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated offset: %v", err)
 	}
@@ -1246,7 +1356,7 @@ func TestEventsPaginated_PaginationAndFilters(t *testing.T) {
 	}
 
 	// Test type filter
-	result, err = fdb.EventsPaginated(50, 0, "worker_start", "", "", "", "")
+	result, err = fdb.EventsPaginated(50, 0, "worker_start", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated type filter: %v", err)
 	}
@@ -1255,7 +1365,7 @@ func TestEventsPaginated_PaginationAndFilters(t *testing.T) {
 	}
 
 	// Test anvil filter
-	result, err = fdb.EventsPaginated(50, 0, "", "anvil2", "", "", "")
+	result, err = fdb.EventsPaginated(50, 0, "", "anvil2", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated anvil filter: %v", err)
 	}
@@ -1264,7 +1374,7 @@ func TestEventsPaginated_PaginationAndFilters(t *testing.T) {
 	}
 
 	// Test date range filter
-	result, err = fdb.EventsPaginated(50, 0, "", "", "", "2026-04-02", "2026-04-04")
+	result, err = fdb.EventsPaginated(50, 0, "", "", "", "2026-04-02", "2026-04-04", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated date range: %v", err)
 	}
@@ -1273,7 +1383,7 @@ func TestEventsPaginated_PaginationAndFilters(t *testing.T) {
 	}
 
 	// Test search
-	result, err = fdb.EventsPaginated(50, 0, "", "", "bead b2", "", "")
+	result, err = fdb.EventsPaginated(50, 0, "", "", "bead b2", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated search: %v", err)
 	}
@@ -1282,7 +1392,7 @@ func TestEventsPaginated_PaginationAndFilters(t *testing.T) {
 	}
 
 	// Test combined filters: type + anvil
-	result, err = fdb.EventsPaginated(50, 0, "worker_start", "anvil1", "", "", "")
+	result, err = fdb.EventsPaginated(50, 0, "worker_start", "anvil1", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated combined: %v", err)
 	}
@@ -1305,7 +1415,7 @@ func TestEventsPaginated_SearchEscapesLIKEChars(t *testing.T) {
 	}
 
 	// Search for literal "%" - should match only the event containing "%"
-	result, err := fdb.EventsPaginated(50, 0, "", "", "100%", "", "")
+	result, err := fdb.EventsPaginated(50, 0, "", "", "100%", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated search %%: %v", err)
 	}
@@ -1314,7 +1424,7 @@ func TestEventsPaginated_SearchEscapesLIKEChars(t *testing.T) {
 	}
 
 	// Search for literal "_" - should match only the event containing "_"
-	result, err = fdb.EventsPaginated(50, 0, "", "", "file_name", "", "")
+	result, err = fdb.EventsPaginated(50, 0, "", "", "file_name", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated search _: %v", err)
 	}
@@ -1327,7 +1437,7 @@ func TestEventsPaginated_DefaultLimitAndOffset(t *testing.T) {
 	fdb := setupTestDB(t)
 
 	// limit <= 0 defaults to 50, offset < 0 defaults to 0
-	result, err := fdb.EventsPaginated(-1, -5, "", "", "", "", "")
+	result, err := fdb.EventsPaginated(-1, -5, "", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("EventsPaginated negative params: %v", err)
 	}

--- a/internal/forge/handlers.go
+++ b/internal/forge/handlers.go
@@ -660,8 +660,10 @@ func ClosedPRsHandler(db *DB) http.HandlerFunc {
 // EventsHandler returns recent forge events.
 // Query params:
 //   - limit: maximum number of events to return (default 50)
-//   - type:  filter by event type
+//   - type:  filter by event type (exact match)
 //   - anvil: filter by anvil name
+//   - level: level=error matches failure events (mirrors the frontend heuristic)
+//   - group: group=prs matches PR/merge/warden/review events
 func EventsHandler(db *DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if db == nil {
@@ -681,8 +683,10 @@ func EventsHandler(db *DB) http.HandlerFunc {
 		}
 		eventType := r.URL.Query().Get("type")
 		anvil := r.URL.Query().Get("anvil")
+		level := r.URL.Query().Get("level")
+		group := r.URL.Query().Get("group")
 
-		events, err := db.Events(limit, eventType, anvil)
+		events, err := db.Events(limit, eventType, anvil, level, group)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to load events")
 			return
@@ -700,6 +704,8 @@ func EventsHandler(db *DB) http.HandlerFunc {
 //   - search: text search across message, bead_id, and type
 //   - from:   start date (YYYY-MM-DD)
 //   - to:     end date (YYYY-MM-DD)
+//   - level:  level=error matches failure events (mirrors the frontend heuristic)
+//   - group:  group=prs matches PR/merge/warden/review events
 func EventsPageHandler(db *DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if db == nil {
@@ -729,8 +735,10 @@ func EventsPageHandler(db *DB) http.HandlerFunc {
 		search := r.URL.Query().Get("search")
 		from := r.URL.Query().Get("from")
 		to := r.URL.Query().Get("to")
+		level := r.URL.Query().Get("level")
+		group := r.URL.Query().Get("group")
 
-		result, err := db.EventsPaginated(limit, offset, eventType, anvil, search, from, to)
+		result, err := db.EventsPaginated(limit, offset, eventType, anvil, search, from, to, level, group)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to load events")
 			return
@@ -1098,7 +1106,7 @@ func ActivityStreamHandler(db *DB) http.HandlerFunc {
 
 		if lastID == 0 {
 			// No Last-Event-ID — send initial batch of recent events, oldest first.
-			initial, err := db.Events(50, "", "")
+			initial, err := db.Events(50, "", "", "", "")
 			if err == nil {
 				for i := len(initial) - 1; i >= 0; i-- {
 					e := initial[i]

--- a/internal/forge/handlers_test.go
+++ b/internal/forge/handlers_test.go
@@ -486,6 +486,58 @@ func TestEventsHandler_FilterByType(t *testing.T) {
 	}
 }
 
+func TestEventsHandler_FilterByLevelError(t *testing.T) {
+	fdb := setupTestDB(t)
+
+	nowStr := time.Now().UTC().Format(time.RFC3339)
+	fdb.db.Exec(`INSERT INTO events (timestamp, type, message, bead_id, anvil) VALUES
+		(?, 'worker_start', 'started', 'b1', 'a'),
+		(?, 'worker_fail', 'crashed', 'b2', 'a'),
+		(?, 'ci_done', 'build failed', 'b3', 'a')
+	`, nowStr, nowStr, nowStr) //nolint:errcheck
+
+	req := httptest.NewRequest(http.MethodGet, "/api/forge/events?level=error", nil)
+	rec := httptest.NewRecorder()
+	EventsHandler(fdb).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var events []Event
+	if err := json.NewDecoder(rec.Body).Decode(&events); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 error events, got %d", len(events))
+	}
+}
+
+func TestEventsHandler_FilterByGroupPRs(t *testing.T) {
+	fdb := setupTestDB(t)
+
+	nowStr := time.Now().UTC().Format(time.RFC3339)
+	fdb.db.Exec(`INSERT INTO events (timestamp, type, message, bead_id, anvil) VALUES
+		(?, 'worker_start', 'started', 'b1', 'a'),
+		(?, 'pr_merged', 'merged', 'b2', 'a'),
+		(?, 'warden_review', 'review', 'b3', 'a')
+	`, nowStr, nowStr, nowStr) //nolint:errcheck
+
+	req := httptest.NewRequest(http.MethodGet, "/api/forge/events?group=prs", nil)
+	rec := httptest.NewRecorder()
+	EventsHandler(fdb).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var events []Event
+	if err := json.NewDecoder(rec.Body).Decode(&events); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 PR-group events, got %d", len(events))
+	}
+}
+
 // --- CostsHandler ---
 
 func TestCostsHandler_NilDB(t *testing.T) {

--- a/web/public/locales/en/forge.json
+++ b/web/public/locales/en/forge.json
@@ -492,6 +492,8 @@
     "searchLabel": "Search events",
     "typeFilterLabel": "Filter by event type",
     "allTypes": "All types",
+    "typeErrors": "Errors",
+    "typePRs": "PRs",
     "typeWorkerStart": "Worker start",
     "typeWorkerDone": "Worker done",
     "typeWorkerFail": "Worker fail",

--- a/web/public/locales/nb/forge.json
+++ b/web/public/locales/nb/forge.json
@@ -492,6 +492,8 @@
     "searchLabel": "S\u00f8k i hendelser",
     "typeFilterLabel": "Filtrer etter hendelsestype",
     "allTypes": "Alle typer",
+    "typeErrors": "Feil",
+    "typePRs": "PRer",
     "typeWorkerStart": "Arbeider startet",
     "typeWorkerDone": "Arbeider ferdig",
     "typeWorkerFail": "Arbeider feilet",

--- a/web/public/locales/th/forge.json
+++ b/web/public/locales/th/forge.json
@@ -492,6 +492,8 @@
     "searchLabel": "ค้นหาเหตุการณ์",
     "typeFilterLabel": "กรองตามประเภทเหตุการณ์",
     "allTypes": "ทุกประเภท",
+    "typeErrors": "ข้อผิดพลาด",
+    "typePRs": "PR",
     "typeWorkerStart": "Worker เริ่มทำงาน",
     "typeWorkerDone": "Worker เสร็จสิ้น",
     "typeWorkerFail": "Worker ล้มเหลว",

--- a/web/src/components/mezzanine/EventsPanel.test.tsx
+++ b/web/src/components/mezzanine/EventsPanel.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import EventsPanel from './EventsPanel'
+import type { WorkerEvent } from '../LiveActivity'
+
+// ── i18n mock: return the key so we can assert on stable strings ──────────────
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// BeadLifecycleModal does its own data loading; keep it inert for this test.
+vi.mock('./BeadLifecycleModal', () => ({ default: () => null }))
+
+// Stub EventSource so the hook's SSE path is a no-op; the tests drive the
+// initial fetch / polling fallback path instead.
+class FakeEventSource {
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  constructor(_url: string) {}
+  close() {}
+}
+
+const fetchMock = vi.fn()
+
+function jsonResponse(data: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  } as Response)
+}
+
+function ev(partial: Partial<WorkerEvent> & { id: number }): WorkerEvent {
+  return {
+    timestamp: '2026-01-01T12:00:00Z',
+    type: 'worker_start',
+    message: `event ${partial.id}`,
+    ...partial,
+  }
+}
+
+function urlsCalled(): string[] {
+  return fetchMock.mock.calls.map(c => String(c[0]))
+}
+
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <EventsPanel />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.stubGlobal('EventSource', FakeEventSource)
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('EventsPanel', () => {
+  it('fetches the unfiltered window with no level/group params by default', async () => {
+    fetchMock.mockImplementation(() =>
+      jsonResponse([ev({ id: 1, message: 'hello world', anvil: 'anvil1' })]),
+    )
+
+    renderPanel()
+
+    await screen.findByText('hello world')
+
+    const urls = urlsCalled()
+    expect(urls.some(u => u.includes('/api/forge/events?') && u.includes('limit=50'))).toBe(true)
+    expect(urls.every(u => !u.includes('level=') && !u.includes('group='))).toBe(true)
+  })
+
+  it('refetches with level=error when the Errors filter is selected', async () => {
+    fetchMock.mockImplementation(() =>
+      jsonResponse([ev({ id: 2, type: 'worker_fail', message: 'it broke', anvil: 'anvil1' })]),
+    )
+
+    renderPanel()
+    await screen.findByText('it broke')
+
+    const select = screen.getByLabelText('mezzanine.events.filterLabel')
+    fireEvent.change(select, { target: { value: 'errors' } })
+
+    await waitFor(() => {
+      expect(urlsCalled().some(u => u.includes('level=error'))).toBe(true)
+    })
+  })
+
+  it('refetches with group=prs when the PRs filter is selected', async () => {
+    fetchMock.mockImplementation(() =>
+      jsonResponse([ev({ id: 3, type: 'pr_merged', message: 'merged it', anvil: 'anvil1' })]),
+    )
+
+    renderPanel()
+    await screen.findByText('merged it')
+
+    const select = screen.getByLabelText('mezzanine.events.filterLabel')
+    fireEvent.change(select, { target: { value: 'prs' } })
+
+    await waitFor(() => {
+      expect(urlsCalled().some(u => u.includes('group=prs'))).toBe(true)
+    })
+  })
+
+  it('refetches with the anvil param when an anvil filter is selected', async () => {
+    fetchMock.mockImplementation(() =>
+      jsonResponse([ev({ id: 4, message: 'on anvil1', anvil: 'anvil1' })]),
+    )
+
+    renderPanel()
+    // The initial unfiltered load seeds the anvil dropdown option.
+    await screen.findByText('on anvil1')
+
+    const select = screen.getByLabelText('mezzanine.events.filterLabel')
+    fireEvent.change(select, { target: { value: 'anvil:anvil1' } })
+
+    await waitFor(() => {
+      expect(urlsCalled().some(u => u.includes('anvil=anvil1'))).toBe(true)
+    })
+  })
+})

--- a/web/src/components/mezzanine/EventsPanel.tsx
+++ b/web/src/components/mezzanine/EventsPanel.tsx
@@ -1,39 +1,14 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Filter } from 'lucide-react'
-import type { WorkerEvent } from '../LiveActivity'
 import { formatTime } from '../../utils/formatDate'
 import { useForgeEvents } from '../../hooks/useForgeEvents'
+import { classifyLevel, filterToParams, type EventFilter } from '../../utils/forgeEventFilter'
 import BeadLifecycleModal from './BeadLifecycleModal'
-
-// 'all' | 'errors' | 'prs' | 'anvil:<name>' — the tagged anvil: prefix keeps
-// the type constrained so arbitrary strings cannot slip through accidentally.
-type EventFilter = 'all' | 'errors' | 'prs' | `anvil:${string}`
 
 interface EventsPanelProps {
   onBeadClick?: (beadId: string) => void
-}
-
-function classifyLevel(event: WorkerEvent): 'success' | 'failure' | 'info' {
-  const type = event.type?.toLowerCase() ?? ''
-  const level = event.level?.toLowerCase() ?? ''
-  const message = event.message?.toLowerCase() ?? ''
-
-  if (level === 'error' || type.includes('fail') || type.includes('error') || message.includes('failed')) {
-    return 'failure'
-  }
-  if (
-    level === 'success' ||
-    type.includes('pass') ||
-    type.includes('merged') ||
-    type.includes('done') ||
-    type.includes('success') ||
-    type.includes('complete')
-  ) {
-    return 'success'
-  }
-  return 'info'
 }
 
 const levelStyles: Record<string, string> = {
@@ -56,37 +31,35 @@ export default function EventsPanel({ onBeadClick: _onBeadClick }: EventsPanelPr
   const [lifecycleBeadId, setLifecycleBeadId] = useState<string | null>(null)
 
   // useForgeEvents connects to /api/forge/activity/stream (SSE) and falls back
-  // to polling /api/forge/events. Events are returned in chronological order
-  // (oldest first); we reverse them here for newest-first display.
-  const { events: chronoEvents } = useForgeEvents({ maxEvents: MAX_EVENTS })
+  // to polling /api/forge/events. When a filter is active we pass the matching
+  // server query params so the entire event log is searched (not just the live
+  // in-memory window). Events are returned in chronological order (oldest
+  // first); we reverse them here for newest-first display.
+  const filterParams = useMemo(() => filterToParams(filter), [filter])
+  const { events: chronoEvents } = useForgeEvents({ maxEvents: MAX_EVENTS, filter: filterParams })
   const events = useMemo(() => [...chronoEvents].reverse(), [chronoEvents])
 
-  const anvils = useMemo(() => {
-    const set = new Set<string>()
-    for (const e of events) {
-      if (e.anvil) set.add(e.anvil)
-    }
-    return [...set].sort()
+  // Accumulate every anvil ever seen so the dropdown stays populated even when
+  // an anvil filter narrows the fetched events down to a single anvil. The
+  // default 'all' load seeds the full set before any filter is applied.
+  const [knownAnvils, setKnownAnvils] = useState<string[]>([])
+  useEffect(() => {
+    setKnownAnvils(prev => {
+      const set = new Set(prev)
+      let changed = false
+      for (const e of events) {
+        if (e.anvil && !set.has(e.anvil)) {
+          set.add(e.anvil)
+          changed = true
+        }
+      }
+      return changed ? [...set].sort() : prev
+    })
   }, [events])
 
-  const filtered = useMemo(() => {
-    // Always exclude noisy poll events — they're 80%+ of all events.
-    const meaningful = events.filter(e => e.type !== 'poll')
-    if (filter === 'all') return meaningful
-    if (filter === 'errors') return meaningful.filter(e => classifyLevel(e) === 'failure')
-    if (filter === 'prs') {
-      return meaningful.filter(e => {
-        const type = e.type?.toLowerCase() ?? ''
-        return type.includes('pr') || type.includes('merge') || type.includes('warden') || type.includes('review')
-      })
-    }
-    // per-anvil filter: filter is `anvil:<name>`
-    if (filter.startsWith('anvil:')) {
-      const anvilName = filter.slice(6)
-      return meaningful.filter(e => e.anvil === anvilName)
-    }
-    return meaningful
-  }, [events, filter])
+  // The level/group/anvil filtering happens server-side (via the hook). Here we
+  // only drop noisy poll events — they're 80%+ of all events.
+  const filtered = useMemo(() => events.filter(e => e.type !== 'poll'), [events])
 
   return (
     <div className="flex flex-col rounded-lg border border-gray-700/50 bg-gray-900/60 overflow-hidden">
@@ -104,7 +77,7 @@ export default function EventsPanel({ onBeadClick: _onBeadClick }: EventsPanelPr
               <option value="all">{t('mezzanine.events.filterAll')}</option>
               <option value="errors">{t('mezzanine.events.filterErrors')}</option>
               <option value="prs">{t('mezzanine.events.filterPRs')}</option>
-              {anvils.map(anvil => (
+              {knownAnvils.map(anvil => (
                 <option key={anvil} value={`anvil:${anvil}`}>{anvil}</option>
               ))}
             </select>

--- a/web/src/components/mezzanine/EventsPanel.tsx
+++ b/web/src/components/mezzanine/EventsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Filter } from 'lucide-react'
@@ -43,19 +43,21 @@ export default function EventsPanel({ onBeadClick: _onBeadClick }: EventsPanelPr
   // an anvil filter narrows the fetched events down to a single anvil. The
   // default 'all' load seeds the full set before any filter is applied.
   const [knownAnvils, setKnownAnvils] = useState<string[]>([])
-  useEffect(() => {
-    setKnownAnvils(prev => {
-      const set = new Set(prev)
-      let changed = false
-      for (const e of events) {
-        if (e.anvil && !set.has(e.anvil)) {
-          set.add(e.anvil)
-          changed = true
-        }
+  const [prevEvents, setPrevEvents] = useState(events)
+  if (events !== prevEvents) {
+    setPrevEvents(events)
+    const set = new Set(knownAnvils)
+    let changed = false
+    for (const e of events) {
+      if (e.anvil && !set.has(e.anvil)) {
+        set.add(e.anvil)
+        changed = true
       }
-      return changed ? [...set].sort() : prev
-    })
-  }, [events])
+    }
+    if (changed) {
+      setKnownAnvils([...set].sort())
+    }
+  }
 
   // The level/group/anvil filtering happens server-side (via the hook). Here we
   // only drop noisy poll events — they're 80%+ of all events.

--- a/web/src/hooks/useEventsPage.ts
+++ b/web/src/hooks/useEventsPage.ts
@@ -5,6 +5,10 @@ export interface EventsPageParams {
   search?: string
   type?: string
   anvil?: string
+  // level=error and group=prs mirror the Mezzanine events panel's "Errors" and
+  // "PRs" filters (see web/src/utils/forgeEventFilter.ts) for consistency.
+  level?: string
+  group?: string
   from?: string
   to?: string
   page: number
@@ -47,6 +51,8 @@ export function useEventsPage(params: EventsPageParams): UseEventsPageReturn {
         if (params.search) qs.set('search', params.search)
         if (params.type) qs.set('type', params.type)
         if (params.anvil) qs.set('anvil', params.anvil)
+        if (params.level) qs.set('level', params.level)
+        if (params.group) qs.set('group', params.group)
         if (params.from) qs.set('from', params.from)
         if (params.to) qs.set('to', params.to)
 
@@ -74,7 +80,7 @@ export function useEventsPage(params: EventsPageParams): UseEventsPageReturn {
       cancelled = true
       controller.abort()
     }
-  }, [params.search, params.type, params.anvil, params.from, params.to, params.page, params.pageSize, refreshKey])
+  }, [params.search, params.type, params.anvil, params.level, params.group, params.from, params.to, params.page, params.pageSize, refreshKey])
 
   return { events, total, loading, error, refresh }
 }

--- a/web/src/hooks/useForgeEvents.ts
+++ b/web/src/hooks/useForgeEvents.ts
@@ -1,10 +1,21 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import type { WorkerEvent } from '../components/LiveActivity'
+import { eventMatchesParams, type ForgeEventFilterParams } from '../utils/forgeEventFilter'
 
 interface UseForgeEventsOptions {
   maxEvents?: number
   pollInterval?: number
+  // When set, the initial fetch and polling fallback query the server with
+  // these filter params so the entire event log is searched (not just the live
+  // window), and live SSE/poll events are matched client-side to stay in the
+  // filtered view. Omit (or pass undefined) for the default unfiltered stream.
+  filter?: ForgeEventFilterParams
 }
+
+// When a server-side filter is active we fetch a deeper slice so the panel can
+// surface older matching events; the unfiltered stream keeps the smaller window.
+const FILTERED_FETCH_LIMIT = 200
+const UNFILTERED_FETCH_LIMIT = 50
 
 /**
  * Subscribes to Forge events via SSE (/api/forge/activity/stream) with a
@@ -12,13 +23,25 @@ interface UseForgeEventsOptions {
  * (oldest first). An initial fetch seeds the list before live updates arrive.
  * All incoming events are deduplicated by id so the initial fetch and the SSE
  * initial batch cannot race each other into dropping or duplicating events.
+ *
+ * When `filter` is provided, the seed/poll fetches pass the filter params to
+ * the server (which filters the full event log) and live events are matched
+ * against the same params client-side so the returned list only ever contains
+ * matching events, newest history included.
  */
-export function useForgeEvents({ maxEvents = 200, pollInterval = 3000 }: UseForgeEventsOptions = {}) {
+export function useForgeEvents({ maxEvents = 200, pollInterval = 3000, filter }: UseForgeEventsOptions = {}) {
   const [events, setEvents] = useState<WorkerEvent[]>([])
   const lastSeenIdRef = useRef(0)
   const esRef = useRef<EventSource | null>(null)
   const pollingRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined)
   const fallbackActiveRef = useRef(false)
+
+  // Destructure to primitive deps so the effect re-runs only when the filter
+  // actually changes (the caller may pass a fresh object each render).
+  const level = filter?.level ?? ''
+  const group = filter?.group ?? ''
+  const anvil = filter?.anvil ?? ''
+  const hasFilter = !!(level || group || anvil)
 
   const mergeEvents = useCallback((incoming: WorkerEvent[]) => {
     if (incoming.length === 0) return
@@ -38,13 +61,31 @@ export function useForgeEvents({ maxEvents = 200, pollInterval = 3000 }: UseForg
     const abortController = new AbortController()
     const pollingInFlightRef = { current: false }
 
+    // Reset when the filter changes so a previous (e.g. unfiltered) result set
+    // cannot leak into the new filtered view.
+    setEvents([])
+    lastSeenIdRef.current = 0
+
+    const params: ForgeEventFilterParams = { level, group, anvil }
+    const fetchURL = () => {
+      const qs = new URLSearchParams()
+      qs.set('limit', String(hasFilter ? FILTERED_FETCH_LIMIT : UNFILTERED_FETCH_LIMIT))
+      if (level) qs.set('level', level)
+      if (group) qs.set('group', group)
+      if (anvil) qs.set('anvil', anvil)
+      return `/api/forge/events?${qs.toString()}`
+    }
+    // Live (SSE) events arrive unfiltered, so match them against the active
+    // filter before merging. With no filter every event matches.
+    const matchesFilter = (e: WorkerEvent) => !hasFilter || eventMatchesParams(e, params)
+
     function startPolling() {
       if (fallbackActiveRef.current) return
       fallbackActiveRef.current = true
       pollingRef.current = setInterval(() => {
         if (pollingInFlightRef.current) return
         pollingInFlightRef.current = true
-        fetch('/api/forge/events?limit=50', { credentials: 'include', signal: abortController.signal })
+        fetch(fetchURL(), { credentials: 'include', signal: abortController.signal })
           .then(res => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
           .then((data: unknown) => {
             if (!Array.isArray(data) || data.length === 0) return
@@ -66,7 +107,7 @@ export function useForgeEvents({ maxEvents = 200, pollInterval = 3000 }: UseForg
       es.onmessage = (e: MessageEvent<string>) => {
         try {
           const event = JSON.parse(e.data) as WorkerEvent
-          mergeEvents([event])
+          if (matchesFilter(event)) mergeEvents([event])
         } catch {
           // ignore unparseable SSE data
         }
@@ -84,7 +125,8 @@ export function useForgeEvents({ maxEvents = 200, pollInterval = 3000 }: UseForg
 
     // Initial fetch to seed the list; merged with any SSE events already received
     // to avoid the race condition where SSE arrives before the fetch resolves.
-    fetch('/api/forge/events?limit=50', { credentials: 'include', signal: abortController.signal })
+    // The server already applied the filter, so merge the results as-is.
+    fetch(fetchURL(), { credentials: 'include', signal: abortController.signal })
       .then(res => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then((data: unknown) => {
         if (!Array.isArray(data) || data.length === 0) return
@@ -105,7 +147,7 @@ export function useForgeEvents({ maxEvents = 200, pollInterval = 3000 }: UseForg
         pollingRef.current = undefined
       }
     }
-  }, [mergeEvents, pollInterval])
+  }, [mergeEvents, pollInterval, level, group, anvil, hasFilter])
 
   return { events }
 }

--- a/web/src/hooks/useForgeEvents.ts
+++ b/web/src/hooks/useForgeEvents.ts
@@ -43,6 +43,12 @@ export function useForgeEvents({ maxEvents = 200, pollInterval = 3000, filter }:
   const anvil = filter?.anvil ?? ''
   const hasFilter = !!(level || group || anvil)
 
+  // When a filter is active we fetch a deeper slice (FILTERED_FETCH_LIMIT) so
+  // older matches surface. Cap the retained list to at least that depth,
+  // otherwise a smaller caller-supplied maxEvents (e.g. the panel's 100) would
+  // silently truncate the deeper fetch and negate its benefit.
+  const effectiveMax = hasFilter ? Math.max(maxEvents, FILTERED_FETCH_LIMIT) : maxEvents
+
   const mergeEvents = useCallback((incoming: WorkerEvent[]) => {
     if (incoming.length === 0) return
     setEvents(prev => {
@@ -53,9 +59,9 @@ export function useForgeEvents({ maxEvents = 200, pollInterval = 3000, filter }:
       if (merged.length > 0) {
         lastSeenIdRef.current = Math.max(lastSeenIdRef.current, merged[merged.length - 1].id)
       }
-      return merged.slice(-maxEvents)
+      return merged.slice(-effectiveMax)
     })
-  }, [maxEvents])
+  }, [effectiveMax])
 
   useEffect(() => {
     const abortController = new AbortController()

--- a/web/src/hooks/useForgeEvents.ts
+++ b/web/src/hooks/useForgeEvents.ts
@@ -49,6 +49,13 @@ export function useForgeEvents({ maxEvents = 200, pollInterval = 3000, filter }:
   // silently truncate the deeper fetch and negate its benefit.
   const effectiveMax = hasFilter ? Math.max(maxEvents, FILTERED_FETCH_LIMIT) : maxEvents
 
+  const [prevFilterKey, setPrevFilterKey] = useState('')
+  const currentFilterKey = `${level}|${group}|${anvil}`
+  if (currentFilterKey !== prevFilterKey) {
+    setPrevFilterKey(currentFilterKey)
+    setEvents([])
+  }
+
   const mergeEvents = useCallback((incoming: WorkerEvent[]) => {
     if (incoming.length === 0) return
     setEvents(prev => {
@@ -67,9 +74,6 @@ export function useForgeEvents({ maxEvents = 200, pollInterval = 3000, filter }:
     const abortController = new AbortController()
     const pollingInFlightRef = { current: false }
 
-    // Reset when the filter changes so a previous (e.g. unfiltered) result set
-    // cannot leak into the new filtered view.
-    setEvents([])
     lastSeenIdRef.current = 0
 
     const params: ForgeEventFilterParams = { level, group, anvil }

--- a/web/src/pages/EventsPage.tsx
+++ b/web/src/pages/EventsPage.tsx
@@ -44,17 +44,21 @@ export default function EventsPage() {
   const [to, setTo] = useState('')
   const [page, setPage] = useState(1)
 
-  const params = useMemo(
-    () => ({
+  // The type dropdown doubles as the level/group filter: the sentinel values
+  // 'level:error' and 'group:prs' map to the shared level/group server params
+  // (mirroring the Mezzanine events panel) rather than an exact type match.
+  const params = useMemo(() => {
+    const base = {
       search,
-      type: typeFilter,
       from,
       to,
       page,
       pageSize: PAGE_SIZE,
-    }),
-    [search, typeFilter, from, to, page],
-  )
+    }
+    if (typeFilter === 'level:error') return { ...base, level: 'error' }
+    if (typeFilter === 'group:prs') return { ...base, group: 'prs' }
+    return { ...base, type: typeFilter }
+  }, [search, typeFilter, from, to, page])
 
   const { events, total, loading, error, refresh } = useEventsPage(params)
 
@@ -135,6 +139,8 @@ export default function EventsPage() {
           aria-label={t('eventsPage.typeFilterLabel')}
         >
           <option value="">{t('eventsPage.allTypes')}</option>
+          <option value="level:error">{t('eventsPage.typeErrors')}</option>
+          <option value="group:prs">{t('eventsPage.typePRs')}</option>
           <option value="worker_start">{t('eventsPage.typeWorkerStart')}</option>
           <option value="worker_done">{t('eventsPage.typeWorkerDone')}</option>
           <option value="worker_fail">{t('eventsPage.typeWorkerFail')}</option>

--- a/web/src/utils/forgeEventFilter.ts
+++ b/web/src/utils/forgeEventFilter.ts
@@ -1,0 +1,71 @@
+import type { WorkerEvent } from '../components/LiveActivity'
+
+// EventFilter is the Mezzanine events panel filter selection. The tagged
+// `anvil:` prefix keeps the type constrained so arbitrary strings cannot slip
+// through accidentally.
+export type EventFilter = 'all' | 'errors' | 'prs' | `anvil:${string}`
+
+// ForgeEventFilterParams are the server query params understood by
+// /api/forge/events (and /api/forge/events/page) for the panel's filters.
+export interface ForgeEventFilterParams {
+  level?: string
+  group?: string
+  anvil?: string
+}
+
+// classifyLevel maps an event to a display level. The failure branch mirrors
+// the backend `level=error` predicate in internal/forge/db.go
+// (appendEventFilters) so client and server agree on what counts as an error.
+export function classifyLevel(
+  event: Pick<WorkerEvent, 'type' | 'level' | 'message'>,
+): 'success' | 'failure' | 'info' {
+  const type = event.type?.toLowerCase() ?? ''
+  const level = event.level?.toLowerCase() ?? ''
+  const message = event.message?.toLowerCase() ?? ''
+
+  if (level === 'error' || type.includes('fail') || type.includes('error') || message.includes('failed')) {
+    return 'failure'
+  }
+  if (
+    level === 'success' ||
+    type.includes('pass') ||
+    type.includes('merged') ||
+    type.includes('done') ||
+    type.includes('success') ||
+    type.includes('complete')
+  ) {
+    return 'success'
+  }
+  return 'info'
+}
+
+// isPRGroupEvent mirrors the backend `group=prs` predicate: the event type
+// references a pull request, merge, warden, or review.
+export function isPRGroupEvent(event: Pick<WorkerEvent, 'type'>): boolean {
+  const type = event.type?.toLowerCase() ?? ''
+  return (
+    type.includes('pr') ||
+    type.includes('merge') ||
+    type.includes('warden') ||
+    type.includes('review')
+  )
+}
+
+// filterToParams maps a UI filter selection to the server query params. 'all'
+// returns undefined, meaning no server-side filtering (default behavior).
+export function filterToParams(filter: EventFilter): ForgeEventFilterParams | undefined {
+  if (filter === 'errors') return { level: 'error' }
+  if (filter === 'prs') return { group: 'prs' }
+  if (filter.startsWith('anvil:')) return { anvil: filter.slice(6) }
+  return undefined
+}
+
+// eventMatchesParams decides whether a live (SSE/poll) event belongs in the
+// current server-filtered view, so live updates stay consistent with the server
+// query without forcing a refetch on every event.
+export function eventMatchesParams(event: WorkerEvent, params: ForgeEventFilterParams): boolean {
+  if (params.level === 'error' && classifyLevel(event) !== 'failure') return false
+  if (params.group === 'prs' && !isPRGroupEvent(event)) return false
+  if (params.anvil && event.anvil !== params.anvil) return false
+  return true
+}


### PR DESCRIPTION
## Changes

- **Mezzanine events panel filters search the full event log** - The Errors, PRs, and per-anvil filters on the Hearth events panel now query the entire event history server-side (newest first) instead of only the ~50-100 events in the live in-memory window, so older matching events are no longer hidden. The events endpoints gained `level=error` and `group=prs` query params (mirroring the old client-side heuristics), and the full Events page reuses them for a matching "Errors" / "PRs" filter. (Hytte-gvl5)

## Original Issue (feature): Mezzanine events panel: filter the full event log, not just the in-memory window

## Problem

The events panel on the Mezzanine dashboard (Hearth 2.0, web/src/components/mezzanine/EventsPanel.tsx) has a filter dropdown (All / Errors / PRs / per-anvil), but it only filters client-side over the small in-memory event window kept by useForgeEvents — an initial fetch of /api/forge/events?limit=50, capped at MAX_EVENTS=100 in the panel. Selecting "Errors" or an anvil therefore only searches the ~50-100 most recent events (~10 visible), so older matching events are invisible and the filtered panel often looks empty even though matches exist in the event log.

## Expected

Choosing a filter should show matching events from the entire event history (newest first), not just whatever happens to be in the live window.

## Implementation notes

The backend already filters server-side for the full Events page:

- GET /api/forge/events (EventsHandler, internal/forge/handlers.go) supports limit, type (exact match), and anvil params via db.Events().
- GET /api/forge/events/page (EventsPageHandler) additionally supports search, from/to dates, and offset pagination via db.EventsPaginated().

What's missing for the panel's filters:

1. "Errors" — the failure classification lives only in the frontend heuristic (classifyLevel in EventsPanel.tsx: level == error, type contains fail/error, message contains failed). Needs a server-side equivalent, e.g. a level=error query param on the events endpoints implementing the same matching in SQL.
2. "PRs" — a type *group* (type contains pr/merge/warden/review), while the backend type param is an exact match. Needs e.g. multi-type support (type=a,b,c), a LIKE-based group match, or a named group param (group=prs).
3. Per-anvil — already supported via the anvil param; the panel just needs to pass it instead of filtering locally.

When a filter is active, the panel should re-fetch with the filter params (and keep appending live SSE events that match the active filter, or fall back to refetch-on-event). With no filter active, current behavior is fine. EventsPage.tsx (/forge/mezzanine/events) already does server-side filtering and can reuse any new level/group params for parity — its type dropdown and the panel's filters should stay consistent.

Frontend tests: web/src/components/mezzanine/ has no EventsPanel test today; the EventsPage tests show the fetch-mocking pattern.

---
Bead: Hytte-gvl5 | Branch: forge/Hytte-gvl5
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->