### PR TITLE
Show device and last-active info in session management so users can identify sessions (Hytte-kuij4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,8 +155,9 @@ All prefixed with `/api/`.
 | GET | /weather/locations | Public | Available Norwegian cities |
 | GET | /settings/preferences | Required | Get user prefs |
 | PUT | /settings/preferences | Required | Set a preference |
-| GET | /settings/sessions | Required | List active sessions |
+| GET | /settings/sessions | Required | List active sessions (device label + last-active) |
 | POST | /settings/sessions/revoke-others | Required | Sign out other sessions |
+| DELETE | /settings/sessions/{id} | Required | Revoke a single session by token prefix |
 | GET | /settings/export | Required | Stream a JSON archive of the user's profile, notes, workouts, lactate tests, preferences and session metadata |
 | DELETE | /settings/account | Required | Delete account + cascade |
 

--- a/changelog.d/Hytte-kuij4.md
+++ b/changelog.d/Hytte-kuij4.md
@@ -1,0 +1,2 @@
+category: Added
+- **Device and last-active info in session management** - Settings → Security now shows a friendly device label (e.g. "Safari on iPhone") and a relative last-active time for each session, plus a per-session sign-out button so a single unfamiliar device can be revoked without signing out everywhere. (Hytte-kuij4)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -305,6 +305,7 @@ func NewRouter(db *sql.DB) http.Handler {
 			// Session management.
 			r.Get("/settings/sessions", auth.SessionsListHandler(db))
 			r.Post("/settings/sessions/revoke-others", auth.SignOutEverywhereHandler(db))
+			r.Delete("/settings/sessions/{id}", auth.SessionRevokeHandler(db))
 
 			// Self-service data export (JSON archive of the user's own data).
 			r.Get("/settings/export", export.ExportHandler(db))

--- a/internal/auth/features_test.go
+++ b/internal/auth/features_test.go
@@ -40,7 +40,8 @@ func setupFeaturesTestDB(t *testing.T) *sql.DB {
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			expires_at DATETIME NOT NULL,
 			user_agent TEXT NOT NULL DEFAULT '',
-			ip_address TEXT NOT NULL DEFAULT ''
+			ip_address TEXT NOT NULL DEFAULT '',
+			last_seen_at DATETIME
 		);
 		CREATE TABLE user_preferences (
 			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -22,7 +22,7 @@ func RequireAuth(db *sql.DB) func(http.Handler) http.Handler {
 				return
 			}
 
-			userID, err := ValidateSession(db, cookie.Value)
+			userID, err := ValidateSessionAndTouch(db, cookie.Value)
 			if err != nil {
 				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 				return
@@ -63,7 +63,7 @@ func OptionalAuth(db *sql.DB) func(http.Handler) http.Handler {
 				return
 			}
 
-			userID, err := ValidateSession(db, cookie.Value)
+			userID, err := ValidateSessionAndTouch(db, cookie.Value)
 			if err != nil {
 				next.ServeHTTP(w, r)
 				return

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -24,6 +24,14 @@ func hashToken(token string) string {
 
 const sessionDuration = 30 * 24 * time.Hour // 30 days
 
+// touchInterval is the minimum gap between last_seen_at writes for a session.
+// Every authenticated request would otherwise write to the sessions table.
+const touchInterval = 5 * time.Minute
+
+// maxUserAgentLength caps how much of a User-Agent header we keep. Real agents
+// are well under this; the cap keeps a hostile client from bloating the row.
+const maxUserAgentLength = 512
+
 // SessionMeta describes the sign-in that created a session. It is stored
 // alongside the session so a user can tell their sessions apart in the settings
 // page and in the data export. Both fields are encrypted at rest.
@@ -41,8 +49,12 @@ func CreateSession(db *sql.DB, userID int64) (string, time.Time, error) {
 // CreateSessionForRequest creates a session and records the user agent and
 // client IP of the request that signed in.
 func CreateSessionForRequest(db *sql.DB, userID int64, r *http.Request) (string, time.Time, error) {
+	ua := r.UserAgent()
+	if len(ua) > maxUserAgentLength {
+		ua = ua[:maxUserAgentLength]
+	}
 	return CreateSessionWithMeta(db, userID, SessionMeta{
-		UserAgent: r.UserAgent(),
+		UserAgent: ua,
 		IPAddress: ClientIP(r),
 	})
 }
@@ -55,13 +67,15 @@ func CreateSessionWithMeta(db *sql.DB, userID int64, meta SessionMeta) (string, 
 		return "", time.Time{}, fmt.Errorf("generate token: %w", err)
 	}
 
-	expiresAt := time.Now().Add(sessionDuration)
+	now := time.Now()
+	expiresAt := now.Add(sessionDuration)
 
 	_, err = db.Exec(
-		"INSERT INTO sessions (token, user_id, expires_at, user_agent, ip_address) VALUES (?, ?, ?, ?, ?)",
+		"INSERT INTO sessions (token, user_id, expires_at, user_agent, ip_address, last_seen_at) VALUES (?, ?, ?, ?, ?, ?)",
 		hashToken(token), userID, expiresAt,
 		encryptSessionMeta("user_agent", meta.UserAgent),
 		encryptSessionMeta("ip_address", meta.IPAddress),
+		now,
 	)
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("insert session: %w", err)
@@ -104,12 +118,50 @@ func ClientIP(r *http.Request) string {
 // ValidateSession looks up a session token and returns the associated user ID.
 // Returns sql.ErrNoRows if the session is invalid or expired.
 func ValidateSession(db *sql.DB, token string) (int64, error) {
-	var userID int64
-	err := db.QueryRow(
-		"SELECT user_id FROM sessions WHERE token = ? AND expires_at > ?",
-		hashToken(token), time.Now(),
-	).Scan(&userID)
+	userID, _, err := validateSession(db, token)
 	return userID, err
+}
+
+// ValidateSessionAndTouch validates a session and, at most once every
+// touchInterval, records that the session was just used. A failed touch is
+// logged but never fails the request — last-seen is informational only.
+func ValidateSessionAndTouch(db *sql.DB, token string) (int64, error) {
+	userID, lastSeen, err := validateSession(db, token)
+	if err != nil {
+		return 0, err
+	}
+	now := time.Now()
+	if now.Sub(lastSeen) > touchInterval {
+		if err := TouchSession(db, token, now); err != nil {
+			log.Printf("Warning: failed to update session last_seen_at: %v", err)
+		}
+	}
+	return userID, nil
+}
+
+// validateSession looks up a session and returns the user ID together with the
+// last time the session was seen. Sessions created before last-seen tracking
+// existed report the zero time.
+func validateSession(db *sql.DB, token string) (int64, time.Time, error) {
+	var userID int64
+	var lastSeen sql.NullTime
+	err := db.QueryRow(
+		"SELECT user_id, last_seen_at FROM sessions WHERE token = ? AND expires_at > ?",
+		hashToken(token), time.Now(),
+	).Scan(&userID, &lastSeen)
+	if err != nil {
+		return 0, time.Time{}, err
+	}
+	return userID, lastSeen.Time, nil
+}
+
+// TouchSession records that a session was used at the given time.
+func TouchSession(db *sql.DB, token string, at time.Time) error {
+	_, err := db.Exec(
+		"UPDATE sessions SET last_seen_at = ? WHERE token = ?",
+		at, hashToken(token),
+	)
+	return err
 }
 
 // DeleteSession removes a session from the database.

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -37,7 +37,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			expires_at DATETIME NOT NULL,
 			user_agent TEXT NOT NULL DEFAULT '',
-			ip_address TEXT NOT NULL DEFAULT ''
+			ip_address TEXT NOT NULL DEFAULT '',
+			last_seen_at DATETIME
 		);
 		CREATE TABLE user_preferences (
 			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -204,6 +205,92 @@ func TestClientIP(t *testing.T) {
 				t.Errorf("ClientIP() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestValidateSessionAndTouch_ThrottlesWrites(t *testing.T) {
+	db := setupTestDB(t)
+	userID := createTestUser(t, db)
+
+	token, _, err := CreateSession(db, userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	lastSeen := func() time.Time {
+		t.Helper()
+		var seen sql.NullTime
+		if err := db.QueryRow(
+			"SELECT last_seen_at FROM sessions WHERE token = ?", hashToken(token),
+		).Scan(&seen); err != nil {
+			t.Fatalf("select last_seen_at: %v", err)
+		}
+		if !seen.Valid {
+			t.Fatal("expected last_seen_at to be set")
+		}
+		return seen.Time
+	}
+
+	// A session is stamped on creation, so an immediate request must not write.
+	atCreation := lastSeen()
+	if _, err := ValidateSessionAndTouch(db, token); err != nil {
+		t.Fatalf("ValidateSessionAndTouch: %v", err)
+	}
+	if got := lastSeen(); !got.Equal(atCreation) {
+		t.Errorf("last_seen_at moved inside the throttle window: %v -> %v", atCreation, got)
+	}
+
+	// Backdate past the throttle window: the next request should refresh it.
+	stale := time.Now().Add(-2 * touchInterval)
+	if _, err := db.Exec(
+		"UPDATE sessions SET last_seen_at = ? WHERE token = ?", stale, hashToken(token),
+	); err != nil {
+		t.Fatalf("backdate last_seen_at: %v", err)
+	}
+	if _, err := ValidateSessionAndTouch(db, token); err != nil {
+		t.Fatalf("ValidateSessionAndTouch after backdating: %v", err)
+	}
+	if got := lastSeen(); !got.After(stale) {
+		t.Errorf("expected last_seen_at to advance past %v, got %v", stale, got)
+	}
+}
+
+func TestValidateSessionAndTouch_LegacyRowWithoutLastSeen(t *testing.T) {
+	db := setupTestDB(t)
+	userID := createTestUser(t, db)
+
+	// A session created before last-seen tracking existed has a NULL column.
+	if _, err := db.Exec(
+		"INSERT INTO sessions (token, user_id, expires_at) VALUES (?, ?, ?)",
+		hashToken("legacy-token"), userID, time.Now().Add(time.Hour),
+	); err != nil {
+		t.Fatalf("insert legacy session: %v", err)
+	}
+
+	gotID, err := ValidateSessionAndTouch(db, "legacy-token")
+	if err != nil {
+		t.Fatalf("ValidateSessionAndTouch: %v", err)
+	}
+	if gotID != userID {
+		t.Errorf("expected user %d, got %d", userID, gotID)
+	}
+
+	var seen sql.NullTime
+	if err := db.QueryRow(
+		"SELECT last_seen_at FROM sessions WHERE token = ?", hashToken("legacy-token"),
+	).Scan(&seen); err != nil {
+		t.Fatalf("select last_seen_at: %v", err)
+	}
+	if !seen.Valid {
+		t.Error("expected a legacy session to get a last_seen_at on first use")
+	}
+}
+
+func TestValidateSessionAndTouch_Invalid(t *testing.T) {
+	db := setupTestDB(t)
+
+	if _, err := ValidateSessionAndTouch(db, "nonexistent-token"); err != sql.ErrNoRows {
+		t.Errorf("expected ErrNoRows, got %v", err)
 	}
 }
 

--- a/internal/auth/settings_handlers.go
+++ b/internal/auth/settings_handlers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/go-chi/chi/v5"
 )
 
 // validCLIPathRe matches safe CLI paths: alphanumeric, slashes, backslashes,
@@ -498,7 +499,7 @@ func SessionsListHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		rows, err := db.Query(
-			"SELECT token, created_at, expires_at FROM sessions WHERE user_id = ? AND expires_at > ? ORDER BY created_at DESC",
+			"SELECT token, created_at, expires_at, user_agent, last_seen_at FROM sessions WHERE user_id = ? AND expires_at > ? ORDER BY created_at DESC",
 			user.ID, time.Now(),
 		)
 		if err != nil {
@@ -509,17 +510,20 @@ func SessionsListHandler(db *sql.DB) http.HandlerFunc {
 		defer rows.Close()
 
 		type sessionInfo struct {
-			ID        string `json:"id"`
-			CreatedAt string `json:"created_at"`
-			ExpiresAt string `json:"expires_at"`
-			Current   bool   `json:"current"`
+			ID          string  `json:"id"`
+			CreatedAt   string  `json:"created_at"`
+			ExpiresAt   string  `json:"expires_at"`
+			DeviceLabel string  `json:"device_label"`
+			LastSeenAt  *string `json:"last_seen_at"`
+			Current     bool    `json:"current"`
 		}
 
 		var sessions []sessionInfo
 		for rows.Next() {
-			var token string
+			var token, userAgent string
 			var createdAt, expiresAt time.Time
-			if err := rows.Scan(&token, &createdAt, &expiresAt); err != nil {
+			var lastSeenAt sql.NullTime
+			if err := rows.Scan(&token, &createdAt, &expiresAt, &userAgent, &lastSeenAt); err != nil {
 				log.Printf("Failed to scan session: %v", err)
 				continue
 			}
@@ -529,11 +533,18 @@ func SessionsListHandler(db *sql.DB) http.HandlerFunc {
 			if len(displayID) > 8 {
 				displayID = displayID[:8]
 			}
+			var lastSeen *string
+			if lastSeenAt.Valid {
+				formatted := lastSeenAt.Time.Format(time.RFC3339)
+				lastSeen = &formatted
+			}
 			sessions = append(sessions, sessionInfo{
-				ID:        displayID,
-				CreatedAt: createdAt.Format(time.RFC3339),
-				ExpiresAt: expiresAt.Format(time.RFC3339),
-				Current:   token == currentTokenHash,
+				ID:          displayID,
+				CreatedAt:   createdAt.Format(time.RFC3339),
+				ExpiresAt:   expiresAt.Format(time.RFC3339),
+				DeviceLabel: DeviceLabel(decryptSessionUserAgent(userAgent)),
+				LastSeenAt:  lastSeen,
+				Current:     token == currentTokenHash,
 			})
 		}
 		if sessions == nil {
@@ -541,6 +552,95 @@ func SessionsListHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{"sessions": sessions})
+	}
+}
+
+// decryptSessionUserAgent decrypts a stored session user agent. Sessions created
+// before user agents were captured hold an empty string, and a decrypt failure
+// means the value is unusable — both return "" so the caller falls back to a
+// generic device label.
+func decryptSessionUserAgent(stored string) string {
+	if stored == "" {
+		return ""
+	}
+	ua, err := encryption.DecryptField(stored)
+	if err != nil {
+		log.Printf("Warning: failed to decrypt session user agent: %v", err)
+		return ""
+	}
+	return ua
+}
+
+// sessionIDRe matches the token prefix used as a session ID in the API. Session
+// tokens are hex, so anything else can never match a row.
+var sessionIDRe = regexp.MustCompile(`^[0-9a-f]{4,64}$`)
+
+// SessionRevokeHandler deletes a single session belonging to the authenticated
+// user, identified by the token prefix returned from SessionsListHandler.
+func SessionRevokeHandler(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user := UserFromContext(r.Context())
+
+		id := chi.URLParam(r, "id")
+		if !sessionIDRe.MatchString(id) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+			return
+		}
+
+		var currentTokenHash string
+		if cookie, err := r.Cookie("session"); err == nil {
+			currentTokenHash = hashToken(cookie.Value)
+		}
+
+		// Resolve the prefix against this user's sessions only, so one user can
+		// never revoke (or probe for) another user's session.
+		rows, err := db.Query(
+			"SELECT token FROM sessions WHERE user_id = ? AND token LIKE ? || '%'",
+			user.ID, id,
+		)
+		if err != nil {
+			log.Printf("Failed to look up session for revoke: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to revoke session"})
+			return
+		}
+		defer rows.Close()
+
+		var matches []string
+		for rows.Next() {
+			var token string
+			if err := rows.Scan(&token); err != nil {
+				log.Printf("Failed to scan session for revoke: %v", err)
+				continue
+			}
+			matches = append(matches, token)
+		}
+		if err := rows.Err(); err != nil {
+			log.Printf("Failed to iterate sessions for revoke: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to revoke session"})
+			return
+		}
+
+		// An unknown or ambiguous prefix is indistinguishable from "no such
+		// session" as far as the caller is concerned.
+		if len(matches) != 1 {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+			return
+		}
+		if matches[0] == currentTokenHash {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "cannot revoke the current session; sign out instead"})
+			return
+		}
+
+		if _, err := db.Exec(
+			"DELETE FROM sessions WHERE token = ? AND user_id = ?",
+			matches[0], user.ID,
+		); err != nil {
+			log.Printf("Failed to revoke session: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to revoke session"})
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/auth/settings_handlers_test.go
+++ b/internal/auth/settings_handlers_test.go
@@ -1,13 +1,16 @@
 package auth
 
 import (
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
+	"github.com/go-chi/chi/v5"
 )
 
 func TestPreferencesGetHandler_Empty(t *testing.T) {
@@ -963,17 +966,7 @@ func TestSessionsListHandler(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	var resp struct {
-		Sessions []struct {
-			ID        string `json:"id"`
-			CreatedAt string `json:"created_at"`
-			ExpiresAt string `json:"expires_at"`
-			Current   bool   `json:"current"`
-		} `json:"sessions"`
-	}
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	resp := decodeSessionsList(t, rec)
 	if len(resp.Sessions) != 1 {
 		t.Fatalf("expected 1 session, got %d", len(resp.Sessions))
 	}
@@ -983,6 +976,257 @@ func TestSessionsListHandler(t *testing.T) {
 	expectedID := hashToken(token)[:8]
 	if resp.Sessions[0].ID != expectedID {
 		t.Errorf("expected ID %s, got %s", expectedID, resp.Sessions[0].ID)
+	}
+	// A session created without a request has no user agent to label.
+	if resp.Sessions[0].DeviceLabel != UnknownDeviceLabel {
+		t.Errorf("expected %q, got %q", UnknownDeviceLabel, resp.Sessions[0].DeviceLabel)
+	}
+	if resp.Sessions[0].LastSeenAt == nil {
+		t.Error("expected last_seen_at to be set on a fresh session")
+	}
+}
+
+// sessionListItem mirrors one entry returned by SessionsListHandler.
+type sessionListItem struct {
+	ID          string  `json:"id"`
+	CreatedAt   string  `json:"created_at"`
+	ExpiresAt   string  `json:"expires_at"`
+	DeviceLabel string  `json:"device_label"`
+	LastSeenAt  *string `json:"last_seen_at"`
+	Current     bool    `json:"current"`
+}
+
+type sessionsListResponse struct {
+	Sessions []sessionListItem `json:"sessions"`
+}
+
+func decodeSessionsList(t *testing.T, rec *httptest.ResponseRecorder) sessionsListResponse {
+	t.Helper()
+	var resp sessionsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+// listSessions runs SessionsListHandler behind RequireAuth for the given token.
+func listSessions(t *testing.T, db *sql.DB, token string) sessionsListResponse {
+	t.Helper()
+	handler := RequireAuth(db)(SessionsListHandler(db))
+	req := httptest.NewRequest("GET", "/api/settings/sessions", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: token})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	return decodeSessionsList(t, rec)
+}
+
+func TestSessionsListHandler_DeviceLabelFromUserAgent(t *testing.T) {
+	t.Setenv("ENCRYPTION_KEY", "test-key-session-device-label")
+	encryption.ResetEncryptionKey()
+	defer encryption.ResetEncryptionKey()
+
+	db := setupTestDB(t)
+	userID := createTestUser(t, db)
+
+	signIn := httptest.NewRequest("GET", "/api/auth/google/callback", nil)
+	signIn.Header.Set("User-Agent", "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1")
+	token, _, err := CreateSessionForRequest(db, userID, signIn)
+	if err != nil {
+		t.Fatalf("CreateSessionForRequest: %v", err)
+	}
+
+	resp := listSessions(t, db, token)
+	if len(resp.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(resp.Sessions))
+	}
+	if resp.Sessions[0].DeviceLabel != "Safari on iPhone" {
+		t.Errorf("expected %q, got %q", "Safari on iPhone", resp.Sessions[0].DeviceLabel)
+	}
+	if resp.Sessions[0].LastSeenAt == nil {
+		t.Fatal("expected last_seen_at to be set")
+	}
+	if _, err := time.Parse(time.RFC3339, *resp.Sessions[0].LastSeenAt); err != nil {
+		t.Errorf("last_seen_at is not RFC3339: %v", err)
+	}
+}
+
+func TestSessionsListHandler_LegacySessionWithoutMetadata(t *testing.T) {
+	db := setupTestDB(t)
+	userID := createTestUser(t, db)
+
+	// The current session, plus a row predating user_agent/last_seen_at.
+	token, _, err := CreateSession(db, userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := db.Exec(
+		"INSERT INTO sessions (token, user_id, expires_at) VALUES (?, ?, ?)",
+		hashToken("legacy-token"), userID, time.Now().Add(time.Hour),
+	); err != nil {
+		t.Fatalf("insert legacy session: %v", err)
+	}
+
+	resp := listSessions(t, db, token)
+	if len(resp.Sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(resp.Sessions))
+	}
+	var legacy *sessionListItem
+	for i := range resp.Sessions {
+		if resp.Sessions[i].ID == hashToken("legacy-token")[:8] {
+			legacy = &resp.Sessions[i]
+		}
+	}
+	if legacy == nil {
+		t.Fatal("legacy session missing from the list")
+	}
+	if legacy.DeviceLabel != UnknownDeviceLabel {
+		t.Errorf("expected %q, got %q", UnknownDeviceLabel, legacy.DeviceLabel)
+	}
+	if legacy.LastSeenAt != nil {
+		t.Errorf("expected last_seen_at to be null, got %q", *legacy.LastSeenAt)
+	}
+}
+
+// revokeSession runs SessionRevokeHandler behind a chi router so {id} resolves.
+func revokeSession(t *testing.T, db *sql.DB, cookieToken, id string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := chi.NewRouter()
+	r.With(RequireAuth(db)).Delete("/api/settings/sessions/{id}", SessionRevokeHandler(db))
+	req := httptest.NewRequest("DELETE", "/api/settings/sessions/"+id, nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: cookieToken})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestSessionRevokeHandler_DeletesOnlyTheTargetSession(t *testing.T) {
+	db := setupTestDB(t)
+	userID := createTestUser(t, db)
+
+	current, _, err := CreateSession(db, userID)
+	if err != nil {
+		t.Fatalf("CreateSession current: %v", err)
+	}
+	other, _, err := CreateSession(db, userID)
+	if err != nil {
+		t.Fatalf("CreateSession other: %v", err)
+	}
+
+	rec := revokeSession(t, db, current, hashToken(other)[:8])
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	// The revoked session's cookie is rejected on its next request.
+	if _, err := ValidateSession(db, other); err != sql.ErrNoRows {
+		t.Errorf("expected the revoked session to be gone, got %v", err)
+	}
+	if _, err := ValidateSession(db, current); err != nil {
+		t.Errorf("current session should survive: %v", err)
+	}
+}
+
+func TestSessionRevokeHandler_CurrentSession(t *testing.T) {
+	db := setupTestDB(t)
+	userID := createTestUser(t, db)
+
+	current, _, err := CreateSession(db, userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	rec := revokeSession(t, db, current, hashToken(current)[:8])
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	if _, err := ValidateSession(db, current); err != nil {
+		t.Errorf("current session should survive: %v", err)
+	}
+}
+
+func TestSessionRevokeHandler_UnknownAndInvalidIDs(t *testing.T) {
+	db := setupTestDB(t)
+	userID := createTestUser(t, db)
+
+	current, _, err := CreateSession(db, userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Unknown prefix, too short, non-hex, and uppercase all fail to resolve.
+	for _, id := range []string{"deadbeef", "abc", "zzzzzzzz", "DEADBEEF"} {
+		rec := revokeSession(t, db, current, id)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("id %q: expected 404, got %d", id, rec.Code)
+		}
+	}
+}
+
+func TestSessionRevokeHandler_AmbiguousPrefix(t *testing.T) {
+	db := setupTestDB(t)
+	userID := createTestUser(t, db)
+
+	current, _, err := CreateSession(db, userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	// Two sessions sharing a prefix: the prefix alone can't identify either.
+	for _, token := range []string{"aaaa1111", "aaaa2222"} {
+		if _, err := db.Exec(
+			"INSERT INTO sessions (token, user_id, expires_at) VALUES (?, ?, ?)",
+			token, userID, time.Now().Add(time.Hour),
+		); err != nil {
+			t.Fatalf("insert session %s: %v", token, err)
+		}
+	}
+
+	rec := revokeSession(t, db, current, "aaaa")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for an ambiguous prefix, got %d", rec.Code)
+	}
+	var remaining int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM sessions WHERE token LIKE 'aaaa%'",
+	).Scan(&remaining); err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if remaining != 2 {
+		t.Errorf("expected both ambiguous sessions to survive, got %d", remaining)
+	}
+}
+
+func TestSessionRevokeHandler_OtherUsersSession(t *testing.T) {
+	db := setupTestDB(t)
+	userID := createTestUser(t, db)
+
+	if _, err := db.Exec(
+		"INSERT INTO users (google_id, email, name) VALUES ('g-other', 'other@test.com', 'Other')",
+	); err != nil {
+		t.Fatalf("insert other user: %v", err)
+	}
+	var otherID int64
+	if err := db.QueryRow("SELECT id FROM users WHERE google_id = 'g-other'").Scan(&otherID); err != nil {
+		t.Fatalf("select other user: %v", err)
+	}
+
+	current, _, err := CreateSession(db, userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	victim, _, err := CreateSession(db, otherID)
+	if err != nil {
+		t.Fatalf("CreateSession victim: %v", err)
+	}
+
+	rec := revokeSession(t, db, current, hashToken(victim)[:8])
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+	if _, err := ValidateSession(db, victim); err != nil {
+		t.Errorf("another user's session must not be revoked: %v", err)
 	}
 }
 

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -86,7 +86,7 @@ func RequireAuthOrToken(db *sql.DB) func(http.Handler) http.Handler {
 				return
 			}
 
-			userID, err := ValidateSession(db, cookie.Value)
+			userID, err := ValidateSessionAndTouch(db, cookie.Value)
 			if err != nil {
 				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 				return

--- a/internal/auth/useragent.go
+++ b/internal/auth/useragent.go
@@ -1,0 +1,95 @@
+package auth
+
+import "strings"
+
+// UnknownDeviceLabel is returned by DeviceLabel when nothing recognisable can be
+// derived from the User-Agent. The frontend matches on this exact value to show a
+// localized placeholder instead.
+const UnknownDeviceLabel = "Unknown device"
+
+// DeviceLabel derives a short, human-friendly description of the device behind a
+// User-Agent string, e.g. "Chrome on Windows" or "Safari on iPhone".
+//
+// It is deliberately dependency-free and best-effort: User-Agent strings are
+// spoofable and full of legacy tokens, so the goal is only to help a user tell
+// their own sessions apart. Anything unrecognised becomes UnknownDeviceLabel.
+func DeviceLabel(ua string) string {
+	ua = strings.TrimSpace(ua)
+	if ua == "" {
+		return UnknownDeviceLabel
+	}
+
+	browser := browserName(ua)
+	platform := platformName(ua)
+
+	switch {
+	case browser != "" && platform != "":
+		return browser + " on " + platform
+	case browser != "":
+		return browser
+	case platform != "":
+		return platform
+	default:
+		return UnknownDeviceLabel
+	}
+}
+
+// browserName picks the browser out of a User-Agent. Order matters: Chromium
+// forks all carry "Chrome" (and often "Safari") in their UA, so the more
+// specific tokens must be tested first.
+func browserName(ua string) string {
+	switch {
+	case strings.Contains(ua, "Edg/"), strings.Contains(ua, "EdgA/"), strings.Contains(ua, "EdgiOS/"), strings.Contains(ua, "Edge/"):
+		return "Edge"
+	case strings.Contains(ua, "OPR/"), strings.Contains(ua, "Opera"):
+		return "Opera"
+	case strings.Contains(ua, "SamsungBrowser/"):
+		return "Samsung Internet"
+	case strings.Contains(ua, "Firefox/"), strings.Contains(ua, "FxiOS/"):
+		return "Firefox"
+	case strings.Contains(ua, "CriOS/"), strings.Contains(ua, "Chrome/"), strings.Contains(ua, "Chromium/"):
+		return "Chrome"
+	// Safari only claims the name when it also reports a Version/ token; the
+	// bare "Safari/" suffix is shared by every WebKit-derived UA.
+	case strings.Contains(ua, "Safari/") && strings.Contains(ua, "Version/"):
+		return "Safari"
+	case strings.HasPrefix(ua, "curl/"):
+		return "curl"
+	case strings.HasPrefix(ua, "Wget/"):
+		return "Wget"
+	case containsFold(ua, "bot"), containsFold(ua, "crawler"), containsFold(ua, "spider"):
+		return "Bot"
+	default:
+		return ""
+	}
+}
+
+// platformName picks the operating system or device out of a User-Agent.
+func platformName(ua string) string {
+	switch {
+	case strings.Contains(ua, "iPhone"):
+		return "iPhone"
+	case strings.Contains(ua, "iPad"):
+		return "iPad"
+	case strings.Contains(ua, "iPod"):
+		return "iPod"
+	case strings.Contains(ua, "Android"):
+		return "Android"
+	case strings.Contains(ua, "CrOS"):
+		return "ChromeOS"
+	case strings.Contains(ua, "Windows"):
+		return "Windows"
+	case strings.Contains(ua, "Macintosh"), strings.Contains(ua, "Mac OS X"):
+		return "macOS"
+	case strings.Contains(ua, "Linux"), strings.Contains(ua, "X11"):
+		return "Linux"
+	default:
+		return ""
+	}
+}
+
+// containsFold reports whether needle (already lowercase) occurs in s,
+// ignoring case.
+func containsFold(s, needle string) bool {
+	return strings.Contains(strings.ToLower(s), needle)
+}

--- a/internal/auth/useragent_test.go
+++ b/internal/auth/useragent_test.go
@@ -1,0 +1,113 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeviceLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		ua   string
+		want string
+	}{
+		{
+			name: "Chrome on Windows",
+			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+			want: "Chrome on Windows",
+		},
+		{
+			name: "Chrome on Android",
+			ua:   "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36",
+			want: "Chrome on Android",
+		},
+		{
+			name: "Chrome on iOS reports CriOS",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.0.0 Mobile/15E148 Safari/604.1",
+			want: "Chrome on iPhone",
+		},
+		{
+			name: "Safari on iPhone",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+			want: "Safari on iPhone",
+		},
+		{
+			name: "Safari on iPad",
+			ua:   "Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+			want: "Safari on iPad",
+		},
+		{
+			name: "Safari on macOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+			want: "Safari on macOS",
+		},
+		{
+			name: "Firefox on Linux",
+			ua:   "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0",
+			want: "Firefox on Linux",
+		},
+		{
+			name: "Edge on Windows wins over the Chrome token",
+			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
+			want: "Edge on Windows",
+		},
+		{
+			name: "Opera wins over the Chrome token",
+			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 OPR/112.0.0.0",
+			want: "Opera on Windows",
+		},
+		{
+			name: "Samsung Internet on Android",
+			ua:   "Mozilla/5.0 (Linux; Android 14; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/121.0.0.0 Mobile Safari/537.36",
+			want: "Samsung Internet on Android",
+		},
+		{
+			name: "ChromeOS",
+			ua:   "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+			want: "Chrome on ChromeOS",
+		},
+		{
+			name: "curl has no platform",
+			ua:   "curl/8.5.0",
+			want: "curl",
+		},
+		{
+			name: "crawler",
+			ua:   "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+			want: "Bot",
+		},
+		{
+			name: "platform without a known browser",
+			ua:   "SomeApp/1.0 (Windows NT 10.0)",
+			want: "Windows",
+		},
+		{
+			name: "empty",
+			ua:   "",
+			want: UnknownDeviceLabel,
+		},
+		{
+			name: "whitespace only",
+			ua:   "   ",
+			want: UnknownDeviceLabel,
+		},
+		{
+			name: "garbage",
+			ua:   "???",
+			want: UnknownDeviceLabel,
+		},
+		{
+			name: "long garbage",
+			ua:   strings.Repeat("x", 2000),
+			want: UnknownDeviceLabel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DeviceLabel(tt.ua); got != tt.want {
+				t.Errorf("DeviceLabel(%q) = %q, want %q", tt.ua, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -125,7 +125,8 @@ func createSchema(db *sql.DB) error {
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 		expires_at DATETIME NOT NULL,
 		user_agent TEXT NOT NULL DEFAULT '',
-		ip_address TEXT NOT NULL DEFAULT ''
+		ip_address TEXT NOT NULL DEFAULT '',
+		last_seen_at DATETIME
 	);
 
 	CREATE TABLE IF NOT EXISTS user_preferences (
@@ -2949,6 +2950,21 @@ func createSchema(db *sql.DB) error {
 			if _, err := db.Exec(col.ddl); err != nil {
 				return fmt.Errorf("add sessions %s column: %w", col.name, err)
 			}
+		}
+	}
+
+	// Add last_seen_at to sessions (Hytte-kuij4): the last time the session made
+	// an authenticated request, refreshed at most once every few minutes. Nullable
+	// so existing sessions read back as "never seen" until their next request.
+	var hasSessionsLastSeen int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'last_seen_at'`,
+	).Scan(&hasSessionsLastSeen); err != nil {
+		return fmt.Errorf("check sessions last_seen_at column: %w", err)
+	}
+	if hasSessionsLastSeen == 0 {
+		if _, err := db.Exec(`ALTER TABLE sessions ADD COLUMN last_seen_at DATETIME`); err != nil {
+			return fmt.Errorf("add sessions last_seen_at column: %w", err)
 		}
 	}
 

--- a/internal/export/handler_test.go
+++ b/internal/export/handler_test.go
@@ -46,7 +46,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			expires_at DATETIME NOT NULL,
 			user_agent TEXT NOT NULL DEFAULT '',
-			ip_address TEXT NOT NULL DEFAULT ''
+			ip_address TEXT NOT NULL DEFAULT '',
+			last_seen_at DATETIME
 		);
 		CREATE TABLE user_preferences (
 			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/web/public/locales/en/settings.json
+++ b/web/public/locales/en/settings.json
@@ -151,7 +151,15 @@
     "current": "Current",
     "createdExpires": "Created {{created}} — Expires {{expires}}",
     "noSessions": "No active sessions found.",
-    "signOutEverywhere": "Sign out everywhere else"
+    "signOutEverywhere": "Sign out everywhere else",
+    "unknownDevice": "Unknown device",
+    "lastActive": "Active {{time}}",
+    "lastActiveUnknown": "Last active unknown",
+    "revoke": "Sign out",
+    "revokeConfirmPrompt": "Sign out this device?",
+    "revokeConfirm": "Sign out device",
+    "revokeCancel": "Cancel",
+    "revokeError": "Could not sign out that session. Please try again."
   },
   "integrations": {
     "heading": "Integrations",

--- a/web/public/locales/nb/settings.json
+++ b/web/public/locales/nb/settings.json
@@ -151,7 +151,15 @@
     "current": "Gjeldende",
     "createdExpires": "Opprettet {{created}} — Utløper {{expires}}",
     "noSessions": "Ingen aktive sesjoner funnet.",
-    "signOutEverywhere": "Logg ut alle andre steder"
+    "signOutEverywhere": "Logg ut alle andre steder",
+    "unknownDevice": "Ukjent enhet",
+    "lastActive": "Aktiv {{time}}",
+    "lastActiveUnknown": "Sist aktiv ukjent",
+    "revoke": "Logg ut",
+    "revokeConfirmPrompt": "Logge ut denne enheten?",
+    "revokeConfirm": "Logg ut enheten",
+    "revokeCancel": "Avbryt",
+    "revokeError": "Kunne ikke logge ut den sesjonen. Prøv igjen."
   },
   "integrations": {
     "heading": "Integrasjoner",

--- a/web/public/locales/th/settings.json
+++ b/web/public/locales/th/settings.json
@@ -151,7 +151,15 @@
     "current": "ปัจจุบัน",
     "createdExpires": "สร้าง {{created}} — หมดอายุ {{expires}}",
     "noSessions": "ไม่พบเซสชันที่ใช้งานอยู่",
-    "signOutEverywhere": "ออกจากระบบทุกที่อื่น"
+    "signOutEverywhere": "ออกจากระบบทุกที่อื่น",
+    "unknownDevice": "อุปกรณ์ที่ไม่รู้จัก",
+    "lastActive": "ใช้งาน {{time}}",
+    "lastActiveUnknown": "ไม่ทราบเวลาใช้งานล่าสุด",
+    "revoke": "ออกจากระบบ",
+    "revokeConfirmPrompt": "ออกจากระบบอุปกรณ์นี้หรือไม่?",
+    "revokeConfirm": "ออกจากระบบอุปกรณ์",
+    "revokeCancel": "ยกเลิก",
+    "revokeError": "ไม่สามารถออกจากระบบเซสชันนั้นได้ กรุณาลองอีกครั้ง"
   },
   "integrations": {
     "heading": "การเชื่อมต่อ",

--- a/web/src/pages/settings/SecuritySection.tsx
+++ b/web/src/pages/settings/SecuritySection.tsx
@@ -4,7 +4,8 @@ import { useNavigate } from 'react-router-dom'
 import { Download, Loader2 } from 'lucide-react'
 import { useAuth } from '../../auth'
 import { formatDate } from '../../utils/formatDate'
-import type { SessionInfo } from './types'
+import { timeAgo } from '../../utils/timeAgo'
+import { UNKNOWN_DEVICE_LABEL, type SessionInfo } from './types'
 
 /** Local-time YYYY-MM-DD, used as the export filename fallback. */
 function localDateStamp(): string {
@@ -21,10 +22,14 @@ function filenameFromDisposition(header: string | null): string {
 
 function SecuritySection() {
   const { t } = useTranslation(['settings', 'common'])
+  const { t: tCommon } = useTranslation('common')
   const { logout } = useAuth()
   const navigate = useNavigate()
   const [sessions, setSessions] = useState<SessionInfo[]>([])
   const [sessionsLoaded, setSessionsLoaded] = useState(false)
+  const [revokeConfirmId, setRevokeConfirmId] = useState<string | null>(null)
+  const [revokingId, setRevokingId] = useState<string | null>(null)
+  const [revokeError, setRevokeError] = useState<string | null>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleteConfirmText, setDeleteConfirmText] = useState('')
   const [isExporting, setIsExporting] = useState(false)
@@ -63,6 +68,27 @@ function SecuritySection() {
     const res = await fetch('/api/settings/sessions/revoke-others', { method: 'POST', credentials: 'include' })
     if (res.ok) {
       await fetchSessions()
+    }
+  }
+
+  const revokeSession = async (id: string) => {
+    setRevokingId(id)
+    setRevokeError(null)
+    try {
+      const res = await fetch(`/api/settings/sessions/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        throw new Error(`revoke failed with status ${res.status}`)
+      }
+      setRevokeConfirmId(null)
+      await fetchSessions()
+    } catch (err) {
+      console.error('Failed to revoke session:', err)
+      setRevokeError(t('sessions.revokeError'))
+    } finally {
+      setRevokingId(null)
     }
   }
 
@@ -116,11 +142,13 @@ function SecuritySection() {
         {sessions.map((session) => (
           <div
             key={session.id}
-            className="flex items-center justify-between bg-gray-700/50 rounded-lg px-4 py-3"
+            className="flex flex-col gap-2 bg-gray-700/50 rounded-lg px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
           >
-            <div>
+            <div className="min-w-0">
               <p className="text-sm font-medium">
-                {t('sessions.session', { id: session.id })}
+                {session.device_label && session.device_label !== UNKNOWN_DEVICE_LABEL
+                  ? session.device_label
+                  : t('sessions.unknownDevice')}
                 {session.current && (
                   <span className="ml-2 text-xs bg-green-600/20 text-green-400 px-2 py-0.5 rounded-full">
                     {t('sessions.current')}
@@ -128,14 +156,58 @@ function SecuritySection() {
                 )}
               </p>
               <p className="text-xs text-gray-400">
+                {session.last_seen_at
+                  ? t('sessions.lastActive', { time: timeAgo(session.last_seen_at, tCommon) })
+                  : t('sessions.lastActiveUnknown')}
+              </p>
+              <p className="text-xs text-gray-500">
+                {t('sessions.session', { id: session.id })} —{' '}
                 {t('sessions.createdExpires', {
                   created: formatDate(session.created_at),
                   expires: formatDate(session.expires_at),
                 })}
               </p>
             </div>
+            {!session.current && (
+              revokeConfirmId === session.id ? (
+                <div className="flex flex-col gap-2 sm:items-end shrink-0">
+                  <p className="text-xs text-gray-300">{t('sessions.revokeConfirmPrompt')}</p>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => revokeSession(session.id)}
+                      disabled={revokingId === session.id}
+                      className="bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed text-xs text-white px-3 py-1.5 rounded-lg transition-colors cursor-pointer"
+                    >
+                      {t('sessions.revokeConfirm')}
+                    </button>
+                    <button
+                      onClick={() => {
+                        setRevokeConfirmId(null)
+                        setRevokeError(null)
+                      }}
+                      className="bg-gray-700 hover:bg-gray-600 text-xs text-white px-3 py-1.5 rounded-lg transition-colors cursor-pointer"
+                    >
+                      {t('sessions.revokeCancel')}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  onClick={() => {
+                    setRevokeConfirmId(session.id)
+                    setRevokeError(null)
+                  }}
+                  className="bg-gray-700 hover:bg-gray-600 text-xs text-white px-3 py-1.5 rounded-lg transition-colors cursor-pointer shrink-0 self-start sm:self-auto"
+                >
+                  {t('sessions.revoke')}
+                </button>
+              )
+            )}
           </div>
         ))}
+        {revokeError && (
+          <p className="text-sm text-red-400" role="alert">{revokeError}</p>
+        )}
         {sessionsLoaded && sessions.length === 0 && (
           <p className="text-sm text-gray-400">{t('sessions.noSessions')}</p>
         )}

--- a/web/src/pages/settings/types.ts
+++ b/web/src/pages/settings/types.ts
@@ -15,8 +15,17 @@ export interface SessionInfo {
   id: string
   created_at: string
   expires_at: string
+  device_label: string
+  last_seen_at: string | null
   current: boolean
 }
+
+/**
+ * Value the backend sends when a session's User-Agent tells us nothing.
+ * Must match auth.UnknownDeviceLabel in internal/auth/useragent.go — the UI
+ * swaps it for a localized string.
+ */
+export const UNKNOWN_DEVICE_LABEL = 'Unknown device'
 
 export interface EventTypeInfo {
   key: string


### PR DESCRIPTION
## Changes

- **Device and last-active info in session management** - Settings → Security now shows a friendly device label (e.g. "Safari on iPhone") and a relative last-active time for each session, plus a per-session sign-out button so a single unfamiliar device can be revoked without signing out everywhere. (Hytte-kuij4)

## Original Issue (feature): Show device and last-active info in session management so users can identify sessions

### Scope
Add device identification and last-active tracking to sessions, plus per-session revoke. Capture the User-Agent at session creation, store it (encrypted) on the `sessions` row along with a throttled `last_seen_at`, derive a friendly device/browser label server-side, expose both in `GET /api/settings/sessions`, add `DELETE /api/settings/sessions/{id}`, and render label + relative last-active + a per-row revoke button in the Security section.

### Files to touch
- `internal/db/db.go` — `sessions` table gains `user_agent TEXT`, `last_seen_at DATETIME`; `ALTER TABLE` with `pragma_table_info` existence checks in the migration block (matching the existing pattern around line 2570)
- `internal/auth/session.go` — new `CreateSessionFromRequest(db, userID, r)` that captures/encrypts the UA (keep `CreateSession` as a thin wrapper so existing call sites and tests compile unchanged); `TouchSession` helper for last-seen
- `internal/auth/useragent.go` (new) — dependency-free UA → label parser (browser + OS/device, e.g. "Chrome on Windows", "Safari on iPhone"); falls back to "Unknown device"
- `internal/auth/useragent_test.go` (new) — table test over representative UA strings incl. empty/garbage
- `internal/auth/middleware.go` — after successful validation, update `last_seen_at` at most once per ~5 minutes per session
- `internal/auth/settings_handlers.go` — return `device_label` and `last_seen_at` from `SessionsListHandler`; new `SessionRevokeHandler`
- `internal/auth/handlers.go`, `internal/auth/test_login.go` — use `CreateSessionFromRequest`
- `internal/api/router.go` — `r.Delete("/settings/sessions/{id}", ...)` in the `RequireAuth` group
- `internal/auth/settings_handlers_test.go`, `internal/auth/session_test.go` — coverage
- `web/src/pages/settings/SecuritySection.tsx` — label, last-active, revoke button + confirm
- `web/public/locales/{en,nb,th}/settings.json` — new keys
- `CLAUDE.md` — add `user_agent` to the encrypted-fields list; add the new route to the API table
- `changelog.d/Hytte-<id>.md` (new)

### Acceptance criteria
- A fresh login stores an encrypted `user_agent`; existing rows keep working and show a generic "Unknown device" label.
- `GET /api/settings/sessions` returns `device_label` and `last_seen_at` per session; `last_seen_at` advances (within the throttle window) as the session makes requests.
- Settings → Security lists each session as e.g. "Safari on iPhone — active 2 hours ago", with the current session badged and its revoke button hidden.
- `DELETE /api/settings/sessions/{id}` removes only that session, only for the authenticated owner; returns 404 for an unknown/ambiguous id prefix and 400 for the current session. A revoked session's cookie is rejected on its next request.
- All new strings resolve in en/nb/th; the row layout is readable at 375px.
- `go test ./...`, `go vet`, `npm run lint`, `npm run build` pass.

### Non-goals
- No IP capture, geolocation, or location display.
- No third-party UA-parsing library; no full UA string shown in the UI.
- No push/email notification on new-device login.
- No change to session duration, hashing, or the existing "sign out other sessions" action.
- No session naming/renaming by the user.

## Source

Created from Suggestions page (suggestion id 234, page slug "settings", source=claude).

## Original suggestion

The active-sessions list exposes only an opaque session id plus created/expires timestamps, so a user cannot tell which entry is their phone versus their laptop and the only safe action is the blunt 'sign out other sessions'. Capture the User-Agent (and optionally a coarse last-seen time / IP-derived location) when a session is created, store it alongside the session, and surface a friendly device/browser label per row with a per-session revoke button. This lets users spot and kill a specific unfamiliar session, improving both security awareness and control.


---
Bead: Hytte-kuij4 | Branch: forge/Hytte-kuij4
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->