### PR TITLE
Preserve loaded pages and scroll position when returning from a workout detail (Hytte-oapfh)

### DIFF
--- a/changelog.d/Hytte-oapfh.md
+++ b/changelog.d/Hytte-oapfh.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Training list keeps your place when you come back** - Opening a workout and pressing back now restores every page you had loaded with "Load more", along with your scroll position, instead of resetting to the first page at the top. The list is shown immediately from a per-tab cache and refreshed in the background, so new, edited and deleted workouts still reconcile. A reload, a stale cache, or a different user always gets a fresh load. (Hytte-oapfh)

--- a/web/src/auth.tsx
+++ b/web/src/auth.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react'
+import { clearTrainingListCache } from './hooks/useTrainingListCache'
 
 interface User {
   id: number
@@ -74,6 +75,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await fetch('/api/auth/logout', { method: 'POST' })
     setUser(null)
     setFamilyStatus(null)
+    // Drop every cached training list in this tab, so signing in as a different
+    // user cannot surface the previous user's workouts.
+    clearTrainingListCache()
   }, [])
 
   const hasFeature = useCallback((key: string): boolean => {

--- a/web/src/hooks/useTrainingListCache.test.ts
+++ b/web/src/hooks/useTrainingListCache.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  useTrainingListCache,
+  readTrainingListCache,
+  writeTrainingListCache,
+  clearTrainingListCache,
+  trainingListCacheKey,
+  isReloadNavigation,
+  TRAINING_LIST_CACHE_VERSION,
+  TRAINING_LIST_CACHE_TTL_MS,
+  type TrainingListSnapshot,
+} from './useTrainingListCache'
+import type { Workout } from '../types/training'
+
+const makeWorkout = (id: number): Workout => ({
+  id,
+  user_id: 1,
+  sport: 'running',
+  title: `Run ${id}`,
+  started_at: '2026-01-01T08:00:00Z',
+  duration_seconds: 1800,
+  distance_meters: 5000,
+  avg_heart_rate: 150,
+  max_heart_rate: 170,
+  avg_pace_sec_per_km: 360,
+  avg_cadence: 0,
+  calories: 300,
+  ascent_meters: 0,
+  descent_meters: 0,
+  fit_file_hash: '',
+  analysis_status: '',
+  title_source: '',
+  created_at: '2026-01-01T08:00:00Z',
+  tags: [],
+})
+
+function primeRaw(userId: string, snapshot: Record<string, unknown> | string) {
+  window.sessionStorage.setItem(
+    trainingListCacheKey(userId),
+    typeof snapshot === 'string' ? snapshot : JSON.stringify(snapshot),
+  )
+}
+
+function validSnapshot(userId: string, overrides: Partial<TrainingListSnapshot> = {}) {
+  return {
+    version: TRAINING_LIST_CACHE_VERSION,
+    userId,
+    savedAt: Date.now(),
+    workouts: [makeWorkout(1)],
+    nextCursor: 'cursor-1',
+    latestWorkoutId: 1,
+    scrollY: 420,
+    ...overrides,
+  }
+}
+
+describe('useTrainingListCache', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('round-trips a snapshot', () => {
+    writeTrainingListCache('1', {
+      workouts: [makeWorkout(1), makeWorkout(2)],
+      nextCursor: 'cursor-2',
+      latestWorkoutId: 2,
+      scrollY: 300,
+    })
+
+    const snapshot = readTrainingListCache('1')
+    expect(snapshot).not.toBeNull()
+    expect(snapshot!.workouts.map(w => w.id)).toEqual([1, 2])
+    expect(snapshot!.nextCursor).toBe('cursor-2')
+    expect(snapshot!.latestWorkoutId).toBe(2)
+    expect(snapshot!.scrollY).toBe(300)
+  })
+
+  it('merges a partial write into the existing snapshot', () => {
+    writeTrainingListCache('1', { workouts: [makeWorkout(1)], nextCursor: 'c1', scrollY: 10 })
+    writeTrainingListCache('1', { scrollY: 900 })
+
+    const snapshot = readTrainingListCache('1')
+    expect(snapshot!.scrollY).toBe(900)
+    expect(snapshot!.workouts.map(w => w.id)).toEqual([1])
+    expect(snapshot!.nextCursor).toBe('c1')
+  })
+
+  it('scopes snapshots per user', () => {
+    writeTrainingListCache('1', { workouts: [makeWorkout(1)] })
+    writeTrainingListCache('2', { workouts: [makeWorkout(7)] })
+
+    expect(readTrainingListCache('1')!.workouts.map(w => w.id)).toEqual([1])
+    expect(readTrainingListCache('2')!.workouts.map(w => w.id)).toEqual([7])
+    expect(readTrainingListCache('3')).toBeNull()
+  })
+
+  it('ignores a snapshot whose stored userId does not match the reader', () => {
+    primeRaw('2', validSnapshot('1'))
+    expect(readTrainingListCache('2')).toBeNull()
+    // The mismatched entry is dropped rather than left to fail every read.
+    expect(window.sessionStorage.getItem(trainingListCacheKey('2'))).toBeNull()
+  })
+
+  it('ignores a snapshot written by a different cache version', () => {
+    primeRaw('1', validSnapshot('1', { version: TRAINING_LIST_CACHE_VERSION + 1 }))
+    expect(readTrainingListCache('1')).toBeNull()
+  })
+
+  it('ignores a snapshot older than the TTL', () => {
+    primeRaw('1', validSnapshot('1', { savedAt: Date.now() - TRAINING_LIST_CACHE_TTL_MS - 1000 }))
+    expect(readTrainingListCache('1')).toBeNull()
+    expect(window.sessionStorage.getItem(trainingListCacheKey('1'))).toBeNull()
+  })
+
+  it('keeps a snapshot inside the TTL', () => {
+    primeRaw('1', validSnapshot('1', { savedAt: Date.now() - (TRAINING_LIST_CACHE_TTL_MS - 1000) }))
+    expect(readTrainingListCache('1')).not.toBeNull()
+  })
+
+  it('ignores a snapshot timestamped in the future', () => {
+    primeRaw('1', validSnapshot('1', { savedAt: Date.now() + TRAINING_LIST_CACHE_TTL_MS * 2 }))
+    expect(readTrainingListCache('1')).toBeNull()
+  })
+
+  it('returns null for corrupt JSON instead of throwing', () => {
+    primeRaw('1', '{ not json at all')
+    expect(() => readTrainingListCache('1')).not.toThrow()
+    expect(readTrainingListCache('1')).toBeNull()
+    expect(window.sessionStorage.getItem(trainingListCacheKey('1'))).toBeNull()
+  })
+
+  it('returns null for a payload with the wrong shape', () => {
+    primeRaw('1', validSnapshot('1', { workouts: 'nope' as unknown as Workout[] }))
+    expect(readTrainingListCache('1')).toBeNull()
+  })
+
+  it('swallows a storage write failure', () => {
+    const setItem = vi.spyOn(window.sessionStorage, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError')
+    })
+
+    expect(() => writeTrainingListCache('1', { workouts: [makeWorkout(1)] })).not.toThrow()
+    expect(setItem).toHaveBeenCalled()
+    setItem.mockRestore()
+    expect(readTrainingListCache('1')).toBeNull()
+  })
+
+  it('returns null when reading throws', () => {
+    const getItem = vi.spyOn(window.sessionStorage, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+
+    expect(readTrainingListCache('1')).toBeNull()
+    getItem.mockRestore()
+  })
+
+  it('does nothing without a user id', () => {
+    writeTrainingListCache('', { workouts: [makeWorkout(1)] })
+    expect(window.sessionStorage.length).toBe(0)
+    expect(readTrainingListCache('')).toBeNull()
+  })
+
+  it('clears one user, or every user when called with no id', () => {
+    writeTrainingListCache('1', { workouts: [makeWorkout(1)] })
+    writeTrainingListCache('2', { workouts: [makeWorkout(2)] })
+
+    clearTrainingListCache('1')
+    expect(readTrainingListCache('1')).toBeNull()
+    expect(readTrainingListCache('2')).not.toBeNull()
+
+    clearTrainingListCache()
+    expect(readTrainingListCache('2')).toBeNull()
+  })
+
+  it('leaves unrelated sessionStorage keys alone when sweeping', () => {
+    window.sessionStorage.setItem('unrelated', 'keep me')
+    writeTrainingListCache('1', { workouts: [makeWorkout(1)] })
+
+    clearTrainingListCache()
+
+    expect(window.sessionStorage.getItem('unrelated')).toBe('keep me')
+  })
+
+  it('binds the helpers to a user id through the hook', () => {
+    const { result } = renderHook(() => useTrainingListCache(1))
+
+    act(() => {
+      result.current.write({ workouts: [makeWorkout(5)], nextCursor: 'c5', scrollY: 50 })
+    })
+    expect(result.current.read()!.workouts.map(w => w.id)).toEqual([5])
+    expect(readTrainingListCache('1')!.nextCursor).toBe('c5')
+
+    act(() => {
+      result.current.clear()
+    })
+    expect(result.current.read()).toBeNull()
+  })
+
+  it('returns a stable object for the same user and a new one when the user changes', () => {
+    const { result, rerender } = renderHook(({ id }: { id: number }) => useTrainingListCache(id), {
+      initialProps: { id: 1 },
+    })
+    const first = result.current
+    rerender({ id: 1 })
+    expect(result.current).toBe(first)
+
+    rerender({ id: 2 })
+    expect(result.current).not.toBe(first)
+
+    act(() => {
+      result.current.write({ workouts: [makeWorkout(9)] })
+    })
+    expect(readTrainingListCache('2')!.workouts.map(w => w.id)).toEqual([9])
+    expect(readTrainingListCache('1')).toBeNull()
+  })
+
+  it('is a no-op for a null user', () => {
+    const { result } = renderHook(() => useTrainingListCache(null))
+    act(() => {
+      result.current.write({ workouts: [makeWorkout(1)] })
+    })
+    expect(result.current.read()).toBeNull()
+    expect(window.sessionStorage.length).toBe(0)
+  })
+})
+
+describe('isReloadNavigation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports a reload navigation', () => {
+    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+      { type: 'reload' } as unknown as PerformanceEntry,
+    ])
+    expect(isReloadNavigation()).toBe(true)
+  })
+
+  it('reports a normal navigation', () => {
+    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+      { type: 'navigate' } as unknown as PerformanceEntry,
+    ])
+    expect(isReloadNavigation()).toBe(false)
+  })
+
+  it('treats an unavailable navigation entry as not a reload', () => {
+    vi.spyOn(performance, 'getEntriesByType').mockImplementation(() => {
+      throw new Error('unsupported')
+    })
+    expect(isReloadNavigation()).toBe(false)
+  })
+})

--- a/web/src/hooks/useTrainingListCache.ts
+++ b/web/src/hooks/useTrainingListCache.ts
@@ -1,0 +1,198 @@
+import { useMemo } from 'react'
+import type { Workout } from '../types/training'
+
+// Snapshot of the paginated training list, kept per user and per tab so that
+// navigating into a workout detail and back restores the pages the user already
+// paged in instead of resetting to page 1.
+export interface TrainingListSnapshot {
+  version: number
+  userId: string
+  savedAt: number
+  workouts: Workout[]
+  nextCursor: string | null
+  latestWorkoutId: number | null
+  scrollY: number
+}
+
+// Bumping the version retires every snapshot written by an older build: it is
+// part of the key (old entries are never read again) and is re-checked on read.
+export const TRAINING_LIST_CACHE_VERSION = 1
+
+// A snapshot older than this is discarded, so a tab left open for hours does not
+// present a stale list as if it were fresh. Every write refreshes the timestamp,
+// so the TTL measures idle time rather than session length.
+export const TRAINING_LIST_CACHE_TTL_MS = 5 * 60 * 1000
+
+const KEY_PREFIX = 'hytte:training-list:'
+
+export function trainingListCacheKey(userId: string): string {
+  return `${KEY_PREFIX}v${TRAINING_LIST_CACHE_VERSION}:${userId}`
+}
+
+// getStorage returns sessionStorage, or null when it is unavailable — private
+// mode and hardened browser settings make even *touching* the property throw, so
+// every access in this module goes through here.
+function getStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') return null
+    return window.sessionStorage ?? null
+  } catch {
+    return null
+  }
+}
+
+function removeKey(storage: Storage, key: string) {
+  try {
+    storage.removeItem(key)
+  } catch {
+    // Best effort — a storage that refuses removal also refuses reads, and read
+    // failures already fall back to "no snapshot".
+  }
+}
+
+function isSnapshot(value: unknown, userId: string): value is TrainingListSnapshot {
+  if (!value || typeof value !== 'object') return false
+  const s = value as Partial<TrainingListSnapshot>
+  return (
+    s.version === TRAINING_LIST_CACHE_VERSION &&
+    s.userId === userId &&
+    typeof s.savedAt === 'number' &&
+    Array.isArray(s.workouts) &&
+    (s.nextCursor === null || typeof s.nextCursor === 'string') &&
+    (s.latestWorkoutId === null || typeof s.latestWorkoutId === 'number') &&
+    typeof s.scrollY === 'number'
+  )
+}
+
+/**
+ * readTrainingListCache returns the snapshot for a user, or null when there is
+ * none, it belongs to another user or cache version, it is older than the TTL,
+ * or the stored payload is unusable. Anything unusable is dropped on the way out
+ * so a corrupt entry cannot keep failing every future read.
+ */
+export function readTrainingListCache(userId: string): TrainingListSnapshot | null {
+  const storage = getStorage()
+  if (!storage || !userId) return null
+  const key = trainingListCacheKey(userId)
+  let raw: string | null
+  try {
+    raw = storage.getItem(key)
+  } catch {
+    return null
+  }
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!isSnapshot(parsed, userId)) {
+      removeKey(storage, key)
+      return null
+    }
+    // A negative age means the clock moved backwards since the write; treat that
+    // as untrustworthy rather than as an eternally fresh snapshot.
+    const age = Date.now() - parsed.savedAt
+    if (age > TRAINING_LIST_CACHE_TTL_MS || age < -TRAINING_LIST_CACHE_TTL_MS) {
+      removeKey(storage, key)
+      return null
+    }
+    return parsed
+  } catch {
+    removeKey(storage, key)
+    return null
+  }
+}
+
+export type TrainingListSnapshotPatch = Partial<
+  Pick<TrainingListSnapshot, 'workouts' | 'nextCursor' | 'latestWorkoutId' | 'scrollY'>
+>
+
+/**
+ * writeTrainingListCache merges a patch into the stored snapshot, so the list
+ * and the scroll offset can be persisted independently. Quota and serialization
+ * failures are swallowed: the cache is an optimization, never a requirement.
+ */
+export function writeTrainingListCache(userId: string, patch: TrainingListSnapshotPatch): void {
+  const storage = getStorage()
+  if (!storage || !userId) return
+  const current = readTrainingListCache(userId)
+  const next: TrainingListSnapshot = {
+    version: TRAINING_LIST_CACHE_VERSION,
+    userId,
+    savedAt: Date.now(),
+    workouts: patch.workouts ?? current?.workouts ?? [],
+    nextCursor: patch.nextCursor !== undefined ? patch.nextCursor : current?.nextCursor ?? null,
+    latestWorkoutId:
+      patch.latestWorkoutId !== undefined ? patch.latestWorkoutId : current?.latestWorkoutId ?? null,
+    scrollY: patch.scrollY ?? current?.scrollY ?? 0,
+  }
+  const key = trainingListCacheKey(userId)
+  try {
+    storage.setItem(key, JSON.stringify(next))
+  } catch {
+    // Most likely a quota error from a very long list. Drop the entry so the
+    // next mount does a clean load rather than restoring a half-written one.
+    removeKey(storage, key)
+  }
+}
+
+/**
+ * clearTrainingListCache removes one user's snapshot, or — with no argument —
+ * every training-list snapshot in the tab. The sweep is what logout uses, so
+ * signing in as a different user in the same tab can never surface the previous
+ * user's workouts.
+ */
+export function clearTrainingListCache(userId?: string): void {
+  const storage = getStorage()
+  if (!storage) return
+  if (userId) {
+    removeKey(storage, trainingListCacheKey(userId))
+    return
+  }
+  try {
+    const keys: string[] = []
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i)
+      if (key && key.startsWith(KEY_PREFIX)) keys.push(key)
+    }
+    for (const key of keys) removeKey(storage, key)
+  } catch {
+    // Storage unavailable — nothing was written either, so nothing to clear.
+  }
+}
+
+/**
+ * isReloadNavigation reports whether the document was reached by a reload.
+ * sessionStorage survives F5, so the snapshot alone cannot distinguish "came
+ * back from a detail page" from "the user asked for a fresh page"; the
+ * navigation type can. Unknown navigations are treated as not-a-reload.
+ */
+export function isReloadNavigation(): boolean {
+  try {
+    const entries = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[]
+    return entries[0]?.type === 'reload'
+  } catch {
+    return false
+  }
+}
+
+export interface TrainingListCache {
+  read: () => TrainingListSnapshot | null
+  write: (patch: TrainingListSnapshotPatch) => void
+  clear: () => void
+}
+
+/**
+ * useTrainingListCache binds the snapshot helpers to a user id. The returned
+ * object is referentially stable for a given user, so it is safe to use as an
+ * effect dependency.
+ */
+export function useTrainingListCache(userId: string | number | null | undefined): TrainingListCache {
+  const key = userId === null || userId === undefined ? '' : String(userId)
+  return useMemo(
+    () => ({
+      read: () => readTrainingListCache(key),
+      write: (patch: TrainingListSnapshotPatch) => writeTrainingListCache(key, patch),
+      clear: () => clearTrainingListCache(key),
+    }),
+    [key],
+  )
+}

--- a/web/src/pages/Training.test.tsx
+++ b/web/src/pages/Training.test.tsx
@@ -4,6 +4,12 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Training from './Training'
 import type { Workout } from '../types/training'
+import {
+  trainingListCacheKey,
+  readTrainingListCache,
+  TRAINING_LIST_CACHE_VERSION,
+  TRAINING_LIST_CACHE_TTL_MS,
+} from '../hooks/useTrainingListCache'
 
 vi.mock('react-i18next', async () => {
   const { default: enTraining } = await import('../../public/locales/en/training.json')
@@ -223,6 +229,9 @@ function stubEventSource() {
 describe('Training filter bar', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    // The page now caches its loaded pages per tab — leaking a snapshot between
+    // tests would let one test hydrate from another's list.
+    window.sessionStorage.clear()
     requests = []
     stubEventSource()
     vi.stubGlobal('fetch', mockFetch(WORKOUTS))
@@ -412,6 +421,9 @@ describe('Training filtered pagination', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks()
+    // The page now caches its loaded pages per tab — leaking a snapshot between
+    // tests would let one test hydrate from another's list.
+    window.sessionStorage.clear()
     requests = []
     stubEventSource()
     vi.stubGlobal('fetch', mockFetch(MANY, ['easy']))
@@ -490,6 +502,9 @@ describe('Training filtered pagination', () => {
 describe('Training zero-workout user', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    // The page now caches its loaded pages per tab — leaking a snapshot between
+    // tests would let one test hydrate from another's list.
+    window.sessionStorage.clear()
     requests = []
     stubEventSource()
     vi.stubGlobal('fetch', mockFetch([], []))
@@ -511,6 +526,9 @@ describe('Training zero-workout user', () => {
 describe('Training error handling', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    // The page now caches its loaded pages per tab — leaking a snapshot between
+    // tests would let one test hydrate from another's list.
+    window.sessionStorage.clear()
     requests = []
     stubEventSource()
   })
@@ -546,9 +564,223 @@ describe('Training error handling', () => {
   })
 })
 
+describe('Training list cache', () => {
+  // A history deep enough to need paging, ordered the way the list endpoint
+  // orders it: started_at DESC (id DESC as the tiebreak). Index 0 is newest.
+  const HISTORY: Workout[] = []
+  for (let i = 0; i < 60; i++) {
+    HISTORY.push(makeWorkout({
+      id: 1000 - i,
+      title: `History ${i}`,
+      sport: 'running',
+      started_at: new Date(Date.UTC(2026, 0, 1) - i * 86_400_000).toISOString(),
+    }))
+  }
+
+  // What the user had loaded when they clicked into a workout: two pages of
+  // history, a cursor pointing past them, and a scroll offset.
+  const CACHED = HISTORY.slice(0, 50)
+  const CACHED_CURSOR = String(CACHED[CACHED.length - 1].id)
+
+  function primeCache(overrides: Record<string, unknown> = {}, userId = '1') {
+    window.sessionStorage.setItem(trainingListCacheKey(userId), JSON.stringify({
+      version: TRAINING_LIST_CACHE_VERSION,
+      userId,
+      savedAt: Date.now(),
+      workouts: CACHED,
+      nextCursor: CACHED_CURSOR,
+      latestWorkoutId: HISTORY[0].id,
+      scrollY: 420,
+      ...overrides,
+    }))
+  }
+
+  // Patched onto window itself (not just globalThis) because that is what the
+  // page calls, and happy-dom keeps the two property slots separate.
+  let scrollToSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    window.sessionStorage.clear()
+    requests = []
+    stubEventSource()
+    scrollToSpy = vi.fn()
+    Object.defineProperty(window, 'scrollTo', {
+      value: scrollToSpy,
+      configurable: true,
+      writable: true,
+    })
+    vi.stubGlobal('fetch', mockFetch(HISTORY, []))
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders the cached pages on the first paint, without a loading skeleton', () => {
+    primeCache()
+    const { container } = renderTraining()
+
+    // No await: the restored rows must be there before any request resolves.
+    expect(screen.getByText('History 0')).toBeInTheDocument()
+    expect(screen.getByText('History 49')).toBeInTheDocument()
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('keeps the cached cursor so "Load more" continues where the user left off', async () => {
+    // The refreshed page 1 carries an edited title, which is how the test knows
+    // the background refresh has landed.
+    const edited = HISTORY.map(w => w.id === HISTORY[0].id ? { ...w, title: 'History 0 renamed' } : w)
+    vi.stubGlobal('fetch', mockFetch(edited, []))
+
+    primeCache()
+    renderTraining()
+
+    // The edit reconciles in place — no second row for the same workout.
+    expect(await screen.findByText('History 0 renamed')).toBeInTheDocument()
+    expect(screen.queryByText('History 0')).not.toBeInTheDocument()
+    expect(screen.getByText('History 49')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }))
+
+    await waitFor(() => {
+      expect(lastListRequest().searchParams.get('cursor')).toBe(CACHED_CURSOR)
+    })
+    expect(await screen.findByText('History 59')).toBeInTheDocument()
+    expect(screen.getByText('History 49')).toBeInTheDocument()
+  })
+
+  it('merges a workout uploaded while away without duplicating restored rows', async () => {
+    const uploaded = makeWorkout({
+      id: 2000,
+      title: 'New Upload',
+      sport: 'running',
+      started_at: '2026-06-01T08:00:00Z',
+    })
+    vi.stubGlobal('fetch', mockFetch([uploaded, ...HISTORY], []))
+
+    primeCache()
+    renderTraining()
+
+    expect(await screen.findByText('New Upload')).toBeInTheDocument()
+    // Every restored row survives, exactly once each.
+    expect(screen.getAllByText('History 0')).toHaveLength(1)
+    expect(screen.getAllByText('History 24')).toHaveLength(1)
+    expect(screen.getByText('History 49')).toBeInTheDocument()
+  })
+
+  it('drops a workout deleted while away', async () => {
+    vi.stubGlobal('fetch', mockFetch(HISTORY.filter(w => w.title !== 'History 5'), []))
+
+    primeCache()
+    renderTraining()
+
+    await waitFor(() => {
+      expect(screen.queryByText('History 5')).not.toBeInTheDocument()
+    })
+    // Only the deleted workout goes: its neighbours and the deeper pages stay.
+    expect(screen.getByText('History 4')).toBeInTheDocument()
+    expect(screen.getByText('History 6')).toBeInTheDocument()
+    expect(screen.getByText('History 49')).toBeInTheDocument()
+  })
+
+  it('does a normal fresh load when the snapshot is older than the TTL', async () => {
+    primeCache({ savedAt: Date.now() - TRAINING_LIST_CACHE_TTL_MS - 1000 })
+    const { container } = renderTraining()
+
+    expect(container.querySelector('.animate-pulse')).not.toBeNull()
+    expect(await screen.findByText('History 0')).toBeInTheDocument()
+    // Only page 1 — the stale deeper pages are not restored.
+    expect(screen.queryByText('History 49')).not.toBeInTheDocument()
+    expect(screen.queryByText('History 30')).not.toBeInTheDocument()
+  })
+
+  it('does a normal fresh load after a reload navigation', async () => {
+    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+      { type: 'reload' } as unknown as PerformanceEntry,
+    ])
+    primeCache()
+    renderTraining()
+
+    expect(await screen.findByText('History 0')).toBeInTheDocument()
+    expect(screen.queryByText('History 49')).not.toBeInTheDocument()
+  })
+
+  it('never restores another user\'s snapshot', async () => {
+    primeCache({}, '2')
+    renderTraining()
+
+    expect(await screen.findByText('History 0')).toBeInTheDocument()
+    expect(screen.queryByText('History 49')).not.toBeInTheDocument()
+  })
+
+  it('restores the cached scroll offset once the rows are rendered', () => {
+    primeCache({ scrollY: 640 })
+    renderTraining()
+
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 640, behavior: 'auto' })
+  })
+
+  it('does not scroll on a fresh load', async () => {
+    renderTraining()
+    expect(await screen.findByText('History 0')).toBeInTheDocument()
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  it('persists the loaded pages and the scroll offset for the next mount', async () => {
+    const { unmount } = renderTraining()
+    await screen.findByText('History 0')
+
+    fireEvent.click(await screen.findByRole('button', { name: /load more/i }))
+    expect(await screen.findByText('History 30')).toBeInTheDocument()
+
+    // Leaving for a workout detail flushes the offset even mid-debounce.
+    Object.defineProperty(window, 'scrollY', { value: 512, configurable: true })
+    unmount()
+
+    const snapshot = readTrainingListCache('1')
+    expect(snapshot).not.toBeNull()
+    expect(snapshot!.workouts.length).toBe(HISTORY.length)
+    expect(snapshot!.nextCursor).toBeNull()
+    expect(snapshot!.scrollY).toBe(512)
+  })
+
+  it('drops the snapshot while a filter is active, since filters are not restored', async () => {
+    primeCache()
+    renderTraining()
+
+    expect(await screen.findByText('History 0')).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText('Filter by sport'), { target: { value: 'cycling' } })
+
+    await waitFor(() => {
+      expect(readTrainingListCache('1')).toBeNull()
+    })
+    // A filtered load replaces the restored list rather than merging into it.
+    expect(screen.queryByText('History 49')).not.toBeInTheDocument()
+  })
+
+  it('falls back to a fresh load when sessionStorage throws', async () => {
+    primeCache()
+    vi.spyOn(window.sessionStorage, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+    vi.spyOn(window.sessionStorage, 'setItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+
+    const { unmount } = renderTraining()
+    expect(await screen.findByText('History 0')).toBeInTheDocument()
+    expect(screen.queryByText('History 49')).not.toBeInTheDocument()
+    expect(() => unmount()).not.toThrow()
+  })
+})
+
 describe('Training new-workouts banner', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    // The page now caches its loaded pages per tab — leaking a snapshot between
+    // tests would let one test hydrate from another's list.
+    window.sessionStorage.clear()
     requests = []
   })
 

--- a/web/src/pages/Training.test.tsx
+++ b/web/src/pages/Training.test.tsx
@@ -740,8 +740,8 @@ describe('Training list cache', () => {
 
     const snapshot = readTrainingListCache('1')
     expect(snapshot).not.toBeNull()
-    expect(snapshot!.workouts.length).toBe(HISTORY.length)
-    expect(snapshot!.nextCursor).toBeNull()
+    expect(snapshot!.workouts.length).toBe(50)
+    expect(snapshot!.nextCursor).not.toBeNull()
     expect(snapshot!.scrollY).toBe(512)
   })
 

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { Dumbbell, Upload, TrendingUp, BarChart3, RefreshCw, X, Database } from 'lucide-react'
 import { useAuth } from '../auth'
@@ -8,6 +8,7 @@ import { formatDistance, formatDuration, formatPace } from '../utils/training'
 import type { Workout, WeeklySummary } from '../types/training'
 import TagBadge from '../components/TagBadge'
 import WorkoutFilterBar from '../components/WorkoutFilterBar'
+import { useTrainingListCache, isReloadNavigation } from '../hooks/useTrainingListCache'
 
 // Page size for the paginated workout list. The list endpoint clamps this
 // server-side; keeping it modest bounds the initial payload and DOM size so a
@@ -17,6 +18,46 @@ const PAGE_SIZE = 25
 // Debounce for the title search box, so typing issues one request per pause
 // rather than one per keystroke.
 const SEARCH_DEBOUNCE_MS = 300
+
+// Trailing debounce for persisting the scroll offset. Long enough that a flick
+// scroll writes once rather than once per frame, short enough that a click into
+// a workout right after scrolling still records where the user was.
+const SCROLL_SAVE_DEBOUNCE_MS = 250
+
+// compareWorkouts orders two workouts the way the list endpoint does
+// (started_at DESC, id DESC), so merged-in workouts land in the same position
+// the server would have put them.
+function compareWorkouts(a: Workout, b: Workout): number {
+  if (a.started_at !== b.started_at) return a.started_at < b.started_at ? 1 : -1
+  return b.id - a.id
+}
+
+// mergeFirstPage folds a freshly fetched page 1 into an already-loaded list
+// instead of replacing it, which is what lets a restored list keep the older
+// pages the user paged in. Matching ids are replaced (edits), workouts the page
+// introduces are inserted in order (uploads), and cached workouts that fall
+// inside the window the page covers but are absent from it are dropped
+// (deletes). Cached workouts older than the window are left alone: page 1 says
+// nothing about them.
+function mergeFirstPage(prev: Workout[], page: Workout[], pageExhausted: boolean): Workout[] {
+  const byId = new Map(page.map(w => [w.id, w]))
+  const oldest = page.length > 0 ? page[page.length - 1] : null
+  const kept = prev.filter(w => {
+    const fresh = byId.get(w.id)
+    if (fresh) return true
+    // next_cursor === null means page 1 was the entire result set, so anything
+    // it omits no longer exists (or no longer matches).
+    if (pageExhausted) return false
+    if (!oldest) return true
+    return compareWorkouts(w, oldest) > 0
+  })
+  const merged = kept.map(w => byId.get(w.id) ?? w)
+  const existing = new Set(merged.map(w => w.id))
+  const added = page.filter(w => !existing.has(w.id))
+  // Sorting rather than prepending: a backdated .fit import (or an edit that
+  // moved a workout's start time) belongs in the middle of the list, not on top.
+  return [...added, ...merged].sort(compareWorkouts)
+}
 
 const sportIcons: Record<string, string> = {
   running: '🏃',
@@ -33,11 +74,25 @@ const sportIcons: Record<string, string> = {
 export default function Training() {
   const { user } = useAuth()
   const { t } = useTranslation(['training', 'common'])
-  const [workouts, setWorkouts] = useState<Workout[]>([])
-  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const listCache = useTrainingListCache(user?.id)
+
+  // Snapshot of the list as it was when the user last left this page in this
+  // tab, read once before the first paint so a return from a workout detail
+  // renders the already-loaded pages immediately. A reload (F5) deliberately
+  // skips it: sessionStorage survives F5, but asking for the page again means
+  // asking for fresh data.
+  const [hydrated] = useState(() => {
+    if (isReloadNavigation()) return null
+    const snapshot = listCache.read()
+    return snapshot && snapshot.workouts.length > 0 ? snapshot : null
+  })
+
+  const [workouts, setWorkouts] = useState<Workout[]>(hydrated?.workouts ?? [])
+  const [nextCursor, setNextCursor] = useState<string | null>(hydrated?.nextCursor ?? null)
   const [loadingMore, setLoadingMore] = useState(false)
   const [summaries, setSummaries] = useState<WeeklySummary[]>([])
-  const [loading, setLoading] = useState(true)
+  // A restored list is already on screen, so the skeleton would only flash.
+  const [loading, setLoading] = useState(hydrated === null)
   const [error, setError] = useState('')
   const [uploading, setUploading] = useState(false)
   const [uploadResult, setUploadResult] = useState<{ imported: number; errors: string[] } | null>(null)
@@ -46,10 +101,16 @@ export default function Training() {
   const [hasNewWorkouts, setHasNewWorkouts] = useState(false)
   const [backfilling, setBackfilling] = useState(false)
   const [backfillResult, setBackfillResult] = useState<string | null>(null)
-  const [hasAnyWorkouts, setHasAnyWorkouts] = useState(false)
+  const [hasAnyWorkouts, setHasAnyWorkouts] = useState(hydrated !== null)
   const [availableTags, setAvailableTags] = useState<string[]>([])
-  const latestWorkoutIdRef = useRef<number | null>(null)
+  const latestWorkoutIdRef = useRef<number | null>(hydrated?.latestWorkoutId ?? null)
   const hasNewWorkoutsRef = useRef(false)
+
+  // Armed while the restored list is still authoritative. The first page-1 load
+  // after a hydrated mount is a background refresh that merges into the restored
+  // pages; any filter change or explicit refresh disarms it, because those own
+  // the list outright and must replace it.
+  const mergeArmedRef = useRef(hydrated !== null)
 
   // Filter state. These are request parameters, not a client-side narrowing of
   // the loaded pages: changing any of them refetches page 1 from the backend so
@@ -137,25 +198,39 @@ export default function Training() {
     const requestId = ++listRequestIdRef.current
     let cancelled = false
     const isCurrent = () => !cancelled && requestId === listRequestIdRef.current
+    // Merge only while the restored list is untouched by a filter or a refresh.
+    // The check itself disarms: once a filter has been applied, later loads
+    // replace even after the filters are cleared again.
+    const merge = mergeArmedRef.current && filterParams === '' && refreshTick === 0
+    if (!merge) mergeArmedRef.current = false
     ;(async () => {
       // Drop the previous filter's cursor up front: it points into a different
       // result set, so "Load more" must not stay clickable with it while page 1
-      // of the new filter is in flight.
-      setNextCursor(null)
+      // of the new filter is in flight. A background refresh keeps its cursor —
+      // the restored pages it points past are still on screen.
+      if (!merge) setNextCursor(null)
       try {
         const res = await fetch(workoutsUrl(null), { credentials: 'include' })
         if (!isCurrent()) return
         if (!res.ok) {
-          setWorkouts([])
+          // A failed background refresh leaves the restored list alone: it is
+          // the last thing the user actually saw, and dropping it would be a
+          // worse answer than showing it alongside the error.
+          if (!merge) setWorkouts([])
           setError(t('errors.failedToLoadWorkouts'))
           return
         }
         const data = await res.json()
         if (!isCurrent()) return
         const list: Workout[] = data.workouts || []
-        setWorkouts(list)
-        setNextCursor(data.next_cursor ?? null)
-        setHasAnyWorkouts(list.length > 0 || filtersActive)
+        if (merge) {
+          setWorkouts(prev => mergeFirstPage(prev, list, (data.next_cursor ?? null) === null))
+          setHasAnyWorkouts(list.length > 0 || filtersActive)
+        } else {
+          setWorkouts(list)
+          setNextCursor(data.next_cursor ?? null)
+          setHasAnyWorkouts(list.length > 0 || filtersActive)
+        }
       } catch {
         if (isCurrent()) setError(t('errors.failedToLoadWorkouts'))
       } finally {
@@ -163,7 +238,7 @@ export default function Training() {
       }
     })()
     return () => { cancelled = true }
-  }, [user, refreshTick, workoutsUrl, filtersActive, t])
+  }, [user, refreshTick, workoutsUrl, filterParams, filtersActive, t])
 
   // Filter-independent page data: weekly summaries, the tag chip source, and
   // the new-workout baseline. The baseline comes from the cheap /latest
@@ -205,6 +280,66 @@ export default function Training() {
     })()
     return () => { cancelled = true }
   }, [user, refreshTick, t])
+
+  // Persist the loaded pages so leaving for a workout detail and coming back
+  // restores them. Only the unfiltered list is cached — filter state is not
+  // restored, so a snapshot taken under a filter would come back as a silently
+  // narrowed history. While a filter is active the snapshot is dropped instead,
+  // which just means the next mount does a normal fresh load.
+  useEffect(() => {
+    if (!user) return
+    if (filterParams !== '') {
+      listCache.clear()
+      return
+    }
+    if (loading || workouts.length === 0) return
+    listCache.write({
+      workouts,
+      nextCursor,
+      latestWorkoutId: latestWorkoutIdRef.current,
+    })
+  }, [user, filterParams, loading, workouts, nextCursor, listCache])
+
+  // Restore the scroll offset once the restored rows are in the DOM, in a layout
+  // effect so the jump happens before the browser paints. Runs at most once per
+  // mount: later renders (the background refresh, "load more") must not yank the
+  // page back.
+  const pendingScrollRef = useRef(hydrated?.scrollY ?? 0)
+  const scrollRestoredRef = useRef(hydrated === null)
+  useLayoutEffect(() => {
+    if (scrollRestoredRef.current || workouts.length === 0) return
+    scrollRestoredRef.current = true
+    const top = pendingScrollRef.current
+    if (top > 0 && typeof window.scrollTo === 'function') {
+      window.scrollTo({ top, behavior: 'auto' })
+    }
+  }, [workouts])
+
+  // Record where the user is, debounced while scrolling and flushed on unmount
+  // so a click straight into a workout detail still captures the offset.
+  useEffect(() => {
+    if (!user) return
+    let timer: ReturnType<typeof setTimeout> | undefined
+    // Only attach the offset to a snapshot that already holds a list: with
+    // nothing to restore, an offset on its own would just be litter.
+    const saveScroll = () => {
+      if (!listCache.read()) return
+      listCache.write({ scrollY: window.scrollY })
+    }
+    const onScroll = () => {
+      if (timer) return
+      timer = setTimeout(() => {
+        timer = undefined
+        saveScroll()
+      }, SCROLL_SAVE_DEBOUNCE_MS)
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      if (timer) clearTimeout(timer)
+      saveScroll()
+    }
+  }, [user, listCache])
 
   // handleLoadMore appends the next older page of *matching* workouts using the
   // keyset cursor returned by the list endpoint, deduplicating by id at the page


### PR DESCRIPTION
## Changes

- **Training list keeps your place when you come back** - Opening a workout and pressing back now restores every page you had loaded with "Load more", along with your scroll position, instead of resetting to the first page at the top. The list is shown immediately from a per-tab cache and refreshed in the background, so new, edited and deleted workouts still reconcile. A reload, a stale cache, or a different user always gets a fresh load. (Hytte-oapfh)

## Original Issue (feature): Preserve loaded pages and scroll position when returning from a workout detail

### Scope
Make `/training` restore its paged workout list and scroll position when the user navigates back from a workout detail (or any in-app route). On remount the page should hydrate immediately from a cached snapshot (workouts, `next_cursor`, scroll offset, latest-workout baseline), render without a loading spinner, and then refresh the first page in the background — merging new workouts into the cached list instead of replacing it. The cache is per-user and per-tab (`sessionStorage`), with a small TTL so a stale tab doesn't show hours-old data as if it were fresh.

### Files to touch
- `web/src/hooks/useTrainingListCache.ts` (new) — read/write/clear the snapshot, keyed by user id, versioned, TTL-guarded, tolerant of quota errors and malformed JSON.
- `web/src/hooks/useTrainingListCache.test.ts` (new) — unit tests for key scoping, versioning, TTL expiry, and corrupt-payload fallback.
- `web/src/pages/Training.tsx` — seed `workouts`/`nextCursor`/`latestWorkoutIdRef` from the cache, skip the initial spinner when hydrated, merge (not replace) the background first-page fetch, persist the snapshot on list/cursor change, save and restore scroll offset.
- `web/src/pages/Training.test.tsx` — coverage for restore-on-remount, background merge, and cache invalidation.
- `web/src/auth.tsx` (or wherever logout clears client state) — clear the snapshot on logout/account switch.
- `changelog.d/` — new fragment under `Changed`.

### Acceptance criteria
- Clicking "Load more" several times, opening a workout, then pressing back shows every previously loaded workout — no re-clicking "Load more".
- Scroll position after back lands within ~50px of where the user left the list, after the restored rows have rendered.
- No full-page loading spinner appears on a cache-hit remount; the list is visible on first paint.
- The background first-page refresh still runs: workouts uploaded while on the detail page appear (via the existing new-workout path) and deleted/edited workouts reconcile without duplicating rows or losing the cursor.
- A hard reload (F5) or a snapshot older than the TTL does a normal fresh first-page load.
- The snapshot is scoped per user: signing out and back in as a different user never shows the previous user's workouts.
- The page still behaves correctly when `sessionStorage` is unavailable or throws (private mode / quota) — it falls back to today's behaviour instead of crashing.
- `npm run lint`, `npm run build`, and `npm test` pass; new tests cover restore and merge.

### Non-goals
- No backend changes — `internal/training/handlers.go` and the cursor API stay as they are.
- No cross-tab or cross-reload persistence (no `localStorage`, no service worker, no IndexedDB).
- No introduction of a data-fetching library (React Query/SWR) or a global store.
- No caching for `TrainingDetail`, `TrainingTrends`, or `TrainingCompare`.
- Filter, tag, and search state restoration is out of scope.
- No infinite scroll or virtualization; "Load more" stays the pagination control.

## Source

Created from Suggestions page (suggestion id 213, page slug "training", source=claude).

## Original suggestion

Now that the workout list is paginated, opening a workout and pressing back remounts Training, which refetches only the first page and resets scroll to the top — discarding every older page the user paged in via 'Load more'. A user who scrolled deep into their history loses their place and must re-click 'Load more' repeatedly to get back. Cache the loaded workouts, next cursor, and scroll offset (e.g. in sessionStorage or a lightweight context keyed by user) and restore them on remount, refreshing in the background instead of resetting. This makes browsing a long training history feel continuous rather than punishing exploration of older workouts.


---
Bead: Hytte-oapfh | Branch: forge/Hytte-oapfh
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->