### PR TITLE
Wrap each widget in an error boundary so one failure doesn't blank the dashboard (Hytte-q1lvu)

### DIFF
--- a/changelog.d/Hytte-q1lvu.md
+++ b/changelog.d/Hytte-q1lvu.md
@@ -1,0 +1,2 @@
+category: Added
+- **Dashboard widgets are isolated by error boundaries** - Every widget on the dashboard is now wrapped in a `WidgetBoundary`, so a render failure in one widget shows a compact "widget unavailable" tile with a Retry button instead of blanking the entire dashboard. (Hytte-q1lvu)

--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -22,6 +22,12 @@
     },
     "unknown": "Activity"
   },
+  "widgetError": {
+    "title": "Widget unavailable",
+    "titleWithLabel": "{{label}} unavailable",
+    "message": "This widget failed to load.",
+    "retry": "Retry"
+  },
   "widgets": {
     "weather": {
       "title": "Weather",

--- a/web/public/locales/nb/dashboard.json
+++ b/web/public/locales/nb/dashboard.json
@@ -22,6 +22,12 @@
     },
     "unknown": "Aktivitet"
   },
+  "widgetError": {
+    "title": "Modulen er utilgjengelig",
+    "titleWithLabel": "{{label}} er utilgjengelig",
+    "message": "Denne modulen kunne ikke lastes.",
+    "retry": "Prøv igjen"
+  },
   "widgets": {
     "weather": {
       "title": "Vær",

--- a/web/public/locales/th/dashboard.json
+++ b/web/public/locales/th/dashboard.json
@@ -22,6 +22,12 @@
     },
     "unknown": "กิจกรรม"
   },
+  "widgetError": {
+    "title": "วิดเจ็ตไม่พร้อมใช้งาน",
+    "titleWithLabel": "{{label}} ไม่พร้อมใช้งาน",
+    "message": "ไม่สามารถโหลดวิดเจ็ตนี้ได้",
+    "retry": "ลองอีกครั้ง"
+  },
   "widgets": {
     "weather": {
       "title": "สภาพอากาศ",

--- a/web/src/components/WidgetBoundary.test.tsx
+++ b/web/src/components/WidgetBoundary.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import WidgetBoundary from './WidgetBoundary'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'widgetError.title') return 'Widget unavailable'
+      if (key === 'widgetError.titleWithLabel') return `${opts?.label} unavailable`
+      if (key === 'widgetError.message') return 'This widget failed to load.'
+      if (key === 'widgetError.retry') return 'Retry'
+      return key
+    },
+    i18n: { language: 'en' },
+  }),
+}))
+
+function Boom() {
+  throw new Error('widget exploded')
+}
+
+let flakyShouldThrow = true
+
+function Flaky() {
+  if (flakyShouldThrow) throw new Error('flaky exploded')
+  return <div>recovered content</div>
+}
+
+describe('WidgetBoundary', () => {
+  let consoleError: MockInstance
+
+  beforeEach(() => {
+    flakyShouldThrow = true
+    // React logs caught render errors itself; silence the noise but keep the calls.
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleError.mockRestore()
+  })
+
+  it('renders children when nothing throws', () => {
+    render(
+      <WidgetBoundary label="Weather">
+        <div>widget body</div>
+      </WidgetBoundary>,
+    )
+
+    expect(screen.getByText('widget body')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('catches a throwing child and shows the fallback tile', () => {
+    render(
+      <WidgetBoundary label="Weather">
+        <Boom />
+      </WidgetBoundary>,
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(alert.className).toContain('bg-gray-800')
+    expect(alert.className).toContain('rounded-xl')
+    expect(alert.className).toContain('p-6')
+    expect(screen.getByText('Weather unavailable')).toBeTruthy()
+    expect(screen.getByText('This widget failed to load.')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy()
+  })
+
+  it('logs the error and component stack to the console', () => {
+    render(
+      <WidgetBoundary label="Weather">
+        <Boom />
+      </WidgetBoundary>,
+    )
+
+    const boundaryLog = consoleError.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].startsWith('[WidgetBoundary]'),
+    )
+    expect(boundaryLog).toBeTruthy()
+    expect(boundaryLog?.[1]).toBe('Weather')
+    expect((boundaryLog?.[2] as Error).message).toBe('widget exploded')
+    expect(typeof boundaryLog?.[3]).toBe('string')
+  })
+
+  it('falls back to a generic title when no label is given', () => {
+    render(
+      <WidgetBoundary>
+        <Boom />
+      </WidgetBoundary>,
+    )
+
+    expect(screen.getByText('Widget unavailable')).toBeTruthy()
+  })
+
+  it('remounts the widget on retry and renders it once the cause is gone', () => {
+    render(
+      <WidgetBoundary label="Fitness">
+        <Flaky />
+      </WidgetBoundary>,
+    )
+
+    expect(screen.getByRole('alert')).toBeTruthy()
+
+    flakyShouldThrow = false
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+    expect(screen.getByText('recovered content')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('keeps showing the fallback when retry does not fix the cause', () => {
+    render(
+      <WidgetBoundary label="Fitness">
+        <Flaky />
+      </WidgetBoundary>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByText('Fitness unavailable')).toBeTruthy()
+  })
+
+  it('isolates the failure so sibling widgets still render', () => {
+    render(
+      <div>
+        <WidgetBoundary label="Weather">
+          <Boom />
+        </WidgetBoundary>
+        <WidgetBoundary label="Daylight">
+          <div>sibling body</div>
+        </WidgetBoundary>
+      </div>,
+    )
+
+    expect(screen.getByText('Weather unavailable')).toBeTruthy()
+    expect(screen.getByText('sibling body')).toBeTruthy()
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+  })
+
+  it('applies extra classes to the fallback tile so grid spans are preserved', () => {
+    render(
+      <WidgetBoundary className="col-span-full">
+        <Boom />
+      </WidgetBoundary>,
+    )
+
+    expect(screen.getByRole('alert').className).toContain('col-span-full')
+  })
+})

--- a/web/src/components/WidgetBoundary.test.tsx
+++ b/web/src/components/WidgetBoundary.test.tsx
@@ -16,7 +16,7 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-function Boom() {
+function Boom(): React.ReactNode {
   throw new Error('widget exploded')
 }
 

--- a/web/src/components/WidgetBoundary.tsx
+++ b/web/src/components/WidgetBoundary.tsx
@@ -1,0 +1,96 @@
+import { Component, Fragment, type ErrorInfo, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle, RotateCw } from 'lucide-react'
+
+interface WidgetBoundaryFallbackProps {
+  label?: string
+  className?: string
+  onRetry: () => void
+}
+
+// Class components can't use hooks, so the localized fallback lives in its own
+// function component.
+function WidgetBoundaryFallback({ label, className = '', onRetry }: WidgetBoundaryFallbackProps) {
+  const { t } = useTranslation('dashboard')
+
+  return (
+    <div role="alert" className={`bg-gray-800 rounded-xl p-6 ${className}`}>
+      <div className="flex items-start gap-3">
+        <AlertTriangle size={20} className="text-amber-400 shrink-0 mt-0.5" />
+        <div className="min-w-0">
+          <h2 className="text-sm font-medium text-gray-200">
+            {label ? t('widgetError.titleWithLabel', { label }) : t('widgetError.title')}
+          </h2>
+          <p className="text-xs text-gray-400 mt-1">{t('widgetError.message')}</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-3 inline-flex items-center gap-1.5 text-xs text-blue-400 hover:text-blue-300"
+          >
+            <RotateCw size={14} />
+            {t('widgetError.retry')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface WidgetBoundaryProps {
+  children: ReactNode
+  /** Human-readable widget name shown in the fallback tile. */
+  label?: string
+  /** Extra classes for the fallback tile, e.g. grid spans the widget itself uses. */
+  className?: string
+}
+
+interface WidgetBoundaryState {
+  hasError: boolean
+  resetKey: number
+}
+
+/**
+ * Isolates a single dashboard widget: a render-time throw degrades to a compact
+ * failure tile instead of unmounting the whole dashboard. Retry bumps a key so
+ * the child subtree remounts without a page reload.
+ */
+class WidgetBoundary extends Component<WidgetBoundaryProps, WidgetBoundaryState> {
+  state: WidgetBoundaryState = { hasError: false, resetKey: 0 }
+
+  static getDerivedStateFromError(): Partial<WidgetBoundaryState> {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // Keep failures debuggable in the browser console — the fallback tile
+    // deliberately shows no technical detail.
+    console.error(
+      '[WidgetBoundary] widget failed to render:',
+      this.props.label ?? '(unlabeled)',
+      error,
+      errorInfo.componentStack,
+    )
+  }
+
+  handleRetry = () => {
+    this.setState((prev) => ({ hasError: false, resetKey: prev.resetKey + 1 }))
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <WidgetBoundaryFallback
+          label={this.props.label}
+          className={this.props.className}
+          onRetry={this.handleRetry}
+        />
+      )
+    }
+
+    // A keyed Fragment remounts the subtree on retry without adding a DOM node,
+    // so the widget stays a direct child of the dashboard grid.
+    return <Fragment key={this.state.resetKey}>{this.props.children}</Fragment>
+  }
+}
+
+export default WidgetBoundary

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,4 +1,6 @@
+import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth'
+import WidgetBoundary from '../components/WidgetBoundary'
 import GreetingWidget from '../components/widgets/GreetingWidget'
 import WeatherWidget from '../components/widgets/WeatherWidget'
 import DaylightWidget from '../components/widgets/DaylightWidget'
@@ -14,22 +16,59 @@ import CalendarWidget from '../components/widgets/CalendarWidget'
 
 function Dashboard() {
   const { hasFeature } = useAuth()
+  const { t } = useTranslation('dashboard')
 
   return (
     <div className="p-6">
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        <GreetingWidget />
-        <WeatherWidget />
-        <DaylightWidget />
-        {hasFeature('calendar') && <CalendarWidget />}
-        {hasFeature('netatmo') && <NetatmoWidget />}
-        {hasFeature('training') && <FitnessWidget />}
-        {hasFeature('lactate') && <LactateSummaryWidget />}
-        <ActivityFeedWidget />
-        {hasFeature('infra') && <InfraStatusWidget />}
-        {hasFeature('infra') && <GitHubStatusWidget />}
-        <NorwegianFunWidget />
-        <QuickLinksWidget />
+        <WidgetBoundary className="col-span-full">
+          <GreetingWidget />
+        </WidgetBoundary>
+        <WidgetBoundary label={t('widgets.weather.title')}>
+          <WeatherWidget />
+        </WidgetBoundary>
+        <WidgetBoundary label={t('widgets.daylight.title')}>
+          <DaylightWidget />
+        </WidgetBoundary>
+        {hasFeature('calendar') && (
+          <WidgetBoundary label={t('widgets.calendar.title')}>
+            <CalendarWidget />
+          </WidgetBoundary>
+        )}
+        {hasFeature('netatmo') && (
+          <WidgetBoundary label={t('widgets.netatmo.title')}>
+            <NetatmoWidget />
+          </WidgetBoundary>
+        )}
+        {hasFeature('training') && (
+          <WidgetBoundary label={t('widgets.training.title')}>
+            <FitnessWidget />
+          </WidgetBoundary>
+        )}
+        {hasFeature('lactate') && (
+          <WidgetBoundary label={t('widgets.lactate.title')}>
+            <LactateSummaryWidget />
+          </WidgetBoundary>
+        )}
+        <WidgetBoundary label={t('widgets.activity.title')}>
+          <ActivityFeedWidget />
+        </WidgetBoundary>
+        {hasFeature('infra') && (
+          <WidgetBoundary label={t('widgets.infra.title')}>
+            <InfraStatusWidget />
+          </WidgetBoundary>
+        )}
+        {hasFeature('infra') && (
+          <WidgetBoundary label={t('widgets.github.title')}>
+            <GitHubStatusWidget />
+          </WidgetBoundary>
+        )}
+        <WidgetBoundary label={t('widgets.norwegianWord.title')}>
+          <NorwegianFunWidget />
+        </WidgetBoundary>
+        <WidgetBoundary label={t('widgets.quickLinks.title')}>
+          <QuickLinksWidget />
+        </WidgetBoundary>
       </div>
     </div>
   )


### PR DESCRIPTION
## Changes

- **Dashboard widgets are isolated by error boundaries** - Every widget on the dashboard is now wrapped in a `WidgetBoundary`, so a render failure in one widget shows a compact "widget unavailable" tile with a Retry button instead of blanking the entire dashboard. (Hytte-q1lvu)

## Original Issue (feature): Wrap each widget in an error boundary so one failure doesn't blank the dashboard

### Scope
Add a reusable React error boundary (`WidgetBoundary`) and wrap every widget rendered by `Dashboard.tsx` so a render-time throw in one widget degrades to a single compact failure tile instead of blanking the whole dashboard. The boundary shows a localized "This widget failed to load" message plus a Retry button that remounts the child subtree (via a key bump), so recovery is possible without a page reload. No widget internals change.

### Files to touch
- `web/src/components/WidgetBoundary.tsx` (new) — class component with `getDerivedStateFromError` + `componentDidCatch`, rendering the fallback tile in the existing `Widget` shell (`bg-gray-800 rounded-xl p-6`) so it matches the grid visually; accepts an optional label for the failed widget and a reset handler.
- `web/src/components/WidgetBoundary.test.tsx` (new) — Vitest/RTL tests: renders children normally, catches a throwing child, retry remounts and renders a recovered child, sibling widgets still render.
- `web/src/pages/Dashboard.tsx` — wrap each of the 12 widget slots (including the feature-gated ones) in `<WidgetBoundary>`; keep the existing `hasFeature(...)` gates outside the boundary so disabled features still render nothing.
- `web/public/locales/{en,nb,th}/dashboard.json` — add keys for the fallback title/message and retry button in all three languages.
- `changelog.d/<slug>.md` (new) — `category: Added` fragment referencing the bead id.

### Acceptance criteria
- A widget that throws during render shows a single compact failure tile in its grid cell; all other widgets on `/dashboard` still render normally.
- The failure tile matches the surrounding widget styling (same card background, radius, padding) and does not break the 1/2/3-column responsive grid at 375px, tablet, and desktop widths.
- The fallback tile has a Retry button; clicking it re-mounts the widget, and if the underlying cause is gone the widget renders successfully without a page reload.
- All fallback strings come from `react-i18next` (`dashboard` namespace) and exist in `en`, `nb`, and `th` — no hardcoded English in JSX.
- The caught error (and component stack) is logged to the browser console so failures remain debuggable.
- Every widget in `Dashboard.tsx` is wrapped; feature-gated widgets remain hidden when the feature is off.
- `npm run lint`, `npm run build`, and `npm test` pass; new boundary tests cover normal render, caught error, retry recovery, and sibling isolation.

### Non-goals
- Not fixing the underlying bugs in any specific widget (Netatmo fields, FitnessWidget date parsing, ActivityFeed undefined access) — this is isolation only.
- No async/fetch error handling changes inside widgets; error boundaries do not catch promise rejections or event-handler errors, and widgets keep their existing loading/error states.
- No global app-level boundary, route-level boundary, or reuse on other pages (HomePage, kiosk) in this change.
- No error reporting/telemetry backend, no changes to `internal/dashboard/activity.go` or any Go code.
- No redesign of the dashboard grid, widget ordering, or per-widget dismiss/hide preferences.

## Source

Created from Suggestions page (suggestion id 107, page slug "dashboard", source=claude).

## Original suggestion

Dashboard.tsx renders ~12 widgets in a flat grid with no error isolation. If any widget throws during render — a missing field on the Netatmo response, a date parse in FitnessWidget, an undefined access in ActivityFeed — React unmounts the entire dashboard and the user sees nothing. Add a small `<WidgetBoundary>` wrapper (a class component implementing `componentDidCatch`) that renders a compact "This widget failed to load" tile with a Retry button, and wrap each widget in the grid with it. The rest of the dashboard keeps working, errors are scoped to the offending tile, and the user gets a way to recover without a full reload.


---
Bead: Hytte-q1lvu | Branch: forge/Hytte-q1lvu
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->