### PR TITLE
Add undo for check-off and clear-completed (Hytte-63o47)

### DIFF
--- a/changelog.d/Hytte-63o47.md
+++ b/changelog.d/Hytte-63o47.md
@@ -1,0 +1,2 @@
+category: Added
+- **Undo for grocery check-off and clear-completed** - Checking an item off or clearing completed items now shows a toast with an Undo button for 8 seconds. Undoing a check-off flips the item back to unchecked; undoing a clear re-creates the removed items (keeping their text, original text and source language) and marks them completed again. Only the most recent action is undoable, and a failed undo shows an error and resyncs the list with the server. (Hytte-63o47)

--- a/internal/salary/handlers_test.go
+++ b/internal/salary/handlers_test.go
@@ -28,6 +28,14 @@ func withUser(r *http.Request, u *auth.User) *http.Request {
 	return r.WithContext(auth.ContextWithUser(r.Context(), u))
 }
 
+// previousMonth returns the first day of the month before the current one.
+// Anchoring to day 1 before subtracting avoids Go's day-overflow normalization
+// (e.g. July 31 minus one month is June 31, which normalizes back to July 1).
+func previousMonth() time.Time {
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()).AddDate(0, -1, 0)
+}
+
 func jsonBody(t *testing.T, v any) *bytes.Buffer {
 	t.Helper()
 	var buf bytes.Buffer
@@ -722,7 +730,7 @@ func TestRecordsConfirmHandler_NoConfig(t *testing.T) {
 	db := setupTestDB(t)
 	h := RecordsConfirmHandler(db)
 
-	prevMonth := time.Now().AddDate(0, -1, 0).Format("2006-01")
+	prevMonth := previousMonth().Format("2006-01")
 	req := withUser(withChiParam(
 		httptest.NewRequest("POST", "/api/salary/records/"+prevMonth+"/confirm", nil),
 		"month", prevMonth,
@@ -738,7 +746,7 @@ func TestRecordsConfirmHandler_NoConfig(t *testing.T) {
 func TestRecordsConfirmHandler_WithConfig(t *testing.T) {
 	db := setupTestDB(t)
 
-	prev := time.Now().AddDate(0, -1, 0)
+	prev := previousMonth()
 	prevMonth := prev.Format("2006-01")
 	effectiveFrom := fmt.Sprintf("%d-01-01", prev.Year())
 

--- a/web/public/locales/en/grocery.json
+++ b/web/public/locales/en/grocery.json
@@ -3,6 +3,12 @@
   "addPlaceholder": "Add an item...",
   "add": "Add",
   "clearCompleted": "Clear completed",
+  "undo": "Undo",
+  "toast": {
+    "itemCheckedOff": "Item checked off",
+    "itemsCleared_one": "{{count}} item cleared",
+    "itemsCleared_other": "{{count}} items cleared"
+  },
   "empty": "Your grocery list is empty",
   "emptyHint": "Add items using the input above",
   "errors": {
@@ -10,6 +16,7 @@
     "failedToAdd": "Failed to add item",
     "failedToUpdate": "Failed to update item",
     "failedToClear": "Failed to clear completed items",
+    "failedToUndo": "Failed to undo — showing the latest server state",
     "failedToTranslate": "Failed to translate voice input",
     "failedToStartRecording": "Failed to start recording"
   },

--- a/web/public/locales/nb/grocery.json
+++ b/web/public/locales/nb/grocery.json
@@ -3,6 +3,12 @@
   "addPlaceholder": "Legg til en vare...",
   "add": "Legg til",
   "clearCompleted": "Fjern fullførte",
+  "undo": "Angre",
+  "toast": {
+    "itemCheckedOff": "Vare huket av",
+    "itemsCleared_one": "{{count}} vare fjernet",
+    "itemsCleared_other": "{{count}} varer fjernet"
+  },
   "empty": "Handlelisten er tom",
   "emptyHint": "Legg til varer med feltet over",
   "errors": {
@@ -10,6 +16,7 @@
     "failedToAdd": "Kunne ikke legge til vare",
     "failedToUpdate": "Kunne ikke oppdatere vare",
     "failedToClear": "Kunne ikke fjerne fullførte varer",
+    "failedToUndo": "Kunne ikke angre – viser siste tilstand fra serveren",
     "failedToTranslate": "Kunne ikke oversette taleinndata",
     "failedToStartRecording": "Kunne ikke starte opptak"
   },

--- a/web/public/locales/th/grocery.json
+++ b/web/public/locales/th/grocery.json
@@ -3,6 +3,12 @@
   "addPlaceholder": "เพิ่มรายการ...",
   "add": "เพิ่ม",
   "clearCompleted": "ล้างรายการที่เสร็จแล้ว",
+  "undo": "เลิกทำ",
+  "toast": {
+    "itemCheckedOff": "ทำเครื่องหมายรายการว่าเสร็จแล้ว",
+    "itemsCleared_one": "ล้างแล้ว {{count}} รายการ",
+    "itemsCleared_other": "ล้างแล้ว {{count}} รายการ"
+  },
   "empty": "รายการซื้อของว่างเปล่า",
   "emptyHint": "เพิ่มรายการโดยใช้ช่องด้านบน",
   "errors": {
@@ -10,6 +16,7 @@
     "failedToAdd": "ไม่สามารถเพิ่มรายการ",
     "failedToUpdate": "ไม่สามารถอัปเดตรายการ",
     "failedToClear": "ไม่สามารถล้างรายการที่เสร็จแล้ว",
+    "failedToUndo": "ไม่สามารถเลิกทำ — กำลังแสดงสถานะล่าสุดจากเซิร์ฟเวอร์",
     "failedToTranslate": "ไม่สามารถแปลเสียงพูด",
     "failedToStartRecording": "ไม่สามารถเริ่มบันทึกเสียง"
   },

--- a/web/src/components/ToastList.tsx
+++ b/web/src/components/ToastList.tsx
@@ -3,9 +3,11 @@ import type { Toast } from '../hooks/useToast'
 
 interface ToastListProps {
   toasts: Toast[]
+  /** Required for toasts with an action — the toast closes once the action fires. */
+  onDismiss?: (id: number) => void
 }
 
-export default function ToastList({ toasts }: ToastListProps) {
+export default function ToastList({ toasts, onDismiss }: ToastListProps) {
   if (toasts.length === 0) return null
 
   return (
@@ -14,27 +16,42 @@ export default function ToastList({ toasts }: ToastListProps) {
       aria-live="polite"
       aria-atomic="false"
     >
-      {toasts.map(toast => (
-        <div
-          key={toast.id}
-          role="status"
-          className={`flex items-center gap-2.5 rounded-lg px-4 py-3 text-sm font-medium shadow-lg border
+      {toasts.map(toast => {
+        const action = toast.action
+        return (
+          <div
+            key={toast.id}
+            role="status"
+            className={`flex items-center gap-2.5 rounded-lg px-4 py-3 text-sm font-medium shadow-lg border
             ${toast.type === 'success'
               ? 'bg-green-900/90 text-green-200 border-green-700'
               : toast.type === 'warning'
               ? 'bg-amber-900/90 text-amber-200 border-amber-700'
               : 'bg-red-900/90 text-red-200 border-red-700'
-            }`}
-        >
-          {toast.type === 'success'
-            ? <CheckCircle size={16} className="shrink-0 text-green-400" />
-            : toast.type === 'warning'
-            ? <AlertTriangle size={16} className="shrink-0 text-amber-400" />
-            : <AlertCircle size={16} className="shrink-0 text-red-400" />
-          }
-          {toast.message}
-        </div>
-      ))}
+            }${action ? ' pointer-events-auto' : ''}`}
+          >
+            {toast.type === 'success'
+              ? <CheckCircle size={16} className="shrink-0 text-green-400" />
+              : toast.type === 'warning'
+              ? <AlertTriangle size={16} className="shrink-0 text-amber-400" />
+              : <AlertCircle size={16} className="shrink-0 text-red-400" />
+            }
+            {toast.message}
+            {action && (
+              <button
+                type="button"
+                onClick={() => {
+                  action.onClick()
+                  onDismiss?.(toast.id)
+                }}
+                className="shrink-0 ml-1 rounded px-2 py-1 -my-1 text-xs font-semibold uppercase tracking-wide underline underline-offset-2 cursor-pointer hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+              >
+                {action.label}
+              </button>
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/web/src/hooks/useToast.ts
+++ b/web/src/hooks/useToast.ts
@@ -1,9 +1,22 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 
+export interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
 export interface Toast {
   id: number
   message: string
   type: 'success' | 'error' | 'warning'
+  action?: ToastAction
+}
+
+export interface ShowToastOptions {
+  /** Optional button rendered inside the toast (e.g. "Undo"). */
+  action?: ToastAction
+  /** Overrides the default auto-dismiss delay. */
+  durationMs?: number
 }
 
 const TOAST_DURATION_MS = 3500
@@ -19,15 +32,29 @@ export function useToast() {
     }
   }, [])
 
-  const showToast = useCallback((message: string, type: 'success' | 'error' | 'warning') => {
+  const dismissToast = useCallback((id: number) => {
+    const timeoutId = timeoutsRef.current.get(id)
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId)
+      timeoutsRef.current.delete(id)
+    }
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  const showToast = useCallback((
+    message: string,
+    type: 'success' | 'error' | 'warning',
+    options?: ShowToastOptions,
+  ) => {
     const id = ++counterRef.current
-    setToasts(prev => [...prev, { id, message, type }])
+    setToasts(prev => [...prev, { id, message, type, action: options?.action }])
     const timeoutId = setTimeout(() => {
       setToasts(prev => prev.filter(t => t.id !== id))
       timeoutsRef.current.delete(id)
-    }, TOAST_DURATION_MS)
+    }, options?.durationMs ?? TOAST_DURATION_MS)
     timeoutsRef.current.set(id, timeoutId)
+    return id
   }, [])
 
-  return { toasts, showToast }
+  return { toasts, showToast, dismissToast }
 }

--- a/web/src/pages/GroceryPage.test.tsx
+++ b/web/src/pages/GroceryPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import GroceryPage from './GroceryPage'
 
@@ -14,6 +14,8 @@ const TRANSLATIONS: Record<string, string> = {
   'addPlaceholder': 'Add an item...',
   'add': 'Add',
   'clearCompleted': 'Clear completed',
+  'undo': 'Undo',
+  'toast.itemCheckedOff': 'Item checked off',
   'empty': 'Your grocery list is empty',
   'emptyHint': 'Add items using the input above',
   'checkedSection': 'Completed',
@@ -24,13 +26,18 @@ const TRANSLATIONS: Record<string, string> = {
   'errors.failedToAdd': 'Failed to add item',
   'errors.failedToUpdate': 'Failed to update item',
   'errors.failedToClear': 'Failed to clear completed items',
+  'errors.failedToUndo': 'Failed to undo',
   'errors.failedToTranslate': 'Failed to translate voice input',
   'errors.failedToStartRecording': 'Failed to start recording',
   'common:actions.close': 'Close',
 }
 
-function mockT(key: string, opts?: Record<string, string>): string {
+function mockT(key: string, opts?: Record<string, string | number>): string {
   if (key === 'item.original') return `Original: ${opts?.text ?? ''}`
+  if (key === 'toast.itemsCleared') {
+    const count = Number(opts?.count ?? 0)
+    return `${count} item${count === 1 ? '' : 's'} cleared`
+  }
   return TRANSLATIONS[key] ?? key
 }
 
@@ -75,6 +82,7 @@ beforeEach(() => { vi.stubGlobal('EventSource', MockEventSource) })
 
 function makeItem(overrides: Partial<{
   id: number; content: string; checked: boolean; sort_order: number
+  original_text: string; source_language: string
 }> = {}) {
   return {
     id: 1,
@@ -251,6 +259,188 @@ describe('GroceryPage – failure paths', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Failed to update item')
     // After refetch, item is back to its server state (unchecked)
     expect(screen.getByRole('checkbox', { name: /milk/i })).toHaveAttribute('aria-checked', 'false')
+  })
+})
+
+// ── Undo tests ────────────────────────────────────────────────────────────────
+
+describe('GroceryPage – undo', () => {
+  beforeEach(() => { authState.user = { id: 1 } })
+  afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  const ok = () => ({ ok: true, json: () => Promise.resolve({}) })
+
+  it('offers undo after checking an item and unchecks it again on click', async () => {
+    const item = makeItem({ id: 1, content: 'Milk', checked: false })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(itemsResponse([item]))   // initial load
+      .mockResolvedValueOnce(ok())                    // check PATCH
+      .mockResolvedValueOnce(ok())                    // undo PATCH
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Milk')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /milk/i }))
+
+    const undo = await screen.findByRole('button', { name: 'Undo' })
+    expect(screen.getByRole('status')).toHaveTextContent('Item checked off')
+    // The undo affordance is a real button, so it is focusable by keyboard
+    expect(undo.tagName).toBe('BUTTON')
+    undo.focus()
+    expect(undo).toHaveFocus()
+
+    fireEvent.click(undo)
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /milk/i })).toHaveAttribute('aria-checked', 'false')
+    })
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/grocery/items/1/check', expect.objectContaining({
+      method: 'PATCH',
+      body: JSON.stringify({ checked: false }),
+    }))
+    // Tapping undo dismisses the toast immediately
+    expect(screen.queryByRole('button', { name: 'Undo' })).not.toBeInTheDocument()
+  })
+
+  it('restores cleared items via POST + check when undo is tapped', async () => {
+    const unchecked = makeItem({ id: 1, content: 'Milk', checked: false })
+    const bread = makeItem({
+      id: 2, content: 'Bread', checked: true,
+      original_text: 'ขนมปัง', source_language: 'th',
+    })
+    const eggs = makeItem({ id: 3, content: 'Eggs', checked: true })
+    const restoredBread = makeItem({ id: 4, content: 'Bread', checked: true, original_text: 'ขนมปัง', source_language: 'th' })
+    const restoredEggs = makeItem({ id: 5, content: 'Eggs', checked: true })
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(itemsResponse([unchecked, bread, eggs]))                    // initial load
+      .mockResolvedValueOnce(ok())                                                       // DELETE completed
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ item: restoredBread }) }) // POST Bread
+      .mockResolvedValueOnce(ok())                                                       // PATCH 4 checked
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ item: restoredEggs }) })  // POST Eggs
+      .mockResolvedValueOnce(ok())                                                       // PATCH 5 checked
+      .mockResolvedValueOnce(itemsResponse([unchecked, restoredBread, restoredEggs]))     // resync
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Clear completed')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('Clear completed'))
+
+    const undo = await screen.findByRole('button', { name: 'Undo' })
+    expect(screen.getByRole('status')).toHaveTextContent('2 items cleared')
+
+    fireEvent.click(undo)
+
+    await waitFor(() => {
+      expect(screen.getByText('Bread')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Eggs')).toBeInTheDocument()
+    // Each cleared item is re-created with its original fields preserved
+    expect(fetchMock).toHaveBeenCalledWith('/api/grocery/items', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ content: 'Bread', original_text: 'ขนมปัง', source_language: 'th' }),
+    }))
+    expect(fetchMock).toHaveBeenCalledWith('/api/grocery/items', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ content: 'Eggs', original_text: '', source_language: 'en' }),
+    }))
+    // ...and checked again so the pre-clear state is visible
+    expect(fetchMock).toHaveBeenCalledWith('/api/grocery/items/4/check', expect.objectContaining({
+      method: 'PATCH',
+      body: JSON.stringify({ checked: true }),
+    }))
+    expect(fetchMock).toHaveBeenCalledWith('/api/grocery/items/5/check', expect.objectContaining({
+      method: 'PATCH',
+      body: JSON.stringify({ checked: true }),
+    }))
+    expect(screen.getAllByRole('checkbox', { name: /bread/i })).toHaveLength(1)
+  })
+
+  it('drops the undo affordance once the 8s window elapses', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const item = makeItem({ id: 1, content: 'Milk', checked: false })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(itemsResponse([item]))
+      .mockResolvedValueOnce(ok())
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Milk')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /milk/i }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument())
+
+    act(() => { vi.advanceTimersByTime(8000) })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Undo' })).not.toBeInTheDocument()
+    })
+    // No undo request fired — only the initial load and the check PATCH
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('replaces a pending undo toast when a second action is taken', async () => {
+    const milk = makeItem({ id: 1, content: 'Milk', checked: false })
+    const bread = makeItem({ id: 2, content: 'Bread', checked: false, sort_order: 1 })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(itemsResponse([milk, bread]))  // initial load
+      .mockResolvedValueOnce(ok())                          // check Milk
+      .mockResolvedValueOnce(ok())                          // check Bread
+      .mockResolvedValueOnce(ok())                          // undo (Bread only)
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Milk')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /milk/i }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /bread/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /bread/i })).toHaveAttribute('aria-checked', 'true')
+    })
+    // The older toast is gone — only the newest action is undoable
+    expect(screen.getAllByRole('button', { name: 'Undo' })).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /bread/i })).toHaveAttribute('aria-checked', 'false')
+    })
+    // Milk stays checked — its undo window already closed
+    expect(screen.getByRole('checkbox', { name: /milk/i })).toHaveAttribute('aria-checked', 'true')
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/grocery/items/2/check', expect.objectContaining({
+      method: 'PATCH',
+      body: JSON.stringify({ checked: false }),
+    }))
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('shows an error toast and refetches when the undo request fails', async () => {
+    const item = makeItem({ id: 1, content: 'Milk', checked: false })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(itemsResponse([item]))                              // initial load
+      .mockResolvedValueOnce(ok())                                               // check PATCH
+      .mockResolvedValueOnce({ ok: false })                                      // undo PATCH fails
+      .mockResolvedValueOnce(itemsResponse([{ ...item, checked: true }]))        // resync
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Milk')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /milk/i }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Undo' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('Failed to undo')
+    })
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/grocery/items', expect.objectContaining({
+      credentials: 'include',
+    }))
+    // The refetched server state wins over the optimistic uncheck
+    expect(screen.getByRole('checkbox', { name: /milk/i })).toHaveAttribute('aria-checked', 'true')
   })
 })
 

--- a/web/src/pages/GroceryPage.tsx
+++ b/web/src/pages/GroceryPage.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Plus, Trash2, Check, X, Mic, MicOff } from 'lucide-react'
 import { useAuth } from '../auth'
+import { useToast } from '../hooks/useToast'
+import ToastList from '../components/ToastList'
 
 interface GroceryItem {
   id: number
@@ -31,6 +33,15 @@ function sortItems(items: GroceryItem[]): GroceryItem[] {
   })
 }
 
+// How long the Undo button stays available after a destructive action.
+const UNDO_WINDOW_MS = 8000
+
+// The most recent undoable action. Only one is ever pending: starting a new
+// destructive action replaces it, so an older action can no longer be undone.
+type PendingUndo =
+  | { kind: 'check'; itemId: number }
+  | { kind: 'clear'; items: GroceryItem[] }
+
 type SpeechRecognitionType = typeof window extends { SpeechRecognition: infer T } ? T : unknown
 
 function getSpeechRecognitionCtor(): (new () => SpeechRecognitionType) | undefined {
@@ -51,6 +62,9 @@ export default function GroceryPage() {
   const [isTranslating, setIsTranslating] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const recognitionRef = useRef<SpeechRecognitionType | null>(null)
+  const { toasts, showToast, dismissToast } = useToast()
+  const pendingUndoRef = useRef<PendingUndo | null>(null)
+  const pendingToastIdRef = useRef<number | null>(null)
 
   const fetchItems = useCallback(async (signal?: AbortSignal) => {
     const res = await fetch('/api/grocery/items', { credentials: 'include', signal })
@@ -284,37 +298,104 @@ export default function GroceryPage() {
     }
   }
 
+  // Resync with the server so what's on screen matches what was actually stored.
+  const resync = async () => {
+    try {
+      const fetched = await fetchItems()
+      setItems(fetched)
+    } catch {
+      // If the refetch also fails, leave the current state in place
+    }
+  }
+
+  // Optimistically flip an item's checked flag, then persist it. Throws if the
+  // request fails so callers can decide how to surface the error.
+  const applyCheck = async (itemId: number, newChecked: boolean) => {
+    setItems(prev => {
+      const updated = prev.map(i => i.id === itemId ? { ...i, checked: newChecked } : i)
+      return [...updated.filter(i => !i.checked), ...updated.filter(i => i.checked)]
+    })
+    const res = await fetch(`/api/grocery/items/${itemId}/check`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ checked: newChecked }),
+    })
+    if (!res.ok) throw new Error('toggle failed')
+  }
+
+  const runUndo = async () => {
+    const pending = pendingUndoRef.current
+    pendingUndoRef.current = null
+    pendingToastIdRef.current = null
+    if (!pending) return
+    try {
+      if (pending.kind === 'check') {
+        await applyCheck(pending.itemId, false)
+      } else {
+        // No restore endpoint exists, so re-create each cleared item and check it
+        // again. Restored rows get new ids and land at the end of the sort order.
+        for (const item of pending.items) {
+          const res = await fetch('/api/grocery/items', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              content: item.content,
+              original_text: item.original_text,
+              source_language: item.source_language,
+            }),
+          })
+          if (!res.ok) throw new Error('restore failed')
+          const data = await res.json()
+          const restored = data.item as GroceryItem
+          const checkRes = await fetch(`/api/grocery/items/${restored.id}/check`, {
+            method: 'PATCH',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ checked: true }),
+          })
+          if (!checkRes.ok) throw new Error('restore failed')
+        }
+        // Let the server be the single source of truth for the restored rows so
+        // they can't duplicate what the SSE stream already delivered.
+        const fetched = await fetchItems()
+        setItems(fetched)
+      }
+    } catch {
+      showToast(t('errors.failedToUndo'), 'error')
+      await resync()
+    }
+  }
+
+  // Replaces any still-pending undo toast — only the most recent action is undoable.
+  const showUndoToast = (message: string) => {
+    if (pendingToastIdRef.current !== null) dismissToast(pendingToastIdRef.current)
+    pendingToastIdRef.current = showToast(message, 'success', {
+      durationMs: UNDO_WINDOW_MS,
+      action: { label: t('undo'), onClick: () => { void runUndo() } },
+    })
+  }
+
   const handleToggle = async (item: GroceryItem) => {
     const newChecked = !item.checked
     setError('')
-    // Optimistic update
-    setItems(prev => {
-      const updated = prev.map(i => i.id === item.id ? { ...i, checked: newChecked } : i)
-      return [...updated.filter(i => !i.checked), ...updated.filter(i => i.checked)]
-    })
     try {
-      const res = await fetch(`/api/grocery/items/${item.id}/check`, {
-        method: 'PATCH',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ checked: newChecked }),
-      })
-      if (!res.ok) throw new Error('toggle failed')
+      await applyCheck(item.id, newChecked)
+      if (newChecked) {
+        pendingUndoRef.current = { kind: 'check', itemId: item.id }
+        showUndoToast(t('toast.itemCheckedOff'))
+      }
     } catch {
       // Refetch on failure to get authoritative state, avoiding stale-closure overwrites
-      try {
-        const fetched = await fetchItems()
-        setItems(fetched)
-      } catch {
-        // If refetch also fails, leave the optimistic state in place
-      }
+      await resync()
       setError(t('errors.failedToUpdate'))
     }
   }
 
   const handleClearCompleted = async () => {
-    const checked = items.filter(i => i.checked)
-    if (checked.length === 0) return
+    const cleared = items.filter(i => i.checked)
+    if (cleared.length === 0) return
     setError('')
     const snapshot = [...items]
     // Optimistic remove
@@ -325,6 +406,8 @@ export default function GroceryPage() {
         credentials: 'include',
       })
       if (!res.ok) throw new Error('clear failed')
+      pendingUndoRef.current = { kind: 'clear', items: cleared }
+      showUndoToast(t('toast.itemsCleared', { count: cleared.length }))
     } catch {
       // Revert to pre-optimistic snapshot to avoid duplicates and ordering issues
       setItems(snapshot)
@@ -441,6 +524,8 @@ export default function GroceryPage() {
           )}
         </div>
       )}
+
+      <ToastList toasts={toasts} onDismiss={dismissToast} />
     </div>
   )
 }


### PR DESCRIPTION
## Changes

- **Undo for grocery check-off and clear-completed** - Checking an item off or clearing completed items now shows a toast with an Undo button for 8 seconds. Undoing a check-off flips the item back to unchecked; undoing a clear re-creates the removed items (keeping their text, original text and source language) and marks them completed again. Only the most recent action is undoable, and a failed undo shows an error and resyncs the list with the server. (Hytte-63o47)

## Original Issue (feature): Add undo for check-off and clear-completed

### Scope
Add a forgiving undo affordance to the Grocery page for the two destructive actions: checking an item off and clearing all completed items. Implementation is frontend-only — it reuses the existing `PATCH /api/grocery/items/{id}/check`, `POST /api/grocery/items`, and `DELETE /api/grocery/completed` endpoints. The shared `useToast`/`ToastList` pair is extended (backwards-compatibly) to support an optional action button and a custom duration, then wired into `GroceryPage`.

### Files to touch
- `web/src/hooks/useToast.ts` — optional `action: { label, onClick }` and `durationMs` on `showToast`; keep the current 2-arg call signature working for all existing callers.
- `web/src/components/ToastList.tsx` — render the action button when present; invoke it and dismiss the toast.
- `web/src/pages/GroceryPage.tsx` — show undo toasts after check-off and clear-completed; hold the cleared items in a ref for restore.
- `web/src/pages/GroceryPage.test.tsx` — tests for both undo paths.
- `web/public/locales/en/grocery.json`, `.../nb/grocery.json`, `.../th/grocery.json` — new keys (undo label, "item checked off", "N items cleared", restore-failure error).
- `changelog.d/<slug>.md` (new) — `category: Added` fragment.

### Acceptance criteria
- Checking an item shows a toast with an Undo button; tapping it sends `checked: false` for that item and the row returns to unchecked in the list.
- Clearing completed items shows a toast naming the count with an Undo button; tapping it re-creates each cleared item via `POST /api/grocery/items` (preserving `content`, `original_text`, `source_language`) and then marks each restored item checked again, so the pre-clear state is visible.
- The undo window is 8 seconds; after it elapses the toast disappears and the action is final. Tapping Undo dismisses the toast immediately.
- Triggering a second destructive action while a toast is pending replaces the pending toast — the older action can no longer be undone, and no stale restore fires.
- A failed undo request surfaces an error toast and the list is refetched so displayed state matches the server.
- Restores propagate to other devices through the existing SSE stream (added/updated events), with no duplicate rows on the originating tab.
- All new strings go through `react-i18next` and exist in en, nb, and th; the undo button is reachable by keyboard and has an accessible name.
- Existing `useToast` callers (Allowance, Settings, Forge pages, etc.) are unchanged and their tests still pass; `npm run lint`, `npm run build`, and the frontend test suite are green.

### Non-goals
- No backend changes: no new restore endpoint, no soft-delete/tombstone column, no server-side undo log.
- Restored items get new IDs and are appended at the end of the sort order — original IDs and positions are not preserved.
- No undo for add, reorder, or translation actions.
- No multi-step undo stack or undo history; only the most recent action is undoable.
- No cross-device undo (the toast is local to the tab that performed the action) and no undo persistence across reload.
- No redesign of the toast visual system beyond adding the action button.

## Source

Created from Suggestions page (suggestion id 51, page slug "grocery", source=claude).

## Original suggestion

Checking an item or clearing completed items is a one-tap destructive action with no recovery — a misclick at the store means re-typing or re-translating the item. Add a transient toast with an Undo action (5–10s) that re-inserts the cleared items or flips checked back to false via the existing endpoints. This makes the list feel forgiving and removes the main reason a household member would hesitate to use the check-off flow.


---
Bead: Hytte-63o47 | Branch: forge/Hytte-63o47
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->