### PR TITLE
Cancel in-flight Stars dashboard fetches on unmount (Hytte-2nzl)

### DIFF
--- a/changelog.d/Hytte-2nzl.md
+++ b/changelog.d/Hytte-2nzl.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Cancel in-flight Stars journey fetch on unmount** - The Stars dashboard journey card now aborts its `/api/stars/journey` request when navigating away before it resolves, preventing state updates and spurious error UI on an unmounted component. (Hytte-2nzl)

--- a/web/src/pages/Stars.tsx
+++ b/web/src/pages/Stars.tsx
@@ -156,14 +156,37 @@ function JourneyCard() {
   const [journeyError, setJourneyError] = useState<string | null>(null)
 
   useEffect(() => {
-    fetch('/api/stars/journey', { credentials: 'include' })
-      .then(res => {
+    const controller = new AbortController()
+
+    const fetchJourney = async () => {
+      try {
+        const res = await fetch('/api/stars/journey', {
+          credentials: 'include',
+          signal: controller.signal,
+        })
         if (!res.ok) throw new Error('fetch failed')
-        return res.json()
-      })
-      .then(data => setJourney(data))
-      .catch(() => setJourneyError(t('stars.journey.failedToLoad')))
-      .finally(() => setJourneyLoading(false))
+        const data: JourneyResponse = await res.json()
+        setJourney(data)
+      } catch (err: unknown) {
+        if (controller.signal.aborted) {
+          return
+        }
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          return
+        }
+        setJourneyError(t('stars.journey.failedToLoad'))
+      } finally {
+        if (!controller.signal.aborted) {
+          setJourneyLoading(false)
+        }
+      }
+    }
+
+    fetchJourney()
+
+    return () => {
+      controller.abort()
+    }
   }, [t])
 
   const handleThemeChange = async (themeKey: string) => {

--- a/web/src/pages/Stars.tsx
+++ b/web/src/pages/Stars.tsx
@@ -166,6 +166,7 @@ function JourneyCard() {
         })
         if (!res.ok) throw new Error('fetch failed')
         const data: JourneyResponse = await res.json()
+        if (controller.signal.aborted) return
         setJourney(data)
       } catch (err: unknown) {
         if (controller.signal.aborted) {


### PR DESCRIPTION
## Changes

- **Cancel in-flight Stars journey fetch on unmount** - The Stars dashboard journey card now aborts its `/api/stars/journey` request when navigating away before it resolves, preventing state updates and spurious error UI on an unmounted component. (Hytte-2nzl)

## Original Issue (feature): Cancel in-flight Stars dashboard fetches on unmount

### Scope
`JourneyCard` inside `web/src/pages/Stars.tsx` fetches `/api/stars/journey` in a `useEffect` with no cleanup, so `setJourney`/`setJourneyError`/`setJourneyLoading` can fire after unmount. This plan wires an `AbortController` into that effect and guards the `catch`/`finally` branches against abort, matching the established pattern in `StarBadges.tsx` (and the `cancelled`-flag variant in the sibling `StarBankCard`). Scope is the single `JourneyCard` fetch effect; no API or behavior changes.

### Files to touch
- `web/src/pages/Stars.tsx` — add an `AbortController` to the `JourneyCard` journey-fetch `useEffect`; pass `signal` to `fetch`; skip state setters when aborted; return a cleanup that calls `controller.abort()`.
- `changelog.d/` — add a fragment (new) under category `Fixed` referencing the bead ID.

### Acceptance criteria
- The `JourneyCard` effect creates an `AbortController`, passes `signal` to the `/api/stars/journey` `fetch`, and returns a cleanup function that calls `controller.abort()`.
- When the fetch is aborted (navigating away from `/stars` before it resolves), no `setJourney`/`setJourneyError`/`setJourneyLoading` call runs — abort is detected in the `catch`/`finally` branches (e.g. checking `controller.signal.aborted` and/or `AbortError`).
- Aborting does NOT set `journeyError` (no spurious error UI on unmount); a genuine non-abort failure still sets `journeyError` as before.
- Successful and error rendering of the journey card on a mounted component is unchanged.
- The `handleThemeChange` flow (separate PUT) continues to work and is unaffected.
- `npm run lint` and `npm run build` pass; `go build`/`go test` remain green.
- A `changelog.d/` fragment exists under `Fixed` with the bead ID.

### Non-goals
- No changes to `BingoCard`, `StarBankCard`, or any other component's fetch logic (the suggestion scopes only to `JourneyCard`; `StarBankCard` already guards with a `cancelled` flag).
- No changes to `internal/stars/handlers.go` or any backend/API behavior.
- No refactor to a shared fetch hook or to the other Star pages (`StarBadges`, `StarChallenges`, `StarLeaderboard`, `StarRewards`).
- No new tests beyond what lint/build/CI require, and no UI/copy/i18n changes.

## Source

Created from Suggestions page (suggestion id 83, page slug "stars", source=claude).

## Original suggestion

Stars.tsx's JourneyCard fetches `/api/stars/journey` in a useEffect without an AbortController, unlike the sibling pages (StarBadges, StarChallenges, StarLeaderboard) which all abort on unmount. If the user navigates away from /stars before the request resolves, `setJourney`/`setJourneyError`/`setJourneyLoading` fire on an unmounted component, producing React warnings and wasted work. Wire up an AbortController in the effect (and check for it in the catch/finally branches) so the page matches the established pattern across the Stars module.


---
Bead: Hytte-2nzl | Branch: forge/Hytte-2nzl
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->