### PR TITLE
Fall back gracefully when set logos and card images fail to load (Hytte-6yoo0)

### DIFF
--- a/changelog.d/Hytte-6yoo0.md
+++ b/changelog.d/Hytte-6yoo0.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Graceful fallback for broken Pokémon set logos and card images** - Set tiles and top-card tiles now show their existing text fallback (set ID / collector number) instead of a broken-image glyph when a logo or card image fails to load. (Hytte-6yoo0)

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -82,6 +82,7 @@ interface SetTileProps {
 
 function SetTile({ set, t }: SetTileProps) {
   const percent = ownershipPercent(set.owned_count, set.total_cards)
+  const [errored, setErrored] = useState(false)
   return (
     <Link
       to={`/pokemon/sets/${set.id}`}
@@ -90,12 +91,13 @@ function SetTile({ set, t }: SetTileProps) {
       data-testid={`set-tile-${set.id}`}
     >
       <div className="h-14 flex items-center justify-center">
-        {set.logo_url ? (
+        {set.logo_url && !errored ? (
           <img
             src={set.logo_url}
             alt=""
             className="max-h-14 max-w-full object-contain"
             loading="lazy"
+            onError={() => setErrored(true)}
           />
         ) : (
           <span className="text-xs uppercase tracking-wide text-gray-500">{set.id}</span>

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -83,6 +83,11 @@ interface SetTileProps {
 function SetTile({ set, t }: SetTileProps) {
   const percent = ownershipPercent(set.owned_count, set.total_cards)
   const [errored, setErrored] = useState(false)
+  const [prevUrl, setPrevUrl] = useState(set.logo_url)
+  if (set.logo_url !== prevUrl) {
+    setPrevUrl(set.logo_url)
+    setErrored(false)
+  }
   return (
     <Link
       to={`/pokemon/sets/${set.id}`}

--- a/web/src/pages/PokemonTop.tsx
+++ b/web/src/pages/PokemonTop.tsx
@@ -122,6 +122,7 @@ function TopCardTile({ card, rank, onClick, t }: TileProps) {
   const variantLabel = card.top_variant_kind
     ? t(`variantKind.${card.top_variant_kind}`, { defaultValue: card.top_variant_kind })
     : ''
+  const [errored, setErrored] = useState(false)
   return (
     <button
       type="button"
@@ -135,12 +136,13 @@ function TopCardTile({ card, rank, onClick, t }: TileProps) {
         }`}
     >
       <div className="relative aspect-[5/7] flex items-center justify-center bg-gray-900/40 rounded overflow-hidden">
-        {card.image_small_url ? (
+        {card.image_small_url && !errored ? (
           <img
             src={card.image_small_url}
             alt=""
             loading="lazy"
             className="max-h-full max-w-full object-contain"
+            onError={() => setErrored(true)}
           />
         ) : (
           <span className="text-xs text-gray-500">{card.collector_no}</span>

--- a/web/src/pages/PokemonTop.tsx
+++ b/web/src/pages/PokemonTop.tsx
@@ -123,6 +123,11 @@ function TopCardTile({ card, rank, onClick, t }: TileProps) {
     ? t(`variantKind.${card.top_variant_kind}`, { defaultValue: card.top_variant_kind })
     : ''
   const [errored, setErrored] = useState(false)
+  const [prevUrl, setPrevUrl] = useState(card.image_small_url)
+  if (card.image_small_url !== prevUrl) {
+    setPrevUrl(card.image_small_url)
+    setErrored(false)
+  }
   return (
     <button
       type="button"


### PR DESCRIPTION
## Changes

- **Graceful fallback for broken Pokémon set logos and card images** - Set tiles and top-card tiles now show their existing text fallback (set ID / collector number) instead of a broken-image glyph when a logo or card image fails to load. (Hytte-6yoo0)

## Original Issue (feature): Fall back gracefully when set logos and card images fail to load

### Scope
Both `SetTile` (in PokemonSets.tsx) and `TopCardTile` (in PokemonTop.tsx) render their `<img>` with `alt=""` and no `onError` handler. When `logo_url`/`image_small_url` is non-null but 404s or fails to load, the browser shows its default broken-image glyph. Each tile already renders a text fallback (`set.id` / `card.collector_no`) when the URL is *absent*; this plan extends that fallback to also cover *load failures*, mirroring the `errored` state pattern already used by `Thumbnail` in PokemonScanned.tsx.

### Files to touch
- `web/src/pages/PokemonSets.tsx` — add an `errored` state to `SetTile`, an `onError` on the logo `<img>`, and show the `set.id` text fallback when errored.
- `web/src/pages/PokemonTop.tsx` — same treatment for `TopCardTile`'s card `<img>`, falling back to `card.collector_no`.
- (Optional, if a shared helper reads cleaner) extract no new file unless the duplicated `useState(false)` + `onError` becomes a tiny shared hook; default is to keep it inline per tile.

### Acceptance criteria
- When a set logo URL fails to load, `SetTile` shows the existing uppercase `set.id` text fallback instead of a broken-image glyph; the `<img>` is no longer rendered/visible.
- When a top-card image URL fails to load, `TopCardTile` shows the existing `card.collector_no` text fallback instead of a broken-image glyph; the rank badge and owned badge still render correctly.
- Tiles whose URL is `null`/empty behave exactly as before (text fallback shown, no regression).
- Successful image loads are unchanged: image displays normally, no flicker or premature fallback.
- The pattern matches `Thumbnail`'s `errored` approach (a per-tile `useState(false)` flag set via `onError`).
- `npm run lint` and `npm run build` pass; existing Pokémon page tests still pass.

### Non-goals
- No retry logic, no custom placeholder graphic/icon — reuse only the existing text fallbacks.
- No changes to PokemonSet.tsx or PokemonScanned.tsx (Scanned already handles this).
- No backend, API, or image-URL-sourcing changes (e.g. validating pokemontcg.io URLs server-side).
- No new shared image component or broad refactor beyond the two tiles.
- No changes to `alt` text semantics beyond what's needed for the fallback.

## Source

Created from Suggestions page (suggestion id 190, page slug "pokemon", source=claude).

## Original suggestion

The `<img>` tags in SetTile (set logo) and TopCardTile (card image) render with `alt=""` and no `onError` handler, so a 404 or broken upstream URL leaves a browser default broken-image glyph in the grid. The Thumbnail component on the Scanned page already solves this with an `errored` state that swaps in a placeholder. Apply the same pattern: on image error, hide the `<img>` and show the existing text fallback (the set ID or collector number). This keeps the set/top grids visually clean even when pokemontcg.io assets are missing or temporarily unreachable.


---
Bead: Hytte-6yoo0 | Branch: forge/Hytte-6yoo0
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->