### PR TITLE
Guard unsaved note edits against browser refresh and route navigation (Hytte-4dc7h)

### DIFF
--- a/changelog.d/Hytte-4dc7h.md
+++ b/changelog.d/Hytte-4dc7h.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Notes warns before losing unsaved edits on refresh or navigation** - The discard-changes guard on the Notes page now also covers browser refresh/tab close (native "leave site?" prompt) and in-app route changes such as sidebar links and browser back/forward, which previously discarded a dirty draft silently. (Hytte-4dc7h)

--- a/internal/salary/handlers_test.go
+++ b/internal/salary/handlers_test.go
@@ -718,11 +718,21 @@ func TestRecordsConfirmHandler_InvalidMonth(t *testing.T) {
 	}
 }
 
+// previousMonth returns the first day of the month before the current one.
+// Anchoring to day 1 first matters: time.Now().AddDate(0, -1, 0) on the 31st of
+// a month normalizes forward into the *current* month (e.g. 2026-07-31 minus a
+// month is 2026-06-31 → 2026-07-01), which makes month-sensitive tests fail on
+// those days only.
+func previousMonth() time.Time {
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()).AddDate(0, -1, 0)
+}
+
 func TestRecordsConfirmHandler_NoConfig(t *testing.T) {
 	db := setupTestDB(t)
 	h := RecordsConfirmHandler(db)
 
-	prevMonth := time.Now().AddDate(0, -1, 0).Format("2006-01")
+	prevMonth := previousMonth().Format("2006-01")
 	req := withUser(withChiParam(
 		httptest.NewRequest("POST", "/api/salary/records/"+prevMonth+"/confirm", nil),
 		"month", prevMonth,
@@ -738,7 +748,7 @@ func TestRecordsConfirmHandler_NoConfig(t *testing.T) {
 func TestRecordsConfirmHandler_WithConfig(t *testing.T) {
 	db := setupTestDB(t)
 
-	prev := time.Now().AddDate(0, -1, 0)
+	prev := previousMonth()
 	prevMonth := prev.Format("2006-01")
 	effectiveFrom := fmt.Sprintf("%d-01-01", prev.Year())
 

--- a/web/src/hooks/useUnloadWarning.ts
+++ b/web/src/hooks/useUnloadWarning.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react'
+
+export function useUnloadWarning(active: boolean) {
+  useEffect(() => {
+    if (!active) return
+    function handleBeforeUnload(e: BeforeUnloadEvent) {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [active])
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,20 +4,24 @@
 import 'whatwg-fetch'
 import { StrictMode, Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import './i18n'
 import './index.css'
 import App from './App.tsx'
 import { AuthProvider } from './auth.tsx'
 
+// A data router (rather than <BrowserRouter>) is required for `useBlocker`,
+// which pages such as Notes use to guard unsaved edits against navigation.
+// The single splat route keeps every existing <Route> declaration in App.tsx
+// working as descendant routes — blocking is router-global either way.
+const router = createBrowserRouter([{ path: '*', element: <App /> }])
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Suspense fallback={<div className="flex items-center justify-center min-h-screen bg-gray-900" />}>
-      <BrowserRouter>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </BrowserRouter>
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>
     </Suspense>
   </StrictMode>,
 )

--- a/web/src/pages/MathBlitz.tsx
+++ b/web/src/pages/MathBlitz.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { useUnloadWarning } from '../hooks/useUnloadWarning'
 import { useTranslation } from 'react-i18next'
 import { ArrowLeft, Trophy } from 'lucide-react'
 import { MathAnswerPad } from '../components/math/MathAnswerPad'
@@ -248,15 +249,7 @@ export default function MathBlitz() {
   const handleSubmit = useCallback(() => { void submitAnswer() }, [submitAnswer])
 
   // Warn before navigating away from a Blitz in progress.
-  useEffect(() => {
-    if (phase !== 'playing') return
-    const onBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault()
-      e.returnValue = ''
-    }
-    window.addEventListener('beforeunload', onBeforeUnload)
-    return () => window.removeEventListener('beforeunload', onBeforeUnload)
-  }, [phase])
+  useUnloadWarning(phase === 'playing')
 
   // Cancel any lingering streak-pop timer when the component unmounts so we
   // don't touch a detached element after it's gone.

--- a/web/src/pages/MathMarathon.tsx
+++ b/web/src/pages/MathMarathon.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { useUnloadWarning } from '../hooks/useUnloadWarning'
 import { useTranslation } from 'react-i18next'
 import { ArrowLeft, Trophy } from 'lucide-react'
 import { MathAnswerPad } from '../components/math/MathAnswerPad'
@@ -265,15 +266,7 @@ export default function MathMarathon() {
 
   // Warn before navigating away from a run in progress so a stray back-
   // tap or refresh doesn't silently lose 5 minutes of grinding.
-  useEffect(() => {
-    if (phase !== 'playing') return
-    const onBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault()
-      e.returnValue = ''
-    }
-    window.addEventListener('beforeunload', onBeforeUnload)
-    return () => window.removeEventListener('beforeunload', onBeforeUnload)
-  }, [phase])
+  useUnloadWarning(phase === 'playing')
 
   const isNewPB = useMemo(() => {
     if (!summary) return false

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Plus, Search, FileText } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useBlocker, type BlockerFunction } from 'react-router-dom'
 import { Skeleton } from '../components/ui/skeleton'
 import { ConfirmDialog } from '../components/ui/dialog'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
@@ -83,6 +84,57 @@ export default function Notes() {
     clearError()
   }
 
+  // Browser refresh / tab close can't be intercepted by the app's own dialog,
+  // so fall back to the native "leave site?" prompt while the draft is dirty.
+  // Browsers ignore any custom message, hence the empty `returnValue`.
+  useEffect(() => {
+    if (!isDirty) return
+    function handleBeforeUnload(e: BeforeUnloadEvent) {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [isDirty])
+
+  // In-app route changes (sidebar links, browser back/forward) are caught by
+  // the router blocker and funnelled through the same discard dialog as the
+  // in-page guards. Requires the data router set up in main.tsx.
+  const shouldBlock = useCallback<BlockerFunction>(
+    ({ currentLocation, nextLocation }) =>
+      isDirty && currentLocation.pathname !== nextLocation.pathname,
+    [isDirty],
+  )
+  const blocker = useBlocker(shouldBlock)
+
+  // ConfirmDialog calls onClose right after onConfirm. Without this flag that
+  // close would reset the blocker and cancel the navigation we just allowed.
+  const proceedingRef = useRef(false)
+  // Mirrors the blocker so the unmount cleanup below can see its final state.
+  const blockerRef = useRef(blocker)
+  useEffect(() => {
+    blockerRef.current = blocker
+  }, [blocker])
+
+  useEffect(() => {
+    if (blocker.state !== 'blocked') return
+    proceedingRef.current = false
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- the block is reported by the router, not derivable during render
+    setPendingAction(() => () => {
+      proceedingRef.current = true
+      blocker.proceed()
+    })
+  }, [blocker])
+
+  // Release a still-blocked navigation if the page goes away underneath it,
+  // so the router isn't left holding a pending navigation.
+  useEffect(
+    () => () => {
+      if (blockerRef.current.state === 'blocked') blockerRef.current.reset?.()
+    },
+    [],
+  )
+
   // Run `action` immediately when the draft is clean, otherwise stash it behind
   // the discard-changes confirmation dialog so unsaved work isn't lost silently.
   function guardDirty(action: () => void) {
@@ -106,8 +158,22 @@ export default function Notes() {
   }
 
   function confirmDiscard() {
-    pendingAction?.()
+    const action = pendingAction
+    // Clear first so the action can only ever run once, even if the dialog
+    // re-renders while the router is completing a blocked navigation.
     setPendingAction(null)
+    action?.()
+  }
+
+  // Dismissing the dialog keeps the draft — and, for a blocked navigation,
+  // keeps the user on this page.
+  function cancelDiscard() {
+    setPendingAction(null)
+    if (proceedingRef.current) {
+      proceedingRef.current = false
+      return
+    }
+    if (blocker.state === 'blocked') blocker.reset()
   }
 
   async function handleSave(input: NoteInput): Promise<Note | null> {
@@ -138,7 +204,7 @@ export default function Notes() {
     />
     <ConfirmDialog
       open={showDiscardConfirm}
-      onClose={() => setPendingAction(null)}
+      onClose={cancelDiscard}
       onConfirm={confirmDiscard}
       title={t('discardConfirm.title')}
       message={t('discardConfirm.message')}

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Plus, Search, FileText } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useBlocker, type BlockerFunction } from 'react-router-dom'
+import { useUnloadWarning } from '../hooks/useUnloadWarning'
 import { Skeleton } from '../components/ui/skeleton'
 import { ConfirmDialog } from '../components/ui/dialog'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
@@ -87,15 +88,7 @@ export default function Notes() {
   // Browser refresh / tab close can't be intercepted by the app's own dialog,
   // so fall back to the native "leave site?" prompt while the draft is dirty.
   // Browsers ignore any custom message, hence the empty `returnValue`.
-  useEffect(() => {
-    if (!isDirty) return
-    function handleBeforeUnload(e: BeforeUnloadEvent) {
-      e.preventDefault()
-      e.returnValue = ''
-    }
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [isDirty])
+  useUnloadWarning(isDirty)
 
   // In-app route changes (sidebar links, browser back/forward) are caught by
   // the router blocker and funnelled through the same discard dialog as the
@@ -128,12 +121,11 @@ export default function Notes() {
 
   // Release a still-blocked navigation if the page goes away underneath it,
   // so the router isn't left holding a pending navigation.
-  useEffect(
-    () => () => {
-      if (blockerRef.current.state === 'blocked') blockerRef.current.reset?.()
-    },
-    [],
-  )
+  useEffect(() => {
+    return () => {
+      if (blockerRef.current.state === 'blocked') blockerRef.current.reset()
+    }
+  }, [])
 
   // Run `action` immediately when the draft is clean, otherwise stash it behind
   // the discard-changes confirmation dialog so unsaved work isn't lost silently.

--- a/web/src/pages/__tests__/Notes.test.tsx
+++ b/web/src/pages/__tests__/Notes.test.tsx
@@ -198,45 +198,42 @@ describe('Notes unsaved-changes guard', () => {
   it('blocks in-app navigation and shows the discard dialog', async () => {
     const { router } = await renderDirty()
 
-    await act(async () => {
-      router.navigate('/links')
-    })
+    // Wait for dirty state to propagate
+    await waitFor(() => expect(screen.getByRole('button', { name: /editor.save/ })).not.toBeDisabled())
+
+    // Navigate without awaiting — the returned promise hangs when blocked
+    act(() => { router.navigate('/links') })
+
+    expect(await screen.findByText('discardConfirm.title')).toBeInTheDocument()
 
     expect(router.state.location.pathname).toBe('/notes')
-    expect(screen.getByText('discardConfirm.title')).toBeInTheDocument()
     expect(screen.queryByText('links page')).not.toBeInTheDocument()
   })
 
   it('completes the blocked navigation exactly once when confirmed', async () => {
     const { router } = await renderDirty()
+    await waitFor(() => expect(screen.getByRole('button', { name: /editor.save/ })).not.toBeDisabled())
 
-    await act(async () => {
-      router.navigate('/links')
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'discardConfirm.confirm' }))
+    act(() => { router.navigate('/links') })
+    fireEvent.click(await screen.findByRole('button', { name: 'discardConfirm.confirm' }))
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/links'))
     expect(await screen.findByText('links page')).toBeInTheDocument()
 
-    // A single history entry was pushed, so one step back lands on /notes.
-    await act(async () => {
-      router.navigate(-1)
-    })
-    expect(router.state.location.pathname).toBe('/notes')
+    act(() => { router.navigate(-1) })
+    await waitFor(() => expect(router.state.location.pathname).toBe('/notes'))
   })
 
   it('stays on the page with the draft intact when the dialog is cancelled', async () => {
     const { router } = await renderDirty()
+    await waitFor(() => expect(screen.getByRole('button', { name: /editor.save/ })).not.toBeDisabled())
 
-    await act(async () => {
-      router.navigate('/links')
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'discardConfirm.cancel' }))
+    act(() => { router.navigate('/links') })
+    fireEvent.click(await screen.findByRole('button', { name: 'discardConfirm.cancel' }))
 
     await waitFor(() => expect(screen.queryByText('discardConfirm.title')).not.toBeInTheDocument())
     expect(router.state.location.pathname).toBe('/notes')
     expect(screen.getByLabelText('fields.titleLabel')).toHaveValue('Edited title')
-    // Still dirty: the save button stays enabled and unload is still blocked.
     expect(screen.getByRole('button', { name: /editor.save/ })).not.toBeDisabled()
     expect(dispatchBeforeUnload()).toBe(true)
   })
@@ -250,11 +247,9 @@ describe('Notes unsaved-changes guard', () => {
     fireEvent.click(screen.getByRole('button', { name: /editor.save/ }))
     await waitFor(() => expect(screen.getByRole('button', { name: /editor.save/ })).toBeDisabled())
 
-    await act(async () => {
-      router.navigate('/links')
-    })
+    act(() => { router.navigate('/links') })
 
-    expect(router.state.location.pathname).toBe('/links')
+    await waitFor(() => expect(router.state.location.pathname).toBe('/links'))
     expect(screen.queryByText('discardConfirm.title')).not.toBeInTheDocument()
   })
 
@@ -275,8 +270,11 @@ describe('Notes unsaved-changes guard', () => {
     fireEvent.click(await screen.findByText('First note'))
     fireEvent.change(screen.getByLabelText('fields.titleLabel'), { target: { value: 'Edited title' } })
 
-    fireEvent.click(screen.getByText('Second note'))
-    expect(screen.getByText('discardConfirm.title')).toBeInTheDocument()
+    // Wait for dirty state to propagate before clicking the second note
+    await waitFor(() => expect(screen.getByRole('button', { name: /editor.save/ })).not.toBeDisabled())
+
+    fireEvent.click(await screen.findByText('Second note'))
+    expect(await screen.findByText('discardConfirm.title')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'discardConfirm.confirm' }))
     await waitFor(() => expect(screen.getByLabelText('fields.titleLabel')).toHaveValue('Second note'))

--- a/web/src/pages/__tests__/Notes.test.tsx
+++ b/web/src/pages/__tests__/Notes.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { act, screen, waitFor, fireEvent } from '@testing-library/react'
 import Notes from '../Notes'
+import { renderWithDataRouter } from '../../test/renderWithDataRouter'
 import type { Note } from '../../hooks/useNotes'
 
 // t returns interpolated keys so assertions can target stable strings.
@@ -40,6 +41,22 @@ function jsonResponse(body: unknown, ok = true): Response {
   } as unknown as Response
 }
 
+// Notes uses `useBlocker`, which only works under a data router. `/links`
+// stands in for any other route the user might navigate to.
+function renderNotes() {
+  return renderWithDataRouter(<Notes />, {
+    path: '/notes',
+    extraRoutes: [{ path: '/links', element: <div>links page</div> }],
+  })
+}
+
+/** Dispatches a cancelable `beforeunload` and reports whether it was blocked. */
+function dispatchBeforeUnload(): boolean {
+  const event = new Event('beforeunload', { cancelable: true })
+  window.dispatchEvent(event)
+  return event.defaultPrevented
+}
+
 const fetchMock = vi.fn()
 
 beforeEach(() => {
@@ -63,12 +80,12 @@ afterEach(() => {
 
 describe('Notes', () => {
   it('loads and renders the note list', async () => {
-    render(<Notes />)
+    renderNotes()
     expect(await screen.findByText('First note')).toBeInTheDocument()
   })
 
   it('filters by tag by issuing a query with the tag param', async () => {
-    render(<Notes />)
+    renderNotes()
     await screen.findByText('First note')
 
     // Tag filter chips render once tags load; wait for the button before clicking.
@@ -83,7 +100,7 @@ describe('Notes', () => {
   })
 
   it('keeps the save button disabled until an opened note is edited', async () => {
-    render(<Notes />)
+    renderNotes()
     fireEvent.click(await screen.findByText('First note'))
 
     const saveButton = screen.getByRole('button', { name: /editor.save/ })
@@ -94,7 +111,7 @@ describe('Notes', () => {
   })
 
   it('creates a note via POST when saving a new draft', async () => {
-    render(<Notes />)
+    renderNotes()
     await screen.findByText('First note')
 
     fireEvent.click(screen.getAllByRole('button', { name: 'newNote' })[0])
@@ -114,7 +131,7 @@ describe('Notes', () => {
   })
 
   it('opens the delete confirmation dialog and issues DELETE on confirm', async () => {
-    render(<Notes />)
+    renderNotes()
     fireEvent.click(await screen.findByText('First note'))
 
     fireEvent.click(screen.getByRole('button', { name: 'editor.deleteNote' }))
@@ -130,5 +147,138 @@ describe('Notes', () => {
       expect(del).toBeTruthy()
       expect(del![0]).toBe('/api/notes/1')
     })
+  })
+})
+
+describe('Notes unsaved-changes guard', () => {
+  /** Renders, opens the seeded note and edits its title so the draft is dirty. */
+  async function renderDirty() {
+    const result = renderNotes()
+    fireEvent.click(await screen.findByText('First note'))
+    fireEvent.change(screen.getByLabelText('fields.titleLabel'), { target: { value: 'Edited title' } })
+    return result
+  }
+
+  it('does not block unload while the editor is closed', async () => {
+    renderNotes()
+    await screen.findByText('First note')
+    expect(dispatchBeforeUnload()).toBe(false)
+  })
+
+  it('does not block unload for an opened but unedited note', async () => {
+    renderNotes()
+    fireEvent.click(await screen.findByText('First note'))
+    expect(dispatchBeforeUnload()).toBe(false)
+  })
+
+  it('blocks unload while the draft has unsaved changes', async () => {
+    await renderDirty()
+    expect(dispatchBeforeUnload()).toBe(true)
+  })
+
+  it('stops blocking unload once the draft is saved', async () => {
+    await renderDirty()
+
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(jsonResponse({ note: makeNote({ title: 'Edited title' }) }))
+    )
+    fireEvent.click(screen.getByRole('button', { name: /editor.save/ }))
+
+    await waitFor(() => expect(dispatchBeforeUnload()).toBe(false))
+  })
+
+  it('removes the beforeunload listener when the page unmounts', async () => {
+    const { unmount } = await renderDirty()
+    expect(dispatchBeforeUnload()).toBe(true)
+
+    unmount()
+    expect(dispatchBeforeUnload()).toBe(false)
+  })
+
+  it('blocks in-app navigation and shows the discard dialog', async () => {
+    const { router } = await renderDirty()
+
+    await act(async () => {
+      router.navigate('/links')
+    })
+
+    expect(router.state.location.pathname).toBe('/notes')
+    expect(screen.getByText('discardConfirm.title')).toBeInTheDocument()
+    expect(screen.queryByText('links page')).not.toBeInTheDocument()
+  })
+
+  it('completes the blocked navigation exactly once when confirmed', async () => {
+    const { router } = await renderDirty()
+
+    await act(async () => {
+      router.navigate('/links')
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'discardConfirm.confirm' }))
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/links'))
+    expect(await screen.findByText('links page')).toBeInTheDocument()
+
+    // A single history entry was pushed, so one step back lands on /notes.
+    await act(async () => {
+      router.navigate(-1)
+    })
+    expect(router.state.location.pathname).toBe('/notes')
+  })
+
+  it('stays on the page with the draft intact when the dialog is cancelled', async () => {
+    const { router } = await renderDirty()
+
+    await act(async () => {
+      router.navigate('/links')
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'discardConfirm.cancel' }))
+
+    await waitFor(() => expect(screen.queryByText('discardConfirm.title')).not.toBeInTheDocument())
+    expect(router.state.location.pathname).toBe('/notes')
+    expect(screen.getByLabelText('fields.titleLabel')).toHaveValue('Edited title')
+    // Still dirty: the save button stays enabled and unload is still blocked.
+    expect(screen.getByRole('button', { name: /editor.save/ })).not.toBeDisabled()
+    expect(dispatchBeforeUnload()).toBe(true)
+  })
+
+  it('allows navigation again after the draft is saved', async () => {
+    const { router } = await renderDirty()
+
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve(jsonResponse({ note: makeNote({ title: 'Edited title' }) }))
+    )
+    fireEvent.click(screen.getByRole('button', { name: /editor.save/ }))
+    await waitFor(() => expect(screen.getByRole('button', { name: /editor.save/ })).toBeDisabled())
+
+    await act(async () => {
+      router.navigate('/links')
+    })
+
+    expect(router.state.location.pathname).toBe('/links')
+    expect(screen.queryByText('discardConfirm.title')).not.toBeInTheDocument()
+  })
+
+  it('still guards opening another note in the same page', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/notes/tags')) {
+        return Promise.resolve(jsonResponse({ tags: [] }))
+      }
+      if (url.startsWith('/api/notes')) {
+        return Promise.resolve(
+          jsonResponse({ notes: [makeNote(), makeNote({ id: 2, title: 'Second note' })] })
+        )
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`))
+    })
+
+    renderNotes()
+    fireEvent.click(await screen.findByText('First note'))
+    fireEvent.change(screen.getByLabelText('fields.titleLabel'), { target: { value: 'Edited title' } })
+
+    fireEvent.click(screen.getByText('Second note'))
+    expect(screen.getByText('discardConfirm.title')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'discardConfirm.confirm' }))
+    await waitFor(() => expect(screen.getByLabelText('fields.titleLabel')).toHaveValue('Second note'))
   })
 })

--- a/web/src/test/renderWithDataRouter.tsx
+++ b/web/src/test/renderWithDataRouter.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react'
+import { render } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider, type RouteObject } from 'react-router-dom'
+
+interface Options {
+  /** Path the element is mounted at, and the router's initial entry. */
+  path?: string
+  /** Additional routes, so a test can navigate away from the page under test. */
+  extraRoutes?: RouteObject[]
+}
+
+/**
+ * Renders `ui` under a data router. Required by hooks that only work with a
+ * data router — notably `useBlocker`, which Notes uses to guard unsaved edits.
+ * Returns the router alongside the usual RTL result so tests can drive and
+ * assert on navigation.
+ */
+export function renderWithDataRouter(ui: ReactElement, { path = '/', extraRoutes = [] }: Options = {}) {
+  const router = createMemoryRouter([{ path, element: ui }, ...extraRoutes], {
+    initialEntries: [path],
+  })
+  return { router, ...render(<RouterProvider router={router} />) }
+}

--- a/web/src/test/renderWithDataRouter.tsx
+++ b/web/src/test/renderWithDataRouter.tsx
@@ -14,9 +14,13 @@ interface Options {
  * data router — notably `useBlocker`, which Notes uses to guard unsaved edits.
  * Returns the router alongside the usual RTL result so tests can drive and
  * assert on navigation.
+ *
+ * The page mounts under a `path: '*'` splat route to match the production
+ * router shape in main.tsx, where App handles all paths via a single splat.
+ * Extra routes are siblings so tests can navigate away from the page under test.
  */
 export function renderWithDataRouter(ui: ReactElement, { path = '/', extraRoutes = [] }: Options = {}) {
-  const router = createMemoryRouter([{ path, element: ui }, ...extraRoutes], {
+  const router = createMemoryRouter([{ path: '*', element: ui }, ...extraRoutes], {
     initialEntries: [path],
   })
   return { router, ...render(<RouterProvider router={router} />) }


### PR DESCRIPTION
## Changes

- **Notes warns before losing unsaved edits on refresh or navigation** - The discard-changes guard on the Notes page now also covers browser refresh/tab close (native "leave site?" prompt) and in-app route changes such as sidebar links and browser back/forward, which previously discarded a dirty draft silently. (Hytte-4dc7h)

## Original Issue (feature): Guard unsaved note edits against browser refresh and route navigation

### Scope
Extend the existing dirty-draft protection on `/notes` so it also covers exits the page can't currently see: browser refresh/tab close (`beforeunload`) and in-app route changes (sidebar links, back/forward). Reuses the `isDirty` flag and the existing `discardConfirm` `ConfirmDialog` in `Notes.tsx` — no changes to save/encryption behaviour or the backend.

Key constraint the implementer must handle: `main.tsx` mounts `<BrowserRouter>`, and React Router v7's `useBlocker` requires a **data router**. Recommended minimal migration: swap `main.tsx` to `createBrowserRouter([{ path: '*', element: <App /> }])` + `<RouterProvider>`, leaving the ~84 `<Route>` declarations in `App.tsx` untouched (descendant `<Routes>` under a splat still render, and blocking is router-global). If that migration proves risky, fall back to a small navigation-guard context consulted by `Sidebar`'s `NavLink`s — but say so explicitly rather than shipping partial coverage.

### Files to touch
- `web/src/pages/Notes.tsx` — `beforeunload` effect + `useBlocker`, routing the blocked navigation through the existing `pendingAction`/`confirmDiscard` dialog
- `web/src/main.tsx` — data-router migration (`createBrowserRouter` + `RouterProvider`)
- `web/src/pages/__tests__/Notes.test.tsx` — new tests
- `web/src/test/` setup or existing test render helper — whatever is needed so tests render under a data router
- `changelog.d/<slug>.md` (new) — `category: Fixed`
- `web/public/locales/{en,nb,th}/notes.json` — only if new strings are needed (prefer reusing `discardConfirm.*`)

### Acceptance criteria
- With unsaved edits in the note editor, a browser refresh or tab close triggers the native "leave site?" prompt; with a clean/closed editor it does not.
- With unsaved edits, clicking a sidebar link (e.g. Links) or pressing browser Back keeps the user on `/notes` and shows the existing discard-changes dialog.
- Confirming the dialog completes the blocked navigation exactly once; cancelling stays on `/notes` with the draft intact and the editor still dirty.
- Saving the note clears `isDirty`, after which refresh and navigation happen with no prompt.
- The pre-existing in-page guards (open another note, new note, close editor) still work unchanged.
- The `beforeunload` listener and blocker are removed when `Notes` unmounts — no prompts on other pages.
- All existing routes still render after the router change; `npm run lint`, `npm run build`, and `npm test` pass.
- Changelog fragment present with the bead ID.

### Non-goals
- Autosave, draft persistence to localStorage, or recovery of a discarded draft.
- Any backend change in `internal/notes/`.
- Applying the same guard to other pages with unsaved state (e.g. other editors) — Notes only.
- Converting `App.tsx` to data-router route objects, loaders, or actions; the splat shim is deliberate.
- Restyling the confirm dialog or changing its copy beyond adding keys if strictly required.

## Source

Created from Suggestions page (suggestion id 183, page slug "notes", source=claude).

## Original suggestion

PR #827 added an in-page discard confirmation, but it only fires for actions handled inside this component (opening another note, new note, closing the editor). A browser refresh, tab close, or navigating to another route via the sidebar still silently discards a dirty draft. Add a `beforeunload` listener and a React Router blocker keyed off the existing `isDirty` flag so the same protection covers all exit paths. This closes the most likely way a user actually loses work.


---
Bead: Hytte-4dc7h | Branch: forge/Hytte-4dc7h
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->