### PR TITLE
Flaky ChatView dedup test fails in isolation (Hytte-n92d)

### DIFF
--- a/changelog.d/Hytte-n92d.md
+++ b/changelog.d/Hytte-n92d.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Family chat message deduplication is now order-independent** - When a sent message arrived via both the POST response and the SSE `message_new` broadcast, a race could leave two identical bubbles if the SSE event was processed before the POST resolved. Reconciling an optimistic bubble now also drops any duplicate row sharing the same server id. (Hytte-n92d)

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -567,11 +567,12 @@ describe('ChatView – SSE live updates', () => {
     // client_id collapses the optimistic bubble and the SSE row into one
     // regardless of whether the POST response or the SSE event lands first —
     // which is what makes this dedup deterministic instead of timing-dependent.
-    const clientId = JSON.parse(
-      (fetchMock.mock.calls.find(
-        c => /\/messages$/.test(String(c[0])) && (c[1] as RequestInit | undefined)?.method === 'POST',
-      )![1] as RequestInit).body as string,
-    ).client_id
+    const postCall = fetchMock.mock.calls.find(
+      c => /\/messages$/.test(String(c[0])) && (c[1] as RequestInit | undefined)?.method === 'POST',
+    )
+    expect(postCall).toBeDefined()
+    const clientId = JSON.parse((postCall![1] as RequestInit).body as string).client_id
+    expect(clientId).toBeTruthy()
 
     await act(async () => {
       sse.push('message_new', { message: { ...newMsg, client_id: clientId } })

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -546,13 +546,13 @@ describe('ChatView – SSE live updates', () => {
   it('deduplicates a message delivered via both POST response and SSE', async () => {
     const sse = streamWithController()
     const newMsg = makeMessage({ id: 7, body: 'Dedup me', sender_user_id: 1 })
-    vi.stubGlobal('fetch', vi.fn()
+    const fetchMock = vi.fn()
       .mockResolvedValueOnce(convOk())
       .mockResolvedValueOnce(msgsOk([]))
       .mockResolvedValueOnce(sse.response)
       .mockResolvedValueOnce({ ok: true }) // typing indicator POST
-      .mockResolvedValueOnce(sendOk(newMsg)),
-    )
+      .mockResolvedValueOnce(sendOk(newMsg))
+    vi.stubGlobal('fetch', fetchMock)
     renderChatView()
     await waitFor(() => screen.getByText('No messages yet. Say hello!'))
 
@@ -562,8 +562,19 @@ describe('ChatView – SSE live updates', () => {
 
     await waitFor(() => screen.getByText('Dedup me'))
 
+    // The server echoes the sender's client_id on the message_new broadcast
+    // (see internal/familychat/handlers.go), so model that here. Reconciling by
+    // client_id collapses the optimistic bubble and the SSE row into one
+    // regardless of whether the POST response or the SSE event lands first —
+    // which is what makes this dedup deterministic instead of timing-dependent.
+    const clientId = JSON.parse(
+      (fetchMock.mock.calls.find(
+        c => /\/messages$/.test(String(c[0])) && (c[1] as RequestInit | undefined)?.method === 'POST',
+      )![1] as RequestInit).body as string,
+    ).client_id
+
     await act(async () => {
-      sse.push('message_new', { message: newMsg })
+      sse.push('message_new', { message: { ...newMsg, client_id: clientId } })
       await Promise.resolve()
     })
 

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -100,8 +100,19 @@ function reconcileMessage(
   if (clientId) {
     const idx = prev.findIndex(m => m.client_id === clientId)
     if (idx !== -1) {
-      const next = prev.slice()
-      next[idx] = { ...incoming, client_id: clientId, status: undefined }
+      const reconciled = { ...incoming, client_id: clientId, status: undefined }
+      // Replace the optimistic bubble in place, and drop any *other* row that
+      // already carries the same authoritative id. That second row appears when
+      // an SSE message_new for this same send lands before the POST response
+      // and gets appended separately (e.g. an event that omitted our
+      // client_id); without this filter the reconcile would leave two bubbles
+      // sharing one id.
+      const next: ChatMessage[] = []
+      prev.forEach((m, i) => {
+        if (i === idx) { next.push(reconciled); return }
+        if (m.id === incoming.id) return
+        next.push(m)
+      })
       return next
     }
   }


### PR DESCRIPTION
## Changes

- **Family chat message deduplication is now order-independent** - When a sent message arrived via both the POST response and the SSE `message_new` broadcast, a race could leave two identical bubbles if the SSE event was processed before the POST resolved. Reconciling an optimistic bubble now also drops any duplicate row sharing the same server id. (Hytte-n92d)

## Original Issue (bug): Flaky ChatView dedup test fails in isolation

src/pages/familychat/ChatView.test.tsx 'deduplicates a message delivered via both POST response and SSE' (around line 423) fails consistently in the worktree environment (expects 1 'Dedup me' bubble, gets 2). Confirmed pre-existing: it also fails with an unmodified ChatView.tsx. Likely a timing/fake-stream interaction in the happy-dom/vitest setup where the optimistic POST-response message and the duplicate SSE message_new (same id) are not deduped under test timing.

---
Bead: Hytte-n92d | Branch: forge/Hytte-n92d
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->