### PR TITLE
Fix daily forecast iteration order so days render chronologically (Hytte-lmqj)

### DIFF
--- a/changelog.d/Hytte-lmqj.md
+++ b/changelog.d/Hytte-lmqj.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Weather forecast day ordering and midday icons** - The multi-day forecast now sorts days chronologically by local calendar date (robust to out-of-order or DST-straddling timeseries) and picks each day's icon from the hour closest to local noon, so a rainy afternoon no longer shows a "clear night" summary. (Hytte-lmqj)

--- a/web/src/lib/weatherForecast.ts
+++ b/web/src/lib/weatherForecast.ts
@@ -1,0 +1,124 @@
+import { formatDate } from '../utils/formatDate'
+
+export interface TimeseriesEntry {
+  time: string
+  data: {
+    instant: {
+      details: {
+        air_temperature: number
+        wind_speed: number
+        relative_humidity: number
+        air_pressure_at_sea_level?: number
+        wind_from_direction?: number
+      }
+    }
+    next_1_hours?: {
+      summary: { symbol_code: string }
+      details: { precipitation_amount: number }
+    }
+    next_6_hours?: {
+      summary: { symbol_code: string }
+      details: { precipitation_amount: number }
+    }
+    next_12_hours?: {
+      summary: { symbol_code: string }
+    }
+  }
+}
+
+export interface DayForecast {
+  date: string
+  dayName: string
+  symbolCode: string
+  tempMin: number
+  tempMax: number
+  precipitation: number
+  windSpeed: number
+}
+
+interface DaySymbolEntry {
+  date: Date
+  symbol: string
+}
+
+function localDateKey(dt: Date): string {
+  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`
+}
+
+function minutesSinceMidnight(dt: Date): number {
+  return dt.getHours() * 60 + dt.getMinutes()
+}
+
+function pickMiddaySymbol(entries: DaySymbolEntry[]): string {
+  if (entries.length === 0) return 'cloudy'
+
+  let best = entries[0]
+  let bestDistance = Math.abs(minutesSinceMidnight(best.date) - 720)
+
+  for (const entry of entries.slice(1)) {
+    const distance = Math.abs(minutesSinceMidnight(entry.date) - 720)
+    if (distance < bestDistance || (distance === bestDistance && entry.date.getTime() < best.date.getTime())) {
+      best = entry
+      bestDistance = distance
+    }
+  }
+
+  return best.symbol
+}
+
+export function buildDailyForecasts(timeseries: TimeseriesEntry[], todayLabel: string): DayForecast[] {
+  const dayMap = new Map<string, {
+    temps: number[]
+    winds: number[]
+    precip: number
+    symbolEntries: DaySymbolEntry[]
+    date: Date
+  }>()
+
+  for (const entry of timeseries) {
+    const dt = new Date(entry.time)
+    const dateKey = localDateKey(dt)
+
+    if (!dayMap.has(dateKey)) {
+      dayMap.set(dateKey, { temps: [], winds: [], precip: 0, symbolEntries: [], date: dt })
+    }
+    const day = dayMap.get(dateKey)!
+
+    day.temps.push(entry.data.instant.details.air_temperature)
+    day.winds.push(entry.data.instant.details.wind_speed)
+
+    const symbol =
+      entry.data.next_1_hours?.summary.symbol_code ||
+      entry.data.next_6_hours?.summary.symbol_code ||
+      entry.data.next_12_hours?.summary.symbol_code
+
+    if (symbol) day.symbolEntries.push({ date: dt, symbol })
+
+    const precip =
+      entry.data.next_1_hours?.details.precipitation_amount ??
+      entry.data.next_6_hours?.details.precipitation_amount ??
+      0
+    day.precip += precip
+  }
+
+  const today = localDateKey(new Date())
+
+  const sortedDays = [...dayMap.entries()].sort(([a], [b]) => a.localeCompare(b))
+
+  return sortedDays.slice(0, 7).map(([dateKey, data]) => {
+    const dayName =
+      dateKey === today
+        ? todayLabel
+        : formatDate(data.date, { weekday: 'short' })
+
+    return {
+      date: dateKey,
+      dayName,
+      symbolCode: pickMiddaySymbol(data.symbolEntries),
+      tempMin: Math.round(Math.min(...data.temps)),
+      tempMax: Math.round(Math.max(...data.temps)),
+      precipitation: Math.round(data.precip * 10) / 10,
+      windSpeed: Math.round(data.winds.reduce((a, b) => a + b, 0) / data.winds.length * 10) / 10,
+    }
+  })
+}

--- a/web/src/pages/Weather.test.tsx
+++ b/web/src/pages/Weather.test.tsx
@@ -104,6 +104,27 @@ describe('buildDailyForecasts', () => {
     expect(days[0].symbolCode).toBe('cloudy')
   })
 
+  it('parses production RFC3339 Z timestamps and groups by local calendar date', () => {
+    // yr.no returns UTC timestamps with trailing Z. Verify that parsing
+    // and local-calendar grouping work with the production format.
+    const series = [
+      entry('2026-07-15T12:00:00Z', 'rain'),
+      entry('2026-07-13T12:00:00Z', 'cloudy'),
+      entry('2026-07-13T09:00:00Z', 'clearsky_day'),
+      entry('2026-07-14T11:00:00Z', 'fair_day'),
+    ]
+
+    const days = buildDailyForecasts(series, 'Today')
+
+    // Three UTC days may become 3 or 4 local days depending on timezone offset
+    expect(days.length).toBeGreaterThanOrEqual(3)
+    expect(days.length).toBeLessThanOrEqual(4)
+    // Must be chronologically sorted regardless of input order
+    for (let i = 1; i < days.length; i++) {
+      expect(days[i].date > days[i - 1].date).toBe(true)
+    }
+  })
+
   it('caps the result at the first 7 chronological days', () => {
     const series = Array.from({ length: 10 }, (_, i) =>
       entry(`2026-06-${String(20 - i).padStart(2, '0')}T12:00:00`, 'cloudy'),

--- a/web/src/pages/Weather.test.tsx
+++ b/web/src/pages/Weather.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest'
-import { buildDailyForecasts, type TimeseriesEntry } from './Weather'
+import { buildDailyForecasts, type TimeseriesEntry } from '../lib/weatherForecast'
 
 /**
  * Build a minimal timeseries entry. `time` is parsed with `new Date(time)`; using

--- a/web/src/pages/Weather.test.tsx
+++ b/web/src/pages/Weather.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import { buildDailyForecasts, type TimeseriesEntry } from './Weather'
+
+/**
+ * Build a minimal timeseries entry. `time` is parsed with `new Date(time)`; using
+ * naive local-time strings (no trailing `Z`/offset) keeps the local wall-clock hour
+ * and calendar date deterministic regardless of the machine's timezone.
+ */
+function entry(
+  time: string,
+  symbol?: string,
+  { temp = 10, wind = 2, precip = 0 }: { temp?: number; wind?: number; precip?: number } = {},
+): TimeseriesEntry {
+  return {
+    time,
+    data: {
+      instant: {
+        details: { air_temperature: temp, wind_speed: wind, relative_humidity: 50 },
+      },
+      ...(symbol
+        ? { next_1_hours: { summary: { symbol_code: symbol }, details: { precipitation_amount: precip } } }
+        : {}),
+    },
+  }
+}
+
+describe('buildDailyForecasts', () => {
+  it('renders days in ascending date order regardless of entry order', () => {
+    const series = [
+      entry('2026-06-12T12:00:00', 'rain'),
+      entry('2026-06-10T12:00:00', 'cloudy'),
+      entry('2026-06-11T12:00:00', 'fair_day'),
+    ]
+
+    const days = buildDailyForecasts(series, 'Today')
+
+    expect(days.map((d) => d.date)).toEqual(['2026-06-10', '2026-06-11', '2026-06-12'])
+  })
+
+  it('picks the symbol closest to 12:00 local time', () => {
+    const series = [
+      entry('2026-06-10T06:00:00', 'clearsky_day'),
+      entry('2026-06-10T11:00:00', 'cloudy'),
+      entry('2026-06-10T12:30:00', 'rain'), // closest to noon (750 vs 720)
+      entry('2026-06-10T18:00:00', 'clearsky_night'),
+    ]
+
+    const days = buildDailyForecasts(series, 'Today')
+
+    expect(days).toHaveLength(1)
+    expect(days[0].symbolCode).toBe('rain')
+  })
+
+  it('breaks midday ties deterministically toward the earliest timestamp', () => {
+    // 13:00 and 11:00 are equidistant from noon (60 min). Earliest (11:00) wins,
+    // even though the later entry appears first in the input.
+    const series = [
+      entry('2026-06-10T13:00:00', 'later'),
+      entry('2026-06-10T11:00:00', 'earlier'),
+    ]
+
+    const days = buildDailyForecasts(series, 'Today')
+
+    expect(days[0].symbolCode).toBe('earlier')
+  })
+
+  it('uses a near/after-noon remaining hour when only afternoon data is left', () => {
+    // Mimics the current day late in the afternoon: no morning/midnight entries remain.
+    const series = [
+      entry('2026-06-10T15:00:00', 'rain'), // closest remaining to noon
+      entry('2026-06-10T18:00:00', 'cloudy'),
+      entry('2026-06-10T21:00:00', 'clearsky_night'),
+    ]
+
+    const days = buildDailyForecasts(series, 'Today')
+
+    expect(days[0].symbolCode).toBe('rain')
+    expect(days[0].symbolCode).not.toBe('clearsky_night')
+  })
+
+  it('groups DST-straddling hours under the correct local calendar date and orders them', () => {
+    // 2026-03-29 is the European spring-forward date (02:00 -> 03:00). All hours on
+    // that wall-clock day must group under 2026-03-29 and stay ordered after the prior day.
+    const series = [
+      entry('2026-03-29T13:00:00', 'fair_day'),
+      entry('2026-03-28T13:00:00', 'cloudy'),
+      entry('2026-03-29T01:30:00', 'partlycloudy_night'),
+      entry('2026-03-29T03:30:00', 'rain'),
+    ]
+
+    const days = buildDailyForecasts(series, 'Today')
+
+    expect(days.map((d) => d.date)).toEqual(['2026-03-28', '2026-03-29'])
+    // 13:00 is closest to noon on the 29th.
+    expect(days[1].symbolCode).toBe('fair_day')
+  })
+
+  it('falls back to "cloudy" when a day has no usable symbol', () => {
+    const series = [entry('2026-06-10T12:00:00', undefined)]
+
+    const days = buildDailyForecasts(series, 'Today')
+
+    expect(days[0].symbolCode).toBe('cloudy')
+  })
+
+  it('caps the result at the first 7 chronological days', () => {
+    const series = Array.from({ length: 10 }, (_, i) =>
+      entry(`2026-06-${String(20 - i).padStart(2, '0')}T12:00:00`, 'cloudy'),
+    )
+
+    const days = buildDailyForecasts(series, 'Today')
+
+    expect(days).toHaveLength(7)
+    expect(days.map((d) => d.date)).toEqual([
+      '2026-06-11',
+      '2026-06-12',
+      '2026-06-13',
+      '2026-06-14',
+      '2026-06-15',
+      '2026-06-16',
+      '2026-06-17',
+    ])
+  })
+})

--- a/web/src/pages/Weather.tsx
+++ b/web/src/pages/Weather.tsx
@@ -28,7 +28,7 @@ import {
 } from 'lucide-react'
 
 
-interface TimeseriesEntry {
+export interface TimeseriesEntry {
   time: string
   data: {
     instant: {
@@ -161,21 +161,36 @@ function windArrowRotation(windFromDirection: number): number {
   return (windFromDirection + 180) % 360
 }
 
-function buildDailyForecasts(timeseries: TimeseriesEntry[], todayLabel: string): DayForecast[] {
+/** Format a Date as a local YYYY-MM-DD calendar key (not UTC, so DST-straddling hours stay on the right day). */
+function localDateKey(dt: Date): string {
+  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`
+}
+
+/** Minutes since local midnight for the given Date. */
+function minutesSinceMidnight(dt: Date): number {
+  return dt.getHours() * 60 + dt.getMinutes()
+}
+
+interface DaySymbolEntry {
+  date: Date
+  symbol: string
+}
+
+export function buildDailyForecasts(timeseries: TimeseriesEntry[], todayLabel: string): DayForecast[] {
   const dayMap = new Map<string, {
     temps: number[]
     winds: number[]
     precip: number
-    symbols: string[]
+    symbolEntries: DaySymbolEntry[]
     date: Date
   }>()
 
   for (const entry of timeseries) {
     const dt = new Date(entry.time)
-    const dateKey = `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`
+    const dateKey = localDateKey(dt)
 
     if (!dayMap.has(dateKey)) {
-      dayMap.set(dateKey, { temps: [], winds: [], precip: 0, symbols: [], date: dt })
+      dayMap.set(dateKey, { temps: [], winds: [], precip: 0, symbolEntries: [], date: dt })
     }
     const day = dayMap.get(dateKey)!
 
@@ -187,7 +202,7 @@ function buildDailyForecasts(timeseries: TimeseriesEntry[], todayLabel: string):
       entry.data.next_6_hours?.summary.symbol_code ||
       entry.data.next_12_hours?.summary.symbol_code
 
-    if (symbol) day.symbols.push(symbol)
+    if (symbol) day.symbolEntries.push({ date: dt, symbol })
 
     const precip =
       entry.data.next_1_hours?.details.precipitation_amount ??
@@ -196,33 +211,51 @@ function buildDailyForecasts(timeseries: TimeseriesEntry[], todayLabel: string):
     day.precip += precip
   }
 
-  const days: DayForecast[] = []
-  const now = new Date()
-  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
-  let count = 0
+  const today = localDateKey(new Date())
 
-  for (const [dateKey, data] of dayMap) {
-    if (count >= 7) break
+  // Sort by parsed local calendar date so days always render chronologically,
+  // regardless of timeseries entry order or DST boundaries.
+  const sortedDays = [...dayMap.entries()].sort(([a], [b]) => a.localeCompare(b))
+
+  return sortedDays.slice(0, 7).map(([dateKey, data]) => {
     const dayName =
       dateKey === today
         ? todayLabel
         : formatDate(data.date, { weekday: 'short' })
-    // Approximate a midday symbol: use the 4th entry if available, otherwise the last, or 'cloudy' if none.
-    const symbolCode = data.symbols[Math.min(3, data.symbols.length - 1)] || 'cloudy'
 
-    days.push({
+    return {
       date: dateKey,
       dayName,
-      symbolCode,
+      symbolCode: pickMiddaySymbol(data.symbolEntries),
       tempMin: Math.round(Math.min(...data.temps)),
       tempMax: Math.round(Math.max(...data.temps)),
       precipitation: Math.round(data.precip * 10) / 10,
       windSpeed: Math.round(data.winds.reduce((a, b) => a + b, 0) / data.winds.length * 10) / 10,
-    })
-    count++
+    }
+  })
+}
+
+/**
+ * Choose the symbol whose local time is closest to 12:00, so each day's icon reflects
+ * conditions near midday rather than an arbitrary index. Ties resolve to the earliest
+ * timestamp. Falls back to 'cloudy' when no usable symbol exists.
+ */
+function pickMiddaySymbol(entries: DaySymbolEntry[]): string {
+  if (entries.length === 0) return 'cloudy'
+
+  let best = entries[0]
+  let bestDistance = Math.abs(minutesSinceMidnight(best.date) - 720)
+
+  for (const entry of entries.slice(1)) {
+    const distance = Math.abs(minutesSinceMidnight(entry.date) - 720)
+    // On equal distance from noon, keep the earliest timestamp for deterministic ties.
+    if (distance < bestDistance || (distance === bestDistance && entry.date.getTime() < best.date.getTime())) {
+      best = entry
+      bestDistance = distance
+    }
   }
 
-  return days
+  return best.symbol
 }
 
 /** Resolve a location name, checking recents first then the fetched known locations. */

--- a/web/src/pages/Weather.tsx
+++ b/web/src/pages/Weather.tsx
@@ -14,6 +14,7 @@ import {
 } from '../recentLocations'
 import LocationSearch from '../components/LocationSearch'
 import { readForecastCache, writeForecastCache } from '../lib/weatherCache'
+import { buildDailyForecasts, type TimeseriesEntry } from '../lib/weatherForecast'
 import { getWeatherIcon, getWeatherDescription } from '../weatherUtils'
 import { formatDate, formatTime } from '../utils/formatDate'
 import {
@@ -28,31 +29,6 @@ import {
 } from 'lucide-react'
 
 
-export interface TimeseriesEntry {
-  time: string
-  data: {
-    instant: {
-      details: {
-        air_temperature: number
-        wind_speed: number
-        relative_humidity: number
-        air_pressure_at_sea_level?: number
-        wind_from_direction?: number
-      }
-    }
-    next_1_hours?: {
-      summary: { symbol_code: string }
-      details: { precipitation_amount: number }
-    }
-    next_6_hours?: {
-      summary: { symbol_code: string }
-      details: { precipitation_amount: number }
-    }
-    next_12_hours?: {
-      summary: { symbol_code: string }
-    }
-  }
-}
 
 interface ForecastResponse {
   properties: {
@@ -74,15 +50,6 @@ function splitDaylight(seconds: number): { hours: number; minutes: number } {
   return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60 }
 }
 
-interface DayForecast {
-  date: string
-  dayName: string
-  symbolCode: string
-  tempMin: number
-  tempMax: number
-  precipitation: number
-  windSpeed: number
-}
 
 type FetchState = { loading: boolean; error: string | null; forecast: ForecastResponse | null; lastUpdated: Date | null }
 type FetchAction =
@@ -159,103 +126,6 @@ function calculateFeelsLike(temp: number, windSpeed: number, humidity: number): 
  */
 function windArrowRotation(windFromDirection: number): number {
   return (windFromDirection + 180) % 360
-}
-
-/** Format a Date as a local YYYY-MM-DD calendar key (not UTC, so DST-straddling hours stay on the right day). */
-function localDateKey(dt: Date): string {
-  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`
-}
-
-/** Minutes since local midnight for the given Date. */
-function minutesSinceMidnight(dt: Date): number {
-  return dt.getHours() * 60 + dt.getMinutes()
-}
-
-interface DaySymbolEntry {
-  date: Date
-  symbol: string
-}
-
-export function buildDailyForecasts(timeseries: TimeseriesEntry[], todayLabel: string): DayForecast[] {
-  const dayMap = new Map<string, {
-    temps: number[]
-    winds: number[]
-    precip: number
-    symbolEntries: DaySymbolEntry[]
-    date: Date
-  }>()
-
-  for (const entry of timeseries) {
-    const dt = new Date(entry.time)
-    const dateKey = localDateKey(dt)
-
-    if (!dayMap.has(dateKey)) {
-      dayMap.set(dateKey, { temps: [], winds: [], precip: 0, symbolEntries: [], date: dt })
-    }
-    const day = dayMap.get(dateKey)!
-
-    day.temps.push(entry.data.instant.details.air_temperature)
-    day.winds.push(entry.data.instant.details.wind_speed)
-
-    const symbol =
-      entry.data.next_1_hours?.summary.symbol_code ||
-      entry.data.next_6_hours?.summary.symbol_code ||
-      entry.data.next_12_hours?.summary.symbol_code
-
-    if (symbol) day.symbolEntries.push({ date: dt, symbol })
-
-    const precip =
-      entry.data.next_1_hours?.details.precipitation_amount ??
-      entry.data.next_6_hours?.details.precipitation_amount ??
-      0
-    day.precip += precip
-  }
-
-  const today = localDateKey(new Date())
-
-  // Sort by parsed local calendar date so days always render chronologically,
-  // regardless of timeseries entry order or DST boundaries.
-  const sortedDays = [...dayMap.entries()].sort(([a], [b]) => a.localeCompare(b))
-
-  return sortedDays.slice(0, 7).map(([dateKey, data]) => {
-    const dayName =
-      dateKey === today
-        ? todayLabel
-        : formatDate(data.date, { weekday: 'short' })
-
-    return {
-      date: dateKey,
-      dayName,
-      symbolCode: pickMiddaySymbol(data.symbolEntries),
-      tempMin: Math.round(Math.min(...data.temps)),
-      tempMax: Math.round(Math.max(...data.temps)),
-      precipitation: Math.round(data.precip * 10) / 10,
-      windSpeed: Math.round(data.winds.reduce((a, b) => a + b, 0) / data.winds.length * 10) / 10,
-    }
-  })
-}
-
-/**
- * Choose the symbol whose local time is closest to 12:00, so each day's icon reflects
- * conditions near midday rather than an arbitrary index. Ties resolve to the earliest
- * timestamp. Falls back to 'cloudy' when no usable symbol exists.
- */
-function pickMiddaySymbol(entries: DaySymbolEntry[]): string {
-  if (entries.length === 0) return 'cloudy'
-
-  let best = entries[0]
-  let bestDistance = Math.abs(minutesSinceMidnight(best.date) - 720)
-
-  for (const entry of entries.slice(1)) {
-    const distance = Math.abs(minutesSinceMidnight(entry.date) - 720)
-    // On equal distance from noon, keep the earliest timestamp for deterministic ties.
-    if (distance < bestDistance || (distance === bestDistance && entry.date.getTime() < best.date.getTime())) {
-      best = entry
-      bestDistance = distance
-    }
-  }
-
-  return best.symbol
 }
 
 /** Resolve a location name, checking recents first then the fetched known locations. */


### PR DESCRIPTION
## Changes

- **Weather forecast day ordering and midday icons** - The multi-day forecast now sorts days chronologically by local calendar date (robust to out-of-order or DST-straddling timeseries) and picks each day's icon from the hour closest to local noon, so a rainy afternoon no longer shows a "clear night" summary. (Hytte-lmqj)

## Original Issue (feature): Fix daily forecast iteration order so days render chronologically

### Scope
Fix `buildDailyForecasts` in `web/src/pages/Weather.tsx` so the multi-day list always renders days chronologically and each day's icon reflects the conditions nearest midday. Currently the function relies on `Map` insertion order (fragile if the yr.no timeseries is out of order or crosses a DST boundary) and picks the icon at array index `min(3, length-1)`, which on the current day grabs an arbitrary remaining hour — yielding e.g. a "clear night" icon for a rainy afternoon. The fix is to sort day entries by date and select the symbol whose timestamp is closest to 12:00 local time.

### Files to touch
- `web/src/pages/Weather.tsx` — modify `buildDailyForecasts` (and its internal day-accumulator type)
- `web/src/pages/Weather.test.tsx` (new, if no test file exists) — unit tests for ordering and midday symbol selection
- `changelog.d/<id>-weather-forecast-order.md` (new) — `Fixed` fragment

### Acceptance criteria
- Day cards render in ascending date order regardless of timeseries entry order (verified by feeding shuffled/out-of-order entries).
- Each day's `symbolCode` is the symbol from the timeseries entry whose local time is closest to 12:00; ties resolve deterministically (e.g. earliest).
- On the current day, when only afternoon/evening hours remain, the icon reflects an actual remaining hour near or after noon — never a midnight/"clear night" symbol for a rainy afternoon.
- Days that straddle a DST transition are still grouped under the correct local calendar date and ordered correctly.
- A day with no usable symbol still falls back to `'cloudy'`.
- The list is still capped at 7 days, now taken as the first 7 chronological days.
- `npm run lint` and `npm run build` pass; existing Weather behavior (temps, precip, wind, today label, i18n) is unchanged.

### Non-goals
- No changes to `internal/weather/handler.go` or the yr.no fetch/caching layer.
- No change to the 7-day cap, temperature/precip/wind aggregation, or the `'cloudy'` fallback semantics.
- No visual/styling redesign of the forecast cards.
- No new translation keys (logic-only change).

## Source

Created from Suggestions page (suggestion id 7, page slug "weather", source=claude).

## Original suggestion

buildDailyForecasts iterates dayMap with a `for...of` and slices the first 7 entries, but Map iteration order is insertion order based on the timeseries — which is fine until the API returns out-of-order entries or the day boundary straddles a DST transition. More importantly, the midday symbol heuristic picks `symbols[Math.min(3, length-1)]` which on the current day silently grabs whatever hour happens to be at index 3 of the *remaining* hours, producing a midnight icon in the evening. Sort dayMap entries by date and pick the symbol closest to 12:00 local time per day. Users will stop seeing a 'clear night' icon as the summary for a rainy afternoon.


---
Bead: Hytte-lmqj | Branch: forge/Hytte-lmqj
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->