### PR TITLE
Fix jumbled/stale bus departures on kiosk (sort by expected time, drop past departures) (Hytte-i0g0)

### DIFF
--- a/changelog.d/Hytte-i0g0.md
+++ b/changelog.d/Hytte-i0g0.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Bus departures now sorted by expected time** - Transit and kiosk departure boards now order buses by their real-time (expected) departure time and drop already-departed buses, so a delayed earlier bus no longer appears above an on-time later one. The kiosk countdown also updates every second. (Hytte-i0g0)

--- a/internal/transit/entur.go
+++ b/internal/transit/entur.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"sync"
 	"time"
 )
@@ -206,10 +207,17 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 
 	stopName := gqlResp.Data.StopPlace.Name
 
+	now := time.Now()
 	departures := make([]Departure, 0, len(gqlResp.Data.StopPlace.EstimatedCalls))
 	for _, call := range gqlResp.Data.StopPlace.EstimatedCalls {
 		expected, err := time.Parse(time.RFC3339, call.ExpectedDepartureTime)
 		if err != nil {
+			continue
+		}
+		// Drop departures whose expected (real-time) time is already in the
+		// past — Entur orders calls by scheduled time, so a delayed earlier bus
+		// can otherwise linger above on-time later ones.
+		if expected.Before(now) {
 			continue
 		}
 		aimed, err := time.Parse(time.RFC3339, call.AimedDepartureTime)
@@ -234,6 +242,12 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 			DelayMinutes:  delayMinutes,
 		})
 	}
+
+	// Sort by expected departure time so real-time delays don't leave the list
+	// out of chronological order (Entur returns calls ordered by scheduled time).
+	sort.Slice(departures, func(i, j int) bool {
+		return departures[i].DepartureTime.Before(departures[j].DepartureTime)
+	})
 
 	// Store in cache.
 	s.mu.Lock()

--- a/internal/transit/entur.go
+++ b/internal/transit/entur.go
@@ -123,7 +123,7 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 	if hasCached {
 		if time.Now().Before(c.expires) {
 			stopName := c.stopName
-			data := c.data
+			data := filterCurrent(c.data)
 			s.mu.RUnlock()
 			return stopName, data, nil
 		}
@@ -141,7 +141,7 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 	if err != nil {
 		if stale != nil {
 			s.extendStale(cacheKey, stale)
-			return stale.stopName, stale.data, nil
+			return stale.stopName, filterCurrent(stale.data), nil
 		}
 		return "", nil, err
 	}
@@ -150,7 +150,7 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 	if err != nil {
 		if stale != nil {
 			s.extendStale(cacheKey, stale)
-			return stale.stopName, stale.data, nil
+			return stale.stopName, filterCurrent(stale.data), nil
 		}
 		return "", nil, err
 	}
@@ -161,7 +161,7 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 	if err != nil {
 		if stale != nil {
 			s.extendStale(cacheKey, stale)
-			return stale.stopName, stale.data, nil
+			return stale.stopName, filterCurrent(stale.data), nil
 		}
 		return "", nil, err
 	}
@@ -170,7 +170,7 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 	if resp.StatusCode != http.StatusOK {
 		if stale != nil {
 			s.extendStale(cacheKey, stale)
-			return stale.stopName, stale.data, nil
+			return stale.stopName, filterCurrent(stale.data), nil
 		}
 		return "", nil, fmt.Errorf("entur returned status %d", resp.StatusCode)
 	}
@@ -188,7 +188,7 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
 		if stale != nil {
 			s.extendStale(cacheKey, stale)
-			return stale.stopName, stale.data, nil
+			return stale.stopName, filterCurrent(stale.data), nil
 		}
 		return "", nil, err
 	}
@@ -196,7 +196,7 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 	if len(gqlResp.Errors) > 0 {
 		if stale != nil {
 			s.extendStale(cacheKey, stale)
-			return stale.stopName, stale.data, nil
+			return stale.stopName, filterCurrent(stale.data), nil
 		}
 		return "", nil, fmt.Errorf("entur GraphQL error: %s", gqlResp.Errors[0].Message)
 	}
@@ -259,6 +259,19 @@ func (s *Service) FetchDepartures(ctx context.Context, stopID string, count int)
 	s.mu.Unlock()
 
 	return stopName, departures, nil
+}
+
+// filterCurrent returns only departures whose expected time is still in the
+// future. Because the input is already sorted ascending by DepartureTime, we
+// can skip the leading past entries and return the tail.
+func filterCurrent(deps []Departure) []Departure {
+	now := time.Now()
+	for i, d := range deps {
+		if !d.DepartureTime.Before(now) {
+			return deps[i:]
+		}
+	}
+	return nil
 }
 
 // extendStale bumps a stale cache entry's TTL to avoid hammering a failing upstream.

--- a/internal/transit/handlers_test.go
+++ b/internal/transit/handlers_test.go
@@ -262,6 +262,76 @@ func TestDeparturesHandler_StaleCache_ServedOnUpstreamFailure(t *testing.T) {
 	}
 }
 
+func TestFetchDepartures_SortsByExpectedAndDropsPast(t *testing.T) {
+	now := time.Now().UTC()
+	// Build calls in SCHEDULED order (as Entur returns them) but with divergent
+	// real-time delays so the expected order differs, plus one already-departed call.
+	past := now.Add(-2 * time.Minute).Format(time.RFC3339)
+	soon := now.Add(5 * time.Minute).Format(time.RFC3339)
+	later := now.Add(10 * time.Minute).Format(time.RFC3339)
+
+	// First call (scheduled earliest) is heavily delayed so it departs LAST;
+	// second call is on time so it departs FIRST among the future ones.
+	body := `{
+		"data": {
+			"stopPlace": {
+				"name": "Test Stop",
+				"estimatedCalls": [
+					{
+						"expectedDepartureTime": "` + past + `",
+						"aimedDepartureTime":    "` + past + `",
+						"destinationDisplay": {"frontText": "Departed"},
+						"serviceJourney": {"line": {"publicCode": "1"}},
+						"realtime": true
+					},
+					{
+						"expectedDepartureTime": "` + later + `",
+						"aimedDepartureTime":    "` + soon + `",
+						"destinationDisplay": {"frontText": "Delayed"},
+						"serviceJourney": {"line": {"publicCode": "2"}},
+						"realtime": true
+					},
+					{
+						"expectedDepartureTime": "` + soon + `",
+						"aimedDepartureTime":    "` + soon + `",
+						"destinationDisplay": {"frontText": "OnTime"},
+						"serviceJourney": {"line": {"publicCode": "3"}},
+						"realtime": true
+					}
+				]
+			}
+		}
+	}`
+
+	enturServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}))
+	defer enturServer.Close()
+
+	svc := newTestService(enturServer.URL, "http://unused")
+
+	_, deps, err := svc.FetchDepartures(context.Background(), "NSR:StopPlace:1", numberOfDepartures)
+	if err != nil {
+		t.Fatalf("FetchDepartures: %v", err)
+	}
+
+	// The past departure must be dropped.
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 future departures, got %d", len(deps))
+	}
+
+	// Output must be sorted ascending by expected departure time:
+	// OnTime (5 min) before Delayed (10 min), even though Delayed was scheduled earlier.
+	if deps[0].Destination != "OnTime" || deps[1].Destination != "Delayed" {
+		t.Errorf("expected [OnTime, Delayed] sorted by expected time, got [%s, %s]",
+			deps[0].Destination, deps[1].Destination)
+	}
+	if deps[1].DepartureTime.Before(deps[0].DepartureTime) {
+		t.Errorf("departures not sorted ascending by expected time")
+	}
+}
+
 // --- SearchHandler ---
 
 func TestSearchHandler_MissingQuery(t *testing.T) {

--- a/internal/transit/handlers_test.go
+++ b/internal/transit/handlers_test.go
@@ -332,6 +332,73 @@ func TestFetchDepartures_SortsByExpectedAndDropsPast(t *testing.T) {
 	}
 }
 
+func TestFetchDepartures_CacheFiltersPastOnReturn(t *testing.T) {
+	// A departure that is in the future when cached can age past its departure
+	// time before the cache expires. The cache-return path must filter it out.
+	soonish := time.Now().Add(2 * time.Second).UTC().Format(time.RFC3339)
+	later := time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)
+
+	body := `{
+		"data": {
+			"stopPlace": {
+				"name": "Cache Test",
+				"estimatedCalls": [
+					{
+						"expectedDepartureTime": "` + soonish + `",
+						"aimedDepartureTime":    "` + soonish + `",
+						"destinationDisplay": {"frontText": "Imminent"},
+						"serviceJourney": {"line": {"publicCode": "1"}},
+						"realtime": true
+					},
+					{
+						"expectedDepartureTime": "` + later + `",
+						"aimedDepartureTime":    "` + later + `",
+						"destinationDisplay": {"frontText": "Later"},
+						"serviceJourney": {"line": {"publicCode": "2"}},
+						"realtime": true
+					}
+				]
+			}
+		}
+	}`
+
+	enturServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}))
+	defer enturServer.Close()
+
+	svc := newTestService(enturServer.URL, "http://unused")
+	stopID := "NSR:StopPlace:cache-test"
+
+	_, deps, err := svc.FetchDepartures(context.Background(), stopID, numberOfDepartures)
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 departures on first fetch, got %d", len(deps))
+	}
+
+	// Manually move the first departure into the past in the cache so that
+	// the cache-return path must filter it out.
+	cacheKey := fmt.Sprintf("%s:%d", stopID, numberOfDepartures)
+	svc.mu.Lock()
+	svc.cache[cacheKey].data[0].DepartureTime = time.Now().Add(-1 * time.Minute)
+	svc.mu.Unlock()
+
+	// Second fetch hits the cache.
+	_, deps2, err := svc.FetchDepartures(context.Background(), stopID, numberOfDepartures)
+	if err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if len(deps2) != 1 {
+		t.Fatalf("expected 1 departure after cache filter, got %d", len(deps2))
+	}
+	if deps2[0].Destination != "Later" {
+		t.Errorf("expected remaining departure to be 'Later', got %q", deps2[0].Destination)
+	}
+}
+
 // --- SearchHandler ---
 
 func TestSearchHandler_MissingQuery(t *testing.T) {

--- a/web/src/components/kiosk/KioskBusDepartures.tsx
+++ b/web/src/components/kiosk/KioskBusDepartures.tsx
@@ -56,11 +56,11 @@ export default function KioskBusDepartures({ stops }: Props) {
   // Toggle visibility to retrigger the fade-in animation whenever stops data refreshes
   const [visible, setVisible] = useState(true)
   const prevStopsRef = useRef(stops)
-  // Tick every 30s so minutesUntil() stays accurate between data refreshes
+  // Tick every second so the countdown stays accurate and minutes don't visibly jump
   const [, setTick] = useState(0)
 
   useEffect(() => {
-    const id = window.setInterval(() => setTick((n) => n + 1), 30_000)
+    const id = window.setInterval(() => setTick((n) => n + 1), 1_000)
     return () => window.clearInterval(id)
   }, [])
 
@@ -90,7 +90,14 @@ export default function KioskBusDepartures({ stops }: Props) {
             {stop.stop_name}
           </div>
           <div className="space-y-1">
-            {stop.departures.slice(0, 6).map((dep) => {
+            {[...stop.departures]
+              .sort(
+                (a, b) =>
+                  new Date(a.departure_time).getTime() -
+                  new Date(b.departure_time).getTime(),
+              )
+              .slice(0, 6)
+              .map((dep) => {
               const mins = minutesUntil(dep.departure_time)
               return (
                 <div
@@ -116,8 +123,8 @@ export default function KioskBusDepartures({ stops }: Props) {
                     <span className="text-xs text-red-400">+{dep.delay_minutes}</span>
                   )}
                 </div>
-              )
-            })}
+                )
+              })}
           </div>
         </div>
       ))}

--- a/web/src/components/kiosk/KioskBusDepartures.tsx
+++ b/web/src/components/kiosk/KioskBusDepartures.tsx
@@ -91,6 +91,10 @@ export default function KioskBusDepartures({ stops }: Props) {
           </div>
           <div className="space-y-1">
             {[...stop.departures]
+              .filter((dep) => {
+                const t = new Date(dep.departure_time).getTime()
+                return !isNaN(t) && t > Date.now()
+              })
               .sort(
                 (a, b) =>
                   new Date(a.departure_time).getTime() -


### PR DESCRIPTION
## Changes

- **Bus departures now sorted by expected time** - Transit and kiosk departure boards now order buses by their real-time (expected) departure time and drop already-departed buses, so a delayed earlier bus no longer appears above an on-time later one. The kiosk countdown also updates every second. (Hytte-i0g0)

## Original Issue (task): Fix jumbled/stale bus departures on kiosk (sort by expected time, drop past departures)

The kiosk transit board renders departures out of chronological order after running for a while (every time, eventually), and keeps showing already-departed buses.

Root cause: departures are never sorted by their real-time (expected) departure time anywhere in the path. Entur's GraphQL estimatedCalls (internal/transit/entur.go:59) returns calls ordered by SCHEDULED time, but the backend stores and the UI renders the EXPECTED time (entur.go:231, DepartureTime: expected). The kiosk computes the countdown from expected (web/src/components/kiosk/KioskBusDepartures.tsx:21-24) and just takes the first 6 in array order (line 93, slice(0,6)) with no re-sort. Once real-time delays appear (most of the day, accumulating as the kiosk runs), scheduled order and expected order diverge, so a delayed earlier bus is listed above an on-time later one — e.g. '10 min' shown above '5 min'. Fresh boot looks fine because there are no delays yet.

Secondary: past departures are never dropped. minutesUntil() clamps with Math.max(0, ...) (line 23) so a departed bus shows 'nå'/0 and keeps its top-6 slot during the 30s backend cache window (longer if the stale-cache fallback at entur.go:141-200 is serving degraded data), pushing real upcoming buses out of view.

---
Bead: Hytte-i0g0 | Branch: forge/Hytte-i0g0
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->