### PR TITLE
Show YTD progress bars for vacation days and feriepenger accrual (Hytte-1md1f)

### DIFF
--- a/changelog.d/Hytte-1md1f.md
+++ b/changelog.d/Hytte-1md1f.md
@@ -1,0 +1,2 @@
+category: Added
+- **Feriepenger accrual progress bar** - The Salary page vacation tracker now shows a second progress bar for holiday pay (feriepenger) accrued against the projected full-year payout, alongside the existing vacation-days bar. (Hytte-1md1f)

--- a/web/public/locales/en/salary.json
+++ b/web/public/locales/en/salary.json
@@ -94,7 +94,10 @@
     "used": "{{used}} of {{allowance}} days used",
     "remaining": "{{remaining}} days remaining",
     "feriepenger": "Holiday pay (feriepenger)",
-    "feriepengerAccrued": "{{amount}} accrued ({{pct}}% of confirmed gross)"
+    "feriepengerAccrued": "{{amount}} accrued ({{pct}}% of confirmed gross)",
+    "feriepengerProgress": "Accrued vs. projected",
+    "feriepengerProjected": "{{amount}} projected",
+    "feriepengerProgressAria": "Feriepenger accrued against projected full-year payout"
   },
   "tax": {
     "title": "Tax Brackets",

--- a/web/public/locales/nb/salary.json
+++ b/web/public/locales/nb/salary.json
@@ -94,7 +94,10 @@
     "used": "{{used}} av {{allowance}} feriedager brukt",
     "remaining": "{{remaining}} dager gjenstår",
     "feriepenger": "Feriepenger",
-    "feriepengerAccrued": "{{amount}} opptjent ({{pct}}% av bekreftet bruttolønn)"
+    "feriepengerAccrued": "{{amount}} opptjent ({{pct}}% av bekreftet bruttolønn)",
+    "feriepengerProgress": "Opptjent mot forventet",
+    "feriepengerProjected": "{{amount}} forventet",
+    "feriepengerProgressAria": "Feriepenger opptjent mot forventet utbetaling for hele året"
   },
   "tax": {
     "title": "Skattetrinn",

--- a/web/public/locales/th/salary.json
+++ b/web/public/locales/th/salary.json
@@ -94,7 +94,10 @@
     "used": "ใช้ไปแล้ว {{used}} จาก {{allowance}} วัน",
     "remaining": "เหลือ {{remaining}} วัน",
     "feriepenger": "เงินค่าลาพักร้อน (feriepenger)",
-    "feriepengerAccrued": "สะสม {{amount}} ({{pct}}% ของรายได้รวมที่ยืนยันแล้ว)"
+    "feriepengerAccrued": "สะสม {{amount}} ({{pct}}% ของรายได้รวมที่ยืนยันแล้ว)",
+    "feriepengerProgress": "สะสมเทียบกับที่คาดการณ์",
+    "feriepengerProjected": "คาดการณ์ {{amount}}",
+    "feriepengerProgressAria": "เงินค่าลาพักร้อนที่สะสมเทียบกับยอดจ่ายที่คาดการณ์ตลอดทั้งปี"
   },
   "tax": {
     "title": "ขั้นอัตราภาษี",

--- a/web/src/pages/SalaryPage.tsx
+++ b/web/src/pages/SalaryPage.tsx
@@ -158,6 +158,34 @@ function addMonth(month: string, delta: number): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
 }
 
+// Projects the full-year feriepenger payout by extrapolating gross_ytd across the
+// selected year (based on the fraction of the year elapsed) and applying the
+// feriepenger rate. For a past year the full year has elapsed, so it uses gross_ytd
+// as-is. Returns 0 when there is no basis to project (avoids NaN/divide-by-zero).
+function computeProjectedFullYearFeriepenger(
+  grossYtd: number,
+  feriepengerPct: number,
+  selectedYear: number,
+  now: Date,
+): number {
+  if (grossYtd <= 0) return 0
+
+  let fractionElapsed: number
+  if (selectedYear < now.getFullYear()) {
+    fractionElapsed = 1
+  } else if (selectedYear > now.getFullYear()) {
+    fractionElapsed = 0
+  } else {
+    const startOfYear = new Date(selectedYear, 0, 1).getTime()
+    const startOfNextYear = new Date(selectedYear + 1, 0, 1).getTime()
+    fractionElapsed = (now.getTime() - startOfYear) / (startOfNextYear - startOfYear)
+  }
+  if (fractionElapsed <= 0) return 0
+
+  const projectedGross = grossYtd / fractionElapsed
+  return projectedGross * (feriepengerPct / 100)
+}
+
 export default function SalaryPage() {
   const { t, i18n } = useTranslation('salary')
   const locale = i18n.language
@@ -1287,15 +1315,54 @@ export default function SalaryPage() {
                   />
                 </div>
               </div>
-              {vacation.feriepenger_accrued > 0 && (
-                <div className="text-sm text-gray-400">
-                  <span className="text-gray-300 font-medium">{t('vacation.feriepenger')}: </span>
-                  {t('vacation.feriepengerAccrued', {
-                    amount: formatCurrency(vacation.feriepenger_accrued),
-                    pct: vacation.feriepenger_pct.toFixed(1),
-                  })}
-                </div>
-              )}
+              {vacation.feriepenger_accrued > 0 && (() => {
+                const projected = computeProjectedFullYearFeriepenger(
+                  vacation.gross_ytd,
+                  vacation.feriepenger_pct,
+                  vacation.year,
+                  new Date(),
+                )
+                const feriepengerFill =
+                  projected > 0
+                    ? Math.min(Math.max((vacation.feriepenger_accrued / projected) * 100, 0), 100)
+                    : 0
+                return (
+                  <div className="space-y-1">
+                    <div className="text-sm text-gray-400">
+                      <span className="text-gray-300 font-medium">{t('vacation.feriepenger')}: </span>
+                      {t('vacation.feriepengerAccrued', {
+                        amount: formatCurrency(vacation.feriepenger_accrued),
+                        pct: vacation.feriepenger_pct.toFixed(1),
+                      })}
+                    </div>
+                    {projected > 0 && (
+                      <>
+                        <div className="flex justify-between text-sm">
+                          <span className="text-gray-400">{t('vacation.feriepengerProgress')}</span>
+                          <span className="text-gray-300">
+                            {t('vacation.feriepengerProjected', {
+                              amount: formatCurrency(projected),
+                            })}
+                          </span>
+                        </div>
+                        <div
+                          className="w-full bg-gray-700 rounded-full h-2"
+                          role="progressbar"
+                          aria-label={t('vacation.feriepengerProgressAria')}
+                          aria-valuenow={Math.round(feriepengerFill)}
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                        >
+                          <div
+                            className="bg-amber-500 h-2 rounded-full transition-all"
+                            style={{ width: `${feriepengerFill}%` }}
+                          />
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )
+              })()}
             </div>
           )}
 


### PR DESCRIPTION
## Changes

- **Feriepenger accrual progress bar** - The Salary page vacation tracker now shows a second progress bar for holiday pay (feriepenger) accrued against the projected full-year payout, alongside the existing vacation-days bar. (Hytte-1md1f)

## Original Issue (feature): Show YTD progress bars for vacation days and feriepenger accrual

### Scope
The Salary page already renders a vacation tracker (`SalaryPage.tsx:1265–1300`) that includes a days-used vs. allowance progress bar, but feriepenger accrual is shown only as a text line. This plan adds a second compact progress bar for feriepenger accrued against the projected full-year payout, and verifies/polishes the existing vacation-days bar. Frontend-only — no backend changes, since `VacationResponse` already exposes all needed fields.

### Files to touch
- `web/src/pages/SalaryPage.tsx` — add the feriepenger progress bar inside the existing vacation tracker block; reuse the days-bar markup pattern.
- `web/public/locales/en/common.json` — add any new label/aria strings (e.g. `vacation.feriepengerProgress`).
- `web/public/locales/nb/common.json` — same keys (Norwegian).
- `web/public/locales/th/common.json` — same keys (Thai).
- `changelog.d/` — new fragment (new).

### Acceptance criteria
- The vacation tracker shows two progress bars: vacation days used/allowance (existing) and feriepenger accrued vs. projected full-year payout.
- The feriepenger bar fill % = `feriepenger_accrued / projectedFullYear`, clamped to 0–100%, where projected full-year payout is derived on the frontend by extrapolating `gross_ytd` across the year (using selected year + current date) and applying `feriepenger_pct`. The derivation is a small named helper and guards against divide-by-zero (`gross_ytd === 0` → 0% fill, no `NaN`).
- The feriepenger bar only renders when `feriepenger_accrued > 0` (matching the existing text condition); the accrued-amount + pct text line is retained.
- Both bars use the existing Tailwind track/fill styling and a distinct fill color for feriepenger; layout works at 375px width.
- All visible/aria strings come from `react-i18next` `common.json` under the `vacation.*` prefix, present in en/nb/th — no hardcoded English.
- A changelog fragment is added (category `Added`, with the bead ID).
- `npm run lint` and `npm run build` pass.

### Non-goals
- No changes to `internal/salary/handlers.go` or `VacationResponse`; no new API fields (e.g. a server-computed projected payout).
- No new charts, animations, tooltips, or historical/monthly breakdowns.
- No changes to the vacation-days bar's calculation logic beyond confirming it works.
- No rework of trekktabell, budget sync, or other Salary page sections.
- No new feature flag or routing changes.

## Source

Created from Suggestions page (suggestion id 149, page slug "salary", source=claude).

## Original suggestion

The VacationResponse already returns days_allowance, days_used, days_remaining, gross_ytd, feriepenger_pct, and feriepenger_accrued, but the page only renders them as bare numbers. Adding two compact progress bars — one for vacation days used vs. allowance, one for feriepenger accrued against the projected full-year payout — would make at-a-glance status much easier without any new backend work. This gives users immediate visual feedback on how much vacation budget they have left and how their holiday pay is building up over the year.


---
Bead: Hytte-1md1f | Branch: forge/Hytte-1md1f
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->