### PR TITLE
Add bulk approve/reject for pending chore completions on the Today tab (Hytte-ixksh)

### DIFF
--- a/changelog.d/Hytte-ixksh.md
+++ b/changelog.d/Hytte-ixksh.md
@@ -1,0 +1,2 @@
+category: Added
+- **Bulk approve/reject for pending chores** - The Allowance page's Today tab now has a selection mode with per-row checkboxes and a select-all control, so a parent can approve or reject a whole day's queue in one request instead of one tap per chore. A single toast summarizes the outcome and reports how many IDs failed, leaving those rows in the list. (Hytte-ixksh)

--- a/internal/allowance/handlers.go
+++ b/internal/allowance/handlers.go
@@ -405,32 +405,42 @@ func ApproveCompletionHandler(db *sql.DB) http.HandlerFunc {
 		}
 		writeJSON(w, http.StatusOK, comp)
 
-		// Notify the child asynchronously.
-		go func(childID, completionID int64) {
-			// Respect the child's quiet hours before sending.
-			if quiethours.IsActive(db, childID) {
-				return
-			}
-			body := "A chore was approved — check your earnings!"
-			// Try to enrich the message with the chore name.
-			if chore, err := GetChoreByID(db, comp.ChoreID, user.ID); err == nil {
-				body = fmt.Sprintf("'%s' approved — check your earnings!", chore.Name)
-			}
-			payload, err := json.Marshal(push.Notification{
-				Title: "Chore approved!",
-				Body:  body,
-				URL:   "/chores",
-				Tag:   fmt.Sprintf("allowance-approval-%d", completionID),
-			})
-			if err != nil {
-				log.Printf("allowance: marshal approval push payload child %d completion %d: %v", childID, completionID, err)
-				return
-			}
-			if _, err := push.SendToUser(db, push.DefaultHTTPClient, childID, payload); err != nil {
-				log.Printf("allowance: approval push child %d: %v", childID, err)
-			}
-		}(comp.ChildID, comp.ID)
+		notifyApproval(db, user.ID, comp)
 	}
+}
+
+// notifyApproval pushes an approval notification to the child in the
+// background. It is a package-level variable so tests can observe calls
+// without a live push stack.
+var notifyApproval = sendApprovalNotification
+
+// sendApprovalNotification tells the child asynchronously that one of their
+// completions was approved, respecting the child's quiet hours.
+func sendApprovalNotification(db *sql.DB, parentID int64, comp *Completion) {
+	go func(childID, completionID, choreID int64) {
+		// Respect the child's quiet hours before sending.
+		if quiethours.IsActive(db, childID) {
+			return
+		}
+		body := "A chore was approved — check your earnings!"
+		// Try to enrich the message with the chore name.
+		if chore, err := GetChoreByID(db, choreID, parentID); err == nil {
+			body = fmt.Sprintf("'%s' approved — check your earnings!", chore.Name)
+		}
+		payload, err := json.Marshal(push.Notification{
+			Title: "Chore approved!",
+			Body:  body,
+			URL:   "/chores",
+			Tag:   fmt.Sprintf("allowance-approval-%d", completionID),
+		})
+		if err != nil {
+			log.Printf("allowance: marshal approval push payload child %d completion %d: %v", childID, completionID, err)
+			return
+		}
+		if _, err := push.SendToUser(db, push.DefaultHTTPClient, childID, payload); err != nil {
+			log.Printf("allowance: approval push child %d: %v", childID, err)
+		}
+	}(comp.ChildID, comp.ID, comp.ChoreID)
 }
 
 // RejectCompletionHandler rejects a pending completion with an optional reason.
@@ -470,6 +480,155 @@ func RejectCompletionHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, http.StatusOK, comp)
+	}
+}
+
+// maxBatchCompletionIDs caps how many completion IDs a single batch
+// approve/reject request may carry.
+const maxBatchCompletionIDs = 100
+
+type batchCompletionRequest struct {
+	IDs []int64 `json:"ids"`
+	// Reason mirrors the single-item reject payload; ignored by the approve
+	// endpoint. The current UI always sends an empty string.
+	Reason string `json:"reason"`
+}
+
+// batchCompletionResult reports the outcome for a single completion ID.
+// Status is one of "approved", "rejected", "skipped" or "error".
+type batchCompletionResult struct {
+	ID     int64  `json:"id"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+type batchCompletionResponse struct {
+	Succeeded int                     `json:"succeeded"`
+	Failed    int                     `json:"failed"`
+	Results   []batchCompletionResult `json:"results"`
+}
+
+// decodeBatchCompletionIDs parses and validates a batch request body. It writes
+// a 400 response and returns ok=false when the payload is unusable.
+func decodeBatchCompletionIDs(w http.ResponseWriter, r *http.Request) (batchCompletionRequest, bool) {
+	var req batchCompletionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errResponse("invalid request body"))
+		return req, false
+	}
+	if len(req.IDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, errResponse("ids must contain at least one completion ID"))
+		return req, false
+	}
+	if len(req.IDs) > maxBatchCompletionIDs {
+		writeJSON(w, http.StatusBadRequest, errResponse(fmt.Sprintf("ids must contain at most %d completion IDs", maxBatchCompletionIDs)))
+		return req, false
+	}
+
+	// Drop duplicates while preserving the caller's order.
+	seen := make(map[int64]struct{}, len(req.IDs))
+	unique := make([]int64, 0, len(req.IDs))
+	for _, id := range req.IDs {
+		if id <= 0 {
+			writeJSON(w, http.StatusBadRequest, errResponse("ids must contain positive completion IDs"))
+			return req, false
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	req.IDs = unique
+	return req, true
+}
+
+// batchCompletionFailure maps a per-completion error to a result entry. Missing
+// or already-resolved completions are skipped rather than failing the batch.
+func batchCompletionFailure(id, parentID int64, action string, err error) batchCompletionResult {
+	switch {
+	case errors.Is(err, ErrCompletionNotFound):
+		return batchCompletionResult{ID: id, Status: "skipped", Error: "completion not found"}
+	case errors.Is(err, ErrCompletionNotPending):
+		return batchCompletionResult{ID: id, Status: "skipped", Error: "completion is not pending"}
+	default:
+		log.Printf("allowance: batch %s completion %d parent %d: %v", action, id, parentID, err)
+		return batchCompletionResult{ID: id, Status: "error", Error: "failed to " + action + " completion"}
+	}
+}
+
+// BatchApproveCompletionsHandler approves several pending completions in one
+// request. Individual failures are reported per ID instead of aborting the
+// batch, so the response is always 200 once the payload validates.
+// POST /api/allowance/approve/batch
+func BatchApproveCompletionsHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if !requireParent(db, w, user) {
+			return
+		}
+
+		req, ok := decodeBatchCompletionIDs(w, r)
+		if !ok {
+			return
+		}
+
+		results := make([]batchCompletionResult, 0, len(req.IDs))
+		approved := make([]*Completion, 0, len(req.IDs))
+		for _, id := range req.IDs {
+			comp, err := ApproveCompletion(db, id, user.ID)
+			if err != nil {
+				results = append(results, batchCompletionFailure(id, user.ID, "approve", err))
+				continue
+			}
+			results = append(results, batchCompletionResult{ID: id, Status: "approved"})
+			approved = append(approved, comp)
+		}
+
+		writeJSON(w, http.StatusOK, batchCompletionResponse{
+			Succeeded: len(approved),
+			Failed:    len(results) - len(approved),
+			Results:   results,
+		})
+
+		// Same per-completion notification as the single-approve path.
+		for _, comp := range approved {
+			notifyApproval(db, user.ID, comp)
+		}
+	}
+}
+
+// BatchRejectCompletionsHandler rejects several pending completions in one
+// request, using the same optional reason as the single-item path.
+// POST /api/allowance/reject/batch
+func BatchRejectCompletionsHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := auth.UserFromContext(r.Context())
+		if !requireParent(db, w, user) {
+			return
+		}
+
+		req, ok := decodeBatchCompletionIDs(w, r)
+		if !ok {
+			return
+		}
+
+		results := make([]batchCompletionResult, 0, len(req.IDs))
+		succeeded := 0
+		for _, id := range req.IDs {
+			if _, err := RejectCompletion(db, id, user.ID, req.Reason); err != nil {
+				results = append(results, batchCompletionFailure(id, user.ID, "reject", err))
+				continue
+			}
+			succeeded++
+			results = append(results, batchCompletionResult{ID: id, Status: "rejected"})
+		}
+
+		writeJSON(w, http.StatusOK, batchCompletionResponse{
+			Succeeded: succeeded,
+			Failed:    len(results) - succeeded,
+			Results:   results,
+		})
 	}
 }
 

--- a/internal/allowance/handlers_test.go
+++ b/internal/allowance/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -2553,3 +2554,349 @@ func TestRecordCompletionHandler_ChoreOwnedByDifferentParent(t *testing.T) {
 	}
 }
 
+
+// ---- Batch approve / reject handler tests ----
+
+// captureApprovalNotifications swaps the package-level approval notifier for a
+// recorder and restores it when the test ends. The stub is invoked
+// synchronously by the handler, so no extra synchronisation is needed.
+func captureApprovalNotifications(t *testing.T) *[]int64 {
+	t.Helper()
+	notified := []int64{}
+	original := notifyApproval
+	notifyApproval = func(_ *sql.DB, _ int64, comp *Completion) {
+		notified = append(notified, comp.ID)
+	}
+	t.Cleanup(func() { notifyApproval = original })
+	return &notified
+}
+
+// seedPendingCompletions creates n pending completions for child 2 on distinct
+// dates under a single chore owned by parent 1.
+func seedPendingCompletions(t *testing.T, db *sql.DB, n int) []int64 {
+	t.Helper()
+	chore, err := CreateChore(db, 1, nil, "Clean room", "", 20, "daily", "🧹", true, "solo", 2, 10.0)
+	if err != nil {
+		t.Fatalf("CreateChore: %v", err)
+	}
+	ids := make([]int64, 0, n)
+	for i := 0; i < n; i++ {
+		comp, err := CreateCompletion(db, chore.ID, 2, fmt.Sprintf("2026-03-%02d", i+1), "")
+		if err != nil {
+			t.Fatalf("CreateCompletion %d: %v", i, err)
+		}
+		ids = append(ids, comp.ID)
+	}
+	return ids
+}
+
+func completionStatus(t *testing.T, db *sql.DB, id int64) string {
+	t.Helper()
+	var status string
+	if err := db.QueryRow(`SELECT status FROM allowance_completions WHERE id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("read status for completion %d: %v", id, err)
+	}
+	return status
+}
+
+func statusByID(results []batchCompletionResult) map[int64]string {
+	byID := make(map[int64]string, len(results))
+	for _, res := range results {
+		byID[res.ID] = res.Status
+	}
+	return byID
+}
+
+func TestBatchApproveCompletionsHandlerRequiresParent(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	handler := BatchApproveCompletionsHandler(db)
+	r := withUser(newRequest(http.MethodPost, "/api/allowance/approve/batch", map[string]any{"ids": []int64{1}}), testChild)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBatchRejectCompletionsHandlerRequiresParent(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	handler := BatchRejectCompletionsHandler(db)
+	r := withUser(newRequest(http.MethodPost, "/api/allowance/reject/batch", map[string]any{"ids": []int64{1}}), testChild)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBatchCompletionHandlersRejectInvalidPayloads(t *testing.T) {
+	oversized := make([]string, maxBatchCompletionIDs+1)
+	for i := range oversized {
+		oversized[i] = strconv.Itoa(i + 1)
+	}
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"malformed json", `{"ids": [1,`},
+		{"missing ids", `{}`},
+		{"empty ids", `{"ids": []}`},
+		{"non-numeric ids", `{"ids": ["abc"]}`},
+		{"zero id", `{"ids": [0]}`},
+		{"negative id", `{"ids": [-3]}`},
+		{"oversized ids", `{"ids": [` + strings.Join(oversized, ",") + `]}`},
+	}
+
+	handlers := map[string]func(*sql.DB) http.HandlerFunc{
+		"approve": BatchApproveCompletionsHandler,
+		"reject":  BatchRejectCompletionsHandler,
+	}
+
+	for action, newHandler := range handlers {
+		for _, tc := range cases {
+			t.Run(action+"/"+tc.name, func(t *testing.T) {
+				db := setupTestDB(t)
+				linkParentChild(t, db)
+
+				r := httptest.NewRequest(http.MethodPost, "/api/allowance/"+action+"/batch", strings.NewReader(tc.body))
+				r.Header.Set("Content-Type", "application/json")
+				w := httptest.NewRecorder()
+				newHandler(db).ServeHTTP(w, withUser(r, testParent))
+
+				if w.Code != http.StatusBadRequest {
+					t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+				}
+			})
+		}
+	}
+}
+
+func TestBatchApproveCompletionsHandler(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+	notified := captureApprovalNotifications(t)
+
+	ids := seedPendingCompletions(t, db, 3)
+
+	handler := BatchApproveCompletionsHandler(db)
+	r := withUser(newRequest(http.MethodPost, "/api/allowance/approve/batch", map[string]any{"ids": ids}), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp batchCompletionResponse
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Succeeded != 3 || resp.Failed != 0 {
+		t.Fatalf("expected 3 succeeded / 0 failed, got %d/%d", resp.Succeeded, resp.Failed)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(resp.Results))
+	}
+	for _, res := range resp.Results {
+		if res.Status != "approved" {
+			t.Errorf("completion %d: expected status approved, got %q", res.ID, res.Status)
+		}
+	}
+	for _, id := range ids {
+		if got := completionStatus(t, db, id); got != "approved" {
+			t.Errorf("completion %d: expected DB status approved, got %q", id, got)
+		}
+	}
+	if len(*notified) != 3 {
+		t.Errorf("expected 3 approval notifications, got %d", len(*notified))
+	}
+}
+
+func TestBatchApproveCompletionsHandlerDeduplicatesIDs(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+	captureApprovalNotifications(t)
+
+	ids := seedPendingCompletions(t, db, 1)
+
+	handler := BatchApproveCompletionsHandler(db)
+	body := map[string]any{"ids": []int64{ids[0], ids[0], ids[0]}}
+	r := withUser(newRequest(http.MethodPost, "/api/allowance/approve/batch", body), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp batchCompletionResponse
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Succeeded != 1 || resp.Failed != 0 || len(resp.Results) != 1 {
+		t.Fatalf("expected a single deduplicated result, got %d/%d with %d results",
+			resp.Succeeded, resp.Failed, len(resp.Results))
+	}
+}
+
+func TestBatchApproveCompletionsHandlerPartialFailure(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+	notified := captureApprovalNotifications(t)
+
+	ids := seedPendingCompletions(t, db, 2)
+	pendingID, alreadyApprovedID := ids[0], ids[1]
+	if _, err := ApproveCompletion(db, alreadyApprovedID, 1); err != nil {
+		t.Fatalf("ApproveCompletion: %v", err)
+	}
+	const unknownID int64 = 9999
+
+	handler := BatchApproveCompletionsHandler(db)
+	body := map[string]any{"ids": []int64{pendingID, unknownID, alreadyApprovedID}}
+	r := withUser(newRequest(http.MethodPost, "/api/allowance/approve/batch", body), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp batchCompletionResponse
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Succeeded != 1 || resp.Failed != 2 {
+		t.Fatalf("expected 1 succeeded / 2 failed, got %d/%d", resp.Succeeded, resp.Failed)
+	}
+	byID := statusByID(resp.Results)
+	if byID[pendingID] != "approved" {
+		t.Errorf("completion %d: expected approved, got %q", pendingID, byID[pendingID])
+	}
+	if byID[unknownID] != "skipped" {
+		t.Errorf("unknown completion: expected skipped, got %q", byID[unknownID])
+	}
+	if byID[alreadyApprovedID] != "skipped" {
+		t.Errorf("already-approved completion: expected skipped, got %q", byID[alreadyApprovedID])
+	}
+	if got := completionStatus(t, db, pendingID); got != "approved" {
+		t.Errorf("completion %d: expected DB status approved, got %q", pendingID, got)
+	}
+	if len(*notified) != 1 {
+		t.Errorf("expected 1 approval notification, got %d", len(*notified))
+	}
+}
+
+func TestBatchApproveCompletionsHandlerSkipsOtherParentsCompletions(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+	captureApprovalNotifications(t)
+
+	// Chore owned by parent 10, so parent 1 must not be able to approve it.
+	if _, err := db.Exec(`INSERT INTO users (id, email, name, google_id) VALUES (10, 'other@test.com', 'Other', 'g10'), (11, 'kid@test.com', 'Kid', 'g11')`); err != nil {
+		t.Fatalf("seed other family: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO family_links (parent_id, child_id, created_at) VALUES (10, 11, '2026-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("link other family: %v", err)
+	}
+	otherChore, err := CreateChore(db, 10, nil, "Other chore", "", 15, "daily", "🧹", true, "solo", 2, 10.0)
+	if err != nil {
+		t.Fatalf("CreateChore: %v", err)
+	}
+	otherComp, err := CreateCompletion(db, otherChore.ID, 11, "2026-04-01", "")
+	if err != nil {
+		t.Fatalf("CreateCompletion: %v", err)
+	}
+
+	handler := BatchApproveCompletionsHandler(db)
+	body := map[string]any{"ids": []int64{otherComp.ID}}
+	r := withUser(newRequest(http.MethodPost, "/api/allowance/approve/batch", body), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp batchCompletionResponse
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Succeeded != 0 || resp.Failed != 1 {
+		t.Fatalf("expected 0 succeeded / 1 failed, got %d/%d", resp.Succeeded, resp.Failed)
+	}
+	if got := completionStatus(t, db, otherComp.ID); got != "pending" {
+		t.Errorf("expected other family's completion to stay pending, got %q", got)
+	}
+}
+
+func TestBatchRejectCompletionsHandler(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	ids := seedPendingCompletions(t, db, 2)
+
+	handler := BatchRejectCompletionsHandler(db)
+	// The UI sends an empty reason, matching the single-item reject payload.
+	body := map[string]any{"ids": ids, "reason": ""}
+	r := withUser(newRequest(http.MethodPost, "/api/allowance/reject/batch", body), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp batchCompletionResponse
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Succeeded != 2 || resp.Failed != 0 {
+		t.Fatalf("expected 2 succeeded / 0 failed, got %d/%d", resp.Succeeded, resp.Failed)
+	}
+	for _, res := range resp.Results {
+		if res.Status != "rejected" {
+			t.Errorf("completion %d: expected status rejected, got %q", res.ID, res.Status)
+		}
+	}
+	for _, id := range ids {
+		if got := completionStatus(t, db, id); got != "rejected" {
+			t.Errorf("completion %d: expected DB status rejected, got %q", id, got)
+		}
+		var notes string
+		if err := db.QueryRow(`SELECT notes FROM allowance_completions WHERE id = ?`, id).Scan(&notes); err != nil {
+			t.Fatalf("read notes for completion %d: %v", id, err)
+		}
+		if notes != "" {
+			t.Errorf("completion %d: expected notes to stay empty with an empty reason, got %q", id, notes)
+		}
+	}
+}
+
+func TestBatchRejectCompletionsHandlerPartialFailure(t *testing.T) {
+	db := setupTestDB(t)
+	linkParentChild(t, db)
+
+	ids := seedPendingCompletions(t, db, 2)
+	pendingID, rejectedID := ids[0], ids[1]
+	if _, err := RejectCompletion(db, rejectedID, 1, ""); err != nil {
+		t.Fatalf("RejectCompletion: %v", err)
+	}
+	const unknownID int64 = 4242
+
+	handler := BatchRejectCompletionsHandler(db)
+	body := map[string]any{"ids": []int64{pendingID, rejectedID, unknownID}, "reason": ""}
+	r := withUser(newRequest(http.MethodPost, "/api/allowance/reject/batch", body), testParent)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp batchCompletionResponse
+	decode(t, w.Body.Bytes(), &resp)
+	if resp.Succeeded != 1 || resp.Failed != 2 {
+		t.Fatalf("expected 1 succeeded / 2 failed, got %d/%d", resp.Succeeded, resp.Failed)
+	}
+	byID := statusByID(resp.Results)
+	if byID[pendingID] != "rejected" {
+		t.Errorf("completion %d: expected rejected, got %q", pendingID, byID[pendingID])
+	}
+	if byID[rejectedID] != "skipped" || byID[unknownID] != "skipped" {
+		t.Errorf("expected skipped for already-rejected and unknown IDs, got %q and %q", byID[rejectedID], byID[unknownID])
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -667,6 +667,8 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.Delete("/allowance/chores/{id}", allowance.DeactivateChoreHandler(db))
 				// Parent: approval flow.
 				r.Get("/allowance/pending", allowance.ListPendingHandler(db))
+				r.Post("/allowance/approve/batch", allowance.BatchApproveCompletionsHandler(db))
+				r.Post("/allowance/reject/batch", allowance.BatchRejectCompletionsHandler(db))
 				r.Post("/allowance/approve/{id}", allowance.ApproveCompletionHandler(db))
 				r.Post("/allowance/reject/{id}", allowance.RejectCompletionHandler(db))
 				r.Post("/allowance/quality-bonus/{id}", allowance.QualityBonusHandler(db))

--- a/web/public/locales/en/allowance.json
+++ b/web/public/locales/en/allowance.json
@@ -33,6 +33,21 @@
     "close": "Close",
     "refresh": "Refresh"
   },
+  "bulk": {
+    "select": "Select",
+    "cancelSelection": "Cancel",
+    "selectAll": "Select all",
+    "selectItem": "Select {{name}}",
+    "selectedCount": "{{selected}} selected",
+    "approveSelected": "Approve selected",
+    "rejectSelected": "Reject selected",
+    "toast": {
+      "approved": "{{succeeded}} approved",
+      "rejected": "{{succeeded}} rejected",
+      "approvedPartial": "{{succeeded}} approved, {{failed}} failed",
+      "rejectedPartial": "{{succeeded}} rejected, {{failed}} failed"
+    }
+  },
   "form": {
     "newChore": "New Chore",
     "editChore": "Edit Chore",

--- a/web/public/locales/nb/allowance.json
+++ b/web/public/locales/nb/allowance.json
@@ -33,6 +33,21 @@
     "close": "Lukk",
     "refresh": "Oppdater"
   },
+  "bulk": {
+    "select": "Velg",
+    "cancelSelection": "Avbryt",
+    "selectAll": "Velg alle",
+    "selectItem": "Velg {{name}}",
+    "selectedCount": "{{selected}} valgt",
+    "approveSelected": "Godkjenn valgte",
+    "rejectSelected": "Avvis valgte",
+    "toast": {
+      "approved": "{{succeeded}} godkjent",
+      "rejected": "{{succeeded}} avvist",
+      "approvedPartial": "{{succeeded}} godkjent, {{failed}} mislyktes",
+      "rejectedPartial": "{{succeeded}} avvist, {{failed}} mislyktes"
+    }
+  },
   "form": {
     "newChore": "Ny oppgave",
     "editChore": "Rediger oppgave",

--- a/web/public/locales/th/allowance.json
+++ b/web/public/locales/th/allowance.json
@@ -33,6 +33,21 @@
     "close": "ปิด",
     "refresh": "รีเฟรช"
   },
+  "bulk": {
+    "select": "เลือก",
+    "cancelSelection": "ยกเลิก",
+    "selectAll": "เลือกทั้งหมด",
+    "selectItem": "เลือก {{name}}",
+    "selectedCount": "เลือกแล้ว {{selected}} รายการ",
+    "approveSelected": "อนุมัติรายการที่เลือก",
+    "rejectSelected": "ปฏิเสธรายการที่เลือก",
+    "toast": {
+      "approved": "อนุมัติแล้ว {{succeeded}} รายการ",
+      "rejected": "ปฏิเสธแล้ว {{succeeded}} รายการ",
+      "approvedPartial": "อนุมัติแล้ว {{succeeded}} รายการ, ล้มเหลว {{failed}} รายการ",
+      "rejectedPartial": "ปฏิเสธแล้ว {{succeeded}} รายการ, ล้มเหลว {{failed}} รายการ"
+    }
+  },
   "form": {
     "newChore": "งานใหม่",
     "editChore": "แก้ไขงาน",

--- a/web/src/pages/AllowancePage.tsx
+++ b/web/src/pages/AllowancePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Camera, CheckCircle, XCircle, Plus, Pencil, Trash2, Star, X, ClipboardCheck, RefreshCw } from 'lucide-react'
+import { Camera, CheckCircle, XCircle, Plus, Pencil, Trash2, Star, X, ClipboardCheck, RefreshCw, ListChecks } from 'lucide-react'
 import { formatDate, formatNumber } from '../utils/formatDate'
 import { Skeleton } from '../components/ui/skeleton'
 import { ConfirmDialog } from '../components/ui/dialog'
@@ -23,6 +23,19 @@ function fetchPendingDeduped(): Promise<{ pending: CompletionWithDetails[] }> {
       .finally(() => { pendingInFlight = null })
   }
   return pendingInFlight
+}
+
+/** Per-ID outcome returned by the batch approve/reject endpoints. */
+interface BatchCompletionResult {
+  id: number
+  status: 'approved' | 'rejected' | 'skipped' | 'error'
+  error?: string
+}
+
+interface BatchCompletionResponse {
+  succeeded: number
+  failed: number
+  results: BatchCompletionResult[]
 }
 
 interface CompletionWithDetails {
@@ -161,6 +174,12 @@ export default function AllowancePage() {
   const enlargedCloseRef = useRef<HTMLButtonElement>(null)
   const enlargedTriggerRef = useRef<HTMLElement | null>(null)
 
+  // Bulk approve/reject selection state (Today tab only)
+  const [selectionMode, setSelectionMode] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(() => new Set())
+  const [batchRunning, setBatchRunning] = useState(false)
+  const selectAllRef = useRef<HTMLInputElement>(null)
+
   // Chores tab state
   const [chores, setChores] = useState<Chore[]>([])
   const [showChoreForm, setShowChoreForm] = useState(false)
@@ -236,7 +255,11 @@ export default function AllowancePage() {
   const pendingFetch = useTabFetch<{ pending: CompletionWithDetails[] }>(
     true,
     () => fetchPendingDeduped(),
-    data => setPending(data.pending ?? []),
+    data => {
+      setPending(data.pending ?? [])
+      // A refreshed list can no longer be matched against the old selection.
+      setSelectedIds(new Set())
+    },
     loadFailed,
   )
 
@@ -350,6 +373,99 @@ export default function AllowancePage() {
       payoutsFetch.invalidate()
     } catch {
       setActionError(t('errors.actionFailed'))
+    }
+  }
+
+  // Only IDs still listed count as selected — a refetch may have removed rows.
+  const selectedPendingIds = pending.filter(c => selectedIds.has(c.id)).map(c => c.id)
+  const allPendingSelected = pending.length > 0 && selectedPendingIds.length === pending.length
+  const somePendingSelected = selectedPendingIds.length > 0 && !allPendingSelected
+
+  // Selection mode is meaningless once the queue is empty, so derive it from
+  // the list rather than resetting the flag in an effect.
+  const inSelectionMode = selectionMode && pending.length > 0
+
+  // Native checkboxes expose "indeterminate" only via the DOM property.
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = somePendingSelected
+    }
+  }, [somePendingSelected, inSelectionMode])
+
+  const toggleSelectionMode = () => {
+    setSelectionMode(prev => !prev)
+    setSelectedIds(new Set())
+  }
+
+  const toggleSelected = (id: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  const toggleSelectAll = () => {
+    setSelectedIds(allPendingSelected ? new Set() : new Set(pending.map(c => c.id)))
+  }
+
+  const handleBatchAction = async (action: 'approve' | 'reject') => {
+    const ids = selectedPendingIds
+    if (ids.length === 0 || batchRunning) return
+
+    setBatchRunning(true)
+    setActionError('')
+    try {
+      const res = await fetch(`/api/allowance/${action}/batch`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        // Rejection sends the same empty reason as the single-item path.
+        body: JSON.stringify(action === 'reject' ? { ids, reason: '' } : { ids }),
+      })
+      if (!res.ok) throw new Error()
+      const data: BatchCompletionResponse = await res.json()
+
+      const resolvedIds = new Set(
+        (data.results ?? [])
+          .filter(r => r.status === 'approved' || r.status === 'rejected')
+          .map(r => r.id),
+      )
+      setPending(prev => prev.filter(c => !resolvedIds.has(c.id)))
+      // Failed rows stay selected so the parent can retry them.
+      setSelectedIds(prev => {
+        const next = new Set(prev)
+        resolvedIds.forEach(id => next.delete(id))
+        return next
+      })
+      payoutsFetch.invalidate()
+
+      const succeeded = data.succeeded ?? resolvedIds.size
+      const failed = data.failed ?? 0
+      if (failed > 0) {
+        showToast(
+          action === 'approve'
+            ? t('bulk.toast.approvedPartial', { succeeded, failed })
+            : t('bulk.toast.rejectedPartial', { succeeded, failed }),
+          'warning',
+        )
+      } else {
+        showToast(
+          action === 'approve'
+            ? t('bulk.toast.approved', { succeeded })
+            : t('bulk.toast.rejected', { succeeded }),
+          'success',
+        )
+        setSelectionMode(false)
+      }
+    } catch {
+      setActionError(t('errors.actionFailed'))
+    } finally {
+      setBatchRunning(false)
     }
   }
 
@@ -583,6 +699,8 @@ export default function AllowancePage() {
   const handleTabSwitch = (newTab: Tab) => {
     if (newTab === tab) return
     setShowEmojiPicker(false)
+    setSelectionMode(false)
+    setSelectedIds(new Set())
     setTab(newTab)
   }
 
@@ -638,11 +756,61 @@ export default function AllowancePage() {
 
       {/* Today — pending approvals */}
       <TabPanel value="today">
-          <div className="flex justify-end mb-3">
+          <div className="flex items-center justify-end gap-2 mb-3">
+            {pending.length > 0 && !pendingFetch.loading && (
+              <button
+                type="button"
+                onClick={toggleSelectionMode}
+                aria-pressed={inSelectionMode}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-gray-300 hover:text-white hover:bg-gray-700 transition-colors cursor-pointer"
+              >
+                <ListChecks size={16} />
+                {inSelectionMode ? t('bulk.cancelSelection') : t('bulk.select')}
+              </button>
+            )}
             {renderRefresh(() => pendingFetch.reload(), pendingFetch.loading)}
           </div>
           {actionError && (
             <p className="text-red-400 text-sm mb-3">{actionError}</p>
+          )}
+          {inSelectionMode && (
+            <div className="bg-gray-800 rounded-xl p-3 mb-3 space-y-3">
+              <div className="flex items-center gap-2">
+                <label className="flex items-center gap-2 text-sm text-gray-200 cursor-pointer">
+                  <input
+                    ref={selectAllRef}
+                    type="checkbox"
+                    checked={allPendingSelected}
+                    onChange={toggleSelectAll}
+                    className="w-4 h-4 accent-green-500 cursor-pointer"
+                  />
+                  {t('bulk.selectAll')}
+                </label>
+                <span className="ml-auto text-xs text-gray-400">
+                  {t('bulk.selectedCount', { selected: selectedPendingIds.length })}
+                </span>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleBatchAction('approve')}
+                  disabled={selectedPendingIds.length === 0 || batchRunning}
+                  className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-green-600 text-white text-sm font-medium hover:bg-green-500 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <CheckCircle size={16} />
+                  {t('bulk.approveSelected')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleBatchAction('reject')}
+                  disabled={selectedPendingIds.length === 0 || batchRunning}
+                  className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-500 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <XCircle size={16} />
+                  {t('bulk.rejectSelected')}
+                </button>
+              </div>
+            </div>
           )}
           {pendingFetch.loading ? (
             <div role="status" aria-live="polite">
@@ -660,7 +828,16 @@ export default function AllowancePage() {
             <div className="space-y-3">
               {pending.map(comp => (
                 <div key={comp.id} className="bg-gray-800 rounded-xl p-4 space-y-2">
-                  <div className="flex items-center gap-4">
+                  <div className="flex items-center gap-3 sm:gap-4">
+                    {inSelectionMode && (
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.has(comp.id)}
+                        onChange={() => toggleSelected(comp.id)}
+                        aria-label={t('bulk.selectItem', { name: comp.chore_name })}
+                        className="w-5 h-5 shrink-0 accent-green-500 cursor-pointer"
+                      />
+                    )}
                     <div className="text-3xl select-none">{comp.child_avatar || '⭐'}</div>
                     <div className="flex-1 min-w-0">
                       <p className="text-xs text-gray-400 uppercase tracking-wide">
@@ -710,22 +887,27 @@ export default function AllowancePage() {
                           <span className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-blue-400 rounded-full" />
                         </button>
                       )}
-                      <button
-                        type="button"
-                        onClick={() => handleReject(comp.id)}
-                        className="p-1.5 rounded-full text-red-400 hover:bg-red-500/20 transition-colors cursor-pointer"
-                        aria-label={t('actions.reject')}
-                      >
-                        <XCircle size={32} />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => handleApprove(comp.id)}
-                        className="p-1.5 rounded-full text-green-400 hover:bg-green-500/20 transition-colors cursor-pointer"
-                        aria-label={t('actions.approve')}
-                      >
-                        <CheckCircle size={32} />
-                      </button>
+                      {/* Per-item actions make room for the checkbox in selection mode. */}
+                      {!inSelectionMode && (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => handleReject(comp.id)}
+                            className="p-1.5 rounded-full text-red-400 hover:bg-red-500/20 transition-colors cursor-pointer"
+                            aria-label={t('actions.reject')}
+                          >
+                            <XCircle size={32} />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleApprove(comp.id)}
+                            className="p-1.5 rounded-full text-green-400 hover:bg-green-500/20 transition-colors cursor-pointer"
+                            aria-label={t('actions.approve')}
+                          >
+                            <CheckCircle size={32} />
+                          </button>
+                        </>
+                      )}
                     </div>
                   </div>
                   {/* Photo thumbnail */}

--- a/web/src/pages/__tests__/AllowancePageBulkApproval.test.tsx
+++ b/web/src/pages/__tests__/AllowancePageBulkApproval.test.tsx
@@ -1,0 +1,314 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import AllowancePage from '../AllowancePage'
+
+// ── Translation mock ──────────────────────────────────────────────────────────
+// mockT must be a stable reference: AllowancePage keeps `t` in effect
+// dependency lists, so a fresh function per render would re-run them.
+
+const TRANSLATIONS: Record<string, string> = {
+  'title': 'Allowance',
+  'loading': 'Loading...',
+  'noPending': 'No pending approvals',
+  'currency': 'kr',
+  'teamMemberSeparator': ' + ',
+  'tabs.label': 'Allowance sections',
+  'tabs.today': 'Today',
+  'tabs.chores': 'Chores',
+  'tabs.payouts': 'Payouts',
+  'tabs.extras': 'Extras',
+  'tabs.bonuses': 'Bonuses',
+  'actions.approve': 'Approve',
+  'actions.reject': 'Reject',
+  'actions.refresh': 'Refresh',
+  'actions.viewPhoto': 'View photo',
+  'actions.close': 'Close',
+  'bulk.select': 'Select',
+  'bulk.cancelSelection': 'Cancel',
+  'bulk.selectAll': 'Select all',
+  'bulk.selectItem': 'Select {{name}}',
+  'bulk.selectedCount': '{{selected}} selected',
+  'bulk.approveSelected': 'Approve selected',
+  'bulk.rejectSelected': 'Reject selected',
+  'bulk.toast.approved': '{{succeeded}} approved',
+  'bulk.toast.rejected': '{{succeeded}} rejected',
+  'bulk.toast.approvedPartial': '{{succeeded}} approved, {{failed}} failed',
+  'bulk.toast.rejectedPartial': '{{succeeded}} rejected, {{failed}} failed',
+  'errors.loadFailed': 'Failed to load data',
+  'errors.actionFailed': 'Action failed',
+}
+
+function mockT(key: string, opts?: Record<string, unknown>): string {
+  const template = TRANSLATIONS[key] ?? key
+  if (!opts) return template
+  return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) =>
+    opts[name] === undefined ? '' : String(opts[name]),
+  )
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockT,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// Keep the HttpBackend out of the test run — formatDate only needs a language.
+vi.mock('../../i18n', () => ({
+  default: { language: 'en' },
+}))
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+interface PendingFixture {
+  id: number
+  chore_name: string
+}
+
+const PENDING: PendingFixture[] = [
+  { id: 1, chore_name: 'Clean room' },
+  { id: 2, chore_name: 'Dishes' },
+  { id: 3, chore_name: 'Trash' },
+]
+
+function makeCompletion({ id, chore_name }: PendingFixture) {
+  return {
+    id,
+    chore_id: id,
+    chore_name,
+    chore_icon: '🧹',
+    chore_amount: 20,
+    child_id: 2,
+    child_nickname: 'Ada',
+    child_avatar: '⭐',
+    date: '2026-03-28',
+    status: 'pending',
+    created_at: '2026-03-28T10:00:00Z',
+  }
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as unknown as Response
+}
+
+const fetchMock = vi.fn()
+
+/** Records every batch call so tests can assert on the request count/payload. */
+function batchCalls(action: 'approve' | 'reject') {
+  return fetchMock.mock.calls.filter(([url]) => url === `/api/allowance/${action}/batch`)
+}
+
+function batchBody(action: 'approve' | 'reject', index = 0): Record<string, unknown> {
+  const call = batchCalls(action)[index]
+  return JSON.parse((call[1] as RequestInit).body as string)
+}
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  fetchMock.mockImplementation((url: string) => {
+    if (url.startsWith('/api/allowance/pending')) {
+      return Promise.resolve(jsonResponse({ pending: PENDING.map(makeCompletion) }))
+    }
+    return Promise.reject(new Error(`unexpected url: ${url}`))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// Chore names render next to their emoji, so match on a substring.
+function choreRow(name: string) {
+  return screen.queryByText(new RegExp(name))
+}
+
+async function renderTodayTab() {
+  render(<AllowancePage />)
+  await screen.findByText(/Clean room/)
+}
+
+function enterSelectionMode() {
+  fireEvent.click(screen.getByRole('button', { name: 'Select' }))
+}
+
+function rowCheckbox(name: string): HTMLInputElement {
+  return screen.getByRole('checkbox', { name: `Select ${name}` }) as HTMLInputElement
+}
+
+describe('AllowancePage bulk approval', () => {
+  it('shows no checkboxes until selection mode is entered', async () => {
+    await renderTodayTab()
+
+    expect(screen.queryByRole('checkbox')).toBeNull()
+    // Per-item actions are available outside selection mode.
+    expect(screen.getAllByRole('button', { name: 'Approve' })).toHaveLength(3)
+
+    enterSelectionMode()
+
+    expect(rowCheckbox('Clean room')).toBeInTheDocument()
+    expect(rowCheckbox('Dishes')).toBeInTheDocument()
+    expect(rowCheckbox('Trash')).toBeInTheDocument()
+  })
+
+  it('disables the batch actions until at least one row is selected', async () => {
+    await renderTodayTab()
+    enterSelectionMode()
+
+    const approve = screen.getByRole('button', { name: 'Approve selected' })
+    const reject = screen.getByRole('button', { name: 'Reject selected' })
+    expect(approve).toBeDisabled()
+    expect(reject).toBeDisabled()
+
+    fireEvent.click(rowCheckbox('Dishes'))
+
+    expect(approve).toBeEnabled()
+    expect(reject).toBeEnabled()
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+  })
+
+  it('select-all toggles every listed pending row', async () => {
+    await renderTodayTab()
+    enterSelectionMode()
+
+    const selectAll = screen.getByRole('checkbox', { name: /Select all/ })
+    fireEvent.click(selectAll)
+
+    expect(rowCheckbox('Clean room').checked).toBe(true)
+    expect(rowCheckbox('Dishes').checked).toBe(true)
+    expect(rowCheckbox('Trash').checked).toBe(true)
+    expect(screen.getByText('3 selected')).toBeInTheDocument()
+
+    fireEvent.click(selectAll)
+
+    expect(rowCheckbox('Clean room').checked).toBe(false)
+    expect(screen.getByText('0 selected')).toBeInTheDocument()
+  })
+
+  it('approves the selection with a single batch request', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/allowance/pending')) {
+        return Promise.resolve(jsonResponse({ pending: PENDING.map(makeCompletion) }))
+      }
+      if (url === '/api/allowance/approve/batch') {
+        return Promise.resolve(jsonResponse({
+          succeeded: 3,
+          failed: 0,
+          results: PENDING.map(p => ({ id: p.id, status: 'approved' })),
+        }))
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`))
+    })
+
+    await renderTodayTab()
+    enterSelectionMode()
+    fireEvent.click(screen.getByRole('checkbox', { name: /Select all/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Approve selected' }))
+
+    await waitFor(() => expect(screen.getByText('3 approved')).toBeInTheDocument())
+
+    expect(batchCalls('approve')).toHaveLength(1)
+    expect(batchBody('approve')).toEqual({ ids: [1, 2, 3] })
+    // Approved rows disappear, so the pending badge count drops with them.
+    expect(choreRow('Clean room')).toBeNull()
+    expect(screen.getByText('No pending approvals')).toBeInTheDocument()
+  })
+
+  it('reports partial failures and keeps the failed rows listed', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/allowance/pending')) {
+        return Promise.resolve(jsonResponse({ pending: PENDING.map(makeCompletion) }))
+      }
+      if (url === '/api/allowance/approve/batch') {
+        return Promise.resolve(jsonResponse({
+          succeeded: 2,
+          failed: 1,
+          results: [
+            { id: 1, status: 'approved' },
+            { id: 2, status: 'approved' },
+            { id: 3, status: 'skipped', error: 'completion is not pending' },
+          ],
+        }))
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`))
+    })
+
+    await renderTodayTab()
+    enterSelectionMode()
+    fireEvent.click(screen.getByRole('checkbox', { name: /Select all/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Approve selected' }))
+
+    await waitFor(() => expect(screen.getByText('2 approved, 1 failed')).toBeInTheDocument())
+
+    expect(choreRow('Clean room')).toBeNull()
+    expect(choreRow('Dishes')).toBeNull()
+    // The failed row stays listed and stays selected so it can be retried.
+    expect(choreRow('Trash')).toBeInTheDocument()
+    expect(rowCheckbox('Trash').checked).toBe(true)
+  })
+
+  it('rejects the selection with the same empty reason as the single-item path', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/allowance/pending')) {
+        return Promise.resolve(jsonResponse({ pending: PENDING.map(makeCompletion) }))
+      }
+      if (url === '/api/allowance/reject/batch') {
+        return Promise.resolve(jsonResponse({
+          succeeded: 2,
+          failed: 0,
+          results: [
+            { id: 1, status: 'rejected' },
+            { id: 3, status: 'rejected' },
+          ],
+        }))
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`))
+    })
+
+    await renderTodayTab()
+    enterSelectionMode()
+    fireEvent.click(rowCheckbox('Clean room'))
+    fireEvent.click(rowCheckbox('Trash'))
+    fireEvent.click(screen.getByRole('button', { name: 'Reject selected' }))
+
+    await waitFor(() => expect(screen.getByText('2 rejected')).toBeInTheDocument())
+
+    expect(batchCalls('reject')).toHaveLength(1)
+    expect(batchBody('reject')).toEqual({ ids: [1, 3], reason: '' })
+    expect(choreRow('Clean room')).toBeNull()
+    expect(choreRow('Dishes')).toBeInTheDocument()
+  })
+
+  it('surfaces an error and keeps the rows when the batch request fails', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.startsWith('/api/allowance/pending')) {
+        return Promise.resolve(jsonResponse({ pending: PENDING.map(makeCompletion) }))
+      }
+      if (url === '/api/allowance/approve/batch') {
+        return Promise.resolve(jsonResponse({ error: 'nope' }, false))
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`))
+    })
+
+    await renderTodayTab()
+    enterSelectionMode()
+    fireEvent.click(rowCheckbox('Dishes'))
+    fireEvent.click(screen.getByRole('button', { name: 'Approve selected' }))
+
+    await waitFor(() => expect(screen.getByText('Action failed')).toBeInTheDocument())
+    expect(choreRow('Dishes')).toBeInTheDocument()
+  })
+
+  it('leaves selection mode when the parent cancels it', async () => {
+    await renderTodayTab()
+    enterSelectionMode()
+    fireEvent.click(rowCheckbox('Dishes'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.queryByRole('checkbox')).toBeNull()
+    expect(screen.getAllByRole('button', { name: 'Reject' })).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
## Changes

- **Bulk approve/reject for pending chores** - The Allowance page's Today tab now has a selection mode with per-row checkboxes and a select-all control, so a parent can approve or reject a whole day's queue in one request instead of one tap per chore. A single toast summarizes the outcome and reports how many IDs failed, leaving those rows in the list. (Hytte-ixksh)

## Original Issue (feature): Add bulk approve/reject for pending chore completions on the Today tab

### Scope
Add a parent-facing bulk approve/reject flow for pending chore completions on the Allowance page's **Today** tab. Introduces a selection mode (per-row checkboxes + select-all), an "Approve selected" / "Reject selected" action bar, and two batch endpoints that loop over the existing `ApproveCompletion` / `RejectCompletion` storage functions so notification and payout side effects stay identical to the single-item path. Results are summarized in one toast; partial failures are reported without losing the successes.

### Files to touch
- `internal/allowance/handlers.go` — add `BatchApproveCompletionsHandler` / `BatchRejectCompletionsHandler`, reusing the existing per-completion logic and push-notification goroutine.
- `internal/allowance/handlers_test.go` — tests for the new handlers.
- `internal/api/router.go` — register `POST /api/allowance/approve/batch` and `POST /api/allowance/reject/batch` in the same auth group as the existing `/allowance/approve/{id}` route.
- `web/src/pages/AllowancePage.tsx` — selection state, checkboxes, select-all, action bar, batch fetch calls, toast summary.
- `web/public/locales/{en,nb,th}/allowance.json` — new keys for select mode, select all, approve/reject selected, and the result toast.
- `web/src/pages/__tests__/AllowancePageBulkApproval.test.tsx` (new) — frontend tests for selection + batch calls.
- `changelog.d/<slug>.md` (new) — `category: Added` fragment.

### Acceptance criteria
- A parent on the Today tab can enter selection mode, tick individual pending completions, and use a select-all control that toggles every currently listed pending item.
- With ≥1 item selected, "Approve selected" and "Reject selected" are enabled; with 0 selected they are disabled or hidden.
- Approving N selected items issues a single request; the approved rows disappear, the pending badge count drops by N, and payouts data is invalidated/refetched.
- Rejecting selected items behaves the same and sends the same empty-reason payload the single-item reject uses today.
- One toast summarizes the outcome (e.g. "3 approved"); if some IDs fail, the toast states how many succeeded and how many failed, and failed rows remain in the list.
- The batch endpoints require parent role, validate the ID array (reject empty/oversized/non-numeric input with 400), skip-and-report IDs that are not found or no longer pending instead of failing the whole request, and return per-ID status.
- Approved children still receive the same push notification (respecting quiet hours) as the single-approve path.
- Per-item approve/reject buttons and the photo preview still work unchanged when not in selection mode.
- The layout works at 375px width; all new strings come from `react-i18next` and exist in en, nb, and th.
- `go test ./...`, `go vet ./...`, `npm run lint`, `npm run build`, and the frontend test suite pass.

### Non-goals
- No bulk actions for extras (`/allowance/extras/{id}/approve`) or any tab other than Today.
- No new bulk approval on the kid-facing `MyChoresPage.tsx`.
- No reject-reason input for bulk rejection (reason stays empty, as in the current single-item UI).
- No undo of a bulk action, no schema changes, and no transactional all-or-nothing semantics.
- No changes to the pending-count badge logic beyond it reflecting the updated list.

## Source

Created from Suggestions page (suggestion id 186, page slug "allowance", source=claude).

## Original suggestion

The Today tab lists pending completions that parents must approve one at a time, which is tedious for families with several kids and daily chores — the recently added pending-count badge highlights how high that volume can get. Add a selection mode (checkboxes plus a select-all control) and an 'Approve selected' / 'Reject selected' action backed by a batch endpoint that reuses the existing single-completion approval logic. Parents could then clear a full day's queue in one tap instead of N round-trips, with a single toast summarizing how many were approved. Keep per-item approve/reject for cases where a parent wants to inspect a photo before deciding.


---
Bead: Hytte-ixksh | Branch: forge/Hytte-ixksh
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->