### PR TITLE
Stop skeleton flash on auto-refresh by tracking initial load separately (Hytte-qswv)

### DIFF
--- a/changelog.d/Hytte-qswv.md
+++ b/changelog.d/Hytte-qswv.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Transit board no longer flashes skeletons on refresh** - The skeleton placeholders now appear only on the first load. The 30-second background refresh and the tab-visibility refresh update departure times silently in place instead of blanking the list twice a minute. (Hytte-qswv)

--- a/web/src/pages/Transit.tsx
+++ b/web/src/pages/Transit.tsx
@@ -92,8 +92,10 @@ export default function Transit() {
         if (err instanceof DOMException && err.name === 'AbortError') return
         setError(t('transit:error'))
       } finally {
-        setLoading(false)
-        isInitialLoad.current = false
+        if (!controller.signal.aborted) {
+          setLoading(false)
+          isInitialLoad.current = false
+        }
       }
     }
 

--- a/web/src/pages/Transit.tsx
+++ b/web/src/pages/Transit.tsx
@@ -70,6 +70,9 @@ export default function Transit() {
   const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const searchAbortRef = useRef<AbortController | null>(null)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Show the loading skeleton only on the very first fetch; subsequent refreshes
+  // (30s interval, tab-visibility, manual) update departures silently in place.
+  const isInitialLoad = useRef(true)
   const [refreshKey, setRefreshKey] = useState(0)
 
   // Initial load + auto-refresh every 30 seconds, paused while the tab is hidden.
@@ -77,7 +80,7 @@ export default function Transit() {
     const controller = new AbortController()
 
     const fetchDepartures = async () => {
-      setLoading(true)
+      if (isInitialLoad.current) setLoading(true)
       try {
         const res = await fetch('/api/transit/departures', { credentials: 'include', signal: controller.signal })
         if (!res.ok) throw new Error(await res.text())
@@ -90,6 +93,7 @@ export default function Transit() {
         setError(t('transit:error'))
       } finally {
         setLoading(false)
+        isInitialLoad.current = false
       }
     }
 


### PR DESCRIPTION
## Changes

- **Transit board no longer flashes skeletons on refresh** - The skeleton placeholders now appear only on the first load. The 30-second background refresh and the tab-visibility refresh update departure times silently in place instead of blanking the list twice a minute. (Hytte-qswv)

## Original Issue (feature): Stop skeleton flash on auto-refresh by tracking initial load separately

### Scope
On the Transit page, `fetchDepartures` calls `setLoading(true)` on every invocation, so the 30-second background refresh and the tab-visibility refresh tear down the rendered departures and replace them with skeleton placeholders, causing a twice-a-minute flash. This plan gates the skeleton to the very first load only, so subsequent refreshes update departure data silently in place. Frontend-only; no API or backend changes.

### Files to touch
- `web/src/pages/Transit.tsx` — gate `setLoading(true)` to the initial load
- `changelog.d/` — add a `Fixed` fragment (new)

### Acceptance criteria
- On first navigation to `/transit`, skeleton placeholders still appear while the initial departures request is in flight.
- After data has loaded once, the 30-second background refresh updates the departure times in place without rendering skeletons or blanking the list.
- The refresh triggered when the tab regains visibility likewise updates silently with no skeleton flash.
- The loading state still resolves to `false` (in `finally`) on every fetch, so a manual/`refreshKey` refresh never leaves a stuck spinner.
- Error handling is unchanged: a failed background refresh surfaces the existing error UI without wiping otherwise-valid on-screen data more than the current behavior does.
- A changelog fragment exists in `changelog.d/` under category `Fixed` referencing the suggestion ID.
- `npm run lint` and `npm run build` pass.

### Non-goals
- No change to the refresh interval, the visibility-change trigger, or the Entur fetch logic itself.
- No backend changes in `internal/transit/handlers.go`.
- No redesign of the skeleton/loading UI or the favorites/settings panels.
- No new tests infrastructure beyond what already exists for this page.
- No broader refactor of the other `useState` flags on the page.

## Source

Created from Suggestions page (suggestion id 177, page slug "transit", source=claude).

## Original suggestion

The fetchDepartures function calls setLoading(true) on every invocation, including the 30-second background refresh and the refresh triggered when the tab becomes visible again. Because loading drives the Skeleton placeholders, the entire departures list gets torn down and replaced with skeletons every 30 seconds even though valid data is already on screen, causing a jarring flash and momentary loss of the current times. The fix is to only show the skeleton on the very first load (e.g. gate setLoading(true) on stops.length === 0 or an isInitialLoad ref) so subsequent refreshes update departures silently in place. Users get a stable, continuously readable board instead of a list that blanks out twice a minute.


---
Bead: Hytte-qswv | Branch: forge/Hytte-qswv
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->