### PR TITLE
Recipes backend foundation: schema, models, store, feature flag, routing (Hytte-evi4c)

### DIFF
--- a/changelog.d/Hytte-evi4c.md
+++ b/changelog.d/Hytte-evi4c.md
@@ -1,0 +1,2 @@
+category: Added
+- **Recipes backend foundation** - Added the `recipes` feature flag (off by default), the recipe/ingredient/step/tag/cook/meal-plan schema, and a store with CRUD, tag filtering, servings scaling, ratings, a cooking log, and seasonal "cook again" suggestions. Recipe titles, notes, ingredient lines and step text are encrypted at rest; the recipes pages and API handlers land in follow-up work. (Hytte-evi4c)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -935,6 +935,13 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.With(auth.RequireAdmin()).Post("/offers/refresh", offers.HandleRefresh(db))
 			})
 
+			// Recipes — gated by "recipes" feature. The store landed in
+			// Hytte-evi4c; the /api/recipes/* handlers are wired into this
+			// group by the follow-up sub-task.
+			r.Group(func(r chi.Router) {
+				r.Use(auth.RequireFeature(db, "recipes"))
+			})
+
 			// Infrastructure monitoring — gated by "infra" feature.
 			r.Group(func(r chi.Router) {
 				r.Use(auth.RequireFeature(db, "infra"))

--- a/internal/auth/features.go
+++ b/internal/auth/features.go
@@ -40,6 +40,7 @@ var FeatureDefaults = map[string]bool{
 	"pokemon":          false,
 	"wardrobe":         false,
 	"offers":           false,
+	"recipes":          false,
 }
 
 // FeatureKeys is a sorted list of all known feature keys, used for stable

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2040,6 +2040,75 @@ func createSchema(db *sql.DB) error {
 		PRIMARY KEY (user_id, article_id)
 	);
 
+	-- Recipes (Hytte-evi4c). Free-form text — recipe title and notes, the
+	-- ingredient line, the step instruction — is encrypted at rest. Tags,
+	-- ratings, timestamps, ingredient quantity/unit/name and step duration stay
+	-- plaintext because the store filters, sorts and scales on them.
+	CREATE TABLE IF NOT EXISTS recipes (
+		id             INTEGER PRIMARY KEY,
+		user_id        INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		title          TEXT NOT NULL DEFAULT '',  -- encrypted
+		notes          TEXT NOT NULL DEFAULT '',  -- encrypted
+		servings       INTEGER NOT NULL DEFAULT 0,
+		rating         INTEGER,
+		rated_at       TEXT,
+		last_cooked_at TEXT,
+		created_at     TEXT NOT NULL DEFAULT '',
+		updated_at     TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_recipes_user ON recipes(user_id);
+
+	CREATE TABLE IF NOT EXISTS recipe_ingredients (
+		id        INTEGER PRIMARY KEY,
+		recipe_id INTEGER NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+		position  INTEGER NOT NULL DEFAULT 0,
+		text      TEXT NOT NULL DEFAULT '',  -- encrypted
+		quantity  REAL NOT NULL DEFAULT 0,
+		unit      TEXT NOT NULL DEFAULT '',
+		name      TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_recipe_ingredients_recipe ON recipe_ingredients(recipe_id, position);
+
+	CREATE TABLE IF NOT EXISTS recipe_steps (
+		id               INTEGER PRIMARY KEY,
+		recipe_id        INTEGER NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+		position         INTEGER NOT NULL DEFAULT 0,
+		text             TEXT NOT NULL DEFAULT '',  -- encrypted
+		duration_seconds INTEGER NOT NULL DEFAULT 0
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_recipe_steps_recipe ON recipe_steps(recipe_id, position);
+
+	CREATE TABLE IF NOT EXISTS recipe_tags (
+		recipe_id INTEGER NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+		tag       TEXT NOT NULL,
+		PRIMARY KEY (recipe_id, tag)
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_recipe_tags_tag ON recipe_tags(tag);
+
+	CREATE TABLE IF NOT EXISTS recipe_cooks (
+		id        INTEGER PRIMARY KEY,
+		recipe_id INTEGER NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+		user_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		cooked_at TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_recipe_cooks_recipe ON recipe_cooks(recipe_id, cooked_at);
+
+	CREATE TABLE IF NOT EXISTS meal_plan_entries (
+		id         INTEGER PRIMARY KEY,
+		user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		recipe_id  INTEGER NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+		plan_date  TEXT NOT NULL DEFAULT '',
+		slot       TEXT NOT NULL DEFAULT 'dinner' CHECK (slot IN ('breakfast', 'lunch', 'dinner', 'snack')),
+		created_at TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_meal_plan_entries_user_date ON meal_plan_entries(user_id, plan_date);
+
 	`
 
 	_, err := db.Exec(schema)

--- a/internal/recipes/models.go
+++ b/internal/recipes/models.go
@@ -1,0 +1,114 @@
+// Package recipes stores personal recipes with ingredients, steps, tags,
+// ratings and a cooking log, plus the meal-plan entries that schedule them.
+//
+// Free-form user text (recipe title and notes, ingredient lines, step text) is
+// encrypted at rest via internal/encryption. Everything the store needs to
+// filter, sort or compute with — tags, ratings, timestamps, ingredient
+// quantities and step durations — stays plaintext, following the same split the
+// training and wardrobe packages use.
+package recipes
+
+import "time"
+
+// Recipe is one recipe owned by a user, together with its ordered ingredients
+// and steps and its tag set. Title and Notes hold plaintext in memory;
+// encryption happens only at the store boundary.
+type Recipe struct {
+	ID     int64  `json:"id"`
+	UserID int64  `json:"user_id"`
+	Title  string `json:"title"` // encrypted at rest
+	Notes  string `json:"notes"` // encrypted at rest
+	// Servings is the yield the stored ingredient quantities describe. It is
+	// the denominator callers divide by to build a scaling factor; 0 means the
+	// recipe does not declare a yield.
+	Servings int `json:"servings"`
+	// Rating is a 1-5 score, nil when the recipe has not been rated.
+	Rating   *int       `json:"rating,omitempty"`
+	RatedAt  *time.Time `json:"rated_at,omitempty"`
+	LastCook *time.Time `json:"last_cooked_at,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	Ingredients []Ingredient `json:"ingredients"`
+	Steps       []Step       `json:"steps"`
+	// Tags are normalised (trimmed, lowercased) and sorted for stable output.
+	Tags []string `json:"tags"`
+}
+
+// Ingredient is one line of a recipe's ingredient list.
+//
+// Text is the full free-form line as the user typed it ("2 dl fløte, romtemperert")
+// and is encrypted. Quantity, Unit and Name are the parsed triple and stay
+// plaintext: Quantity is what ScaleIngredients multiplies, and Unit/Name let a
+// scaled list be re-rendered (and later matched against the grocery list)
+// without decrypting every row.
+type Ingredient struct {
+	ID       int64   `json:"id"`
+	RecipeID int64   `json:"recipe_id"`
+	Position int     `json:"position"`
+	Text     string  `json:"text"` // encrypted at rest
+	Quantity float64 `json:"quantity"`
+	Unit     string  `json:"unit"`
+	Name     string  `json:"name"`
+}
+
+// Step is one instruction in a recipe's method. Text is encrypted;
+// DurationSeconds stays plaintext so timers and total-time sums can be computed
+// in SQL. 0 means the step has no timed duration.
+type Step struct {
+	ID              int64  `json:"id"`
+	RecipeID        int64  `json:"recipe_id"`
+	Position        int    `json:"position"`
+	Text            string `json:"text"` // encrypted at rest
+	DurationSeconds int    `json:"duration_seconds"`
+}
+
+// Tag is a plaintext label attached to a recipe ("dinner", "vegetarian",
+// "summer"). Tags drive filtering and the in-season component of CookAgain, so
+// they are deliberately not encrypted.
+type Tag struct {
+	RecipeID int64  `json:"recipe_id"`
+	Tag      string `json:"tag"`
+}
+
+// Rating is a 1-5 star score for a recipe. It lives on the recipes row rather
+// than in its own table — a recipe has exactly one rating from its owner.
+type Rating struct {
+	RecipeID int64     `json:"recipe_id"`
+	Value    int       `json:"value"`
+	RatedAt  time.Time `json:"rated_at"`
+}
+
+// Cook is one entry in the cooking log: the user made this recipe at this time.
+// The log is append-only so "cook again" can rank by time since last cook.
+type Cook struct {
+	ID       int64     `json:"id"`
+	RecipeID int64     `json:"recipe_id"`
+	UserID   int64     `json:"user_id"`
+	CookedAt time.Time `json:"cooked_at"`
+}
+
+// PlanEntry schedules a recipe into a meal slot on a given day.
+type PlanEntry struct {
+	ID        int64     `json:"id"`
+	UserID    int64     `json:"user_id"`
+	RecipeID  int64     `json:"recipe_id"`
+	PlanDate  string    `json:"plan_date"` // YYYY-MM-DD, local calendar day
+	Slot      string    `json:"slot"`      // breakfast | lunch | dinner | snack
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// TagFilter narrows a recipe listing by tags. Any matches recipes carrying at
+// least one of the listed tags; All matches recipes carrying every listed tag.
+// Both empty means "no tag filter". Tags are compared after normalisation, so
+// callers may pass user input verbatim.
+type TagFilter struct {
+	Any []string `json:"any"`
+	All []string `json:"all"`
+}
+
+// IsEmpty reports whether the filter would exclude nothing.
+func (f TagFilter) IsEmpty() bool {
+	return len(normalizeTags(f.Any)) == 0 && len(normalizeTags(f.All)) == 0
+}

--- a/internal/recipes/store.go
+++ b/internal/recipes/store.go
@@ -1,0 +1,686 @@
+package recipes
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+// ErrInvalidRating is returned by SetRating for a score outside 0-5.
+// 0 clears an existing rating; 1-5 set one.
+var ErrInvalidRating = errors.New("rating must be between 0 and 5")
+
+// Store is the persistence layer for the recipes feature. It owns all
+// encryption and decryption of recipe text — callers above it only ever see
+// plaintext models.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore wraps an existing database handle.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+func nowRFC3339() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func formatTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
+func parseTime(s string) time.Time {
+	parsed, _ := time.Parse(time.RFC3339, s)
+	return parsed
+}
+
+// normalizeTags trims, lowercases and de-duplicates a tag list, dropping empty
+// entries. The result is sorted so stored and returned tag sets are stable.
+func normalizeTags(tags []string) []string {
+	seen := make(map[string]struct{}, len(tags))
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// placeholders builds "?, ?, ?" for an IN clause of n values.
+func placeholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
+}
+
+// --- Recipes ---
+
+// CreateRecipe inserts a recipe together with its ingredients, steps and tags
+// in a single transaction and returns it with all generated IDs populated.
+func (s *Store) CreateRecipe(ctx context.Context, userID int64, r Recipe) (Recipe, error) {
+	encTitle, err := encryption.EncryptField(r.Title)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("encrypt recipe title: %w", err)
+	}
+	encNotes, err := encryption.EncryptField(r.Notes)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("encrypt recipe notes: %w", err)
+	}
+
+	now := nowRFC3339()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("begin create recipe: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx, `
+		INSERT INTO recipes (user_id, title, notes, servings, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, userID, encTitle, encNotes, r.Servings, now, now)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("insert recipe: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Recipe{}, fmt.Errorf("last insert id: %w", err)
+	}
+
+	r.ID = id
+	r.UserID = userID
+	r.CreatedAt = parseTime(now)
+	r.UpdatedAt = r.CreatedAt
+	// Rating and cooking history are not settable at creation — SetRating and
+	// RecordCook own those columns, so don't echo back values we didn't store.
+	r.Rating, r.RatedAt, r.LastCook = nil, nil, nil
+	if err := writeChildren(ctx, tx, &r); err != nil {
+		return Recipe{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return Recipe{}, fmt.Errorf("commit create recipe: %w", err)
+	}
+	return r, nil
+}
+
+// writeChildren inserts the recipe's ingredients, steps and tags, rewriting
+// Position from slice order so stored positions are always dense and ordered.
+// It fills r's child slices with the generated IDs; the caller's slices are
+// copied first so a create/update never writes back into the argument it was
+// handed.
+func writeChildren(ctx context.Context, tx *sql.Tx, r *Recipe) error {
+	ings := make([]Ingredient, len(r.Ingredients))
+	copy(ings, r.Ingredients)
+	r.Ingredients = ings
+
+	steps := make([]Step, len(r.Steps))
+	copy(steps, r.Steps)
+	r.Steps = steps
+
+	for i := range r.Ingredients {
+		ing := &r.Ingredients[i]
+		encText, err := encryption.EncryptField(ing.Text)
+		if err != nil {
+			return fmt.Errorf("encrypt ingredient text: %w", err)
+		}
+		ing.RecipeID = r.ID
+		ing.Position = i
+		res, err := tx.ExecContext(ctx, `
+			INSERT INTO recipe_ingredients (recipe_id, position, text, quantity, unit, name)
+			VALUES (?, ?, ?, ?, ?, ?)
+		`, r.ID, i, encText, ing.Quantity, ing.Unit, ing.Name)
+		if err != nil {
+			return fmt.Errorf("insert recipe ingredient: %w", err)
+		}
+		if ing.ID, err = res.LastInsertId(); err != nil {
+			return fmt.Errorf("last insert id: %w", err)
+		}
+	}
+
+	for i := range r.Steps {
+		step := &r.Steps[i]
+		encText, err := encryption.EncryptField(step.Text)
+		if err != nil {
+			return fmt.Errorf("encrypt step text: %w", err)
+		}
+		step.RecipeID = r.ID
+		step.Position = i
+		res, err := tx.ExecContext(ctx, `
+			INSERT INTO recipe_steps (recipe_id, position, text, duration_seconds)
+			VALUES (?, ?, ?, ?)
+		`, r.ID, i, encText, step.DurationSeconds)
+		if err != nil {
+			return fmt.Errorf("insert recipe step: %w", err)
+		}
+		if step.ID, err = res.LastInsertId(); err != nil {
+			return fmt.Errorf("last insert id: %w", err)
+		}
+	}
+
+	r.Tags = normalizeTags(r.Tags)
+	for _, tag := range r.Tags {
+		if _, err := tx.ExecContext(ctx,
+			"INSERT OR IGNORE INTO recipe_tags (recipe_id, tag) VALUES (?, ?)", r.ID, tag); err != nil {
+			return fmt.Errorf("insert recipe tag: %w", err)
+		}
+	}
+	return nil
+}
+
+// GetRecipe loads one recipe with its children, scoped to the owning user.
+// Returns sql.ErrNoRows when the recipe does not exist or belongs elsewhere.
+func (s *Store) GetRecipe(ctx context.Context, userID, id int64) (Recipe, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, user_id, title, notes, servings, rating, rated_at, last_cooked_at, created_at, updated_at
+		FROM recipes
+		WHERE id = ? AND user_id = ?
+	`, id, userID)
+
+	r, err := scanRecipe(row)
+	if err != nil {
+		return Recipe{}, err
+	}
+	if err := s.attachChildren(ctx, []*Recipe{&r}); err != nil {
+		return Recipe{}, err
+	}
+	return r, nil
+}
+
+// ListRecipes returns the user's recipes, newest first, optionally narrowed by
+// tags. An empty filter returns everything the user owns.
+func (s *Store) ListRecipes(ctx context.Context, userID int64, filter TagFilter) ([]Recipe, error) {
+	query := `
+		SELECT id, user_id, title, notes, servings, rating, rated_at, last_cooked_at, created_at, updated_at
+		FROM recipes r
+		WHERE r.user_id = ?`
+	args := []any{userID}
+
+	if anyTags := normalizeTags(filter.Any); len(anyTags) > 0 {
+		query += fmt.Sprintf(`
+		AND EXISTS (SELECT 1 FROM recipe_tags t WHERE t.recipe_id = r.id AND t.tag IN (%s))`, placeholders(len(anyTags)))
+		for _, tag := range anyTags {
+			args = append(args, tag)
+		}
+	}
+	if allTags := normalizeTags(filter.All); len(allTags) > 0 {
+		query += fmt.Sprintf(`
+		AND (SELECT COUNT(DISTINCT t.tag) FROM recipe_tags t WHERE t.recipe_id = r.id AND t.tag IN (%s)) = ?`,
+			placeholders(len(allTags)))
+		for _, tag := range allTags {
+			args = append(args, tag)
+		}
+		args = append(args, len(allTags))
+	}
+	query += `
+		ORDER BY r.created_at DESC, r.id DESC`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query recipes: %w", err)
+	}
+	defer rows.Close()
+
+	recipes := []Recipe{}
+	for rows.Next() {
+		r, err := scanRecipe(rows)
+		if err != nil {
+			return nil, err
+		}
+		recipes = append(recipes, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recipes: %w", err)
+	}
+
+	ptrs := make([]*Recipe, len(recipes))
+	for i := range recipes {
+		ptrs[i] = &recipes[i]
+	}
+	if err := s.attachChildren(ctx, ptrs); err != nil {
+		return nil, err
+	}
+	return recipes, nil
+}
+
+// UpdateRecipe replaces a recipe's editable fields and its child rows, scoped
+// to the owning user. Children are deleted and re-inserted wholesale so
+// positions stay dense. Rating and cooking history are untouched — SetRating
+// and RecordCook own those.
+func (s *Store) UpdateRecipe(ctx context.Context, userID int64, r Recipe) (Recipe, error) {
+	encTitle, err := encryption.EncryptField(r.Title)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("encrypt recipe title: %w", err)
+	}
+	encNotes, err := encryption.EncryptField(r.Notes)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("encrypt recipe notes: %w", err)
+	}
+
+	now := nowRFC3339()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("begin update recipe: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx, `
+		UPDATE recipes SET title = ?, notes = ?, servings = ?, updated_at = ?
+		WHERE id = ? AND user_id = ?
+	`, encTitle, encNotes, r.Servings, now, r.ID, userID)
+	if err != nil {
+		return Recipe{}, fmt.Errorf("update recipe: %w", err)
+	}
+	if err := requireRow(res); err != nil {
+		return Recipe{}, err
+	}
+
+	for _, stmt := range []string{
+		"DELETE FROM recipe_ingredients WHERE recipe_id = ?",
+		"DELETE FROM recipe_steps WHERE recipe_id = ?",
+		"DELETE FROM recipe_tags WHERE recipe_id = ?",
+	} {
+		if _, err := tx.ExecContext(ctx, stmt, r.ID); err != nil {
+			return Recipe{}, fmt.Errorf("clear recipe children: %w", err)
+		}
+	}
+
+	// Re-read the columns this method does not own so the returned recipe
+	// reflects what is stored rather than whatever the caller sent.
+	var rating sql.NullInt64
+	var ratedAt sql.NullString
+	var lastCooked sql.NullString
+	var createdAt string
+	if err := tx.QueryRowContext(ctx,
+		"SELECT rating, rated_at, last_cooked_at, created_at FROM recipes WHERE id = ?", r.ID).
+		Scan(&rating, &ratedAt, &lastCooked, &createdAt); err != nil {
+		return Recipe{}, fmt.Errorf("reload recipe metadata: %w", err)
+	}
+	r.Rating, r.RatedAt, r.LastCook = nil, nil, nil
+	if rating.Valid {
+		v := int(rating.Int64)
+		r.Rating = &v
+	}
+	if ratedAt.Valid && ratedAt.String != "" {
+		t := parseTime(ratedAt.String)
+		r.RatedAt = &t
+	}
+	if lastCooked.Valid && lastCooked.String != "" {
+		t := parseTime(lastCooked.String)
+		r.LastCook = &t
+	}
+	r.CreatedAt = parseTime(createdAt)
+
+	r.UserID = userID
+	r.UpdatedAt = parseTime(now)
+	if err := writeChildren(ctx, tx, &r); err != nil {
+		return Recipe{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return Recipe{}, fmt.Errorf("commit update recipe: %w", err)
+	}
+	return r, nil
+}
+
+// DeleteRecipe removes a recipe; ingredients, steps, tags, cooking log entries
+// and meal-plan entries cascade.
+func (s *Store) DeleteRecipe(ctx context.Context, userID, id int64) error {
+	res, err := s.db.ExecContext(ctx, "DELETE FROM recipes WHERE id = ? AND user_id = ?", id, userID)
+	if err != nil {
+		return fmt.Errorf("delete recipe: %w", err)
+	}
+	return requireRow(res)
+}
+
+// SetRating stores a 1-5 score for a recipe. A rating of 0 clears it.
+// Returns ErrInvalidRating for anything outside that range and sql.ErrNoRows
+// when the recipe is not the user's.
+func (s *Store) SetRating(ctx context.Context, userID, recipeID int64, rating int) error {
+	if rating < 0 || rating > 5 {
+		return ErrInvalidRating
+	}
+	var value any
+	var ratedAt any
+	if rating > 0 {
+		value = rating
+		ratedAt = nowRFC3339()
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE recipes SET rating = ?, rated_at = ?
+		WHERE id = ? AND user_id = ?
+	`, value, ratedAt, recipeID, userID)
+	if err != nil {
+		return fmt.Errorf("set recipe rating: %w", err)
+	}
+	return requireRow(res)
+}
+
+// RecordCook appends an entry to the cooking log and advances the recipe's
+// last_cooked_at. Backfilling an older cook keeps the newer last_cooked_at:
+// the column tracks the most recent cook, not the most recently logged one.
+func (s *Store) RecordCook(ctx context.Context, userID, recipeID int64, at time.Time) error {
+	stamp := formatTime(at)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin record cook: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Scoping the UPDATE by user_id doubles as the ownership check.
+	res, err := tx.ExecContext(ctx, `
+		UPDATE recipes SET last_cooked_at = MAX(COALESCE(last_cooked_at, ''), ?)
+		WHERE id = ? AND user_id = ?
+	`, stamp, recipeID, userID)
+	if err != nil {
+		return fmt.Errorf("update last cooked: %w", err)
+	}
+	if err := requireRow(res); err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO recipe_cooks (recipe_id, user_id, cooked_at) VALUES (?, ?, ?)
+	`, recipeID, userID, stamp); err != nil {
+		return fmt.Errorf("insert recipe cook: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit record cook: %w", err)
+	}
+	return nil
+}
+
+// ListCooks returns a recipe's cooking log, most recent first.
+func (s *Store) ListCooks(ctx context.Context, userID, recipeID int64) ([]Cook, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT c.id, c.recipe_id, c.user_id, c.cooked_at
+		FROM recipe_cooks c
+		JOIN recipes r ON r.id = c.recipe_id
+		WHERE c.recipe_id = ? AND r.user_id = ?
+		ORDER BY c.cooked_at DESC, c.id DESC
+	`, recipeID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("query recipe cooks: %w", err)
+	}
+	defer rows.Close()
+
+	cooks := []Cook{}
+	for rows.Next() {
+		var c Cook
+		var cookedAt string
+		if err := rows.Scan(&c.ID, &c.RecipeID, &c.UserID, &cookedAt); err != nil {
+			return nil, fmt.Errorf("scan recipe cook: %w", err)
+		}
+		c.CookedAt = parseTime(cookedAt)
+		cooks = append(cooks, c)
+	}
+	return cooks, rows.Err()
+}
+
+// --- Scaling ---
+
+// ScaleIngredients returns a copy of ings with every Quantity multiplied by
+// factor. It is pure: the input slice, its elements and the stored rows are all
+// left untouched, so a scaled shopping list never overwrites the base recipe.
+// A factor of 0 or less is treated as 1 (no scaling) rather than producing a
+// list of zero quantities.
+func ScaleIngredients(ings []Ingredient, factor float64) []Ingredient {
+	if factor <= 0 {
+		factor = 1
+	}
+	out := make([]Ingredient, len(ings))
+	copy(out, ings)
+	for i := range out {
+		out[i].Quantity = ings[i].Quantity * factor
+	}
+	return out
+}
+
+// --- Cook again ---
+
+// seasonOf returns the meteorological season for t's month.
+func seasonOf(t time.Time) string {
+	switch t.Month() {
+	case time.December, time.January, time.February:
+		return "winter"
+	case time.March, time.April, time.May:
+		return "spring"
+	case time.June, time.July, time.August:
+		return "summer"
+	default:
+		return "autumn"
+	}
+}
+
+// seasonTags maps a season to the (already normalised) tags that mean it.
+// Norwegian spellings are accepted alongside English because tags are free
+// text and the UI is Norwegian-first.
+var seasonTags = map[string]map[string]bool{
+	"winter": {"winter": true, "vinter": true},
+	"spring": {"spring": true, "vår": true, "var": true},
+	"summer": {"summer": true, "sommer": true},
+	"autumn": {"autumn": true, "fall": true, "høst": true, "host": true},
+}
+
+// isInSeason reports whether any of the recipe's tags names the season that
+// contains now.
+func isInSeason(tags []string, now time.Time) bool {
+	want := seasonTags[seasonOf(now)]
+	for _, tag := range tags {
+		if want[tag] {
+			return true
+		}
+	}
+	return false
+}
+
+// CookAgain suggests recipes worth making again. Recipes tagged with the
+// current season rank above everything else; within each group the one cooked
+// longest ago comes first, with never-cooked recipes treated as maximally
+// overdue. Ties break on recipe ID so the order is deterministic. A limit of 0
+// or less returns every candidate.
+func (s *Store) CookAgain(ctx context.Context, userID int64, now time.Time, limit int) ([]Recipe, error) {
+	candidates, err := s.ListRecipes(ctx, userID, TagFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	type scored struct {
+		recipe    Recipe
+		inSeason  bool
+		daysSince float64
+	}
+	ranked := make([]scored, len(candidates))
+	for i, r := range candidates {
+		days := math.MaxFloat64
+		if r.LastCook != nil {
+			days = now.Sub(*r.LastCook).Hours() / 24
+		}
+		ranked[i] = scored{recipe: r, inSeason: isInSeason(r.Tags, now), daysSince: days}
+	}
+
+	sort.Slice(ranked, func(i, j int) bool {
+		a, b := ranked[i], ranked[j]
+		if a.inSeason != b.inSeason {
+			return a.inSeason
+		}
+		if a.daysSince != b.daysSince {
+			return a.daysSince > b.daysSince
+		}
+		return a.recipe.ID < b.recipe.ID
+	})
+
+	if limit > 0 && limit < len(ranked) {
+		ranked = ranked[:limit]
+	}
+	out := make([]Recipe, len(ranked))
+	for i, sc := range ranked {
+		out[i] = sc.recipe
+	}
+	return out, nil
+}
+
+// --- scanning helpers ---
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRecipe(sc rowScanner) (Recipe, error) {
+	var r Recipe
+	var rating sql.NullInt64
+	var ratedAt, lastCooked sql.NullString
+	var createdAt, updatedAt string
+	if err := sc.Scan(&r.ID, &r.UserID, &r.Title, &r.Notes, &r.Servings,
+		&rating, &ratedAt, &lastCooked, &createdAt, &updatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Recipe{}, err
+		}
+		return Recipe{}, fmt.Errorf("scan recipe: %w", err)
+	}
+
+	var err error
+	if r.Title, err = encryption.DecryptField(r.Title); err != nil {
+		return Recipe{}, fmt.Errorf("decrypt recipe title: %w", err)
+	}
+	if r.Notes, err = encryption.DecryptField(r.Notes); err != nil {
+		return Recipe{}, fmt.Errorf("decrypt recipe notes: %w", err)
+	}
+	if rating.Valid {
+		v := int(rating.Int64)
+		r.Rating = &v
+	}
+	if ratedAt.Valid && ratedAt.String != "" {
+		t := parseTime(ratedAt.String)
+		r.RatedAt = &t
+	}
+	if lastCooked.Valid && lastCooked.String != "" {
+		t := parseTime(lastCooked.String)
+		r.LastCook = &t
+	}
+	r.CreatedAt = parseTime(createdAt)
+	r.UpdatedAt = parseTime(updatedAt)
+	r.Ingredients = []Ingredient{}
+	r.Steps = []Step{}
+	r.Tags = []string{}
+	return r, nil
+}
+
+// attachChildren loads ingredients, steps and tags for the given recipes in
+// three queries rather than three per recipe.
+func (s *Store) attachChildren(ctx context.Context, recipes []*Recipe) error {
+	if len(recipes) == 0 {
+		return nil
+	}
+	byID := make(map[int64]*Recipe, len(recipes))
+	ids := make([]any, 0, len(recipes))
+	for _, r := range recipes {
+		byID[r.ID] = r
+		ids = append(ids, r.ID)
+	}
+	in := placeholders(len(ids))
+
+	ingRows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, recipe_id, position, text, quantity, unit, name
+		FROM recipe_ingredients
+		WHERE recipe_id IN (%s)
+		ORDER BY recipe_id, position, id
+	`, in), ids...)
+	if err != nil {
+		return fmt.Errorf("query recipe ingredients: %w", err)
+	}
+	defer ingRows.Close()
+	for ingRows.Next() {
+		var ing Ingredient
+		if err := ingRows.Scan(&ing.ID, &ing.RecipeID, &ing.Position, &ing.Text,
+			&ing.Quantity, &ing.Unit, &ing.Name); err != nil {
+			return fmt.Errorf("scan recipe ingredient: %w", err)
+		}
+		if ing.Text, err = encryption.DecryptField(ing.Text); err != nil {
+			return fmt.Errorf("decrypt ingredient text: %w", err)
+		}
+		if r, ok := byID[ing.RecipeID]; ok {
+			r.Ingredients = append(r.Ingredients, ing)
+		}
+	}
+	if err := ingRows.Err(); err != nil {
+		return fmt.Errorf("iterate recipe ingredients: %w", err)
+	}
+
+	stepRows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, recipe_id, position, text, duration_seconds
+		FROM recipe_steps
+		WHERE recipe_id IN (%s)
+		ORDER BY recipe_id, position, id
+	`, in), ids...)
+	if err != nil {
+		return fmt.Errorf("query recipe steps: %w", err)
+	}
+	defer stepRows.Close()
+	for stepRows.Next() {
+		var step Step
+		if err := stepRows.Scan(&step.ID, &step.RecipeID, &step.Position, &step.Text,
+			&step.DurationSeconds); err != nil {
+			return fmt.Errorf("scan recipe step: %w", err)
+		}
+		if step.Text, err = encryption.DecryptField(step.Text); err != nil {
+			return fmt.Errorf("decrypt step text: %w", err)
+		}
+		if r, ok := byID[step.RecipeID]; ok {
+			r.Steps = append(r.Steps, step)
+		}
+	}
+	if err := stepRows.Err(); err != nil {
+		return fmt.Errorf("iterate recipe steps: %w", err)
+	}
+
+	tagRows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT recipe_id, tag FROM recipe_tags
+		WHERE recipe_id IN (%s)
+		ORDER BY recipe_id, tag
+	`, in), ids...)
+	if err != nil {
+		return fmt.Errorf("query recipe tags: %w", err)
+	}
+	defer tagRows.Close()
+	for tagRows.Next() {
+		var t Tag
+		if err := tagRows.Scan(&t.RecipeID, &t.Tag); err != nil {
+			return fmt.Errorf("scan recipe tag: %w", err)
+		}
+		if r, ok := byID[t.RecipeID]; ok {
+			r.Tags = append(r.Tags, t.Tag)
+		}
+	}
+	return tagRows.Err()
+}
+
+func requireRow(res sql.Result) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}

--- a/internal/recipes/store_test.go
+++ b/internal/recipes/store_test.go
@@ -1,0 +1,642 @@
+package recipes
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/db"
+	"github.com/Robin831/Hytte/internal/encryption"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-key-for-recipes-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+
+	database, err := db.Init(":memory:")
+	if err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	t.Cleanup(func() { database.Close() })
+
+	_, err = database.Exec(`INSERT INTO users (id, email, name, picture, google_id, created_at) VALUES
+		(1, 'owner@example.com', 'Owner', '', 'g1', ''),
+		(2, 'other@example.com', 'Other', '', 'g2', '')`)
+	if err != nil {
+		t.Fatalf("insert test users: %v", err)
+	}
+	return database
+}
+
+// sampleRecipe is a fully populated recipe used across the tests.
+func sampleRecipe() Recipe {
+	return Recipe{
+		Title:    "Fiskegrateng",
+		Notes:    "Grandmother's version — plenty of dill.",
+		Servings: 4,
+		Ingredients: []Ingredient{
+			{Text: "400 g torsk, i terninger", Quantity: 400, Unit: "g", Name: "torsk"},
+			{Text: "3 dl melk", Quantity: 3, Unit: "dl", Name: "melk"},
+			{Text: "1 ts salt", Quantity: 1, Unit: "ts", Name: "salt"},
+		},
+		Steps: []Step{
+			{Text: "Kok makaronien.", DurationSeconds: 480},
+			{Text: "Rør sammen hvit saus.", DurationSeconds: 300},
+			{Text: "Stek i ovnen.", DurationSeconds: 1800},
+		},
+		Tags: []string{"Dinner", "fish", "winter"},
+	}
+}
+
+func mustCreate(t *testing.T, s *Store, userID int64, r Recipe) Recipe {
+	t.Helper()
+	created, err := s.CreateRecipe(context.Background(), userID, r)
+	if err != nil {
+		t.Fatalf("create recipe: %v", err)
+	}
+	return created
+}
+
+func TestCreateAndGetRecipe_EncryptionRoundTrip(t *testing.T) {
+	database := setupTestDB(t)
+	s := NewStore(database)
+	ctx := context.Background()
+
+	in := sampleRecipe()
+	created := mustCreate(t, s, 1, in)
+	if created.ID == 0 {
+		t.Fatal("expected a generated recipe ID")
+	}
+	for i, ing := range created.Ingredients {
+		if ing.ID == 0 || ing.RecipeID != created.ID || ing.Position != i {
+			t.Fatalf("ingredient %d not populated: %+v", i, ing)
+		}
+	}
+	for i, st := range created.Steps {
+		if st.ID == 0 || st.RecipeID != created.ID || st.Position != i {
+			t.Fatalf("step %d not populated: %+v", i, st)
+		}
+	}
+
+	got, err := s.GetRecipe(ctx, 1, created.ID)
+	if err != nil {
+		t.Fatalf("get recipe: %v", err)
+	}
+	if got.Title != in.Title {
+		t.Errorf("title round-trip: got %q, want %q", got.Title, in.Title)
+	}
+	if got.Notes != in.Notes {
+		t.Errorf("notes round-trip: got %q, want %q", got.Notes, in.Notes)
+	}
+	if got.Servings != in.Servings {
+		t.Errorf("servings: got %d, want %d", got.Servings, in.Servings)
+	}
+	if len(got.Ingredients) != len(in.Ingredients) {
+		t.Fatalf("ingredients: got %d, want %d", len(got.Ingredients), len(in.Ingredients))
+	}
+	for i, ing := range got.Ingredients {
+		want := in.Ingredients[i]
+		if ing.Text != want.Text || ing.Quantity != want.Quantity || ing.Unit != want.Unit || ing.Name != want.Name {
+			t.Errorf("ingredient %d round-trip: got %+v, want %+v", i, ing, want)
+		}
+	}
+	if len(got.Steps) != len(in.Steps) {
+		t.Fatalf("steps: got %d, want %d", len(got.Steps), len(in.Steps))
+	}
+	for i, st := range got.Steps {
+		want := in.Steps[i]
+		if st.Text != want.Text || st.DurationSeconds != want.DurationSeconds {
+			t.Errorf("step %d round-trip: got %+v, want %+v", i, st, want)
+		}
+	}
+	// Tags are normalised: trimmed, lowercased and sorted.
+	wantTags := []string{"dinner", "fish", "winter"}
+	if strings.Join(got.Tags, ",") != strings.Join(wantTags, ",") {
+		t.Errorf("tags: got %v, want %v", got.Tags, wantTags)
+	}
+
+	// The raw columns must not hold the plaintext.
+	var rawTitle, rawNotes string
+	if err := database.QueryRow("SELECT title, notes FROM recipes WHERE id = ?", created.ID).
+		Scan(&rawTitle, &rawNotes); err != nil {
+		t.Fatalf("read raw recipe row: %v", err)
+	}
+	if rawTitle == in.Title || strings.Contains(rawTitle, in.Title) {
+		t.Errorf("recipe title stored in plaintext: %q", rawTitle)
+	}
+	if rawNotes == in.Notes || strings.Contains(rawNotes, in.Notes) {
+		t.Errorf("recipe notes stored in plaintext: %q", rawNotes)
+	}
+
+	var rawIngText, rawUnit, rawName string
+	var rawQty float64
+	if err := database.QueryRow(
+		"SELECT text, quantity, unit, name FROM recipe_ingredients WHERE recipe_id = ? AND position = 0",
+		created.ID).Scan(&rawIngText, &rawQty, &rawUnit, &rawName); err != nil {
+		t.Fatalf("read raw ingredient row: %v", err)
+	}
+	if strings.Contains(rawIngText, in.Ingredients[0].Text) {
+		t.Errorf("ingredient text stored in plaintext: %q", rawIngText)
+	}
+	// Quantity/unit/name stay plaintext — the store scales and filters on them.
+	if rawQty != 400 || rawUnit != "g" || rawName != "torsk" {
+		t.Errorf("ingredient scalars should be plaintext: got %v %q %q", rawQty, rawUnit, rawName)
+	}
+
+	var rawStepText string
+	var rawDuration int
+	if err := database.QueryRow(
+		"SELECT text, duration_seconds FROM recipe_steps WHERE recipe_id = ? AND position = 0",
+		created.ID).Scan(&rawStepText, &rawDuration); err != nil {
+		t.Fatalf("read raw step row: %v", err)
+	}
+	if strings.Contains(rawStepText, in.Steps[0].Text) {
+		t.Errorf("step text stored in plaintext: %q", rawStepText)
+	}
+	if rawDuration != 480 {
+		t.Errorf("step duration should be plaintext: got %d", rawDuration)
+	}
+
+	// Tags are deliberately plaintext so they can be filtered in SQL.
+	var rawTag string
+	if err := database.QueryRow(
+		"SELECT tag FROM recipe_tags WHERE recipe_id = ? ORDER BY tag LIMIT 1", created.ID).Scan(&rawTag); err != nil {
+		t.Fatalf("read raw tag row: %v", err)
+	}
+	if rawTag != "dinner" {
+		t.Errorf("tag should be stored plaintext and normalised: got %q", rawTag)
+	}
+}
+
+func TestGetRecipe_OtherUserIsNotFound(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	created := mustCreate(t, s, 1, sampleRecipe())
+
+	if _, err := s.GetRecipe(context.Background(), 2, created.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows for another user, got %v", err)
+	}
+}
+
+func TestUpdateRecipe_ReplacesChildren(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+	created := mustCreate(t, s, 1, sampleRecipe())
+
+	created.Title = "Fiskegrateng v2"
+	created.Notes = ""
+	created.Servings = 6
+	created.Ingredients = []Ingredient{
+		{Text: "500 g sei", Quantity: 500, Unit: "g", Name: "sei"},
+	}
+	created.Steps = []Step{{Text: "Bare stek det.", DurationSeconds: 900}}
+	created.Tags = []string{"dinner", "quick"}
+
+	if _, err := s.UpdateRecipe(ctx, 1, created); err != nil {
+		t.Fatalf("update recipe: %v", err)
+	}
+
+	got, err := s.GetRecipe(ctx, 1, created.ID)
+	if err != nil {
+		t.Fatalf("get recipe: %v", err)
+	}
+	if got.Title != "Fiskegrateng v2" || got.Notes != "" || got.Servings != 6 {
+		t.Errorf("scalar fields not updated: %+v", got)
+	}
+	if len(got.Ingredients) != 1 || got.Ingredients[0].Name != "sei" || got.Ingredients[0].Position != 0 {
+		t.Errorf("ingredients not replaced: %+v", got.Ingredients)
+	}
+	if len(got.Steps) != 1 || got.Steps[0].Text != "Bare stek det." {
+		t.Errorf("steps not replaced: %+v", got.Steps)
+	}
+	if strings.Join(got.Tags, ",") != "dinner,quick" {
+		t.Errorf("tags not replaced: %v", got.Tags)
+	}
+
+	// The old child rows are gone, not merely orphaned.
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM recipe_ingredients WHERE recipe_id = ?", created.ID).Scan(&count); err != nil {
+		t.Fatalf("count ingredients: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 ingredient row after update, got %d", count)
+	}
+}
+
+func TestUpdateRecipe_PreservesRatingAndCookingHistory(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+	created := mustCreate(t, s, 1, sampleRecipe())
+
+	cookedAt := time.Date(2026, 5, 2, 17, 30, 0, 0, time.UTC)
+	if err := s.SetRating(ctx, 1, created.ID, 5); err != nil {
+		t.Fatalf("set rating: %v", err)
+	}
+	if err := s.RecordCook(ctx, 1, created.ID, cookedAt); err != nil {
+		t.Fatalf("record cook: %v", err)
+	}
+
+	// A caller editing the recipe sends a struct with no rating/cook metadata.
+	edit := created
+	edit.Title = "Fiskegrateng, justert"
+	edit.Rating = nil
+	edit.LastCook = nil
+
+	updated, err := s.UpdateRecipe(ctx, 1, edit)
+	if err != nil {
+		t.Fatalf("update recipe: %v", err)
+	}
+	if updated.Rating == nil || *updated.Rating != 5 {
+		t.Errorf("update should return the stored rating, got %v", updated.Rating)
+	}
+	if updated.LastCook == nil || !updated.LastCook.Equal(cookedAt) {
+		t.Errorf("update should return the stored last cook, got %v", updated.LastCook)
+	}
+
+	got, err := s.GetRecipe(ctx, 1, created.ID)
+	if err != nil {
+		t.Fatalf("get recipe: %v", err)
+	}
+	if got.Rating == nil || *got.Rating != 5 {
+		t.Errorf("rating should survive an update, got %v", got.Rating)
+	}
+	if got.LastCook == nil || !got.LastCook.Equal(cookedAt) {
+		t.Errorf("last cook should survive an update, got %v", got.LastCook)
+	}
+}
+
+func TestUpdateRecipe_OtherUserIsNotFound(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	created := mustCreate(t, s, 1, sampleRecipe())
+
+	created.Title = "Hijacked"
+	if _, err := s.UpdateRecipe(context.Background(), 2, created); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows updating another user's recipe, got %v", err)
+	}
+}
+
+func TestDeleteRecipe_CascadesChildren(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+	created := mustCreate(t, s, 1, sampleRecipe())
+	if err := s.RecordCook(ctx, 1, created.ID, time.Now()); err != nil {
+		t.Fatalf("record cook: %v", err)
+	}
+
+	if err := s.DeleteRecipe(ctx, 2, created.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows deleting another user's recipe, got %v", err)
+	}
+	if err := s.DeleteRecipe(ctx, 1, created.ID); err != nil {
+		t.Fatalf("delete recipe: %v", err)
+	}
+
+	for _, table := range []string{"recipe_ingredients", "recipe_steps", "recipe_tags", "recipe_cooks"} {
+		var count int
+		if err := s.db.QueryRow("SELECT COUNT(*) FROM "+table+" WHERE recipe_id = ?", created.ID).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Errorf("%s rows not cascaded: %d remain", table, count)
+		}
+	}
+}
+
+func TestSetRating(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+	created := mustCreate(t, s, 1, sampleRecipe())
+
+	if created.Rating != nil {
+		t.Fatalf("new recipe should be unrated, got %v", *created.Rating)
+	}
+
+	if err := s.SetRating(ctx, 1, created.ID, 4); err != nil {
+		t.Fatalf("set rating: %v", err)
+	}
+	got, err := s.GetRecipe(ctx, 1, created.ID)
+	if err != nil {
+		t.Fatalf("get recipe: %v", err)
+	}
+	if got.Rating == nil || *got.Rating != 4 {
+		t.Fatalf("expected rating 4, got %v", got.Rating)
+	}
+	if got.RatedAt == nil || got.RatedAt.IsZero() {
+		t.Error("expected rated_at to be set alongside the rating")
+	}
+
+	// 0 clears the rating.
+	if err := s.SetRating(ctx, 1, created.ID, 0); err != nil {
+		t.Fatalf("clear rating: %v", err)
+	}
+	got, err = s.GetRecipe(ctx, 1, created.ID)
+	if err != nil {
+		t.Fatalf("get recipe: %v", err)
+	}
+	if got.Rating != nil {
+		t.Errorf("expected rating cleared, got %v", *got.Rating)
+	}
+
+	for _, bad := range []int{-1, 6, 100} {
+		if err := s.SetRating(ctx, 1, created.ID, bad); !errors.Is(err, ErrInvalidRating) {
+			t.Errorf("rating %d: expected ErrInvalidRating, got %v", bad, err)
+		}
+	}
+	if err := s.SetRating(ctx, 2, created.ID, 3); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows rating another user's recipe, got %v", err)
+	}
+}
+
+func TestRecordCook_KeepsMostRecentTimestamp(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+	created := mustCreate(t, s, 1, sampleRecipe())
+
+	recent := time.Date(2026, 6, 1, 18, 0, 0, 0, time.UTC)
+	older := time.Date(2025, 12, 24, 16, 0, 0, 0, time.UTC)
+
+	if err := s.RecordCook(ctx, 1, created.ID, recent); err != nil {
+		t.Fatalf("record recent cook: %v", err)
+	}
+	if err := s.RecordCook(ctx, 1, created.ID, older); err != nil {
+		t.Fatalf("record older cook: %v", err)
+	}
+
+	got, err := s.GetRecipe(ctx, 1, created.ID)
+	if err != nil {
+		t.Fatalf("get recipe: %v", err)
+	}
+	if got.LastCook == nil || !got.LastCook.Equal(recent) {
+		t.Errorf("last_cooked_at should stay at the most recent cook: got %v, want %v", got.LastCook, recent)
+	}
+
+	cooks, err := s.ListCooks(ctx, 1, created.ID)
+	if err != nil {
+		t.Fatalf("list cooks: %v", err)
+	}
+	if len(cooks) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(cooks))
+	}
+	if !cooks[0].CookedAt.Equal(recent) || !cooks[1].CookedAt.Equal(older) {
+		t.Errorf("cooking log should be newest first: %+v", cooks)
+	}
+
+	if err := s.RecordCook(ctx, 2, created.ID, recent); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows recording a cook for another user's recipe, got %v", err)
+	}
+}
+
+func TestScaleIngredients_PureAndLeavesRowsUntouched(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+	created := mustCreate(t, s, 1, sampleRecipe())
+
+	base, err := s.GetRecipe(ctx, 1, created.ID)
+	if err != nil {
+		t.Fatalf("get recipe: %v", err)
+	}
+
+	scaled := ScaleIngredients(base.Ingredients, 1.5)
+	want := []float64{600, 4.5, 1.5}
+	for i, ing := range scaled {
+		if ing.Quantity != want[i] {
+			t.Errorf("scaled ingredient %d: got %v, want %v", i, ing.Quantity, want[i])
+		}
+		// Everything except the quantity is copied verbatim.
+		if ing.ID != base.Ingredients[i].ID || ing.Text != base.Ingredients[i].Text ||
+			ing.Unit != base.Ingredients[i].Unit || ing.Name != base.Ingredients[i].Name {
+			t.Errorf("scaled ingredient %d changed a non-quantity field: %+v", i, ing)
+		}
+	}
+
+	// The input slice is untouched.
+	original := []float64{400, 3, 1}
+	for i, ing := range base.Ingredients {
+		if ing.Quantity != original[i] {
+			t.Errorf("input ingredient %d mutated: got %v, want %v", i, ing.Quantity, original[i])
+		}
+	}
+
+	// And so are the stored rows.
+	reread, err := s.GetRecipe(ctx, 1, created.ID)
+	if err != nil {
+		t.Fatalf("re-read recipe: %v", err)
+	}
+	for i, ing := range reread.Ingredients {
+		if ing.Quantity != original[i] {
+			t.Errorf("stored ingredient %d changed after scaling: got %v, want %v", i, ing.Quantity, original[i])
+		}
+	}
+
+	// A non-positive factor is a no-op rather than zeroing the list.
+	for _, factor := range []float64{0, -2} {
+		noop := ScaleIngredients(base.Ingredients, factor)
+		for i, ing := range noop {
+			if ing.Quantity != original[i] {
+				t.Errorf("factor %v should be a no-op, ingredient %d got %v", factor, i, ing.Quantity)
+			}
+		}
+	}
+
+	if got := ScaleIngredients(nil, 2); len(got) != 0 {
+		t.Errorf("scaling nil should return an empty slice, got %v", got)
+	}
+}
+
+func TestListRecipes_TagFiltering(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+
+	stew := mustCreate(t, s, 1, Recipe{Title: "Lapskaus", Tags: []string{"dinner", "winter", "beef"}})
+	salad := mustCreate(t, s, 1, Recipe{Title: "Sommersalat", Tags: []string{"dinner", "summer", "vegetarian"}})
+	bread := mustCreate(t, s, 1, Recipe{Title: "Grovbrød", Tags: []string{"baking"}})
+	// Another user's recipe carrying the same tags must never leak.
+	mustCreate(t, s, 2, Recipe{Title: "Andres lapskaus", Tags: []string{"dinner", "winter", "beef"}})
+
+	ids := func(rs []Recipe) map[int64]bool {
+		out := make(map[int64]bool, len(rs))
+		for _, r := range rs {
+			out[r.ID] = true
+		}
+		return out
+	}
+
+	cases := []struct {
+		name   string
+		filter TagFilter
+		want   []int64
+	}{
+		{"no filter returns all of the user's recipes", TagFilter{}, []int64{stew.ID, salad.ID, bread.ID}},
+		{"any matches either tag", TagFilter{Any: []string{"winter", "baking"}}, []int64{stew.ID, bread.ID}},
+		{"any is case-insensitive", TagFilter{Any: []string{"  WINTER "}}, []int64{stew.ID}},
+		{"all requires every tag", TagFilter{All: []string{"dinner", "winter"}}, []int64{stew.ID}},
+		{"all with an absent tag matches nothing", TagFilter{All: []string{"dinner", "dessert"}}, nil},
+		{"any and all combine", TagFilter{Any: []string{"summer", "winter"}, All: []string{"dinner", "vegetarian"}}, []int64{salad.ID}},
+		{"unknown tag matches nothing", TagFilter{Any: []string{"nonexistent"}}, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := s.ListRecipes(ctx, 1, tc.filter)
+			if err != nil {
+				t.Fatalf("list recipes: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d recipes, want %d (%+v)", len(got), len(tc.want), got)
+			}
+			gotIDs := ids(got)
+			for _, id := range tc.want {
+				if !gotIDs[id] {
+					t.Errorf("recipe %d missing from result", id)
+				}
+			}
+		})
+	}
+
+	// The other user sees only their own recipe.
+	others, err := s.ListRecipes(ctx, 2, TagFilter{Any: []string{"winter"}})
+	if err != nil {
+		t.Fatalf("list recipes for user 2: %v", err)
+	}
+	if len(others) != 1 || others[0].Title != "Andres lapskaus" {
+		t.Fatalf("user 2 should see exactly their own recipe, got %+v", others)
+	}
+}
+
+func TestListRecipes_LoadsChildrenPerRecipe(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+
+	a := mustCreate(t, s, 1, sampleRecipe())
+	b := mustCreate(t, s, 1, Recipe{
+		Title:       "Havregrøt",
+		Ingredients: []Ingredient{{Text: "1 dl havregryn", Quantity: 1, Unit: "dl", Name: "havregryn"}},
+		Steps:       []Step{{Text: "Kok i 5 minutter.", DurationSeconds: 300}},
+		Tags:        []string{"breakfast"},
+	})
+
+	list, err := s.ListRecipes(ctx, 1, TagFilter{})
+	if err != nil {
+		t.Fatalf("list recipes: %v", err)
+	}
+	byID := map[int64]Recipe{}
+	for _, r := range list {
+		byID[r.ID] = r
+	}
+	if got := byID[a.ID]; len(got.Ingredients) != 3 || len(got.Steps) != 3 || len(got.Tags) != 3 {
+		t.Errorf("recipe A children mis-assigned: %d ingredients, %d steps, %d tags",
+			len(got.Ingredients), len(got.Steps), len(got.Tags))
+	}
+	if got := byID[b.ID]; len(got.Ingredients) != 1 || len(got.Steps) != 1 || len(got.Tags) != 1 {
+		t.Errorf("recipe B children mis-assigned: %d ingredients, %d steps, %d tags",
+			len(got.Ingredients), len(got.Steps), len(got.Tags))
+	}
+	if got := byID[b.ID]; got.Ingredients[0].Name != "havregryn" || got.Steps[0].Text != "Kok i 5 minutter." {
+		t.Errorf("recipe B children decrypted incorrectly: %+v", got)
+	}
+}
+
+func TestSeasonOf(t *testing.T) {
+	cases := map[time.Month]string{
+		time.January: "winter", time.February: "winter", time.December: "winter",
+		time.March: "spring", time.April: "spring", time.May: "spring",
+		time.June: "summer", time.July: "summer", time.August: "summer",
+		time.September: "autumn", time.October: "autumn", time.November: "autumn",
+	}
+	for month, want := range cases {
+		got := seasonOf(time.Date(2026, month, 15, 12, 0, 0, 0, time.UTC))
+		if got != want {
+			t.Errorf("%v: got season %q, want %q", month, got, want)
+		}
+	}
+}
+
+func TestCookAgain_Ranking(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC) // summer
+
+	inSeasonRecent := mustCreate(t, s, 1, Recipe{Title: "Grillet laks", Tags: []string{"summer"}})
+	outOfSeasonOld := mustCreate(t, s, 1, Recipe{Title: "Lapskaus", Tags: []string{"winter"}})
+	inSeasonNever := mustCreate(t, s, 1, Recipe{Title: "Rekesalat", Tags: []string{"sommer"}})
+	untaggedMiddle := mustCreate(t, s, 1, Recipe{Title: "Pasta", Tags: []string{"quick"}})
+	// Another user's in-season recipe must not appear.
+	mustCreate(t, s, 2, Recipe{Title: "Andres grillmat", Tags: []string{"summer"}})
+
+	if err := s.RecordCook(ctx, 1, inSeasonRecent.ID, now.AddDate(0, 0, -5)); err != nil {
+		t.Fatalf("record cook: %v", err)
+	}
+	if err := s.RecordCook(ctx, 1, outOfSeasonOld.ID, now.AddDate(0, 0, -100)); err != nil {
+		t.Fatalf("record cook: %v", err)
+	}
+	if err := s.RecordCook(ctx, 1, untaggedMiddle.ID, now.AddDate(0, 0, -50)); err != nil {
+		t.Fatalf("record cook: %v", err)
+	}
+
+	got, err := s.CookAgain(ctx, 1, now, 0)
+	if err != nil {
+		t.Fatalf("cook again: %v", err)
+	}
+	want := []int64{inSeasonNever.ID, inSeasonRecent.ID, outOfSeasonOld.ID, untaggedMiddle.ID}
+	if len(got) != len(want) {
+		t.Fatalf("got %d suggestions, want %d", len(got), len(want))
+	}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Fatalf("position %d: got recipe %d (%q), want %d", i, got[i].ID, got[i].Title, id)
+		}
+	}
+
+	limited, err := s.CookAgain(ctx, 1, now, 2)
+	if err != nil {
+		t.Fatalf("cook again with limit: %v", err)
+	}
+	if len(limited) != 2 || limited[0].ID != inSeasonNever.ID || limited[1].ID != inSeasonRecent.ID {
+		t.Fatalf("limit not respected: %+v", limited)
+	}
+}
+
+func TestCookAgain_SeasonFollowsTheClock(t *testing.T) {
+	s := NewStore(setupTestDB(t))
+	ctx := context.Background()
+
+	summerDish := mustCreate(t, s, 1, Recipe{Title: "Grillet laks", Tags: []string{"summer"}})
+	winterDish := mustCreate(t, s, 1, Recipe{Title: "Lapskaus", Tags: []string{"vinter"}})
+
+	inJuly, err := s.CookAgain(ctx, 1, time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC), 1)
+	if err != nil {
+		t.Fatalf("cook again in July: %v", err)
+	}
+	if len(inJuly) != 1 || inJuly[0].ID != summerDish.ID {
+		t.Errorf("July should surface the summer dish, got %+v", inJuly)
+	}
+
+	inJanuary, err := s.CookAgain(ctx, 1, time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC), 1)
+	if err != nil {
+		t.Fatalf("cook again in January: %v", err)
+	}
+	if len(inJanuary) != 1 || inJanuary[0].ID != winterDish.ID {
+		t.Errorf("January should surface the winter dish, got %+v", inJanuary)
+	}
+}
+
+func TestNormalizeTagsAndFilterIsEmpty(t *testing.T) {
+	got := normalizeTags([]string{" Dinner ", "dinner", "", "  ", "Winter"})
+	if strings.Join(got, ",") != "dinner,winter" {
+		t.Errorf("normalizeTags: got %v", got)
+	}
+	if !(TagFilter{}).IsEmpty() {
+		t.Error("zero TagFilter should be empty")
+	}
+	if !(TagFilter{Any: []string{"  "}}).IsEmpty() {
+		t.Error("whitespace-only tags should count as empty")
+	}
+	if (TagFilter{All: []string{"dinner"}}).IsEmpty() {
+		t.Error("filter with a real tag should not be empty")
+	}
+}

--- a/internal/suggestions/pages.go
+++ b/internal/suggestions/pages.go
@@ -204,6 +204,17 @@ var Pages = []Page{
 		FeatureFlag: "wardrobe",
 	},
 	{
+		Slug:        "recipes",
+		Title:       "Recipes",
+		Route:       "/recipes",
+		Description: "Personal recipe collection with encrypted ingredients and steps, tag filtering, servings scaling, ratings, a cooking log, and seasonal cook-again suggestions.",
+		SourceFiles: []string{
+			"internal/recipes/store.go",
+			"internal/recipes/models.go",
+		},
+		FeatureFlag: "recipes",
+	},
+	{
 		Slug:        "infra",
 		Title:       "Infra",
 		Route:       "/infra",


### PR DESCRIPTION
## Changes

- **Recipes backend foundation** - Added the `recipes` feature flag (off by default), the recipe/ingredient/step/tag/cook/meal-plan schema, and a store with CRUD, tag filtering, servings scaling, ratings, a cooking log, and seasonal "cook again" suggestions. Recipe titles, notes, ingredient lines and step text are encrypted at rest; the recipes pages and API handlers land in follow-up work. (Hytte-evi4c)

## Original Issue (task): Recipes backend foundation: schema, models, store, feature flag, routing

Create `internal/recipes/models.go` with Recipe, Ingredient, Step, Tag, Rating, Cook and PlanEntry types (Recipe holds encrypted Title/Notes; Ingredient holds encrypted Text plus plaintext Quantity/Unit/Name fields needed for scaling; Step holds encrypted Text plus plaintext DurationSeconds). Create `internal/recipes/store.go` with a Store struct over the existing DB handle and CRUD: `CreateRecipe(ctx, userID, Recipe) (Recipe, error)`, `GetRecipe`, `ListRecipes(ctx, userID, filter TagFilter)`, `UpdateRecipe`, `DeleteRecipe`, `SetRating`, `RecordCook`, plus `ScaleIngredients(ings []Ingredient, factor float64) []Ingredient` (pure helper, never mutates stored rows) and `CookAgain(ctx, userID, now time.Time, limit int) ([]Recipe, error)` ranking by in-season tag match + longest time since last cook. Add `CREATE TABLE IF NOT EXISTS` statements in `internal/db/db.go` for `recipes`, `recipe_ingredients`, `recipe_steps`, `recipe_tags`, `recipe_cooks`, `meal_plan_entries` (tags/ratings/dates stored plaintext; title/notes/ingredient text/step text stored encrypted per the project's encryption rules — follow the pattern used by an existing encrypted package). Add `"recipes": false` to `internal/auth/features.go`. Add the `/api/recipes/*` group in `internal/api/router.go` wrapped in `RequireFeature(db, "recipes")` (handlers wired in the next sub-task; a stub group is fine here). Add the registry entry (slug `recipes`, route `/recipes`) in `internal/suggestions/pages.go`. Tests in `internal/recipes/store_test.go` cover encryption round-trip, scaling arithmetic leaving base rows untouched, tag filtering, and cook-again ranking. This sub-task defines the types and store API that the handler and frontend sub-tasks consume.

---
Bead: Hytte-evi4c | Branch: forge/Hytte-evi4c
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->