### PR TITLE
Tick relative departure countdowns every second between API refreshes (Hytte-udcs)

### DIFF
--- a/changelog.d/Hytte-udcs.md
+++ b/changelog.d/Hytte-udcs.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Transit countdowns tick every second** - Relative departure labels on the Transit page now recompute every second against the current time, so a "5 min" label drops to "4 min" right at the minute boundary instead of staying frozen until the next 30s data refresh. No extra network requests are made. (Hytte-udcs)

--- a/web/src/pages/Transit.tsx
+++ b/web/src/pages/Transit.tsx
@@ -31,13 +31,13 @@ interface SearchResult {
 
 const REFRESH_INTERVAL_MS = 30_000
 
-function minutesUntil(departureTime: string): number {
-  const diff = new Date(departureTime).getTime() - Date.now()
+function minutesUntil(departureTime: string, now: number): number {
+  const diff = new Date(departureTime).getTime() - now
   return Math.round(diff / 60_000)
 }
 
-function formatDeparture(departureTime: string, t: (key: string) => string): string {
-  const mins = minutesUntil(departureTime)
+function formatDeparture(departureTime: string, now: number, t: (key: string) => string): string {
+  const mins = minutesUntil(departureTime, now)
   if (mins <= 0) return '0 ' + t('transit:min')
   if (mins < 30) return `${mins} ${t('transit:min')}`
   return new Date(departureTime).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
@@ -74,6 +74,16 @@ export default function Transit() {
   // (30s interval, tab-visibility, manual) update departures silently in place.
   const isInitialLoad = useRef(true)
   const [refreshKey, setRefreshKey] = useState(0)
+
+  // Tick a clock value every second so relative departure labels ("5 min")
+  // recompute against the current time between the 30s Entur polls. This is a
+  // pure client-side timer — deliberately NOT wired to refreshKey, so it never
+  // triggers a data fetch.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
 
   // Initial load + auto-refresh every 30 seconds, paused while the tab is hidden.
   useEffect(() => {
@@ -486,7 +496,7 @@ export default function Transit() {
             ) : (
               <div className="divide-y divide-gray-700/50">
                 {stop.departures.map((dep) => {
-                  const mins = minutesUntil(dep.departure_time)
+                  const mins = minutesUntil(dep.departure_time, now)
                   return (
                     <div key={`${dep.line}-${dep.departure_time}`} className="flex items-center gap-3 px-4 py-2.5">
                       {/* Line badge */}
@@ -515,7 +525,7 @@ export default function Transit() {
 
                       {/* Time */}
                       <span className={`text-sm font-medium shrink-0 ${mins <= 1 ? 'text-red-400' : mins <= 5 ? 'text-orange-400' : 'text-white'}`}>
-                        {formatDeparture(dep.departure_time, t as (key: string) => string)}
+                        {formatDeparture(dep.departure_time, now, t as (key: string) => string)}
                       </span>
                     </div>
                   )


### PR DESCRIPTION
## Changes

- **Transit countdowns tick every second** - Relative departure labels on the Transit page now recompute every second against the current time, so a "5 min" label drops to "4 min" right at the minute boundary instead of staying frozen until the next 30s data refresh. No extra network requests are made. (Hytte-udcs)

## Original Issue (feature): Tick relative departure countdowns every second between API refreshes

### Scope
Add a lightweight clock ticker to `Transit.tsx` so the relative departure labels (`minutesUntil` / `formatDeparture`) recompute every 1 second against the current time, independent of the 30s Entur poll. No new fetches — only the already-fetched `departure_time` values are re-evaluated against a ticking `now`. Critically, the ticker must NOT reuse `refreshKey` (which is wired to the data-fetch `useEffect`), or it would trigger Entur API calls every second.

### Files to touch
- `web/src/pages/Transit.tsx`
- `changelog.d/` (new) — a fragment file describing the change

### Acceptance criteria
- A new state value (e.g. `now`) advances on a `setInterval` of 1–5 seconds, forcing re-render of the departures list.
- `minutesUntil` / `formatDeparture` results visibly update between the 30s polls — a "5 min" label changes to "4 min" within ~1s of the true minute boundary, not up to 30s late.
- The ticker fires no network requests; `/api/transit/departures` is still called only on initial load, the 30s poll, tab re-show, manual refresh, and settings save (verify in Network tab — no extra calls).
- The ticker interval is created once and cleared in a `useEffect` cleanup (no accumulating intervals on re-render); it does not depend on `refreshKey`.
- The color thresholds (`mins <= 1` red, `mins <= 5` orange) update in step with the ticking labels.
- Existing behavior unchanged: visibility-aware polling, skeleton-on-first-load, settings panel, search, drag-reorder all still work.
- `npm run lint` and `npm run build` pass.

### Non-goals
- No changes to the 30s data-refresh cadence or `REFRESH_INTERVAL_MS`.
- No backend changes (`internal/transit/handlers.go` untouched).
- No pausing of the ticker on tab-hidden (a pure client-side timer with no I/O is cheap; reuse the existing visibility logic only if trivial — not required).
- No new translation keys (labels reuse existing `transit:min` etc.).
- No changes to the absolute time format used for departures ≥30 min away.

## Source

Created from Suggestions page (suggestion id 212, page slug "transit", source=claude).

## Original suggestion

Departure labels like "5 min" are computed by minutesUntil() only when the component re-renders, which currently happens just every 30 seconds when the Entur poll fires. Between polls the countdowns sit frozen, so a departure can read "5 min" for nearly half a minute and the number jumps by two at a time, making imminent departures feel inaccurate. Add a lightweight setInterval that bumps a 'now' state value every 1–5 seconds to force a re-render of the existing labels — no extra fetches, just recomputing the already-fetched departure_time against the current clock. Users get a smoothly ticking, trustworthy countdown that matches what they see on the physical stop sign.


---
Bead: Hytte-udcs | Branch: forge/Hytte-udcs
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->