### PR TITLE
Stop the scanned-page poll when no scans are in flight (Hytte-l7bs)

### DIFF
--- a/changelog.d/Hytte-l7bs.md
+++ b/changelog.d/Hytte-l7bs.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Scanned-cards page stops polling when idle** - The scan list now only polls the scan API while a job is queued/processing or the Pending filter is active, and tears the interval down once everything settles — saving needless network, battery, and server load on the long-lived Needs review / Recently resolved tabs. (Hytte-l7bs)

--- a/web/src/pages/PokemonScanned.test.tsx
+++ b/web/src/pages/PokemonScanned.test.tsx
@@ -199,6 +199,23 @@ function makeQueued(over: Partial<ScanFixture> = {}): ScanFixture {
   }
 }
 
+function makeNeedsReviewPageWithQueuedChild(over: {
+  pageId?: number
+  matchedId?: number
+  queuedId?: number
+} = {}): PageFixture {
+  return {
+    id: over.pageId ?? 100,
+    expected_count: 2,
+    matched_count: 1,
+    created_at: new Date('2026-05-15T10:00:00Z').toISOString(),
+    children: [
+      makeMatched({ id: over.matchedId ?? 10 }),
+      makeQueued({ id: over.queuedId ?? 11 }),
+    ],
+  }
+}
+
 interface PageFixture {
   id: number
   expected_count: number
@@ -853,8 +870,12 @@ describe('PokemonScanned – visibility-aware polling', () => {
   it('polls /api/pokemon/scans at the SCAN_POLL_MS cadence while visible with in-flight work', async () => {
     setVisibility('visible')
     vi.useFakeTimers()
-    // A queued job is loaded, so there is something worth polling for.
-    const fetchMock = makeFetchMock({ needsReview: [makeMatched(), makeQueued()] })
+    // A page block with a queued child triggers hasInFlightWork even on the
+    // needsReview tab (children are returned regardless of individual status).
+    const fetchMock = makeFetchMock({
+      needsReview: [makeMatched()],
+      pages: { needsReview: [makeNeedsReviewPageWithQueuedChild()] },
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     renderPage()
@@ -901,14 +922,24 @@ describe('PokemonScanned – visibility-aware polling', () => {
   it('clears the interval once the last in-flight job settles', async () => {
     setVisibility('visible')
     vi.useFakeTimers()
-    // Phase 0 returns a queued job (poll armed); after the first poll we flip to
-    // phase 1, which returns the same job settled, so the interval should stop.
+    // Phase 0: a page block has a matched child (so it appears on needsReview)
+    // plus a queued child (arms the poll). Phase 1: the queued child settles to
+    // matched, so hasInFlightWork flips false and the interval tears down.
     let phase = 0
     const fetchMock = vi.fn((url: string) => {
       if (url.startsWith('/api/pokemon/scans?')) {
-        const scans = phase === 0 ? [makeQueued()] : [makeMatched({ id: 4 })]
+        const children = phase === 0
+          ? [makeMatched({ id: 10 }), makeQueued({ id: 11 })]
+          : [makeMatched({ id: 10 }), makeMatched({ id: 11 })]
+        const pages = [{
+          id: 100,
+          expected_count: 2,
+          matched_count: phase === 0 ? 1 : 2,
+          created_at: new Date('2026-05-15T10:00:00Z').toISOString(),
+          children,
+        }]
         return Promise.resolve(
-          jsonResponse({ scans, pages: [], today: { used: 0, cap: 600 } }),
+          jsonResponse({ scans: [], pages, today: { used: 0, cap: 600 } }),
         )
       }
       return Promise.resolve(jsonResponse({}, 404))
@@ -973,7 +1004,11 @@ describe('PokemonScanned – visibility-aware polling', () => {
   it('stops polling once the tab becomes hidden', async () => {
     setVisibility('visible')
     vi.useFakeTimers()
-    const fetchMock = makeFetchMock({ needsReview: [makeQueued()] })
+    // In-flight work via a page block child so the poll is armed.
+    const fetchMock = makeFetchMock({
+      needsReview: [],
+      pages: { needsReview: [makeNeedsReviewPageWithQueuedChild()] },
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     renderPage()
@@ -999,7 +1034,11 @@ describe('PokemonScanned – visibility-aware polling', () => {
   it('refetches immediately on refocus and resumes the interval while work is in flight', async () => {
     setVisibility('visible')
     vi.useFakeTimers()
-    const fetchMock = makeFetchMock({ needsReview: [makeQueued()] })
+    // In-flight work via a page block child so the poll is armed.
+    const fetchMock = makeFetchMock({
+      needsReview: [],
+      pages: { needsReview: [makeNeedsReviewPageWithQueuedChild()] },
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     renderPage()
@@ -1060,8 +1099,11 @@ describe('PokemonScanned – visibility-aware polling', () => {
   it('clears the interval and removes the visibilitychange listener on unmount', async () => {
     setVisibility('visible')
     vi.useFakeTimers()
-    // In-flight work so the poll (and its visibilitychange listener) is armed.
-    const fetchMock = makeFetchMock({ needsReview: [makeQueued()] })
+    // In-flight work via a page block child so the poll is armed.
+    const fetchMock = makeFetchMock({
+      needsReview: [],
+      pages: { needsReview: [makeNeedsReviewPageWithQueuedChild()] },
+    })
     vi.stubGlobal('fetch', fetchMock)
     const removeSpy = vi.spyOn(document, 'removeEventListener')
 

--- a/web/src/pages/PokemonScanned.test.tsx
+++ b/web/src/pages/PokemonScanned.test.tsx
@@ -850,10 +850,11 @@ describe('PokemonScanned – visibility-aware polling', () => {
     })
   }
 
-  it('polls /api/pokemon/scans at the SCAN_POLL_MS cadence while visible', async () => {
+  it('polls /api/pokemon/scans at the SCAN_POLL_MS cadence while visible with in-flight work', async () => {
     setVisibility('visible')
     vi.useFakeTimers()
-    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    // A queued job is loaded, so there is something worth polling for.
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched(), makeQueued()] })
     vi.stubGlobal('fetch', fetchMock)
 
     renderPage()
@@ -873,10 +874,106 @@ describe('PokemonScanned – visibility-aware polling', () => {
     expect(scanListCalls(fetchMock)).toBe(baseline + 3)
   })
 
+  it('does not poll on needsReview when nothing is queued or processing', async () => {
+    setVisibility('visible')
+    vi.useFakeTimers()
+    // Everything on this tab is already settled — no queued/processing jobs.
+    const fetchMock = makeFetchMock({
+      needsReview: [makeMatched(), makeNoMatch(), makeFailed()],
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await flush()
+
+    const baseline = scanListCalls(fetchMock)
+    expect(baseline).toBe(1) // only the initial mount fetch
+
+    // Advancing well past the poll cadence must not fire any background poll.
+    await act(async () => {
+      vi.advanceTimersByTime(SCAN_POLL_MS * 3)
+    })
+    await flush()
+
+    expect(scanListCalls(fetchMock)).toBe(baseline)
+  })
+
+  it('clears the interval once the last in-flight job settles', async () => {
+    setVisibility('visible')
+    vi.useFakeTimers()
+    // Phase 0 returns a queued job (poll armed); after the first poll we flip to
+    // phase 1, which returns the same job settled, so the interval should stop.
+    let phase = 0
+    const fetchMock = vi.fn((url: string) => {
+      if (url.startsWith('/api/pokemon/scans?')) {
+        const scans = phase === 0 ? [makeQueued()] : [makeMatched({ id: 4 })]
+        return Promise.resolve(
+          jsonResponse({ scans, pages: [], today: { used: 0, cap: 600 } }),
+        )
+      }
+      return Promise.resolve(jsonResponse({}, 404))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await flush()
+    const baseline = scanListCalls(fetchMock)
+    expect(baseline).toBe(1)
+
+    // Next poll returns the job settled → the derived in-flight signal flips off.
+    phase = 1
+    await act(async () => {
+      vi.advanceTimersByTime(SCAN_POLL_MS)
+    })
+    await flush()
+    const afterSettle = scanListCalls(fetchMock)
+    expect(afterSettle).toBe(baseline + 1) // the poll that observed the settle
+
+    // Interval torn down: further time advances produce no more polls.
+    await act(async () => {
+      vi.advanceTimersByTime(SCAN_POLL_MS * 3)
+    })
+    await flush()
+    expect(scanListCalls(fetchMock)).toBe(afterSettle)
+  })
+
+  it('re-arms the poll when switching to the pending filter', async () => {
+    setVisibility('visible')
+    vi.useFakeTimers()
+    const fetchMock = makeFetchMock({ needsReview: [makeMatched()], pending: [] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await flush()
+
+    // needsReview is settled → no polling yet.
+    const baseline = scanListCalls(fetchMock)
+    await act(async () => {
+      vi.advanceTimersByTime(SCAN_POLL_MS * 2)
+    })
+    await flush()
+    expect(scanListCalls(fetchMock)).toBe(baseline)
+
+    // Switching to "pending" refetches for the new filter and arms the poll.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('scanned-filter-pending'))
+    })
+    await flush()
+    const afterSwitch = scanListCalls(fetchMock)
+    expect(afterSwitch).toBeGreaterThan(baseline)
+
+    // The interval is now running for the pending tab.
+    await act(async () => {
+      vi.advanceTimersByTime(SCAN_POLL_MS)
+    })
+    await flush()
+    expect(scanListCalls(fetchMock)).toBe(afterSwitch + 1)
+  })
+
   it('stops polling once the tab becomes hidden', async () => {
     setVisibility('visible')
     vi.useFakeTimers()
-    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    const fetchMock = makeFetchMock({ needsReview: [makeQueued()] })
     vi.stubGlobal('fetch', fetchMock)
 
     renderPage()
@@ -899,10 +996,10 @@ describe('PokemonScanned – visibility-aware polling', () => {
     expect(scanListCalls(fetchMock)).toBe(baseline)
   })
 
-  it('refetches immediately on refocus and resumes the interval', async () => {
+  it('refetches immediately on refocus and resumes the interval while work is in flight', async () => {
     setVisibility('visible')
     vi.useFakeTimers()
-    const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    const fetchMock = makeFetchMock({ needsReview: [makeQueued()] })
     vi.stubGlobal('fetch', fetchMock)
 
     renderPage()
@@ -935,10 +1032,36 @@ describe('PokemonScanned – visibility-aware polling', () => {
     expect(scanListCalls(fetchMock)).toBe(beforeRefocus + 2)
   })
 
-  it('clears the interval and removes the visibilitychange listener on unmount', async () => {
+  it('does not re-poll on refocus when nothing is in flight', async () => {
     setVisibility('visible')
     vi.useFakeTimers()
     const fetchMock = makeFetchMock({ needsReview: [makeMatched()] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await flush()
+    const baseline = scanListCalls(fetchMock)
+
+    // Background then refocus: with no queued/processing work, the poll effect
+    // never armed its visibilitychange listener, so refocus triggers no refetch.
+    await act(async () => {
+      setVisibility('hidden')
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await act(async () => {
+      setVisibility('visible')
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await flush()
+
+    expect(scanListCalls(fetchMock)).toBe(baseline)
+  })
+
+  it('clears the interval and removes the visibilitychange listener on unmount', async () => {
+    setVisibility('visible')
+    vi.useFakeTimers()
+    // In-flight work so the poll (and its visibilitychange listener) is armed.
+    const fetchMock = makeFetchMock({ needsReview: [makeQueued()] })
     vi.stubGlobal('fetch', fetchMock)
     const removeSpy = vi.spyOn(document, 'removeEventListener')
 

--- a/web/src/pages/PokemonScanned.tsx
+++ b/web/src/pages/PokemonScanned.tsx
@@ -532,11 +532,27 @@ export default function PokemonScannedPage() {
     return () => controller.abort()
   }, [filter, attempt, t])
 
-  // Poll while the page is visible so the kid sees queued→processing→matched
-  // transitions without manually refreshing. We pause polling when the tab is
-  // hidden to avoid wasting bandwidth on background tabs.
+  // hasInFlightWork is true when there is something worth polling for: at least
+  // one loaded scan (standalone or inside a page block) is still queued or
+  // processing, OR the user is sitting on the "pending" filter (where a freshly
+  // enqueued scan would land). When it's false — e.g. the needsReview/resolved
+  // tabs with everything settled — the poll below tears itself down so the page
+  // goes quiet instead of hitting the scan API forever.
+  const hasInFlightWork = useMemo(() => {
+    if (filter === 'pending') return true
+    const isInFlight = (status: string) => status === 'queued' || status === 'processing'
+    if (scans.some(s => isInFlight(s.status))) return true
+    return pages.some(p => p.children.some(c => isInFlight(c.status)))
+  }, [filter, scans, pages])
+
+  // Poll while the page is visible AND there is in-flight work so the kid sees
+  // queued→processing→matched transitions without manually refreshing. We pause
+  // polling when the tab is hidden to avoid wasting bandwidth on background tabs,
+  // and skip it entirely once nothing is queued/processing so idle needsReview/
+  // resolved tabs don't keep hitting the API.
   useEffect(() => {
     if (typeof document === 'undefined') return
+    if (!hasInFlightWork) return
     let intervalId: ReturnType<typeof window.setInterval> | null = null
 
     const start = () => {
@@ -568,7 +584,7 @@ export default function PokemonScannedPage() {
       stop()
       document.removeEventListener('visibilitychange', onVisibility)
     }
-  }, [silentRefetch])
+  }, [silentRefetch, hasInFlightWork])
 
   const visibleScans = useMemo(() => {
     if (filter !== 'resolved') return scans


### PR DESCRIPTION
## Changes

- **Scanned-cards page stops polling when idle** - The scan list now only polls the scan API while a job is queued/processing or the Pending filter is active, and tears the interval down once everything settles — saving needless network, battery, and server load on the long-lived Needs review / Recently resolved tabs. (Hytte-l7bs)

## Original Issue (feature): Stop the scanned-page poll when no scans are in flight

### Scope
Make the 30 s scan poll in `PokemonScanned` conditional on actual in-flight work. Today the interval (`useEffect` at ~538, gated only on tab visibility) runs for the page's whole lifetime regardless of job state. The change introduces a derived "has in-flight work" signal (any loaded scan/page child in `queued` or `processing`, and/or the `pending` filter being active) and adds it to the effect so the interval is torn down when nothing is pending and re-armed when a new scan is enqueued or the filter changes. Visibility-pause behavior is preserved.

### Files to touch
- `web/src/pages/PokemonScanned.tsx`
- `web/src/pages/PokemonScanned.test.tsx` (or existing co-located test file) — add/adjust tests for poll start/stop
- `changelog.d/<id>.md` (new)

### Acceptance criteria
- On the `needsReview` and `resolved` tabs with no `queued`/`processing` jobs loaded, no recurring `GET` to the scan API fires after the initial fetch (verifiable via fake timers + mocked fetch: advancing past `SCAN_POLL_MS` triggers zero extra calls).
- While at least one visible job is `queued` or `processing`, the poll still fires every `SCAN_POLL_MS` exactly as before.
- When a poll result transitions the last in-flight job to a settled state, the interval is cleared (no further polls).
- Enqueuing a new scan (or switching to the `pending` filter) re-arms the interval and a fresh poll resumes.
- Tab-visibility pause/resume still works: hidden tab does not poll; returning to visible re-arms only if work is in flight.
- The effect cleanly clears the interval on unmount and on dependency changes (no leaked/duplicate intervals).
- `npm run lint` and `npm run build` pass.

### Non-goals
- No changes to the scan API, backend polling cadence, or `SCAN_POLL_MS` value.
- No switch to WebSocket/SSE/long-polling or any push mechanism.
- No changes to filter logic, sorting, the resolved-window filter, or the 1 s elapsed-time clock.
- No changes to the other Pokémon pages (`PokemonSets`, `PokemonSet`, `PokemonTop`).

## Source

Created from Suggestions page (suggestion id 221, page slug "pokemon", source=claude).

## Original suggestion

PokemonScanned polls the scan API every 30 s (SCAN_POLL_MS) for the lifetime of the page, even when every job is already resolved and nothing is queued or processing — wasted network/battery on mobile and needless server load. Change the polling effect to only run the interval while at least one job is in a 'queued' or 'processing' state (and on the active filter being 'pending'), tearing the interval down once the in-flight set empties and re-arming it when a new scan is enqueued. Users keep the same live progress on pending scans but the page goes quiet once everything settles, which matters most on the long-lived needsReview/resolved tabs that never have work to poll for.


---
Bead: Hytte-l7bs | Branch: forge/Hytte-l7bs
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->