### PR TITLE
Extract shared Wordfeud tile constants into one module (Hytte-5cn3)

### DIFF
--- a/changelog.d/Hytte-5cn3.md
+++ b/changelog.d/Hytte-5cn3.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Consolidated shared Wordfeud tile constants** - Moved `LETTER_VALUES`, `TILE_BAG`, and `BOARD_LAYOUT` (plus the `BonusType` type) into a single `wordfeudConstants.ts` module so scoring, bag distribution, and board layout have one source of truth. Pure refactor with no value changes. (Hytte-5cn3)

--- a/web/src/pages/WordfeudBoard.tsx
+++ b/web/src/pages/WordfeudBoard.tsx
@@ -4,59 +4,11 @@ import { Link } from 'react-router-dom'
 import { Trash2, Search, Loader2, Trophy, ChevronDown, ChevronRight, RefreshCw } from 'lucide-react'
 import { formatDate } from '../utils/formatDate'
 import { useAuth } from '../auth'
-
-// Scoring table: official Norwegian Wordfeud tile point values from the API
-// (POST /tile_points/1/). Q, X, Z are included here for completeness but have
-// 0 tiles in the Norwegian bag and will never appear in actual play.
-const LETTER_VALUES: Record<string, number> = {
-  A: 1, B: 4, C: 10, D: 1, E: 1, F: 2, G: 4, H: 3, I: 2, J: 4,
-  K: 3, L: 2, M: 2, N: 1, O: 3, P: 4, Q: 10, R: 1, S: 1, T: 1,
-  U: 4, V: 5, W: 10, X: 10, Y: 8, Z: 10, 'Æ': 8, 'Ø': 5, 'Å': 4,
-}
-
-// Norwegian Wordfeud tile bag distribution — Q, X, Z have 0 tiles and are absent
-const TILE_BAG: { letter: string; count: number }[] = [
-  { letter: 'A', count: 7 }, { letter: 'B', count: 3 }, { letter: 'C', count: 1 },
-  { letter: 'D', count: 5 }, { letter: 'E', count: 9 }, { letter: 'F', count: 4 },
-  { letter: 'G', count: 4 }, { letter: 'H', count: 3 }, { letter: 'I', count: 6 },
-  { letter: 'J', count: 2 }, { letter: 'K', count: 4 }, { letter: 'L', count: 5 },
-  { letter: 'M', count: 3 }, { letter: 'N', count: 6 }, { letter: 'O', count: 4 },
-  { letter: 'P', count: 2 }, { letter: 'R', count: 7 },
-  { letter: 'S', count: 7 }, { letter: 'T', count: 7 }, { letter: 'U', count: 3 },
-  { letter: 'V', count: 3 }, { letter: 'W', count: 1 },
-  { letter: 'Y', count: 1 }, { letter: 'Æ', count: 1 },
-  { letter: 'Ø', count: 2 }, { letter: 'Å', count: 2 }, { letter: '*', count: 2 },
-]
+import { LETTER_VALUES, TILE_BAG, BOARD_LAYOUT, type BonusType } from './wordfeudConstants'
 
 const TOTAL_TILES = 104
 
-// Board cell multiplier types
-// 0=normal, 1=DL, 2=TL, 3=DW, 4=TW, 5=center
-type BonusType = 0 | 1 | 2 | 3 | 4 | 5
-
 const BONUS_LABELS = ['', 'DL', 'TL', 'DW', 'TW', '\u2605'] as const
-
-// Standard Wordfeud board layout (15x15, symmetric)
-// prettier-ignore
-// Standard Wordfeud board layout (board ID 0), fetched from POST /board/0/.
-// 0=normal, 1=DL, 2=TL, 3=DW, 4=TW, 5=center star
-const BOARD_LAYOUT: BonusType[][] = [
-  [2,0,0,0,4,0,0,1,0,0,4,0,0,0,2],
-  [0,1,0,0,0,2,0,0,0,2,0,0,0,1,0],
-  [0,0,3,0,0,0,1,0,1,0,0,0,3,0,0],
-  [0,0,0,2,0,0,0,3,0,0,0,2,0,0,0],
-  [4,0,0,0,3,0,1,0,1,0,3,0,0,0,4],
-  [0,2,0,0,0,2,0,0,0,2,0,0,0,2,0],
-  [0,0,1,0,1,0,0,0,0,0,1,0,1,0,0],
-  [1,0,0,3,0,0,0,5,0,0,0,3,0,0,1],
-  [0,0,1,0,1,0,0,0,0,0,1,0,1,0,0],
-  [0,2,0,0,0,2,0,0,0,2,0,0,0,2,0],
-  [4,0,0,0,3,0,1,0,1,0,3,0,0,0,4],
-  [0,0,0,2,0,0,0,3,0,0,0,2,0,0,0],
-  [0,0,3,0,0,0,1,0,1,0,0,0,3,0,0],
-  [0,1,0,0,0,2,0,0,0,2,0,0,0,1,0],
-  [2,0,0,0,4,0,0,1,0,0,4,0,0,0,2],
-]
 
 function bonusClass(type: BonusType): string {
   switch (type) {

--- a/web/src/pages/wordfeudConstants.ts
+++ b/web/src/pages/wordfeudConstants.ts
@@ -30,10 +30,10 @@ export const TILE_BAG: { letter: string; count: number }[] = [
 // 0=normal, 1=DL, 2=TL, 3=DW, 4=TW, 5=center
 export type BonusType = 0 | 1 | 2 | 3 | 4 | 5
 
-// Standard Wordfeud board layout (15x15, symmetric)
-// prettier-ignore
-// Standard Wordfeud board layout (board ID 0), fetched from POST /board/0/.
+// Standard Wordfeud board layout (board ID 0, 15x15 symmetric),
+// fetched from POST /board/0/.
 // 0=normal, 1=DL, 2=TL, 3=DW, 4=TW, 5=center star
+// prettier-ignore
 export const BOARD_LAYOUT: BonusType[][] = [
   [2,0,0,0,4,0,0,1,0,0,4,0,0,0,2],
   [0,1,0,0,0,2,0,0,0,2,0,0,0,1,0],

--- a/web/src/pages/wordfeudConstants.ts
+++ b/web/src/pages/wordfeudConstants.ts
@@ -1,0 +1,53 @@
+// Shared Wordfeud tile constants — single source of truth for scoring, bag
+// distribution, and board layout. These were previously duplicated/drifting
+// across components, which caused recurring mismatch bugs. Keep all tile/letter
+// value corrections in this one module.
+
+// Scoring table: official Norwegian Wordfeud tile point values from the API
+// (POST /tile_points/1/). Q, X, Z are included here for completeness but have
+// 0 tiles in the Norwegian bag and will never appear in actual play.
+export const LETTER_VALUES: Record<string, number> = {
+  A: 1, B: 4, C: 10, D: 1, E: 1, F: 2, G: 4, H: 3, I: 2, J: 4,
+  K: 3, L: 2, M: 2, N: 1, O: 3, P: 4, Q: 10, R: 1, S: 1, T: 1,
+  U: 4, V: 5, W: 10, X: 10, Y: 8, Z: 10, 'Æ': 8, 'Ø': 5, 'Å': 4,
+}
+
+// Norwegian Wordfeud tile bag distribution — Q, X, Z have 0 tiles and are absent
+export const TILE_BAG: { letter: string; count: number }[] = [
+  { letter: 'A', count: 7 }, { letter: 'B', count: 3 }, { letter: 'C', count: 1 },
+  { letter: 'D', count: 5 }, { letter: 'E', count: 9 }, { letter: 'F', count: 4 },
+  { letter: 'G', count: 4 }, { letter: 'H', count: 3 }, { letter: 'I', count: 6 },
+  { letter: 'J', count: 2 }, { letter: 'K', count: 4 }, { letter: 'L', count: 5 },
+  { letter: 'M', count: 3 }, { letter: 'N', count: 6 }, { letter: 'O', count: 4 },
+  { letter: 'P', count: 2 }, { letter: 'R', count: 7 },
+  { letter: 'S', count: 7 }, { letter: 'T', count: 7 }, { letter: 'U', count: 3 },
+  { letter: 'V', count: 3 }, { letter: 'W', count: 1 },
+  { letter: 'Y', count: 1 }, { letter: 'Æ', count: 1 },
+  { letter: 'Ø', count: 2 }, { letter: 'Å', count: 2 }, { letter: '*', count: 2 },
+]
+
+// Board cell multiplier types
+// 0=normal, 1=DL, 2=TL, 3=DW, 4=TW, 5=center
+export type BonusType = 0 | 1 | 2 | 3 | 4 | 5
+
+// Standard Wordfeud board layout (15x15, symmetric)
+// prettier-ignore
+// Standard Wordfeud board layout (board ID 0), fetched from POST /board/0/.
+// 0=normal, 1=DL, 2=TL, 3=DW, 4=TW, 5=center star
+export const BOARD_LAYOUT: BonusType[][] = [
+  [2,0,0,0,4,0,0,1,0,0,4,0,0,0,2],
+  [0,1,0,0,0,2,0,0,0,2,0,0,0,1,0],
+  [0,0,3,0,0,0,1,0,1,0,0,0,3,0,0],
+  [0,0,0,2,0,0,0,3,0,0,0,2,0,0,0],
+  [4,0,0,0,3,0,1,0,1,0,3,0,0,0,4],
+  [0,2,0,0,0,2,0,0,0,2,0,0,0,2,0],
+  [0,0,1,0,1,0,0,0,0,0,1,0,1,0,0],
+  [1,0,0,3,0,0,0,5,0,0,0,3,0,0,1],
+  [0,0,1,0,1,0,0,0,0,0,1,0,1,0,0],
+  [0,2,0,0,0,2,0,0,0,2,0,0,0,2,0],
+  [4,0,0,0,3,0,1,0,1,0,3,0,0,0,4],
+  [0,0,0,2,0,0,0,3,0,0,0,2,0,0,0],
+  [0,0,3,0,0,0,1,0,1,0,0,0,3,0,0],
+  [0,1,0,0,0,2,0,0,0,2,0,0,0,1,0],
+  [2,0,0,0,4,0,0,1,0,0,4,0,0,0,2],
+]


### PR DESCRIPTION
## Changes

- **Consolidated shared Wordfeud tile constants** - Moved `LETTER_VALUES`, `TILE_BAG`, and `BOARD_LAYOUT` (plus the `BonusType` type) into a single `wordfeudConstants.ts` module so scoring, bag distribution, and board layout have one source of truth. Pure refactor with no value changes. (Hytte-5cn3)

## Original Issue (feature): Extract shared Wordfeud tile constants into one module

### Scope
Extract the three hardcoded Wordfeud constants (`LETTER_VALUES`, `TILE_BAG`, `BOARD_LAYOUT`) currently living inside `WordfeudBoard.tsx` into a single new frontend module, then update every consumer to import from that module. This is a pure refactor: no behavioral change to scoring, bag distribution, or board rendering. The goal is one source of truth so future tile/scoring corrections happen in exactly one place, ending the recurring drift-induced bug class.

### Files to touch
- `web/src/pages/wordfeudConstants.ts` (new) — exports `LETTER_VALUES`, `TILE_BAG`, `BOARD_LAYOUT` and any related types.
- `web/src/pages/WordfeudBoard.tsx` — remove inline definitions, import from the new module.
- `web/src/pages/WordfeudPage.tsx` — import from the new module if it currently redefines or hardcodes any of these values.
- `web/src/pages/WordfeudLocalGames.tsx` — same, if it uses copies of these constants.
- Any other `web/src` file found (via grep for `LETTER_VALUES`/`TILE_BAG`/`BOARD_LAYOUT` and the literal Norwegian tile values) that holds a duplicate.

### Acceptance criteria
- A single new module exports all three constants; no other `web/src` file defines its own copy of `LETTER_VALUES`, `TILE_BAG`, or `BOARD_LAYOUT`.
- A repo-wide grep confirms each constant is declared exactly once and only imported elsewhere.
- The extracted values are byte-for-byte identical to the current `WordfeudBoard.tsx` definitions (correct letter values, no Q/X/Z, verified Norwegian bag counts) — no values changed during the move.
- The board renders identically and scoring/bag displays are unchanged in the running app at `/wordfeud`.
- `npm run lint` and `npm run build` pass with no new warnings or unused-import errors.
- A changelog fragment is added under `changelog.d/` (category `Changed`).

### Non-goals
- No changes to backend constants in `internal/wordfeud/*.go`; this plan is frontend-only and does not attempt to share constants across the Go/TS boundary.
- No correctness changes to letter values, tile counts, or board layout — only relocation.
- No refactor of component logic, rendering, or the solver beyond swapping the constant source.
- No new tests for unchanged values (optional snapshot assertion may be added but is not required).
- No renaming of the constants' exported identifiers.

## Source

Created from Suggestions page (suggestion id 179, page slug "wordfeud", source=claude).

## Original suggestion

LETTER_VALUES, TILE_BAG, and BOARD_LAYOUT are hardcoded inside WordfeudBoard.tsx and overlap with values used elsewhere; the commit history ("correct letter values + remove Q/X/Z in frontend Board component too", "verify exact Norwegian tile bag counts") shows these constants have drifted between copies and caused repeated bugs. Move them to a single web/src/pages/wordfeudConstants.ts (or similar) and import them everywhere they are needed. This gives one source of truth for scoring and bag distribution so future corrections only need to be made once, preventing the recurring mismatch class of bugs.


---
Bead: Hytte-5cn3 | Branch: forge/Hytte-5cn3
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->