### PR TITLE
Persist saved articles so they survive the 48h age and 100-item feed caps (Hytte-6mxo)

### DIFF
--- a/changelog.d/Hytte-6mxo.md
+++ b/changelog.d/Hytte-6mxo.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Saved news articles now persist across feed caps** - Bookmarked articles are served from their own encrypted snapshot store, so they survive the 48h feed age cap and 100-item truncation. Re-saving a churned article now refreshes all snapshot fields (source, source name, image, publish time), not just title/url/summary. (Hytte-6mxo)

--- a/internal/news/handlers_test.go
+++ b/internal/news/handlers_test.go
@@ -1,0 +1,91 @@
+package news
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+)
+
+// TestSavedListHandlerIndependentOfFeedCaps verifies that GET /api/news/saved
+// serves bookmarked articles straight from the store — including ones older than
+// the feed's 48h age cap and beyond its 100-item truncation cap — with the full
+// decrypted snapshot payload.
+func TestSavedListHandlerIndependentOfFeedCaps(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService()
+
+	// One article that the feed would have aged out (10 days old) and enough
+	// total articles to exceed the feed's maxArticles truncation cap.
+	total := maxArticles + 5
+	for i := 0; i < total; i++ {
+		a := sampleArticle("h-"+itoa(i), time.Now().Add(-10*24*time.Hour))
+		if err := SetSaved(d, 1, a, true); err != nil {
+			t.Fatalf("SetSaved %d: %v", i, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/news/saved", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: 1}))
+	rec := httptest.NewRecorder()
+
+	svc.SavedListHandler(d)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Articles []Article `json:"articles"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Articles) != total {
+		t.Fatalf("got %d saved articles, want %d (feed caps must not apply)", len(resp.Articles), total)
+	}
+
+	// Verify the snapshot fields come back decrypted and complete.
+	got := resp.Articles[0]
+	if got.Title == "" || got.URL == "" || got.Summary == "" {
+		t.Errorf("expected decrypted text fields, got %+v", got)
+	}
+	if got.Source == "" || got.SourceName == "" {
+		t.Errorf("expected source metadata, got %+v", got)
+	}
+	if got.PublishedAt.IsZero() {
+		t.Error("expected non-zero published_at")
+	}
+}
+
+// TestSavedListHandlerEmpty verifies the handler returns an empty array (not
+// null) when the user has no saved articles.
+func TestSavedListHandlerEmpty(t *testing.T) {
+	d := setupTestDB(t)
+	svc := NewService()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/news/saved", nil)
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: 1}))
+	rec := httptest.NewRecorder()
+
+	svc.SavedListHandler(d)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var resp struct {
+		Articles []Article `json:"articles"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Articles == nil {
+		t.Error("expected non-nil articles array")
+	}
+	if len(resp.Articles) != 0 {
+		t.Errorf("expected 0 articles, got %d", len(resp.Articles))
+	}
+}

--- a/internal/news/store.go
+++ b/internal/news/store.go
@@ -209,7 +209,9 @@ func SetSaved(db *sql.DB, userID int64, a Article, saved bool) error {
 		(user_id, article_id, source, source_name, title, url, summary, image_url, published_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(user_id, article_id) DO UPDATE SET
-			title=excluded.title, url=excluded.url, summary=excluded.summary`,
+			source=excluded.source, source_name=excluded.source_name,
+			title=excluded.title, url=excluded.url, summary=excluded.summary,
+			image_url=excluded.image_url, published_at=excluded.published_at`,
 		userID, a.ID, a.Source, a.SourceName, titleEnc, urlEnc, summaryEnc, a.ImageURL, pub)
 	return err
 }

--- a/internal/news/store_test.go
+++ b/internal/news/store_test.go
@@ -1,0 +1,249 @@
+package news
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/db"
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-key-for-news-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+	database, err := db.Init(":memory:")
+	if err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	t.Cleanup(func() { database.Close() })
+
+	_, err = database.Exec(`INSERT INTO users (id, email, name, picture, google_id, created_at) VALUES (1, 'test@example.com', 'Test', '', 'g1', '')`)
+	if err != nil {
+		t.Fatalf("insert test user: %v", err)
+	}
+	return database
+}
+
+// sampleArticle builds a fully-populated article for save tests.
+func sampleArticle(id string, published time.Time) Article {
+	return Article{
+		ID:          id,
+		Source:      "vg",
+		SourceName:  "VG",
+		Title:       "Saved headline " + id,
+		URL:         "https://example.com/" + id,
+		Summary:     "A summary for " + id,
+		ImageURL:    "https://example.com/" + id + ".jpg",
+		PublishedAt: published,
+	}
+}
+
+// TestSavedArticleSurvivesAgeCap verifies that an article saved with a publish
+// time well past the feed's 48h age cap is still returned by ListSaved — the
+// saved store does not apply the feed's withinAge filtering.
+func TestSavedArticleSurvivesAgeCap(t *testing.T) {
+	d := setupTestDB(t)
+
+	old := time.Now().Add(-10 * 24 * time.Hour) // 10 days ago, well past maxArticleAge
+	a := sampleArticle("aged-out", old)
+	if err := SetSaved(d, 1, a, true); err != nil {
+		t.Fatalf("SetSaved: %v", err)
+	}
+
+	saved, err := ListSaved(d, 1)
+	if err != nil {
+		t.Fatalf("ListSaved: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("expected 1 saved article, got %d", len(saved))
+	}
+	if saved[0].ID != "aged-out" {
+		t.Errorf("got id %q, want %q", saved[0].ID, "aged-out")
+	}
+	if saved[0].Title != a.Title {
+		t.Errorf("got title %q, want %q", saved[0].Title, a.Title)
+	}
+}
+
+// TestSavedArticleSurvivesTruncationCap verifies that saving many more articles
+// than the feed's maxArticles cap still returns all of them from the store —
+// ListSaved does not truncate to the newest N.
+func TestSavedArticleSurvivesTruncationCap(t *testing.T) {
+	d := setupTestDB(t)
+
+	total := maxArticles + 50 // beyond the feed truncation cap
+	base := time.Now().Add(-time.Hour)
+	for i := 0; i < total; i++ {
+		a := sampleArticle("art-"+itoa(i), base.Add(-time.Duration(i)*time.Minute))
+		if err := SetSaved(d, 1, a, true); err != nil {
+			t.Fatalf("SetSaved %d: %v", i, err)
+		}
+	}
+
+	saved, err := ListSaved(d, 1)
+	if err != nil {
+		t.Fatalf("ListSaved: %v", err)
+	}
+	if len(saved) != total {
+		t.Fatalf("expected %d saved articles, got %d", total, len(saved))
+	}
+}
+
+// TestSavedSnapshotFieldsRoundTrip verifies all snapshot fields survive a
+// save/list round-trip, with the encrypted text fields decrypted correctly.
+func TestSavedSnapshotFieldsRoundTrip(t *testing.T) {
+	d := setupTestDB(t)
+
+	published := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	a := sampleArticle("round-trip", published)
+	if err := SetSaved(d, 1, a, true); err != nil {
+		t.Fatalf("SetSaved: %v", err)
+	}
+
+	saved, err := ListSaved(d, 1)
+	if err != nil {
+		t.Fatalf("ListSaved: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("expected 1 saved article, got %d", len(saved))
+	}
+	got := saved[0]
+	if got.Title != a.Title || got.URL != a.URL || got.Summary != a.Summary {
+		t.Errorf("text fields mismatch: %+v", got)
+	}
+	if got.Source != a.Source || got.SourceName != a.SourceName || got.ImageURL != a.ImageURL {
+		t.Errorf("metadata fields mismatch: %+v", got)
+	}
+	if !got.PublishedAt.Equal(published) {
+		t.Errorf("got published_at %v, want %v", got.PublishedAt, published)
+	}
+	if !got.Saved {
+		t.Error("expected Saved=true")
+	}
+}
+
+// TestSavedSnapshotEncryptedAtRest verifies the sensitive text fields are not
+// stored in plaintext (encryption-at-rest invariant from CLAUDE.md).
+func TestSavedSnapshotEncryptedAtRest(t *testing.T) {
+	d := setupTestDB(t)
+
+	a := sampleArticle("encrypted", time.Now())
+	if err := SetSaved(d, 1, a, true); err != nil {
+		t.Fatalf("SetSaved: %v", err)
+	}
+
+	var title, url, summary string
+	err := d.QueryRow(`SELECT title, url, summary FROM news_saved WHERE user_id=1 AND article_id=?`, a.ID).
+		Scan(&title, &url, &summary)
+	if err != nil {
+		t.Fatalf("query raw row: %v", err)
+	}
+	if title == a.Title {
+		t.Error("title stored in plaintext")
+	}
+	if url == a.URL {
+		t.Error("url stored in plaintext")
+	}
+	if summary == a.Summary {
+		t.Error("summary stored in plaintext")
+	}
+}
+
+// TestReSaveRefreshesAllSnapshotFields is the regression test for the upsert
+// fix: re-saving an article whose feed snapshot changed must update every
+// snapshot field, not just title/url/summary.
+func TestReSaveRefreshesAllSnapshotFields(t *testing.T) {
+	d := setupTestDB(t)
+
+	first := sampleArticle("churned", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err := SetSaved(d, 1, first, true); err != nil {
+		t.Fatalf("SetSaved first: %v", err)
+	}
+
+	updated := Article{
+		ID:          "churned",
+		Source:      "nrk",
+		SourceName:  "NRK",
+		Title:       "Updated headline",
+		URL:         "https://example.com/updated",
+		Summary:     "Updated summary",
+		ImageURL:    "https://example.com/updated.jpg",
+		PublishedAt: time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC),
+	}
+	if err := SetSaved(d, 1, updated, true); err != nil {
+		t.Fatalf("SetSaved updated: %v", err)
+	}
+
+	saved, err := ListSaved(d, 1)
+	if err != nil {
+		t.Fatalf("ListSaved: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("expected 1 saved article after re-save, got %d", len(saved))
+	}
+	got := saved[0]
+	if got.Source != updated.Source {
+		t.Errorf("source not refreshed: got %q, want %q", got.Source, updated.Source)
+	}
+	if got.SourceName != updated.SourceName {
+		t.Errorf("source_name not refreshed: got %q, want %q", got.SourceName, updated.SourceName)
+	}
+	if got.ImageURL != updated.ImageURL {
+		t.Errorf("image_url not refreshed: got %q, want %q", got.ImageURL, updated.ImageURL)
+	}
+	if !got.PublishedAt.Equal(updated.PublishedAt) {
+		t.Errorf("published_at not refreshed: got %v, want %v", got.PublishedAt, updated.PublishedAt)
+	}
+	if got.Title != updated.Title || got.URL != updated.URL || got.Summary != updated.Summary {
+		t.Errorf("text fields not refreshed: %+v", got)
+	}
+}
+
+// TestUnsaveRemovesOnlyThatRow verifies unsaving one article leaves the others.
+func TestUnsaveRemovesOnlyThatRow(t *testing.T) {
+	d := setupTestDB(t)
+
+	keep := sampleArticle("keep", time.Now())
+	drop := sampleArticle("drop", time.Now())
+	if err := SetSaved(d, 1, keep, true); err != nil {
+		t.Fatalf("SetSaved keep: %v", err)
+	}
+	if err := SetSaved(d, 1, drop, true); err != nil {
+		t.Fatalf("SetSaved drop: %v", err)
+	}
+
+	if err := SetSaved(d, 1, drop, false); err != nil {
+		t.Fatalf("unsave drop: %v", err)
+	}
+
+	saved, err := ListSaved(d, 1)
+	if err != nil {
+		t.Fatalf("ListSaved: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("expected 1 saved article after unsave, got %d", len(saved))
+	}
+	if saved[0].ID != "keep" {
+		t.Errorf("wrong row survived: got %q, want %q", saved[0].ID, "keep")
+	}
+}
+
+// itoa is a tiny dependency-free int-to-string for building test IDs.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## Changes

- **Saved news articles now persist across feed caps** - Bookmarked articles are served from their own encrypted snapshot store, so they survive the 48h feed age cap and 100-item truncation. Re-saving a churned article now refreshes all snapshot fields (source, source name, image, publish time), not just title/url/summary. (Hytte-6mxo)

## Original Issue (feature): Persist saved articles so they survive the 48h age and 100-item feed caps

### Scope
Investigation shows the persistence store the suggestion describes **already exists**: `news_saved` (in `internal/news/store.go`) stores an encrypted snapshot (title, url, summary, source, source_name, image_url, published_at) at save time via `SetSaved`, and the Saved tab fetches from the dedicated `GET /api/news/articles → /api/news/saved` endpoint (`SavedListHandler` → `ListSaved`), **not** the live feed — the frontend `SavedTab` in `News.tsx` calls `/api/news/saved` independently. So saved articles already survive the 48h/100-item feed caps. This plan therefore covers **verifying that invariant with tests and closing snapshot-completeness gaps**, rather than building the store from scratch. The project owner should confirm whether the suggestion is stale before a full rebuild is scheduled.

### Files to touch
- `internal/news/store.go` — make `SetSaved` ON CONFLICT also refresh `source`, `source_name`, `image_url`, `published_at` (currently only title/url/summary), so re-saving a churned article updates the stale snapshot.
- `internal/news/store_test.go` (new or existing) — test that a saved article is returned by `ListSaved` after it would have aged out / been truncated from the feed.
- `internal/news/handlers_test.go` (if present) — assert `SavedListHandler` returns saved items independent of `ArticlesHandler` caps.
- `web/src/pages/News.tsx` — no logic change expected; confirm `SavedTab` reads `/api/news/saved` (it does). Touch only if a gap surfaces.
- `changelog.d/` (new) — `Fixed` fragment.

### Acceptance criteria
- An article saved >48h ago, and one beyond the newest 100 feed items, both still appear in the Saved tab.
- `GET /api/news/saved` returns full snapshot fields (title, url, summary, source, source_name, published_at) decrypted, regardless of current feed contents.
- Re-saving an article whose feed snapshot changed updates all stored snapshot fields, not just title/url/summary.
- Unsaving removes only that row; other saved items persist.
- New/updated Go tests cover the age-out and truncation cases and pass under `make test`.
- Snapshot text fields remain encrypted at rest per CLAUDE.md.
- Changelog fragment present.

### Non-goals
- Redesigning the saved-articles schema or migrating existing rows.
- Persisting `categories`, `also_in`, relevance `score`, or read state for saved items.
- Changing feed caps (`maxArticleAge`, `maxArticles`) or feed ranking behavior.
- Any UI redesign of the Saved tab beyond confirming it reads from the store.
- Backfilling snapshots for articles saved before any field is added.

## Source

Created from Suggestions page (suggestion id 200, page slug "news", source=claude).

## Original suggestion

The Saved tab is rendered from the same `articles` list the feed returns, but the backend drops anything older than `maxArticleAge` (48h) and truncates to `maxArticles` (100). That means an article a user explicitly saved disappears from their Saved list a couple of days later or once the feed churns past 100 items — silently breaking 'save for later'. Store the full article snapshot (title, url, summary, source) at save time and serve the Saved tab from that store instead of the live feed. Users keep everything they bookmarked regardless of feed age or volume.


---
Bead: Hytte-6mxo | Branch: forge/Hytte-6mxo
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->