### PR TITLE
Reset WordFinder results when the search mode changes (Hytte-prp9)

### DIFF
--- a/changelog.d/Hytte-prp9.md
+++ b/changelog.d/Hytte-prp9.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **WordFinder clears results on mode switch** - Switching the search mode (anagram, contains, starts with, ends with) now resets the results, total match count, error message, and search status together, so the empty state appears immediately instead of showing stale results from the previous mode. (Hytte-prp9)

--- a/web/src/pages/WordfeudPage.tsx
+++ b/web/src/pages/WordfeudPage.tsx
@@ -224,6 +224,7 @@ function WordFinder() {
               setSearching(false)
               setMode(m.value)
               setResults([])
+              setTotalMatches(0)
               setHasSearched(false)
               setError(null)
             }}


### PR DESCRIPTION
## Changes

- **WordFinder clears results on mode switch** - Switching the search mode (anagram, contains, starts with, ends with) now resets the results, total match count, error message, and search status together, so the empty state appears immediately instead of showing stale results from the previous mode. (Hytte-prp9)

## Original Issue (feature): Reset WordFinder results when the search mode changes

### Scope
The WordFinder section of `WordfeudPage.tsx` already clears most state on mode switch, but the mode-selector `onClick` handler (lines 221–229) omits `setTotalMatches(0)`. The stale `totalMatches` value persists and surfaces in the results-count label the next time `hasSearched` becomes true, and is conceptually inconsistent with the rest of the reset. This plan closes that gap so all result-related state (`results`, `totalMatches`, `error`, `hasSearched`) is reset together whenever the `SearchMode` changes.

### Files to touch
- `web/src/pages/WordfeudPage.tsx` — add `setTotalMatches(0)` to the mode-button `onClick` reset block (or consolidate the four resets into a single `resetResults()` helper used by the handler).
- `changelog.d/` — add a `Fixed` changelog fragment (new).

### Acceptance criteria
- Switching between any two `SearchMode` values (anagram, starts_with, ends_with, contains) clears `results`, `totalMatches`, `error`, and `hasSearched` in one action.
- After a search returns results (or an error) and the user switches mode, the empty-state UI appears immediately — no stale result list, no lingering error message, and no carried-over match count.
- An in-flight search is still aborted on mode switch (existing `controllerRef.current?.abort()` / `setSearching(false)` behavior is preserved).
- The new changelog fragment is present in `changelog.d/` under the `Fixed` category, English only, referencing the bead id.
- `npm run lint` and `npm run build` pass; no TypeScript errors introduced.

### Non-goals
- No changes to backend search logic (`internal/wordfeud/handlers.go`, `api.go`) or the board/local-games components.
- No redesign of the WordFinder UI, mode selector, or input fields.
- No new tests infrastructure beyond what the change warrants (the project has no existing React test harness for this page).
- No behavioral change to how searches are triggered or how results are rendered.

## Source

Created from Suggestions page (suggestion id 178, page slug "wordfeud", source=claude).

## Original suggestion

In WordFinder, switching the SearchMode (anagram, starts_with, ends_with, contains) does not clear the previous results, totalMatches, error, or hasSearched state — so the old result list and any error message linger until the user runs a new search, falsely implying they belong to the newly selected mode. Add an effect or onChange handler that clears results, totalMatches, error, and hasSearched whenever mode changes. This removes the confusing stale-results flash and makes the empty-state appear correctly after switching modes.


---
Bead: Hytte-prp9 | Branch: forge/Hytte-prp9
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->