### PR TITLE
Show skeleton placeholders while auth resolves and widgets lazy-load (Hytte-mgmn)

### DIFF
--- a/changelog.d/Hytte-mgmn.md
+++ b/changelog.d/Hytte-mgmn.md
@@ -1,0 +1,2 @@
+category: Added
+- **Skeleton placeholders on the Today view** - The Today page now shows pulsing header and 2-column grid skeletons while authentication resolves and the role widget chunk lazy-loads, instead of a blank screen followed by an abrupt pop-in. (Hytte-mgmn)

--- a/web/public/locales/en/today.json
+++ b/web/public/locales/en/today.json
@@ -1,6 +1,8 @@
 {
   "unavailable": "Unavailable",
   "viewMore": "View more",
+  "loading": "Loading your day…",
+  "loadingWidgets": "Loading widgets…",
   "role": {
     "parent": "Parent",
     "child": "Kid",

--- a/web/public/locales/nb/today.json
+++ b/web/public/locales/nb/today.json
@@ -1,6 +1,8 @@
 {
   "unavailable": "Ikke tilgjengelig",
   "viewMore": "Se mer",
+  "loading": "Laster dagen din…",
+  "loadingWidgets": "Laster moduler…",
   "role": {
     "parent": "Forelder",
     "child": "Barn",

--- a/web/public/locales/th/today.json
+++ b/web/public/locales/th/today.json
@@ -1,6 +1,8 @@
 {
   "unavailable": "ไม่พร้อมใช้งาน",
   "viewMore": "ดูเพิ่มเติม",
+  "loading": "กำลังโหลดวันของคุณ…",
+  "loadingWidgets": "กำลังโหลดวิดเจ็ต…",
   "role": {
     "parent": "\u0e1c\u0e39\u0e49\u0e1b\u0e01\u0e04\u0e23\u0e2d\u0e07",
     "child": "\u0e40\u0e14\u0e47\u0e01",

--- a/web/src/components/today/TodaySkeleton.tsx
+++ b/web/src/components/today/TodaySkeleton.tsx
@@ -1,9 +1,6 @@
 import { useTranslation } from 'react-i18next'
+import type { FamilyRole } from '../../pages/TodayView'
 
-/**
- * Pulsing placeholder that mirrors the watch-face header (time + date lines)
- * so the frame stays stable while auth resolves.
- */
 export function TodayHeaderSkeleton() {
   const { t } = useTranslation('today')
   return (
@@ -12,23 +9,50 @@ export function TodayHeaderSkeleton() {
       aria-busy="true"
       aria-label={t('loading')}
     >
-      {/* Time line */}
       <div className="mx-auto h-10 sm:h-12 w-40 sm:w-48 rounded bg-gray-800 animate-pulse" />
-      {/* Date line */}
       <div className="mx-auto mt-2 h-4 sm:h-5 w-48 sm:w-56 rounded bg-gray-800 animate-pulse" />
-      {/* Ambient line */}
       <div className="mx-auto mt-2 h-3 w-32 rounded bg-gray-800 animate-pulse" />
-      {/* Role line */}
       <div className="mx-auto mt-2 h-3 w-16 rounded bg-gray-800 animate-pulse" />
     </header>
   )
 }
 
-/**
- * Pulsing 2-column grid that mirrors the real widget grid layout so there is
- * no layout shift when the lazy role chunk finishes downloading.
- */
-export function TodayGridSkeleton() {
+const cell = "rounded-xl bg-gray-800 animate-pulse"
+const wide = `${cell} col-span-2`
+
+function GuestGridCells() {
+  return (
+    <>
+      <div className={wide} />
+      <div className={wide} />
+      <div className={wide} />
+    </>
+  )
+}
+
+function ChildGridCells() {
+  return (
+    <>
+      <div className={wide} />
+      <div className={cell} />
+      <div className={cell} />
+    </>
+  )
+}
+
+function ParentGridCells() {
+  return (
+    <>
+      <div className={wide} />
+      <div className={cell} />
+      <div className={cell} />
+      <div className={cell} />
+      <div className={cell} />
+    </>
+  )
+}
+
+export function TodayGridSkeleton({ role }: { role?: FamilyRole | null }) {
   const { t } = useTranslation('today')
   return (
     <div
@@ -36,9 +60,9 @@ export function TodayGridSkeleton() {
       aria-busy="true"
       aria-label={t('loadingWidgets')}
     >
-      {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="rounded-xl bg-gray-800 animate-pulse" />
-      ))}
+      {role === 'child' ? <ChildGridCells /> :
+       role === 'parent' ? <ParentGridCells /> :
+       <GuestGridCells />}
     </div>
   )
 }

--- a/web/src/components/today/TodaySkeleton.tsx
+++ b/web/src/components/today/TodaySkeleton.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Pulsing placeholder that mirrors the watch-face header (time + date lines)
+ * so the frame stays stable while auth resolves.
+ */
+export function TodayHeaderSkeleton() {
+  const { t } = useTranslation('today')
+  return (
+    <header
+      className="text-center mb-4 sm:mb-6 shrink-0"
+      aria-busy="true"
+      aria-label={t('loading')}
+    >
+      {/* Time line */}
+      <div className="mx-auto h-10 sm:h-12 w-40 sm:w-48 rounded bg-gray-800 animate-pulse" />
+      {/* Date line */}
+      <div className="mx-auto mt-2 h-4 sm:h-5 w-48 sm:w-56 rounded bg-gray-800 animate-pulse" />
+      {/* Ambient line */}
+      <div className="mx-auto mt-2 h-3 w-32 rounded bg-gray-800 animate-pulse" />
+      {/* Role line */}
+      <div className="mx-auto mt-2 h-3 w-16 rounded bg-gray-800 animate-pulse" />
+    </header>
+  )
+}
+
+/**
+ * Pulsing 2-column grid that mirrors the real widget grid layout so there is
+ * no layout shift when the lazy role chunk finishes downloading.
+ */
+export function TodayGridSkeleton() {
+  const { t } = useTranslation('today')
+  return (
+    <div
+      className="grid grid-cols-2 gap-3 sm:gap-4 flex-1 min-h-0 auto-rows-fr"
+      aria-busy="true"
+      aria-label={t('loadingWidgets')}
+    >
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="rounded-xl bg-gray-800 animate-pulse" />
+      ))}
+    </div>
+  )
+}

--- a/web/src/pages/TodayView.tsx
+++ b/web/src/pages/TodayView.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../auth'
 import { useCurrentTime } from '../hooks/useCurrentTime'
 import { formatDate, formatTime } from '../utils/formatDate'
 import AmbientLine from '../components/today/AmbientLine'
+import { TodayHeaderSkeleton, TodayGridSkeleton } from '../components/today/TodaySkeleton'
 
 const ParentTodayView = lazy(() => import('../components/today/ParentTodayView'))
 const KidTodayView = lazy(() => import('../components/today/KidTodayView'))
@@ -32,7 +33,14 @@ export default function TodayView() {
   const role = useFamilyRole()
   const now = useCurrentTime()
 
-  if (role === null) return null
+  if (role === null) {
+    return (
+      <div className="h-[calc(100dvh-3.5rem)] md:h-[100dvh] flex flex-col p-4 sm:p-6 overflow-hidden">
+        <TodayHeaderSkeleton />
+        <TodayGridSkeleton />
+      </div>
+    )
+  }
 
   const timeStr = formatTime(now, { hour: '2-digit', minute: '2-digit' })
   const dateStr = formatDate(now, { weekday: 'long', month: 'long', day: 'numeric' })
@@ -57,11 +65,11 @@ export default function TodayView() {
       </header>
 
       {/* Widget grid */}
-      <div className="grid grid-cols-2 gap-3 sm:gap-4 flex-1 min-h-0 auto-rows-fr">
-        <Suspense fallback={null}>
+      <Suspense fallback={<TodayGridSkeleton />}>
+        <div className="grid grid-cols-2 gap-3 sm:gap-4 flex-1 min-h-0 auto-rows-fr">
           <Widgets />
-        </Suspense>
-      </div>
+        </div>
+      </Suspense>
     </div>
   )
 }

--- a/web/src/pages/TodayView.tsx
+++ b/web/src/pages/TodayView.tsx
@@ -65,7 +65,7 @@ export default function TodayView() {
       </header>
 
       {/* Widget grid */}
-      <Suspense fallback={<TodayGridSkeleton />}>
+      <Suspense fallback={<TodayGridSkeleton role={role} />}>
         <div className="grid grid-cols-2 gap-3 sm:gap-4 flex-1 min-h-0 auto-rows-fr">
           <Widgets />
         </div>


### PR DESCRIPTION
## Changes

- **Skeleton placeholders on the Today view** - The Today page now shows pulsing header and 2-column grid skeletons while authentication resolves and the role widget chunk lazy-loads, instead of a blank screen followed by an abrupt pop-in. (Hytte-mgmn)

## Original Issue (feature): Show skeleton placeholders while auth resolves and widgets lazy-load

### Scope
Replace the two blank states in `web/src/pages/TodayView.tsx` — the `if (role === null) return null` early return (auth loading) and the `<Suspense fallback={null}>` (role chunk download) — with lightweight skeleton placeholders. The skeletons mirror the existing watch-face header (time/date) and the `grid-cols-2` widget grid so the frame stays stable and users get immediate visual feedback instead of a blank screen followed by pop-in.

### Files to touch
- `web/src/pages/TodayView.tsx` — render a header skeleton when `role === null`; pass a grid skeleton as the `Suspense` fallback instead of `null`.
- `web/src/components/today/TodaySkeleton.tsx` (new) — presentational skeleton component(s) for the header and 2-column widget grid (e.g. a `TodayHeaderSkeleton` and `TodayGridSkeleton`, or one combined component).

### Acceptance criteria
- While auth is loading (`role === null`), the page shows a skeleton header (pulsing placeholders sized like the time + date lines) inside the same `h-[calc(100dvh-3.5rem)] md:h-[100dvh]` flex container — no blank screen.
- While the role widget chunk is downloading, the `Suspense` fallback renders a 2-column skeleton grid matching `grid-cols-2 gap-3 sm:gap-4 auto-rows-fr` — not nothing.
- Skeleton layout dimensions/spacing match the real header and grid so there is no layout shift / abrupt pop-in when content resolves.
- Skeletons use Tailwind only (e.g. `animate-pulse`, `bg-gray-800`), consistent with the dark theme, and render correctly at 375px width.
- Any user-facing text (e.g. an `aria-label`/`aria-busy` loading hint) uses `react-i18next` with keys added to `en`, `nb`, and `th`; purely visual skeleton bars need no copy.
- A changelog fragment is added under `changelog.d/`.
- `npm run lint`, `npm run build`, and `go build`/`go test` pass.

### Non-goals
- No changes to the widget components themselves (`ParentTodayView`, `KidTodayView`, `GuestTodayView`) or their internal loading states.
- No changes to auth, `useFamilyRole`, or `useAuth` logic — only the rendered loading UI.
- No new shared/global skeleton library or refactor of skeletons on other pages.
- No data-fetching, caching, or chunk-splitting/performance changes beyond the visual placeholders.

## Source

Created from Suggestions page (suggestion id 181, page slug "today", source=claude).

## Original suggestion

When `role` is null during auth loading the whole page returns null, and `Suspense fallback={null}` renders nothing while the role chunk downloads, so users see a blank screen followed by an abrupt pop-in of the clock and widget grid. Replace both null states with lightweight skeleton placeholders that mirror the header and 2-column grid layout. This keeps the watch-face frame stable and gives immediate visual feedback, which especially helps on slower mobile connections where the lazy chunk load is noticeable.


---
Bead: Hytte-mgmn | Branch: forge/Hytte-mgmn
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->