### PR TITLE
Add sport, tag, and text filtering to the workout list (Hytte-u9as)

### DIFF
--- a/changelog.d/Hytte-u9as.md
+++ b/changelog.d/Hytte-u9as.md
@@ -1,0 +1,2 @@
+category: Added
+- **Workout list filtering** - Added a client-side filter bar above the Training workout list with a sport dropdown, selectable tag chips, and a free-text title search. Filters combine (a workout must match the selected sport, carry all selected tags, and contain the search text), update live, and can be reset with a clear-filters control. A localized empty state shows when nothing matches. (Hytte-u9as)

--- a/web/public/locales/en/training.json
+++ b/web/public/locales/en/training.json
@@ -35,6 +35,25 @@
     "loadingMore": "Loading…",
     "noMoreWorkouts": "No more workouts"
   },
+  "filters": {
+    "sportLabel": "Filter by sport",
+    "allSports": "All sports",
+    "searchLabel": "Search workouts by title",
+    "searchPlaceholder": "Search by title…",
+    "clear": "Clear filters",
+    "noMatches": "No workouts match your filters",
+    "sports": {
+      "running": "Running",
+      "cycling": "Cycling",
+      "swimming": "Swimming",
+      "walking": "Walking",
+      "hiking": "Hiking",
+      "strength": "Strength training",
+      "rowing": "Rowing",
+      "cross_country_skiing": "Cross-country skiing",
+      "other": "Other"
+    }
+  },
   "nav": {
     "trends": "Trends",
     "compare": "Compare"

--- a/web/public/locales/nb/training.json
+++ b/web/public/locales/nb/training.json
@@ -35,6 +35,25 @@
     "loadingMore": "Laster…",
     "noMoreWorkouts": "Ingen flere økter"
   },
+  "filters": {
+    "sportLabel": "Filtrer etter idrett",
+    "allSports": "Alle idretter",
+    "searchLabel": "Søk i økter etter tittel",
+    "searchPlaceholder": "Søk etter tittel…",
+    "clear": "Nullstill filtre",
+    "noMatches": "Ingen økter samsvarer med filtrene dine",
+    "sports": {
+      "running": "Løping",
+      "cycling": "Sykling",
+      "swimming": "Svømming",
+      "walking": "Gåing",
+      "hiking": "Fjelltur",
+      "strength": "Styrketrening",
+      "rowing": "Roing",
+      "cross_country_skiing": "Langrenn",
+      "other": "Annet"
+    }
+  },
   "nav": {
     "trends": "Trender",
     "compare": "Sammenlign"

--- a/web/public/locales/th/training.json
+++ b/web/public/locales/th/training.json
@@ -35,6 +35,25 @@
     "loadingMore": "กำลังโหลด…",
     "noMoreWorkouts": "ไม่มีการออกกำลังกายเพิ่มเติม"
   },
+  "filters": {
+    "sportLabel": "กรองตามกีฬา",
+    "allSports": "กีฬาทั้งหมด",
+    "searchLabel": "ค้นหาการออกกำลังกายตามชื่อ",
+    "searchPlaceholder": "ค้นหาตามชื่อ…",
+    "clear": "ล้างตัวกรอง",
+    "noMatches": "ไม่มีการออกกำลังกายที่ตรงกับตัวกรองของคุณ",
+    "sports": {
+      "running": "วิ่ง",
+      "cycling": "ปั่นจักรยาน",
+      "swimming": "ว่ายน้ำ",
+      "walking": "เดิน",
+      "hiking": "เดินป่า",
+      "strength": "ฝึกความแข็งแรง",
+      "rowing": "พายเรือ",
+      "cross_country_skiing": "สกีทางไกล",
+      "other": "อื่น ๆ"
+    }
+  },
   "nav": {
     "trends": "แนวโน้ม",
     "compare": "เปรียบเทียบ"

--- a/web/src/components/WorkoutFilterBar.tsx
+++ b/web/src/components/WorkoutFilterBar.tsx
@@ -38,7 +38,7 @@ export default function WorkoutFilterBar({
     [workouts],
   )
 
-  const hasActiveFilters = sport !== '' || selectedTags.length > 0 || query !== ''
+  const hasActiveFilters = sport !== '' || selectedTags.length > 0 || query.trim() !== ''
 
   return (
     <div className="mb-4 space-y-3 bg-gray-800/50 border border-gray-700 rounded-xl p-3 sm:p-4">
@@ -106,6 +106,7 @@ export default function WorkoutFilterBar({
                 type="button"
                 onClick={() => toggleTag(tag)}
                 aria-pressed={selected}
+                aria-label={tag}
                 className={`rounded-full transition-shadow ${
                   selected
                     ? 'ring-2 ring-orange-400'

--- a/web/src/components/WorkoutFilterBar.tsx
+++ b/web/src/components/WorkoutFilterBar.tsx
@@ -57,7 +57,7 @@ export default function WorkoutFilterBar({
             <option value="">{t('filters.allSports')}</option>
             {sports.map((s) => (
               <option key={s} value={s}>
-                {t(`filters.sports.${s}`)}
+                {t(`filters.sports.${s}`, { defaultValue: s })}
               </option>
             ))}
           </select>

--- a/web/src/components/WorkoutFilterBar.tsx
+++ b/web/src/components/WorkoutFilterBar.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from 'react'
+import { Search, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { Workout } from '../types/training'
+import { displayTag } from '../tags'
+
+interface WorkoutFilterBarProps {
+  // The already-loaded workouts; used to derive the available tag set so chips
+  // only ever show tags the user actually has.
+  workouts: Workout[]
+  // The sport keys to offer in the dropdown (the sportIcons keys from the page).
+  sports: string[]
+  sport: string
+  setSport: (s: string) => void
+  selectedTags: string[]
+  toggleTag: (t: string) => void
+  query: string
+  setQuery: (q: string) => void
+  onClear: () => void
+}
+
+export default function WorkoutFilterBar({
+  workouts,
+  sports,
+  sport,
+  setSport,
+  selectedTags,
+  toggleTag,
+  query,
+  setQuery,
+  onClear,
+}: WorkoutFilterBarProps) {
+  const { t } = useTranslation('training')
+
+  // Unique, stably-sorted set of tags present across the loaded workouts.
+  const availableTags = useMemo(
+    () => Array.from(new Set(workouts.flatMap((w) => w.tags ?? []))).sort(),
+    [workouts],
+  )
+
+  const hasActiveFilters = sport !== '' || selectedTags.length > 0 || query !== ''
+
+  return (
+    <div className="mb-4 space-y-3 bg-gray-800/50 border border-gray-700 rounded-xl p-3 sm:p-4">
+      <div className="flex flex-col sm:flex-row gap-3">
+        {/* Sport dropdown */}
+        <div className="flex-shrink-0">
+          <label htmlFor="workout-sport-filter" className="sr-only">
+            {t('filters.sportLabel')}
+          </label>
+          <select
+            id="workout-sport-filter"
+            value={sport}
+            onChange={(e) => setSport(e.target.value)}
+            className="w-full sm:w-auto px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-sm text-gray-200 focus:outline-none focus:border-orange-400"
+          >
+            <option value="">{t('filters.allSports')}</option>
+            {sports.map((s) => (
+              <option key={s} value={s}>
+                {t(`filters.sports.${s}`)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Text search */}
+        <div className="relative flex-1">
+          <label htmlFor="workout-search-filter" className="sr-only">
+            {t('filters.searchLabel')}
+          </label>
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none"
+          />
+          <input
+            id="workout-search-filter"
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('filters.searchPlaceholder')}
+            className="w-full pl-9 pr-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-orange-400"
+          />
+        </div>
+
+        {/* Clear filters */}
+        {hasActiveFilters && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="flex-shrink-0 flex items-center justify-center gap-1 px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-sm text-gray-300 transition-colors"
+          >
+            <X size={16} />
+            {t('filters.clear')}
+          </button>
+        )}
+      </div>
+
+      {/* Tag chips */}
+      {availableTags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {availableTags.map((tag) => {
+            const selected = selectedTags.includes(tag)
+            return (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleTag(tag)}
+                aria-pressed={selected}
+                className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs transition-colors ${
+                  selected
+                    ? 'bg-orange-500 text-white ring-2 ring-orange-400'
+                    : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                }`}
+              >
+                {displayTag(tag)}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/WorkoutFilterBar.tsx
+++ b/web/src/components/WorkoutFilterBar.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { Search, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { Workout } from '../types/training'
-import { displayTag } from '../tags'
+import TagBadge from './TagBadge'
 
 interface WorkoutFilterBarProps {
   // The already-loaded workouts; used to derive the available tag set so chips
@@ -106,13 +106,13 @@ export default function WorkoutFilterBar({
                 type="button"
                 onClick={() => toggleTag(tag)}
                 aria-pressed={selected}
-                className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs transition-colors ${
+                className={`rounded-full transition-shadow ${
                   selected
-                    ? 'bg-orange-500 text-white ring-2 ring-orange-400'
-                    : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                    ? 'ring-2 ring-orange-400'
+                    : 'hover:ring-2 hover:ring-gray-500'
                 }`}
               >
-                {displayTag(tag)}
+                <TagBadge tag={tag} />
               </button>
             )
           })}

--- a/web/src/pages/Training.test.tsx
+++ b/web/src/pages/Training.test.tsx
@@ -1,0 +1,290 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Training from './Training'
+import type { Workout } from '../types/training'
+
+vi.mock('react-i18next', async () => {
+  const { default: enTraining } = await import('../../public/locales/en/training.json')
+
+  function resolveKey(obj: Record<string, unknown>, parts: string[]): unknown {
+    const [head, ...rest] = parts
+    const val = obj[head]
+    if (rest.length === 0) return val
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      return resolveKey(val as Record<string, unknown>, rest)
+    }
+    return undefined
+  }
+
+  function makeT(translations: Record<string, unknown>) {
+    return function t(key: string, opts?: Record<string, unknown>): string {
+      if (opts?.defaultValue && typeof opts.defaultValue === 'string') return opts.defaultValue
+      const val = resolveKey(translations, key.split('.'))
+      if (typeof val === 'string') {
+        if (opts) return val.replace(/\{\{(\w+)\}\}/g, (_, k) => String(opts[k] ?? `{{${k}}}`))
+        return val
+      }
+      return key
+    }
+  }
+
+  const trainingT = makeT(enTraining as Record<string, unknown>)
+  const emptyT = makeT({})
+
+  const tCache = new Map<string, (key: string, opts?: Record<string, unknown>) => string>()
+  function getT(namespaces: string[]) {
+    const cacheKey = namespaces.join(',')
+    const cached = tCache.get(cacheKey)
+    if (cached) return cached
+    const fn = (key: string, opts?: Record<string, unknown>): string => {
+      let namespace: string | null
+      let localKey = key
+      const colonIdx = key.indexOf(':')
+      if (colonIdx >= 0) {
+        namespace = key.slice(0, colonIdx)
+        localKey = key.slice(colonIdx + 1)
+      } else if (typeof opts?.ns === 'string') {
+        namespace = opts.ns
+      } else {
+        namespace = namespaces[0] ?? null
+      }
+      if (namespace === 'training') return trainingT(localKey, opts)
+      return emptyT(localKey, opts)
+    }
+    tCache.set(cacheKey, fn)
+    return fn
+  }
+
+  const i18nObj = { language: 'en' }
+  return {
+    useTranslation: (ns?: string | string[]) => {
+      const namespaces = Array.isArray(ns) ? ns : ns ? [ns] : []
+      return { t: getT(namespaces), i18n: i18nObj }
+    },
+    Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+    initReactI18next: { type: '3rdParty', init: () => {} },
+  }
+})
+
+vi.mock('../auth', () => ({
+  useAuth: () => ({
+    user: { id: 1, email: 'a@b.c', name: 'Tester', is_admin: true, features: {} },
+    hasFeature: () => false,
+  }),
+}))
+
+vi.mock('../components/TagBadge', () => ({
+  default: ({ tag }: { tag: string }) => <span data-testid={`tag-${tag}`}>{tag}</span>,
+}))
+
+vi.mock('lucide-react', () => {
+  const Stub = () => null
+  return {
+    Dumbbell: Stub, Upload: Stub, TrendingUp: Stub, BarChart3: Stub,
+    RefreshCw: Stub, X: Stub, Database: Stub, Search: Stub, Sparkles: Stub,
+  }
+})
+
+vi.mock('../utils/formatDate', () => ({
+  formatDate: () => 'Jan 1, 2026',
+  formatTime: () => '08:00',
+}))
+
+vi.mock('../utils/training', () => ({
+  formatDistance: () => '5.0 km',
+  formatDuration: () => '30:00',
+  formatPace: () => '6:00',
+}))
+
+const makeWorkout = (overrides: Partial<Workout> & { id: number; title: string; sport: string }): Workout => ({
+  user_id: 1,
+  started_at: '2026-01-01T08:00:00Z',
+  duration_seconds: 1800,
+  distance_meters: 5000,
+  avg_heart_rate: 150,
+  max_heart_rate: 170,
+  avg_pace_sec_per_km: 360,
+  avg_cadence: 0,
+  calories: 300,
+  ascent_meters: 0,
+  descent_meters: 0,
+  fit_file_hash: '',
+  analysis_status: '',
+  title_source: '',
+  created_at: '2026-01-01T08:00:00Z',
+  tags: [],
+  ...overrides,
+})
+
+const WORKOUTS: Workout[] = [
+  makeWorkout({ id: 1, title: 'Morning Run', sport: 'running', tags: ['easy', 'ai:recovery'] }),
+  makeWorkout({ id: 2, title: 'Hill Intervals', sport: 'running', tags: ['hard', 'auto:intervals'] }),
+  makeWorkout({ id: 3, title: 'Easy Spin', sport: 'cycling', tags: ['easy'] }),
+  makeWorkout({ id: 4, title: 'Pool Laps', sport: 'swimming', tags: [] }),
+]
+
+function mockFetch(workouts: Workout[]) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/training/workouts/latest')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ latest_id: workouts.length > 0 ? Math.max(...workouts.map(w => w.id)) : 0 }),
+      })
+    }
+    if (url.includes('/api/training/workouts')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ workouts, next_cursor: null }),
+      })
+    }
+    if (url.includes('/api/training/summary')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ summaries: [] }),
+      })
+    }
+    if (url.includes('/api/training/events')) {
+      return Promise.resolve({ ok: true })
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
+  })
+}
+
+function renderTraining() {
+  return render(
+    <MemoryRouter initialEntries={['/training']}>
+      <Training />
+    </MemoryRouter>,
+  )
+}
+
+describe('Training filter bar', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    // Stub EventSource globally
+    vi.stubGlobal('EventSource', class {
+      onopen: (() => void) | null = null
+      addEventListener() {}
+      close() {}
+    })
+    vi.stubGlobal('fetch', mockFetch(WORKOUTS))
+  })
+
+  it('shows all workouts when no filter is active', async () => {
+    renderTraining()
+    for (const w of WORKOUTS) {
+      expect(await screen.findByText(w.title)).toBeInTheDocument()
+    }
+  })
+
+  it('filters by sport', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    const select = screen.getByLabelText('Filter by sport') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'cycling' } })
+
+    expect(screen.getByText('Easy Spin')).toBeInTheDocument()
+    expect(screen.queryByText('Morning Run')).not.toBeInTheDocument()
+    expect(screen.queryByText('Hill Intervals')).not.toBeInTheDocument()
+    expect(screen.queryByText('Pool Laps')).not.toBeInTheDocument()
+  })
+
+  it('filters by title search query', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    const input = screen.getByPlaceholderText(/search by title/i)
+    fireEvent.change(input, { target: { value: 'pool' } })
+
+    expect(screen.getByText('Pool Laps')).toBeInTheDocument()
+    expect(screen.queryByText('Morning Run')).not.toBeInTheDocument()
+  })
+
+  it('filters by tag (AND across multiple tags)', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    const easyBtn = screen.getByRole('button', { name: /easy/i, pressed: false })
+    fireEvent.click(easyBtn)
+
+    expect(screen.getByText('Morning Run')).toBeInTheDocument()
+    expect(screen.getByText('Easy Spin')).toBeInTheDocument()
+    expect(screen.queryByText('Hill Intervals')).not.toBeInTheDocument()
+
+    const aiRecoveryBtn = screen.getByRole('button', { name: /ai:recovery/i })
+    fireEvent.click(aiRecoveryBtn)
+
+    expect(screen.getByText('Morning Run')).toBeInTheDocument()
+    expect(screen.queryByText('Easy Spin')).not.toBeInTheDocument()
+  })
+
+  it('combines sport + tag + query filters with AND', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    const select = screen.getByLabelText('Filter by sport') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'running' } })
+
+    const easyBtn = screen.getByRole('button', { name: /easy/i, pressed: false })
+    fireEvent.click(easyBtn)
+
+    const input = screen.getByPlaceholderText(/search by title/i)
+    fireEvent.change(input, { target: { value: 'morning' } })
+
+    expect(screen.getByText('Morning Run')).toBeInTheDocument()
+    expect(screen.queryByText('Hill Intervals')).not.toBeInTheDocument()
+    expect(screen.queryByText('Easy Spin')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when no workouts match and offers clear-filters', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    const input = screen.getByPlaceholderText(/search by title/i)
+    fireEvent.change(input, { target: { value: 'nonexistent workout title xyz' } })
+
+    expect(screen.getByText('No workouts match your filters')).toBeInTheDocument()
+
+    const clearBtn = screen.getAllByRole('button').find(b => b.textContent?.includes('Clear filters'))
+    expect(clearBtn).toBeTruthy()
+    fireEvent.click(clearBtn!)
+
+    for (const w of WORKOUTS) {
+      expect(screen.getByText(w.title)).toBeInTheDocument()
+    }
+  })
+
+  it('clears all filters when the clear button is clicked', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    const select = screen.getByLabelText('Filter by sport') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'swimming' } })
+
+    expect(screen.getByText('Pool Laps')).toBeInTheDocument()
+    expect(screen.queryByText('Morning Run')).not.toBeInTheDocument()
+
+    const clearBtn = screen.getAllByRole('button').find(b => b.textContent?.includes('Clear filters'))
+    expect(clearBtn).toBeTruthy()
+    fireEvent.click(clearBtn!)
+
+    for (const w of WORKOUTS) {
+      expect(screen.getByText(w.title)).toBeInTheDocument()
+    }
+  })
+
+  it('deselects a tag when clicked again', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    const easyBtn = screen.getByRole('button', { name: /easy/i, pressed: false })
+    fireEvent.click(easyBtn)
+    expect(screen.queryByText('Hill Intervals')).not.toBeInTheDocument()
+
+    fireEvent.click(easyBtn)
+    expect(screen.getByText('Hill Intervals')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Training.test.tsx
+++ b/web/src/pages/Training.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Training from './Training'
@@ -170,6 +170,10 @@ describe('Training filter bar', () => {
       close() {}
     })
     vi.stubGlobal('fetch', mockFetch(WORKOUTS))
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
   })
 
   it('shows all workouts when no filter is active', async () => {

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { Dumbbell, Upload, TrendingUp, BarChart3, RefreshCw, X, Database } from 'lucide-react'
 import { useAuth } from '../auth'
@@ -7,6 +7,7 @@ import { formatDate, formatTime } from '../utils/formatDate'
 import { formatDistance, formatDuration, formatPace } from '../utils/training'
 import type { Workout, WeeklySummary } from '../types/training'
 import TagBadge from '../components/TagBadge'
+import WorkoutFilterBar from '../components/WorkoutFilterBar'
 
 // Page size for the paginated workout list. The list endpoint clamps this
 // server-side; keeping it modest bounds the initial payload and DOM size so a
@@ -43,6 +44,39 @@ export default function Training() {
   const [backfillResult, setBackfillResult] = useState<string | null>(null)
   const latestWorkoutIdRef = useRef<number | null>(null)
   const hasNewWorkoutsRef = useRef(false)
+
+  // Client-side filter state. These narrow the already-loaded `workouts` array
+  // in memory only — no backend query or network request is involved.
+  const [sportFilter, setSportFilter] = useState('')
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [query, setQuery] = useState('')
+
+  const toggleTag = useCallback((tag: string) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    )
+  }, [])
+
+  const clearFilters = useCallback(() => {
+    setSportFilter('')
+    setSelectedTags([])
+    setQuery('')
+  }, [])
+
+  // Derived, filtered view of the loaded workouts. Filters combine with AND
+  // across the three types; for tags a workout must carry ALL selected tags.
+  const filteredWorkouts = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return workouts.filter(
+      (w) =>
+        (!sportFilter || w.sport === sportFilter) &&
+        (selectedTags.length === 0 ||
+          selectedTags.every((tag) => (w.tags ?? []).includes(tag))) &&
+        (!q || w.title.toLowerCase().includes(q)),
+    )
+  }, [workouts, sportFilter, selectedTags, query])
+
+  const filtersActive = sportFilter !== '' || selectedTags.length > 0 || query !== ''
 
   useEffect(() => {
     if (!user) return
@@ -453,7 +487,33 @@ export default function Training() {
       ) : (
         <div className="space-y-2">
           <h2 className="text-lg font-semibold mb-3">{t('workouts.title')}</h2>
-          {workouts.map((w) => {
+          <WorkoutFilterBar
+            workouts={workouts}
+            sports={Object.keys(sportIcons)}
+            sport={sportFilter}
+            setSport={setSportFilter}
+            selectedTags={selectedTags}
+            toggleTag={toggleTag}
+            query={query}
+            setQuery={setQuery}
+            onClear={clearFilters}
+          />
+          {filteredWorkouts.length === 0 ? (
+            <div className="bg-gray-800 rounded-xl p-8 text-center">
+              <p className="text-gray-400">{t('filters.noMatches')}</p>
+              {filtersActive && (
+                <button
+                  type="button"
+                  onClick={clearFilters}
+                  className="mt-3 inline-flex items-center gap-1 px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-sm text-gray-300 transition-colors"
+                >
+                  <X size={16} />
+                  {t('filters.clear')}
+                </button>
+              )}
+            </div>
+          ) : (
+          filteredWorkouts.map((w) => {
             const date = new Date(w.started_at)
             const dateStr = formatDate(date, {
               year: 'numeric',
@@ -515,7 +575,8 @@ export default function Training() {
                 </div>
               </Link>
             )
-          })}
+          })
+          )}
           {nextCursor !== null ? (
             <div className="pt-2 flex justify-center">
               <button

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -76,7 +76,7 @@ export default function Training() {
     )
   }, [workouts, sportFilter, selectedTags, query])
 
-  const filtersActive = sportFilter !== '' || selectedTags.length > 0 || query !== ''
+  const filtersActive = sportFilter !== '' || selectedTags.length > 0 || query.trim() !== ''
 
   useEffect(() => {
     if (!user) return


### PR DESCRIPTION
## Changes

- **Workout list filtering** - Added a client-side filter bar above the Training workout list with a sport dropdown, selectable tag chips, and a free-text title search. Filters combine (a workout must match the selected sport, carry all selected tags, and contain the search text), update live, and can be reset with a clear-filters control. A localized empty state shows when nothing matches. (Hytte-u9as)

## Original Issue (feature): Add sport, tag, and text filtering to the workout list

### Scope
Add a client-side filter bar above the workout list on the Training page. It lets users narrow the in-memory `workouts` array by sport (dropdown), tag (chip toggles reusing `TagBadge`), and a free-text title search. Filtering is purely client-side over already-loaded data — no backend or query changes. The existing list rendering (`workouts.map(...)`) is fed a derived `filteredWorkouts` array instead of the raw one.

### Files to touch
- `web/src/pages/Training.tsx` — add filter state, a `filteredWorkouts` derivation, and render the filter bar above the list; map over the filtered array.
- `web/src/components/WorkoutFilterBar.tsx` (new) — optional extraction of the filter UI to keep `Training.tsx` manageable; otherwise inline.
- `web/public/locales/en/training.json`, `.../nb/training.json`, `.../th/training.json` — add filter labels/placeholders (sport, tag, search, "no matches", clear filters).

### Acceptance criteria
- A filter bar is visible above the workout list, working at 375px width (responsive, stacks on mobile).
- Sport dropdown is populated from the `sportIcons` keys plus an "All sports" default; selecting one shows only matching workouts.
- Tag filter renders selectable `TagBadge` chips drawn from tags present in the loaded workouts; selecting tags filters to workouts carrying all (or any — pick one, document it) selected tags. Selected chips are visually distinct.
- A text input filters workouts by case-insensitive substring match on title.
- Filters combine (AND across the three filter types); the list updates live as filters change.
- A "clear filters" affordance resets all three to default.
- When no workout matches, a localized empty-state message is shown instead of a blank list.
- All new user-facing strings use `react-i18next` with keys added to en/nb/th; no hardcoded English in JSX.
- Filtering is client-side only — no new network requests fire when changing filters.
- `npm run lint` and `npm run build` pass.

### Non-goals
- No server-side filtering, pagination, or new API parameters in `internal/training/handlers.go`.
- No changes to `TrainingDetail.tsx`, `TrainingTrends.tsx`, or `TrainingCompare.tsx`.
- No date-range, distance, duration, or training-load filters (sport/tag/text only).
- No persistence of filter state across reloads or URL query syncing.
- No changes to how workouts are fetched, sorted, or to the existing virtualization/pagination of the list.

## Source

Created from Suggestions page (suggestion id 196, page slug "training", source=claude).

## Original suggestion

The Training page renders every workout the user has ever uploaded as one flat, unfiltered list (`workouts.map(...)` at Training.tsx:365), so finding a specific run or all swims means scrolling indefinitely. Add a lightweight filter bar above the list with a sport dropdown (the `sportIcons` keys already enumerate sports), a tag chip filter reusing `TagBadge`, and a free-text title search, filtering the in-memory `workouts` array client-side. This makes the page usable as the history grows past a few dozen entries and lets users quickly isolate a discipline or training block.


---
Bead: Hytte-u9as | Branch: forge/Hytte-u9as
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->