### PR TITLE
Family chat: message list scrolls off-screen when input focused with keyboard open (mobile) (Hytte-7xbc)

### DIFF
--- a/changelog.d/Hytte-7xbc.md
+++ b/changelog.d/Hytte-7xbc.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Family chat stays readable with the keyboard open on mobile** - Focusing the message input no longer scrolls the conversation off the top of the screen. The chat now resizes to the keyboard-reduced viewport (via the VisualViewport API, `dvh` heights, and `interactive-widget=resizes-content`) so the composer stays pinned above the keyboard and the newest messages remain visible. (Hytte-7xbc)

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/hytte-icon.svg" />
     <link rel="manifest" href="/manifest.json" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
     <meta name="theme-color" content="#030712" />
     <title>Hytte</title>
   </head>

--- a/web/src/hooks/useKeyboardInset.ts
+++ b/web/src/hooks/useKeyboardInset.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+
+// useKeyboardInset returns the height (in CSS pixels) currently covered by the
+// on-screen keyboard, derived from the VisualViewport API. It is 0 when no
+// keyboard is open, while the page is scrolled normally, or when the API is
+// unavailable (older browsers, SSR-style environments without window).
+//
+// The value lets a full-height view shrink so its bottom edge (e.g. a chat
+// composer) stays pinned above the keyboard instead of being pushed off-screen.
+//
+// It composes cleanly with the CSS `interactive-widget=resizes-content`
+// viewport hint: on browsers that honour it (Chrome Android) the layout
+// viewport already shrinks when the keyboard opens, so `window.innerHeight`
+// tracks the keyboard and this inset stays ~0 — no double-counting. On browsers
+// that don't (notably iOS Safari) the layout viewport stays full and this inset
+// reports the real keyboard height.
+export function useKeyboardInset(): number {
+  const [inset, setInset] = useState(0)
+
+  useEffect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+    const opts: AddEventListenerOptions = { passive: true }
+
+    const onResize = () => {
+      // window.innerHeight is the layout viewport; vv.height + vv.offsetTop is
+      // the bottom edge of the visible (keyboard-reduced) viewport. The gap is
+      // the keyboard. Clamp at 0 so a transient negative (rounding) never grows
+      // the container.
+      const next = Math.max(0, window.innerHeight - (vv.height + vv.offsetTop))
+      // Ignore sub-pixel jitter so we don't thrash re-renders while scrolling.
+      setInset(prev => (Math.abs(prev - next) < 1 ? prev : next))
+    }
+
+    vv.addEventListener('resize', onResize, opts)
+    vv.addEventListener('scroll', onResize, opts)
+    onResize()
+    return () => {
+      vv.removeEventListener('resize', onResize, opts)
+      vv.removeEventListener('scroll', onResize, opts)
+    }
+  }, [])
+
+  return inset
+}

--- a/web/src/hooks/useKeyboardInset.ts
+++ b/web/src/hooks/useKeyboardInset.ts
@@ -18,6 +18,7 @@ export function useKeyboardInset(): number {
   const [inset, setInset] = useState(0)
 
   useEffect(() => {
+    if (typeof window === 'undefined') return
     const vv = window.visualViewport
     if (!vv) return
     const opts: AddEventListenerOptions = { passive: true }

--- a/web/src/pages/FamilyChat.tsx
+++ b/web/src/pages/FamilyChat.tsx
@@ -1,13 +1,19 @@
-import { useState } from 'react'
+import { useState, type CSSProperties } from 'react'
 import ConversationList from './familychat/ConversationList'
 import ChatView from './familychat/ChatView'
 import NewConversationModal from './familychat/NewConversationModal'
 import { FamilyChatProvider, useFamilyChat } from './familychat/FamilyChatContext'
+import { useKeyboardInset } from '../hooks/useKeyboardInset'
 
 function FamilyChatInner() {
   const { refreshConversations } = useFamilyChat()
   const [selectedConversationId, setSelectedConversationId] = useState<number | null>(null)
   const [newConversationOpen, setNewConversationOpen] = useState(false)
+  // When the mobile on-screen keyboard opens it covers the bottom of the
+  // viewport. We shrink the chat shell by that amount (and use dvh instead of
+  // vh) so the composer stays pinned above the keyboard and the message list
+  // keeps the newest messages visible instead of scrolling off the top.
+  const keyboardInset = useKeyboardInset()
 
   const handleSelectConversation = (id: number) => {
     setSelectedConversationId(id)
@@ -32,7 +38,10 @@ function FamilyChatInner() {
   }
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)] md:h-screen">
+    <div
+      className="flex h-[calc(100dvh-3.5rem-var(--kb,0px))] md:h-[calc(100dvh-var(--kb,0px))]"
+      style={{ '--kb': `${keyboardInset}px` } as CSSProperties}
+    >
       {/* Left column: conversation list. Hidden on mobile when a conversation is selected. */}
       <aside
         className={`${

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -852,25 +852,16 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     }
   }, [conversationId, t])
 
-  // Auto-scroll to the bottom whenever the message list updates. useLayoutEffect
-  // avoids a visible jump between initial paint and the scroll snap.
-  useLayoutEffect(() => {
-    if (messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ block: 'end' })
-    }
-  }, [messages.length, conversationId])
-
-  // keyboardInset drives the shell height in FamilyChat (the composer stays
-  // pinned above the on-screen keyboard). When it changes — the keyboard opens
-  // or closes and the visible viewport resizes — re-anchor to the bottom so the
-  // newest messages stay in view above the input instead of being left
-  // scrolled out of sight.
   const keyboardInset = useKeyboardInset()
+
+  // Auto-scroll to the bottom whenever the message list updates or the keyboard
+  // opens/closes (keyboardInset changes). useLayoutEffect avoids a visible jump
+  // between initial paint and the scroll snap.
   useLayoutEffect(() => {
     if (messagesEndRef.current) {
       messagesEndRef.current.scrollIntoView({ block: 'end' })
     }
-  }, [keyboardInset])
+  }, [messages.length, conversationId, keyboardInset])
 
   // Lightbox: ESC closes; scroll on body locked while open.
   useEffect(() => {

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react'
 import { Skeleton } from '../../components/ui/skeleton'
 import { useAuth } from '../../auth'
+import { useKeyboardInset } from '../../hooks/useKeyboardInset'
 import Composer from './Composer'
 import ReactionChips from './ReactionChips'
 import ReactionPicker from './ReactionPicker'
@@ -859,6 +860,18 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     }
   }, [messages.length, conversationId])
 
+  // keyboardInset drives the shell height in FamilyChat (the composer stays
+  // pinned above the on-screen keyboard). When it changes — the keyboard opens
+  // or closes and the visible viewport resizes — re-anchor to the bottom so the
+  // newest messages stay in view above the input instead of being left
+  // scrolled out of sight.
+  const keyboardInset = useKeyboardInset()
+  useLayoutEffect(() => {
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ block: 'end' })
+    }
+  }, [keyboardInset])
+
   // Lightbox: ESC closes; scroll on body locked while open.
   useEffect(() => {
     if (!lightbox) return
@@ -1468,7 +1481,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       </header>
 
       <div
-        className="flex-1 min-h-0 overflow-y-auto px-3 sm:px-4 py-3 space-y-2"
+        className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 sm:px-4 py-3 space-y-2"
         role="log"
         aria-live="polite"
         aria-relevant="additions"


### PR DESCRIPTION
## Changes

- **Family chat stays readable with the keyboard open on mobile** - Focusing the message input no longer scrolls the conversation off the top of the screen. The chat now resizes to the keyboard-reduced viewport (via the VisualViewport API, `dvh` heights, and `interactive-widget=resizes-content`) so the composer stays pinned above the keyboard and the newest messages remain visible. (Hytte-7xbc)

## Original Issue (bug): Family chat: message list scrolls off-screen when input focused with keyboard open (mobile)

On mobile, in the family chat, focusing the message input (which opens the on-screen keyboard) causes the message list to scroll up past the top of the screen, leaving a blank screen. While composing, no messages are visible. To read messages, the user has to tap away from the input to dismiss the keyboard.

Expected: with the keyboard open and the input focused, the most recent messages should stay visible above the input. The chat view should anchor to the bottom of the message list and resize to the visible (keyboard-reduced) viewport instead of letting content scroll out of view.

Steps to reproduce:
1. Open family chat on mobile.
2. Tap the message input to focus it; on-screen keyboard opens.
3. Observe the message list scrolls off the top, showing a blank screen.
4. Tap away from the input to dismiss the keyboard; messages reappear.

Environment: mobile browser, on-screen keyboard open. Reported from hytte.

---
Bead: Hytte-7xbc | Branch: forge/Hytte-7xbc
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->