### PR TITLE
Keep kiosk screen awake via Screen Wake Lock API (Hytte-ghlf)

### DIFF
--- a/changelog.d/Hytte-ghlf.md
+++ b/changelog.d/Hytte-ghlf.md
@@ -1,0 +1,2 @@
+category: Added
+- **Keep kiosk screen awake** - The kiosk display now requests a Screen Wake Lock so the device screen stays on while showing the kiosk, re-acquiring after the tab regains visibility and gracefully no-opping on unsupported browsers. (Hytte-ghlf)

--- a/web/src/hooks/useWakeLock.ts
+++ b/web/src/hooks/useWakeLock.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react'
+
+/**
+ * Keeps the device screen awake for as long as the component is mounted by
+ * holding a {@link https://developer.mozilla.org/docs/Web/API/Screen_Wake_Lock_API
+ * Screen Wake Lock}.
+ *
+ * The lock is auto-released by the browser whenever the tab is backgrounded or
+ * the screen briefly turns off, so it is re-acquired on `visibilitychange`
+ * whenever the page becomes visible again. The lock is released on unmount.
+ *
+ * Feature-detects `navigator.wakeLock` and no-ops (with a `console.debug`) on
+ * unsupported browsers. Never throws.
+ *
+ * Note: the lock only holds while this is the foreground tab, and Android
+ * battery saver can still override it. For a permanent kiosk, also max out the
+ * device's display/screen-timeout setting.
+ */
+export function useWakeLock(): void {
+  useEffect(() => {
+    if (!('wakeLock' in navigator)) {
+      console.debug('Screen Wake Lock API not supported')
+      return
+    }
+
+    let wakeLock: WakeLockSentinel | null = null
+
+    async function acquire() {
+      try {
+        wakeLock = await navigator.wakeLock.request('screen')
+      } catch (err) {
+        // e.g. lock denied while not visible, or battery saver active
+        console.debug('Wake lock request failed', err)
+      }
+    }
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'visible') acquire()
+    }
+
+    acquire()
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      wakeLock?.release().catch(() => {})
+      wakeLock = null
+    }
+  }, [])
+}

--- a/web/src/hooks/useWakeLock.ts
+++ b/web/src/hooks/useWakeLock.ts
@@ -24,12 +24,18 @@ export function useWakeLock(): void {
     }
 
     let wakeLock: WakeLockSentinel | null = null
+    let cancelled = false
 
     async function acquire() {
+      if (cancelled || (wakeLock && !wakeLock.released)) return
       try {
-        wakeLock = await navigator.wakeLock.request('screen')
+        const sentinel = await navigator.wakeLock.request('screen')
+        if (cancelled) {
+          sentinel.release().catch(() => {})
+          return
+        }
+        wakeLock = sentinel
       } catch (err) {
-        // e.g. lock denied while not visible, or battery saver active
         console.debug('Wake lock request failed', err)
       }
     }
@@ -42,6 +48,7 @@ export function useWakeLock(): void {
     document.addEventListener('visibilitychange', handleVisibilityChange)
 
     return () => {
+      cancelled = true
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       wakeLock?.release().catch(() => {})
       wakeLock = null

--- a/web/src/pages/KioskPage.tsx
+++ b/web/src/pages/KioskPage.tsx
@@ -8,6 +8,7 @@ import type { ForecastData } from '../components/kiosk/KioskWeather'
 import KioskSunrise from '../components/kiosk/KioskSunrise'
 import KioskStaleBadge from '../components/kiosk/KioskStaleBadge'
 import mockData from '../mocks/kioskData.json'
+import { useWakeLock } from '../hooks/useWakeLock'
 
 // Error boundary so that JS errors show a visible message instead of a blank
 // white page. This is especially important on older browsers (Android 5 /
@@ -145,6 +146,10 @@ const KIOSK_TOKEN_KEY = 'hytte_kiosk_token'
 
 function KioskPageInner() {
   const [searchParams] = useSearchParams()
+
+  // Keep the screen awake while the kiosk is displayed (re-acquires on
+  // visibility change; no-ops on browsers without the Wake Lock API).
+  useWakeLock()
 
   // Override the PWA manifest so "Add to Home Screen" uses /kiosk as start_url
   useEffect(() => {


### PR DESCRIPTION
## Changes

- **Keep kiosk screen awake** - The kiosk display now requests a Screen Wake Lock so the device screen stays on while showing the kiosk, re-acquiring after the tab regains visibility and gracefully no-opping on unsupported browsers. (Hytte-ghlf)

## Original Issue (task): Keep kiosk screen awake via Screen Wake Lock API

The kiosk display lets the device screen sleep after a while; Robin asked whether the screen can be forced to stay on without installing a separate app. It can, via the browser Screen Wake Lock API (navigator.wakeLock.request('screen')), which is supported in Chrome on Android (the family's only platform). There is currently zero wake-lock code in the repo.

---
Bead: Hytte-ghlf | Branch: forge/Hytte-ghlf
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->