### PR TITLE
Add a name/series search box to filter sets on the sets page (Hytte-wtqnr)

### DIFF
--- a/changelog.d/Hytte-wtqnr.md
+++ b/changelog.d/Hytte-wtqnr.md
@@ -1,0 +1,2 @@
+category: Added
+- **Search box on the Pokémon sets page** - Added a free-text search input above the sets grid that filters sets by name or series (case-insensitive substring). The query is mirrored to a `?q=` URL param so reloads, the Back button and shared links preserve it, and it composes with the existing owned/older filters. (Hytte-wtqnr)

--- a/web/public/locales/en/pokemon.json
+++ b/web/public/locales/en/pokemon.json
@@ -5,7 +5,10 @@
   "olderSets": "Older sets",
   "sets": {
     "filterOwnedOnly": "Owned only",
-    "emptyOwned": "You don't own any cards yet — go scan some!"
+    "emptyOwned": "You don't own any cards yet — go scan some!",
+    "searchLabel": "Search sets by name or series",
+    "searchPlaceholder": "Search sets — e.g. \"Obsidian Flames\"",
+    "noMatches": "No sets match \"{{query}}\"."
   },
   "value": {
     "title": "Collection value",

--- a/web/public/locales/nb/pokemon.json
+++ b/web/public/locales/nb/pokemon.json
@@ -5,7 +5,10 @@
   "olderSets": "Eldre sett",
   "sets": {
     "filterOwnedOnly": "Bare eide",
-    "emptyOwned": "Du eier ingen kort enda — gå og scan noen!"
+    "emptyOwned": "Du eier ingen kort enda — gå og scan noen!",
+    "searchLabel": "Søk i sett etter navn eller serie",
+    "searchPlaceholder": "Søk i sett — f.eks. «Obsidian Flames»",
+    "noMatches": "Ingen sett samsvarer med «{{query}}»."
   },
   "value": {
     "title": "Samlingsverdi",

--- a/web/public/locales/th/pokemon.json
+++ b/web/public/locales/th/pokemon.json
@@ -5,7 +5,10 @@
   "olderSets": "ชุดเก่ากว่า",
   "sets": {
     "filterOwnedOnly": "เฉพาะที่มี",
-    "emptyOwned": "คุณยังไม่มีการ์ดเลย — ไปสแกนก่อนสิ!"
+    "emptyOwned": "คุณยังไม่มีการ์ดเลย — ไปสแกนก่อนสิ!",
+    "searchLabel": "ค้นหาชุดตามชื่อหรือซีรีส์",
+    "searchPlaceholder": "ค้นหาชุด — เช่น \"Obsidian Flames\"",
+    "noMatches": "ไม่มีชุดที่ตรงกับ \"{{query}}\""
   },
   "value": {
     "title": "มูลค่าคอลเลกชัน",

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -177,6 +177,15 @@ export default function PokemonSets() {
     return params.get('older')?.toLowerCase() === 'true'
   }, [location.search])
 
+  // The free-text search box is mirrored to ?q=<value> in the URL, matching the
+  // ownedOnly / showOlder pattern, so reloads, the Back button and shared links
+  // preserve the query. Filtering itself happens client-side over the already
+  // loaded `sets` array (see `filtered` below).
+  const query = useMemo(() => {
+    const params = new URLSearchParams(location.search)
+    return params.get('q') ?? ''
+  }, [location.search])
+
   const [sets, setSets] = useState<PokemonSet[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -212,6 +221,17 @@ export default function PokemonSets() {
     const next = params.toString()
     navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false, state: location.state })
   }, [showOlder, navigate, location.pathname, location.search, location.state])
+
+  const handleSearchChange = useCallback((value: string) => {
+    const params = new URLSearchParams(location.search)
+    if (value.trim()) {
+      params.set('q', value)
+    } else {
+      params.delete('q')
+    }
+    const next = params.toString()
+    navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false, state: location.state })
+  }, [navigate, location.pathname, location.search, location.state])
 
   // After the AddCardPanel consumes its initialQuery we strip the hint from
   // history so a subsequent back/forward navigation doesn't re-open the
@@ -308,13 +328,24 @@ export default function PokemonSets() {
     return () => { controller.abort() }
   }, [attempt])
 
+  // Free-text filter applied client-side over the already-loaded sets. A set
+  // matches when the case-insensitive, trimmed query is a substring of its
+  // name or series. An empty query matches everything.
+  const filtered = useMemo(() => {
+    const term = query.trim().toLowerCase()
+    if (!term) return sets
+    return sets.filter(
+      s => s.name.toLowerCase().includes(term) || s.series.toLowerCase().includes(term),
+    )
+  }, [sets, query])
+
   // The top 3 series ranked by the most-recent release_date in each series are
   // shown expanded; everything else is hidden behind the "Show older sets"
   // toggle. Older series are sorted newest-first by their max release_date,
   // with ties broken alphabetically for determinism.
   const { recent, older } = useMemo(() => {
     const byEra = new Map<string, PokemonSet[]>()
-    for (const s of sets) {
+    for (const s of filtered) {
       const list = byEra.get(s.series)
       if (list) list.push(s)
       else byEra.set(s.series, [s])
@@ -333,7 +364,7 @@ export default function PokemonSets() {
     const recentGroups = erasByLatest.slice(0, 3)
     const olderGroups = erasByLatest.slice(3)
     return { recent: recentGroups, older: olderGroups }
-  }, [sets])
+  }, [filtered])
 
   return (
     <div className="min-h-screen bg-gray-900 text-white">
@@ -428,6 +459,31 @@ export default function PokemonSets() {
 
         {!loading && !error && !(ownedOnly && sets.length === 0) && (
           <>
+            <div>
+              <label htmlFor="pokemon-sets-search" className="sr-only">
+                {t('sets.searchLabel')}
+              </label>
+              <input
+                id="pokemon-sets-search"
+                type="search"
+                value={query}
+                onChange={e => handleSearchChange(e.target.value)}
+                placeholder={t('sets.searchPlaceholder')}
+                aria-label={t('sets.searchLabel')}
+                data-testid="pokemon-sets-search"
+                className="w-full px-3 py-2 text-sm bg-gray-800/60 border border-gray-700 rounded text-white placeholder-gray-500 focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500"
+              />
+            </div>
+
+            {query.trim() && filtered.length === 0 ? (
+              <p
+                data-testid="pokemon-sets-empty-search"
+                className="text-sm text-gray-400 px-3 py-8 text-center"
+              >
+                {t('sets.noMatches', { query: query.trim() })}
+              </p>
+            ) : (
+              <>
             {recent.map(([era, list]) => {
               const slug = eraSlug(era)
               return (
@@ -460,6 +516,8 @@ export default function PokemonSets() {
                   )
                 })}
               </section>
+            )}
+              </>
             )}
           </>
         )}

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -230,8 +230,13 @@ export default function PokemonSets() {
       params.delete('q')
     }
     const next = params.toString()
-    navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: false, state: location.state })
-  }, [navigate, location.pathname, location.search, location.state])
+    // Replace the current history entry while editing within an active search
+    // (both the old and new query are non-empty) so each keystroke doesn't push
+    // a new back-stack entry. Only the empty <-> non-empty transitions push, so
+    // Back leaves the search as a single step rather than one entry per char.
+    const replace = query.trim() !== '' && value.trim() !== ''
+    navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace, state: location.state })
+  }, [query, navigate, location.pathname, location.search, location.state])
 
   // After the AddCardPanel consumes its initialQuery we strip the hint from
   // history so a subsequent back/forward navigation doesn't re-open the

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -230,13 +230,8 @@ export default function PokemonSets() {
       params.delete('q')
     }
     const next = params.toString()
-    // Replace the current history entry while editing within an active search
-    // (both the old and new query are non-empty) so each keystroke doesn't push
-    // a new back-stack entry. Only the empty <-> non-empty transitions push, so
-    // Back leaves the search as a single step rather than one entry per char.
-    const replace = query.trim() !== '' && value.trim() !== ''
-    navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace, state: location.state })
-  }, [query, navigate, location.pathname, location.search, location.state])
+    navigate({ pathname: location.pathname, search: next ? `?${next}` : '' }, { replace: true, state: location.state })
+  }, [navigate, location.pathname, location.search, location.state])
 
   // After the AddCardPanel consumes its initialQuery we strip the hint from
   // history so a subsequent back/forward navigation doesn't re-open the


### PR DESCRIPTION
## Changes

- **Search box on the Pokémon sets page** - Added a free-text search input above the sets grid that filters sets by name or series (case-insensitive substring). The query is mirrored to a `?q=` URL param so reloads, the Back button and shared links preserve it, and it composes with the existing owned/older filters. (Hytte-wtqnr)

## Original Issue (feature): Add a name/series search box to filter sets on the sets page

### Scope
Add a free-text search box above the sets grid on `/pokemon` (`PokemonSets.tsx`) that filters the rendered sets by case-insensitive substring match against each set's `name` and `series`. The query is mirrored to a `?q=` URL param using the exact pattern already established for `owned` and `older` (read via `useMemo` over `location.search`, written via `navigate`), so reloads, the Back button, and shared links preserve it. Filtering happens client-side over the already-loaded `sets` array (the page fetches all sets), feeding the existing `recent`/`older` era grouping.

### Files to touch
- `web/src/pages/PokemonSets.tsx` — add controlled search input, derive `q` from URL, apply filter before the era-grouping `useMemo`, handle empty-results state.
- `web/public/locales/en/pokemon.json` — add search placeholder/label + "no matches" keys.
- `web/public/locales/nb/pokemon.json` — same keys (Norwegian).
- `web/public/locales/th/pokemon.json` — same keys (Thai).
- `changelog.d/<id>-pokemon-sets-search.md` (new) — `Added` fragment.

### Acceptance criteria
- A text input renders above the sets grid with an i18n placeholder (no hardcoded English); all three locale files have the new keys.
- Typing filters visible sets to those whose `name` or `series` contains the query (case-insensitive, trimmed); non-matching sets and now-empty era sections disappear.
- The query is reflected in the URL as `?q=<value>`; clearing the input removes the param. Loading a URL with `?q=` pre-fills the box and applies the filter on first render.
- `q` composes with the existing `owned` and `older` params without clobbering them (uses the same `URLSearchParams` set/delete + `navigate` pattern).
- When a query matches no sets, a distinct "no matches" message shows (mirroring the existing `emptyOwned` empty state), not a blank page.
- The Back button restores the previous query state; existing owned/older behavior is unchanged.
- `npm run lint` and `npm run build` pass.

### Non-goals
- No backend/API changes — filtering is purely client-side over the already-fetched set list.
- No server-side `?q=` query param on `/api/pokemon/sets`.
- No filtering inside an individual set's card list (`PokemonSet.tsx`) or on the Top/Scanned pages.
- No fuzzy matching, tokenization, ranking, or highlighting — plain substring only.
- No debounce/perf work or new dependencies; no changes to era grouping or sort order beyond passing the filtered list in.

## Source

Created from Suggestions page (suggestion id 191, page slug "pokemon", source=claude).

## Original suggestion

The sets page renders every set grouped by era with only an 'owned' toggle and a 'show older' expander, so finding one specific set (e.g. 'Obsidian Flames') means scrolling and scanning logos. Add a text input above the grid that filters the visible sets by name and series substring, mirrored to a `?q=` URL param like the existing `owned`/`older` params so reloads and shared links preserve it. This makes the page usable as the collection grows past a screenful of sets and complements the existing owned-only filter.


---
Bead: Hytte-wtqnr | Branch: forge/Hytte-wtqnr
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->