### PR TITLE
Use requested date when building moon calendar instead of always today (Hytte-d3qy)

### DIFF
--- a/changelog.d/Hytte-d3qy.md
+++ b/changelog.d/Hytte-d3qy.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Moon calendar honors the requested date** - The `/api/skywatch/moon` endpoint now accepts an optional `date=YYYY-MM-DD` query parameter and seeds the calendar from that day instead of always starting today, mirroring the `now` endpoint and keeping the two consistent. (Hytte-d3qy)

--- a/internal/skywatch/handlers.go
+++ b/internal/skywatch/handlers.go
@@ -154,7 +154,8 @@ func NowHandler() http.HandlerFunc {
 }
 
 // MoonCalendarHandler returns a moon phase calendar for the given number of days.
-// GET /api/skywatch/moon?days=30&lat=...&lon=...
+// GET /api/skywatch/moon?days=30&lat=...&lon=...&date=YYYY-MM-DD
+// The optional date parameter sets the first day of the calendar (defaults to today).
 func MoonCalendarHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		lat, lon, err := parseCoords(r)
@@ -170,11 +171,20 @@ func MoonCalendarHandler() http.HandlerFunc {
 			}
 		}
 
-		now := time.Now()
+		start := time.Now()
+		if dateStr := r.URL.Query().Get("date"); dateStr != "" {
+			parsed, err := time.ParseInLocation("2006-01-02", dateStr, start.Location())
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid date format, expected YYYY-MM-DD"})
+				return
+			}
+			// Use noon of the requested date for consistent calculations.
+			start = time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 12, 0, 0, 0, start.Location())
+		}
 
 		// Cache key incorporates all inputs that affect output. The calendar is
-		// anchored on today, so include the date to avoid serving yesterday's run.
-		key := fmt.Sprintf("%v|%v|%d|%s", lat, lon, days, now.Format("2006-01-02"))
+		// anchored on the start day, so include the date to avoid serving a stale run.
+		key := fmt.Sprintf("%v|%v|%d|%s", lat, lon, days, start.Format("2006-01-02"))
 		if data, ok := moonCache.get(key); ok {
 			writeCachedJSON(w, data, moonCacheTTL)
 			return
@@ -183,7 +193,7 @@ func MoonCalendarHandler() http.HandlerFunc {
 		calendar := make([]MoonCalendarDay, days)
 
 		for i := range days {
-			date := now.AddDate(0, 0, i)
+			date := start.AddDate(0, 0, i)
 			// Use noon for consistent daily calculations.
 			noon := time.Date(date.Year(), date.Month(), date.Day(), 12, 0, 0, 0, date.Location())
 			illum := GetMoonPhase(noon, lat, lon)

--- a/internal/skywatch/handlers_test.go
+++ b/internal/skywatch/handlers_test.go
@@ -221,6 +221,80 @@ func TestMoonHandlerKeySeparationByDays(t *testing.T) {
 	}
 }
 
+func TestMoonHandlerDefaultDateStartsToday(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/skywatch/moon?days=3&lat=15&lon=25", nil)
+	w := httptest.NewRecorder()
+	MoonCalendarHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Calendar []MoonCalendarDay `json:"calendar"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(resp.Calendar) == 0 {
+		t.Fatal("expected non-empty calendar")
+	}
+	want := time.Now().Format("2006-01-02")
+	if resp.Calendar[0].Date != want {
+		t.Errorf("first date = %q, want today %q", resp.Calendar[0].Date, want)
+	}
+}
+
+func TestMoonHandlerHonorsDateParam(t *testing.T) {
+	const date = "2026-03-10"
+	req := httptest.NewRequest("GET", "/api/skywatch/moon?days=5&lat=16&lon=26&date="+date, nil)
+	w := httptest.NewRecorder()
+	MoonCalendarHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp struct {
+		Days     int               `json:"days"`
+		Calendar []MoonCalendarDay `json:"calendar"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.Days != 5 || len(resp.Calendar) != 5 {
+		t.Fatalf("days = %d, calendar len = %d, want 5/5", resp.Days, len(resp.Calendar))
+	}
+	if resp.Calendar[0].Date != date {
+		t.Errorf("first date = %q, want %q", resp.Calendar[0].Date, date)
+	}
+	// Subsequent entries increment by one day from the requested date.
+	start := time.Date(2026, 3, 10, 12, 0, 0, 0, time.Now().Location())
+	for i, day := range resp.Calendar {
+		want := start.AddDate(0, 0, i).Format("2006-01-02")
+		if day.Date != want {
+			t.Errorf("calendar[%d].Date = %q, want %q", i, day.Date, want)
+		}
+	}
+}
+
+func TestMoonHandlerInvalidDate(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/skywatch/moon?date=2026-13-99&lat=17&lon=27", nil)
+	w := httptest.NewRecorder()
+	MoonCalendarHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp["error"] != "invalid date format, expected YYYY-MM-DD" {
+		t.Errorf("error = %q, want %q", resp["error"], "invalid date format, expected YYYY-MM-DD")
+	}
+}
+
 func TestAuroraHandlerCacheControl(t *testing.T) {
 	mockObserved := `[
 		["time_tag", "Kp"],

--- a/internal/skywatch/handlers_test.go
+++ b/internal/skywatch/handlers_test.go
@@ -222,9 +222,11 @@ func TestMoonHandlerKeySeparationByDays(t *testing.T) {
 }
 
 func TestMoonHandlerDefaultDateStartsToday(t *testing.T) {
+	before := time.Now().Format("2006-01-02")
 	req := httptest.NewRequest("GET", "/api/skywatch/moon?days=3&lat=15&lon=25", nil)
 	w := httptest.NewRecorder()
 	MoonCalendarHandler().ServeHTTP(w, req)
+	after := time.Now().Format("2006-01-02")
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
@@ -239,9 +241,9 @@ func TestMoonHandlerDefaultDateStartsToday(t *testing.T) {
 	if len(resp.Calendar) == 0 {
 		t.Fatal("expected non-empty calendar")
 	}
-	want := time.Now().Format("2006-01-02")
-	if resp.Calendar[0].Date != want {
-		t.Errorf("first date = %q, want today %q", resp.Calendar[0].Date, want)
+	got := resp.Calendar[0].Date
+	if got != before && got != after {
+		t.Errorf("first date = %q, want today (%q or %q)", got, before, after)
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Moon calendar honors the requested date** - The `/api/skywatch/moon` endpoint now accepts an optional `date=YYYY-MM-DD` query parameter and seeds the calendar from that day instead of always starting today, mirroring the `now` endpoint and keeping the two consistent. (Hytte-d3qy)

## Original Issue (feature): Use requested date when building moon calendar instead of always today

### Scope
`MoonCalendarHandler` in `internal/skywatch/handlers.go` always seeds its loop from `time.Now()`, ignoring any `date` query parameter even though the sibling `NowHandler` (same file) accepts `date=YYYY-MM-DD`. This plan adds an optional `date` parameter to the moon-calendar endpoint, validated identically to `NowHandler`, so the calendar can start from any requested day and stays consistent with the "now" endpoint. This is a small, backend-only change.

### Files to touch
- `internal/skywatch/handlers.go` — accept and validate the optional `date` param in `MoonCalendarHandler`, seed the loop from it.
- `internal/skywatch/handlers_test.go` (new, or existing skywatch test file) — cover default, valid `date`, and invalid `date` cases.
- `changelog.d/<id>-moon-calendar-date.md` (new) — `Fixed` fragment.

### Acceptance criteria
- `GET /api/skywatch/moon` with no `date` behaves exactly as today (calendar starts from the current day).
- `GET /api/skywatch/moon?date=YYYY-MM-DD` returns a calendar whose first entry's `date` equals the requested date, and subsequent entries increment by one day for `days` total.
- The `date` value is parsed with `time.ParseInLocation("2006-01-02", ...)` in the same location as `time.Now()`, mirroring `NowHandler` (noon-of-day used for phase calculations).
- An invalid `date` returns `400` with JSON `{"error":"invalid date format, expected YYYY-MM-DD"}`, identical to `NowHandler`.
- The `days` parameter continues to work and combines correctly with `date`.
- Handler doc comment updates the example URL to include the optional `date` param.
- `go build`, `go vet`, and `go test ./internal/skywatch/...` pass.

### Non-goals
- No frontend changes to `SkyWatchPage.tsx` (wiring a date scroller into the UI is separate work).
- No change to `NowHandler`, the response shape, or moon-phase math.
- No new route, no date-range/end-date parameter, no timezone parameter beyond the existing server-local behavior.
- No i18n changes (backend error strings are not localized here, consistent with `NowHandler`).

## Source

Created from Suggestions page (suggestion id 80, page slug "skywatch", source=claude).

## Original suggestion

MoonCalendarHandler ignores the `date` query parameter and always starts the calendar from `time.Now()`, even though NowHandler accepts a `date` param. This means the frontend cannot scroll a calendar starting from any other day, and the moon icons in the calendar can drift out of sync with the highlighted 'now' date if the UI ever offsets the view. Accept an optional `date=YYYY-MM-DD` (mirroring NowHandler), validate it the same way, and seed the loop from that date so the two endpoints stay consistent.


---
Bead: Hytte-d3qy | Branch: forge/Hytte-d3qy
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->