### PR TITLE
Cache /api/skywatch/now and /moon responses with short TTLs (Hytte-u5ps)

### DIFF
--- a/changelog.d/Hytte-u5ps.md
+++ b/changelog.d/Hytte-u5ps.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Cache skywatch responses with short TTLs** - The `/api/skywatch/now` and `/moon` endpoints now serve repeat requests from a small in-memory TTL cache keyed by location and date, avoiding redundant astronomy math, and all three skywatch endpoints emit `Cache-Control: public, max-age=...` headers (300s for now, 3600s for moon, 900s for aurora) for snappier repeat visits. (Hytte-u5ps)

--- a/internal/skywatch/aurora.go
+++ b/internal/skywatch/aurora.go
@@ -91,6 +91,9 @@ func (s *AuroraService) AuroraHandler() http.HandlerFunc {
 			return
 		}
 
+		// Match the existing 15-minute upstream cache so clients don't re-fetch
+		// more often than the data can change.
+		w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(auroraCacheDuration.Seconds())))
 		writeJSON(w, http.StatusOK, forecast)
 	}
 }

--- a/internal/skywatch/cache.go
+++ b/internal/skywatch/cache.go
@@ -49,9 +49,16 @@ func (c *ttlCache) get(key string) ([]byte, bool) {
 	return e.data, true
 }
 
-// set stores data under key with the cache's TTL.
+// set stores data under key with the cache's TTL. It opportunistically drops
+// expired entries so keys that are never read again don't accumulate.
 func (c *ttlCache) set(key string, data []byte) {
+	now := time.Now()
 	c.mu.Lock()
-	c.entries[key] = ttlEntry{data: data, expires: time.Now().Add(c.ttl)}
+	c.entries[key] = ttlEntry{data: data, expires: now.Add(c.ttl)}
+	for k, e := range c.entries {
+		if k != key && now.After(e.expires) {
+			delete(c.entries, k)
+		}
+	}
 	c.mu.Unlock()
 }

--- a/internal/skywatch/cache.go
+++ b/internal/skywatch/cache.go
@@ -1,0 +1,57 @@
+package skywatch
+
+import (
+	"sync"
+	"time"
+)
+
+// ttlCache is a tiny in-memory cache that stores serialized response bytes
+// keyed by a string, expiring entries after a fixed TTL. It is safe for
+// concurrent use. There is no eviction policy beyond TTL expiry — the cache is
+// bounded by the small number of distinct coordinate/date keys in practice.
+type ttlCache struct {
+	mu      sync.RWMutex
+	ttl     time.Duration
+	entries map[string]ttlEntry
+}
+
+type ttlEntry struct {
+	data    []byte
+	expires time.Time
+}
+
+// newTTLCache creates a cache whose entries live for the given TTL.
+func newTTLCache(ttl time.Duration) *ttlCache {
+	return &ttlCache{
+		ttl:     ttl,
+		entries: make(map[string]ttlEntry),
+	}
+}
+
+// get returns the cached bytes for key. The second return value is false if the
+// key is missing or the entry has expired; expired entries are dropped lazily.
+func (c *ttlCache) get(key string) ([]byte, bool) {
+	c.mu.RLock()
+	e, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(e.expires) {
+		c.mu.Lock()
+		// Re-check under the write lock in case another goroutine refreshed it.
+		if cur, ok := c.entries[key]; ok && time.Now().After(cur.expires) {
+			delete(c.entries, key)
+		}
+		c.mu.Unlock()
+		return nil, false
+	}
+	return e.data, true
+}
+
+// set stores data under key with the cache's TTL.
+func (c *ttlCache) set(key string, data []byte) {
+	c.mu.Lock()
+	c.entries[key] = ttlEntry{data: data, expires: time.Now().Add(c.ttl)}
+	c.mu.Unlock()
+}

--- a/internal/skywatch/handlers.go
+++ b/internal/skywatch/handlers.go
@@ -32,6 +32,19 @@ type Location struct {
 	Lon float64 `json:"lon"`
 }
 
+// Response cache TTLs and their matching Cache-Control max-age values.
+const (
+	nowCacheTTL  = 5 * time.Minute
+	moonCacheTTL = time.Hour
+)
+
+var (
+	// nowCache caches NowHandler responses keyed by lat/lon/date.
+	nowCache = newTTLCache(nowCacheTTL)
+	// moonCache caches MoonCalendarHandler responses keyed by lat/lon/days.
+	moonCache = newTTLCache(moonCacheTTL)
+)
+
 // parseCoords extracts lat/lon from query parameters, falling back to defaults.
 // Both lat and lon must be provided together; if only one is given, an error is returned.
 // Latitude must be in [-90, 90] and longitude in [-180, 180].
@@ -75,6 +88,15 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	json.NewEncoder(w).Encode(v)
 }
 
+// writeCachedJSON writes pre-serialized JSON bytes with a matching
+// Cache-Control: public, max-age=<ttl> header.
+func writeCachedJSON(w http.ResponseWriter, data []byte, ttl time.Duration) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(ttl.Seconds())))
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
+}
+
 // NowHandler returns the current moon phase and sun times.
 // GET /api/skywatch/now?lat=...&lon=...&date=YYYY-MM-DD
 // The optional date parameter allows fetching data for a specific date (defaults to today).
@@ -97,6 +119,14 @@ func NowHandler() http.HandlerFunc {
 			t = time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 12, 0, 0, 0, t.Location())
 		}
 
+		// Cache key incorporates all inputs that affect output. The no-date path
+		// resolves to today's date so repeat visits within the TTL are cached too.
+		key := fmt.Sprintf("%v|%v|%s", lat, lon, t.Format("2006-01-02"))
+		if data, ok := nowCache.get(key); ok {
+			writeCachedJSON(w, data, nowCacheTTL)
+			return
+		}
+
 		// Compute planet positions once to avoid redundant rise/set calculations.
 		planets := GetPlanetPositions(t, lat, lon)
 		highlights := GetTonightHighlights(t, lat, lon, planets)
@@ -112,7 +142,14 @@ func NowHandler() http.HandlerFunc {
 			Planets:    planets,
 			Highlights: highlights,
 		}
-		writeJSON(w, http.StatusOK, resp)
+
+		data, err := json.Marshal(resp)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to encode response"})
+			return
+		}
+		nowCache.set(key, data)
+		writeCachedJSON(w, data, nowCacheTTL)
 	}
 }
 
@@ -134,6 +171,15 @@ func MoonCalendarHandler() http.HandlerFunc {
 		}
 
 		now := time.Now()
+
+		// Cache key incorporates all inputs that affect output. The calendar is
+		// anchored on today, so include the date to avoid serving yesterday's run.
+		key := fmt.Sprintf("%v|%v|%d|%s", lat, lon, days, now.Format("2006-01-02"))
+		if data, ok := moonCache.get(key); ok {
+			writeCachedJSON(w, data, moonCacheTTL)
+			return
+		}
+
 		calendar := make([]MoonCalendarDay, days)
 
 		for i := range days {
@@ -149,10 +195,16 @@ func MoonCalendarHandler() http.HandlerFunc {
 			}
 		}
 
-		writeJSON(w, http.StatusOK, map[string]any{
+		data, err := json.Marshal(map[string]any{
 			"location": Location{Lat: lat, Lon: lon},
 			"days":     days,
 			"calendar": calendar,
 		})
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to encode response"})
+			return
+		}
+		moonCache.set(key, data)
+		writeCachedJSON(w, data, moonCacheTTL)
 	}
 }

--- a/internal/skywatch/handlers_test.go
+++ b/internal/skywatch/handlers_test.go
@@ -1,0 +1,234 @@
+package skywatch
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestTTLCacheHit(t *testing.T) {
+	c := newTTLCache(time.Minute)
+	c.set("k", []byte("value"))
+
+	data, ok := c.get("k")
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if string(data) != "value" {
+		t.Errorf("got %q, want %q", data, "value")
+	}
+}
+
+func TestTTLCacheMiss(t *testing.T) {
+	c := newTTLCache(time.Minute)
+	if _, ok := c.get("missing"); ok {
+		t.Error("expected cache miss for unknown key")
+	}
+}
+
+func TestTTLCacheExpiry(t *testing.T) {
+	c := newTTLCache(time.Nanosecond)
+	c.set("k", []byte("value"))
+	// Ensure the TTL has elapsed.
+	time.Sleep(time.Millisecond)
+
+	if _, ok := c.get("k"); ok {
+		t.Error("expected expired entry to be a miss")
+	}
+	// Expired entry should have been dropped lazily.
+	c.mu.RLock()
+	_, present := c.entries["k"]
+	c.mu.RUnlock()
+	if present {
+		t.Error("expected expired entry to be removed on access")
+	}
+}
+
+func TestTTLCacheKeySeparation(t *testing.T) {
+	c := newTTLCache(time.Minute)
+	c.set("a", []byte("A"))
+	c.set("b", []byte("B"))
+
+	if data, _ := c.get("a"); string(data) != "A" {
+		t.Errorf("key a = %q, want A", data)
+	}
+	if data, _ := c.get("b"); string(data) != "B" {
+		t.Errorf("key b = %q, want B", data)
+	}
+}
+
+func nowKey(lat, lon float64, t time.Time) string {
+	return fmt.Sprintf("%v|%v|%s", lat, lon, t.Format("2006-01-02"))
+}
+
+func TestNowHandlerCacheControl(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/skywatch/now?lat=11&lon=22", nil)
+	w := httptest.NewRecorder()
+
+	NowHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := w.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=300")
+	}
+
+	var resp NowResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.Location.Lat != 11 || resp.Location.Lon != 22 {
+		t.Errorf("location = %+v, want {11 22}", resp.Location)
+	}
+}
+
+func TestNowHandlerServesFromCache(t *testing.T) {
+	lat, lon := 31.0, 41.0
+	key := nowKey(lat, lon, time.Now())
+	sentinel := []byte(`{"sentinel":"now"}`)
+	nowCache.set(key, sentinel)
+
+	req := httptest.NewRequest("GET", "/api/skywatch/now?lat=31&lon=41", nil)
+	w := httptest.NewRecorder()
+
+	NowHandler().ServeHTTP(w, req)
+
+	// Receiving the sentinel bytes back proves the handler served from cache
+	// rather than recomputing planet/moon/sun positions.
+	if got := w.Body.String(); got != string(sentinel) {
+		t.Errorf("body = %q, want cached sentinel %q", got, sentinel)
+	}
+	if got := w.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=300")
+	}
+}
+
+func TestNowHandlerKeySeparation(t *testing.T) {
+	// Seed a sentinel for one coordinate; a different coordinate must miss it.
+	seedLat, seedLon := 51.0, 61.0
+	nowCache.set(nowKey(seedLat, seedLon, time.Now()), []byte(`{"sentinel":"seeded"}`))
+
+	req := httptest.NewRequest("GET", "/api/skywatch/now?lat=52&lon=62", nil)
+	w := httptest.NewRecorder()
+
+	NowHandler().ServeHTTP(w, req)
+
+	if w.Body.String() == `{"sentinel":"seeded"}` {
+		t.Error("different coordinates should not return another key's cached entry")
+	}
+	var resp NowResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.Location.Lat != 52 {
+		t.Errorf("location lat = %v, want 52", resp.Location.Lat)
+	}
+}
+
+func TestNowHandlerDefaultCoordsCached(t *testing.T) {
+	// Clear any prior entry for the default-coords key.
+	key := nowKey(DefaultLat, DefaultLon, time.Now())
+	nowCache.mu.Lock()
+	delete(nowCache.entries, key)
+	nowCache.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/skywatch/now", nil)
+	w := httptest.NewRecorder()
+	NowHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if _, ok := nowCache.get(key); !ok {
+		t.Error("default-coords request should populate the cache")
+	}
+}
+
+func TestMoonHandlerCacheControl(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/skywatch/moon?days=10&lat=12&lon=23", nil)
+	w := httptest.NewRecorder()
+
+	MoonCalendarHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := w.Header().Get("Cache-Control"); got != "public, max-age=3600" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=3600")
+	}
+
+	var resp struct {
+		Days     int               `json:"days"`
+		Calendar []MoonCalendarDay `json:"calendar"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.Days != 10 || len(resp.Calendar) != 10 {
+		t.Errorf("days = %d, calendar len = %d, want 10/10", resp.Days, len(resp.Calendar))
+	}
+}
+
+func TestMoonHandlerServesFromCache(t *testing.T) {
+	lat, lon, days := 33.0, 44.0, 7
+	key := fmt.Sprintf("%v|%v|%d|%s", lat, lon, days, time.Now().Format("2006-01-02"))
+	sentinel := []byte(`{"sentinel":"moon"}`)
+	moonCache.set(key, sentinel)
+
+	req := httptest.NewRequest("GET", "/api/skywatch/moon?days=7&lat=33&lon=44", nil)
+	w := httptest.NewRecorder()
+
+	MoonCalendarHandler().ServeHTTP(w, req)
+
+	if got := w.Body.String(); got != string(sentinel) {
+		t.Errorf("body = %q, want cached sentinel %q", got, sentinel)
+	}
+	if got := w.Header().Get("Cache-Control"); got != "public, max-age=3600" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=3600")
+	}
+}
+
+func TestMoonHandlerKeySeparationByDays(t *testing.T) {
+	// Different `days` values must not share a cache entry.
+	lat, lon := 34.0, 45.0
+	moonCache.set(fmt.Sprintf("%v|%v|%d|%s", lat, lon, 5, time.Now().Format("2006-01-02")), []byte(`{"sentinel":"days5"}`))
+
+	req := httptest.NewRequest("GET", "/api/skywatch/moon?days=6&lat=34&lon=45", nil)
+	w := httptest.NewRecorder()
+	MoonCalendarHandler().ServeHTTP(w, req)
+
+	if w.Body.String() == `{"sentinel":"days5"}` {
+		t.Error("different days value should not return another key's cached entry")
+	}
+}
+
+func TestAuroraHandlerCacheControl(t *testing.T) {
+	mockObserved := `[
+		["time_tag", "Kp"],
+		["2026-04-07 12:00:00.000", 1.0]
+	]`
+	mockForecast := `[
+		["time_tag", "Kp"],
+		["2026-04-07 21:00:00.000", 2.0]
+	]`
+
+	svc := NewAuroraService()
+	svc.cache["observed"] = &auroraCached{data: []byte(mockObserved), expires: time.Now().Add(time.Hour)}
+	svc.cache["forecast"] = &auroraCached{data: []byte(mockForecast), expires: time.Now().Add(time.Hour)}
+
+	req := httptest.NewRequest("GET", "/api/skywatch/aurora?lat=60.36&lon=5.24", nil)
+	w := httptest.NewRecorder()
+
+	svc.AuroraHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := w.Header().Get("Cache-Control"); got != "public, max-age=900" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=900")
+	}
+}

--- a/internal/skywatch/handlers_test.go
+++ b/internal/skywatch/handlers_test.go
@@ -88,17 +88,16 @@ func TestNowHandlerCacheControl(t *testing.T) {
 
 func TestNowHandlerServesFromCache(t *testing.T) {
 	lat, lon := 31.0, 41.0
-	key := nowKey(lat, lon, time.Now())
+	date := "2026-01-15"
+	key := fmt.Sprintf("%v|%v|%s", lat, lon, date)
 	sentinel := []byte(`{"sentinel":"now"}`)
 	nowCache.set(key, sentinel)
 
-	req := httptest.NewRequest("GET", "/api/skywatch/now?lat=31&lon=41", nil)
+	req := httptest.NewRequest("GET", "/api/skywatch/now?lat=31&lon=41&date="+date, nil)
 	w := httptest.NewRecorder()
 
 	NowHandler().ServeHTTP(w, req)
 
-	// Receiving the sentinel bytes back proves the handler served from cache
-	// rather than recomputing planet/moon/sun positions.
 	if got := w.Body.String(); got != string(sentinel) {
 		t.Errorf("body = %q, want cached sentinel %q", got, sentinel)
 	}
@@ -130,13 +129,13 @@ func TestNowHandlerKeySeparation(t *testing.T) {
 }
 
 func TestNowHandlerDefaultCoordsCached(t *testing.T) {
-	// Clear any prior entry for the default-coords key.
-	key := nowKey(DefaultLat, DefaultLon, time.Now())
+	date := "2026-01-15"
+	key := fmt.Sprintf("%v|%v|%s", DefaultLat, DefaultLon, date)
 	nowCache.mu.Lock()
 	delete(nowCache.entries, key)
 	nowCache.mu.Unlock()
 
-	req := httptest.NewRequest("GET", "/api/skywatch/now", nil)
+	req := httptest.NewRequest("GET", "/api/skywatch/now?date="+date, nil)
 	w := httptest.NewRecorder()
 	NowHandler().ServeHTTP(w, req)
 
@@ -175,19 +174,35 @@ func TestMoonHandlerCacheControl(t *testing.T) {
 
 func TestMoonHandlerServesFromCache(t *testing.T) {
 	lat, lon, days := 33.0, 44.0, 7
-	key := fmt.Sprintf("%v|%v|%d|%s", lat, lon, days, time.Now().Format("2006-01-02"))
+
+	// Call the handler once to discover the date it uses internally,
+	// avoiding a flaky mismatch if the test runs across midnight.
+	req1 := httptest.NewRequest("GET", "/api/skywatch/moon?days=7&lat=33&lon=44", nil)
+	w1 := httptest.NewRecorder()
+	MoonCalendarHandler().ServeHTTP(w1, req1)
+
+	var first struct {
+		Calendar []struct {
+			Date string `json:"date"`
+		} `json:"calendar"`
+	}
+	if err := json.NewDecoder(w1.Body).Decode(&first); err != nil {
+		t.Fatalf("decode first response: %v", err)
+	}
+	date := first.Calendar[0].Date
+
+	key := fmt.Sprintf("%v|%v|%d|%s", lat, lon, days, date)
 	sentinel := []byte(`{"sentinel":"moon"}`)
 	moonCache.set(key, sentinel)
 
-	req := httptest.NewRequest("GET", "/api/skywatch/moon?days=7&lat=33&lon=44", nil)
-	w := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "/api/skywatch/moon?days=7&lat=33&lon=44", nil)
+	w2 := httptest.NewRecorder()
+	MoonCalendarHandler().ServeHTTP(w2, req2)
 
-	MoonCalendarHandler().ServeHTTP(w, req)
-
-	if got := w.Body.String(); got != string(sentinel) {
+	if got := w2.Body.String(); got != string(sentinel) {
 		t.Errorf("body = %q, want cached sentinel %q", got, sentinel)
 	}
-	if got := w.Header().Get("Cache-Control"); got != "public, max-age=3600" {
+	if got := w2.Header().Get("Cache-Control"); got != "public, max-age=3600" {
 		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=3600")
 	}
 }


### PR DESCRIPTION
## Changes

- **Cache skywatch responses with short TTLs** - The `/api/skywatch/now` and `/moon` endpoints now serve repeat requests from a small in-memory TTL cache keyed by location and date, avoiding redundant astronomy math, and all three skywatch endpoints emit `Cache-Control: public, max-age=...` headers (300s for now, 3600s for moon, 900s for aurora) for snappier repeat visits. (Hytte-u5ps)

## Original Issue (feature): Cache /api/skywatch/now and /moon responses with short TTLs

### Scope
Add lightweight in-memory TTL caches to the two skywatch handlers that currently recompute every request (`/now`, `/moon`), keyed by their inputs, and emit matching `Cache-Control: public, max-age=…` response headers on all three skywatch endpoints. The aurora service already has a 15-minute in-memory cache (with singleflight); this plan leaves its internal caching as-is and only adds the response header for it. The goal is less repeated CPU on the astronomy math and a snappier page on repeat visits, with no behavior change to the returned payloads.

### Files to touch
- `internal/skywatch/handlers.go` — wrap `NowHandler` and `MoonCalendarHandler` results in a small TTL cache keyed by request inputs; set `Cache-Control` on both.
- `internal/skywatch/aurora.go` — set a `Cache-Control` header on `AuroraHandler` responses matching the existing 15-minute cache duration.
- `internal/skywatch/cache.go` (new) — tiny generic/`map`-based TTL cache helper with `sync.RWMutex`, storing serialized JSON keyed by a string; or place the helper inline in `handlers.go` if simpler.
- `internal/skywatch/handlers_test.go` (new or existing test file) — tests for cache hit/expiry and header presence.

### Acceptance criteria
- `GET /api/skywatch/now` returns identical JSON to today and includes `Cache-Control: public, max-age=300` (≈5 min, or chosen value in minutes).
- `GET /api/skywatch/moon` returns identical JSON and includes `Cache-Control: public, max-age=3600` (1 hour).
- `GET /api/skywatch/aurora` responses carry `Cache-Control: public, max-age=900` (15 min, matching `auroraCacheDuration`).
- A second `/now` (or `/moon`) request with the same `lat`/`lon`/`date`(/`days`) inputs within the TTL is served from cache without recomputing planet/moon/sun positions; different inputs miss the cache and recompute.
- Cache keys incorporate all inputs that affect output (`lat`, `lon`, `date` for `/now`; `lat`, `lon`, `days` for `/moon`); the default-coords path is cached too.
- Entries expire after their TTL and are recomputed; stale entries do not leak across differing keys.
- Tests cover cache hit, expiry/miss, key separation, and `Cache-Control` header values. `go test ./internal/skywatch/...`, `go build`, and `go vet` pass.
- A changelog fragment is added under `changelog.d/`.

### Non-goals
- No persistent/disk/Redis cache, no cross-process sharing — in-memory per server process only.
- No changes to the aurora service's existing internal cache, singleflight, or stale-fallback logic beyond adding the response header.
- No ETag/conditional-request (`If-None-Match`/304) support.
- No cache size eviction/LRU policy or metrics; bounded only by the small number of distinct coordinate/date keys.
- No frontend changes to `SkyWatchPage.tsx` and no change to response payload shapes.
- No configurable/env-tunable TTLs (constants are sufficient for this size).

## Source

Created from Suggestions page (suggestion id 81, page slug "skywatch", source=claude).

## Original suggestion

Moon phase, sun times, and planet positions only meaningfully change on the order of minutes to hours, but every page visit recomputes them from scratch and the aurora Kp feed is hit on every reload. Add an in-memory TTL cache keyed by (lat, lon, date) — a few minutes for `/now`, an hour for `/moon`, and ~10 minutes for the aurora fetch — and set a matching `Cache-Control: public, max-age=...` header. This cuts CPU on the server, makes the page snappier on repeat visits, and reduces load on the upstream NOAA aurora endpoint.


---
Bead: Hytte-u5ps | Branch: forge/Hytte-u5ps
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->