### PR TITLE
Grocery bulk add with case-insensitive de-duplication (Hytte-2m0ky)

### DIFF
--- a/changelog.d/Hytte-2m0ky.md
+++ b/changelog.d/Hytte-2m0ky.md
@@ -1,0 +1,2 @@
+category: Added
+- **Bulk add for grocery items with duplicate detection** - The grocery store can now add several items at once in a single transaction, skipping names already on the list and repeats within the batch (matching ignores case and surrounding whitespace). This is the groundwork for pushing recipe ingredients onto the grocery list. (Hytte-2m0ky)

--- a/internal/grocery/store.go
+++ b/internal/grocery/store.go
@@ -1,12 +1,20 @@
 package grocery
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
 )
+
+// execer is satisfied by both *sql.DB and *sql.Tx so the single-item insert can
+// run standalone or as one step of a bulk transaction.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
 
 // ListByHousehold returns all grocery items for the given household, ordered by checked, then sort_order, then created_at.
 func ListByHousehold(db *sql.DB, householdID int64) ([]GroceryItem, error) {
@@ -59,15 +67,6 @@ func ListByHousehold(db *sql.DB, householdID int64) ([]GroceryItem, error) {
 
 // Add inserts a new grocery item and returns it with its generated ID.
 func Add(db *sql.DB, item GroceryItem) (GroceryItem, error) {
-	encContent, err := encryption.EncryptField(item.Content)
-	if err != nil {
-		return GroceryItem{}, fmt.Errorf("encrypt content: %w", err)
-	}
-	encOriginalText, err := encryption.EncryptField(item.OriginalText)
-	if err != nil {
-		return GroceryItem{}, fmt.Errorf("encrypt original_text: %w", err)
-	}
-
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	// Default sort_order to the next value for this household.
@@ -79,7 +78,111 @@ func Add(db *sql.DB, item GroceryItem) (GroceryItem, error) {
 		item.SortOrder = int(maxOrder.Int64) + 1
 	}
 
-	res, err := db.Exec(`
+	return insertItem(context.Background(), db, item, now)
+}
+
+// AddItems bulk-inserts grocery items for a household from a list of names,
+// skipping any name that already appears on the list and any repeat within the
+// batch. Matching is case- and whitespace-insensitive.
+//
+// Item content is encrypted at rest, so de-duplication cannot be pushed into
+// SQL: the household's current list is loaded and decrypted, and comparison
+// happens in Go on the trimmed, lowercased name. Names are stored trimmed, and
+// both content and original_text are set to the name — callers pushing already
+// normalized text (e.g. recipe ingredients) have nothing to translate back.
+//
+// The inserts run in a single transaction and the created items are returned in
+// input order, so callers can publish one event per added item.
+func AddItems(ctx context.Context, db *sql.DB, householdID, addedBy int64, names []string) ([]GroceryItem, error) {
+	if len(names) == 0 {
+		return []GroceryItem{}, nil
+	}
+
+	existing, err := ListByHousehold(db, householdID)
+	if err != nil {
+		return nil, fmt.Errorf("load existing items: %w", err)
+	}
+	seen := make(map[string]struct{}, len(existing)+len(names))
+	for _, item := range existing {
+		seen[dedupeKey(item.Content)] = struct{}{}
+	}
+
+	toInsert := make([]string, 0, len(names))
+	for _, name := range names {
+		trimmed := strings.TrimSpace(name)
+		key := dedupeKey(trimmed)
+		if key == "" {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		toInsert = append(toInsert, trimmed)
+	}
+	if len(toInsert) == 0 {
+		return []GroceryItem{}, nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin add grocery items: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Sort order continues from the end of the list, matching what repeated
+	// Add calls would produce.
+	var maxOrder sql.NullInt64
+	if err := tx.QueryRowContext(ctx, "SELECT MAX(sort_order) FROM grocery_items WHERE household_id = ?", householdID).Scan(&maxOrder); err != nil {
+		return nil, fmt.Errorf("select max sort_order: %w", err)
+	}
+	sortOrder := 0
+	if maxOrder.Valid {
+		sortOrder = int(maxOrder.Int64) + 1
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	created := make([]GroceryItem, 0, len(toInsert))
+	for _, name := range toInsert {
+		item, err := insertItem(ctx, tx, GroceryItem{
+			HouseholdID:  householdID,
+			Content:      name,
+			OriginalText: name,
+			SortOrder:    sortOrder,
+			AddedBy:      addedBy,
+		}, now)
+		if err != nil {
+			return nil, err
+		}
+		created = append(created, item)
+		sortOrder++
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit add grocery items: %w", err)
+	}
+	return created, nil
+}
+
+// dedupeKey normalizes an item name for duplicate comparison.
+func dedupeKey(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// insertItem writes one grocery item, encrypting the free-form fields. The
+// caller owns sort_order and the created_at timestamp so a bulk insert can
+// share one clock reading and number its rows consecutively.
+func insertItem(ctx context.Context, ex execer, item GroceryItem, now string) (GroceryItem, error) {
+	encContent, err := encryption.EncryptField(item.Content)
+	if err != nil {
+		return GroceryItem{}, fmt.Errorf("encrypt content: %w", err)
+	}
+	encOriginalText, err := encryption.EncryptField(item.OriginalText)
+	if err != nil {
+		return GroceryItem{}, fmt.Errorf("encrypt original_text: %w", err)
+	}
+
+	res, err := ex.ExecContext(ctx, `
 		INSERT INTO grocery_items (household_id, content, original_text, source_language, checked, sort_order, added_by, created_at)
 		VALUES (?, ?, ?, ?, 0, ?, ?, ?)
 	`, item.HouseholdID, encContent, encOriginalText, item.SourceLanguage, item.SortOrder, item.AddedBy, now)

--- a/internal/grocery/store_test.go
+++ b/internal/grocery/store_test.go
@@ -1,6 +1,7 @@
 package grocery
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -150,6 +151,237 @@ func TestDeleteCompleted(t *testing.T) {
 	}
 	if items[0].Content != "Milk" {
 		t.Errorf("remaining item should be Milk, got %q", items[0].Content)
+	}
+}
+
+// contents returns the content of every item on a household's list, in list order.
+func contents(t *testing.T, d *sql.DB, householdID int64) []string {
+	t.Helper()
+	items, err := ListByHousehold(d, householdID)
+	if err != nil {
+		t.Fatalf("ListByHousehold: %v", err)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.Content)
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestAddItemsAllNew(t *testing.T) {
+	d := setupTestDB(t)
+
+	created, err := AddItems(context.Background(), d, 1, 1, []string{"Milk", "Eggs", "Bread"})
+	if err != nil {
+		t.Fatalf("AddItems: %v", err)
+	}
+	if len(created) != 3 {
+		t.Fatalf("created %d items, want 3", len(created))
+	}
+	for i, item := range created {
+		if item.ID == 0 {
+			t.Errorf("item %d has zero ID", i)
+		}
+		if item.SortOrder != i {
+			t.Errorf("item %d has sort_order %d, want %d", i, item.SortOrder, i)
+		}
+		if item.CreatedAt.IsZero() {
+			t.Errorf("item %d has zero created_at", i)
+		}
+		if item.OriginalText != item.Content {
+			t.Errorf("item %d original_text %q, want %q", i, item.OriginalText, item.Content)
+		}
+	}
+
+	want := []string{"Milk", "Eggs", "Bread"}
+	if got := contents(t, d, 1); !equalStrings(got, want) {
+		t.Errorf("list is %v, want %v", got, want)
+	}
+}
+
+func TestAddItemsMixedNewAndDuplicate(t *testing.T) {
+	d := setupTestDB(t)
+
+	seeded, err := Add(d, GroceryItem{HouseholdID: 1, Content: "Milk", OriginalText: "Melk", SourceLanguage: "nb", AddedBy: 1})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	created, err := AddItems(context.Background(), d, 1, 1, []string{"Milk", "Eggs", "Bread"})
+	if err != nil {
+		t.Fatalf("AddItems: %v", err)
+	}
+	if len(created) != 2 {
+		t.Fatalf("created %d items, want 2", len(created))
+	}
+
+	want := []string{"Milk", "Eggs", "Bread"}
+	if got := contents(t, d, 1); !equalStrings(got, want) {
+		t.Errorf("list is %v, want %v", got, want)
+	}
+
+	// The pre-existing item must be left exactly as it was.
+	items, err := ListByHousehold(d, 1)
+	if err != nil {
+		t.Fatalf("ListByHousehold: %v", err)
+	}
+	if items[0].ID != seeded.ID {
+		t.Errorf("existing item ID changed: got %d, want %d", items[0].ID, seeded.ID)
+	}
+	if items[0].OriginalText != "Melk" {
+		t.Errorf("existing original_text is %q, want %q", items[0].OriginalText, "Melk")
+	}
+	if !items[0].CreatedAt.Equal(seeded.CreatedAt) {
+		t.Errorf("existing created_at changed: got %v, want %v", items[0].CreatedAt, seeded.CreatedAt)
+	}
+}
+
+func TestAddItemsCaseAndWhitespaceInsensitive(t *testing.T) {
+	d := setupTestDB(t)
+
+	if _, err := Add(d, GroceryItem{HouseholdID: 1, Content: "Milk", OriginalText: "Milk", AddedBy: 1}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	created, err := AddItems(context.Background(), d, 1, 1, []string{"  milk ", "MILK", "\tMiLk"})
+	if err != nil {
+		t.Fatalf("AddItems: %v", err)
+	}
+	if len(created) != 0 {
+		t.Fatalf("created %d items, want 0", len(created))
+	}
+	if got := contents(t, d, 1); !equalStrings(got, []string{"Milk"}) {
+		t.Errorf("list is %v, want [Milk]", got)
+	}
+}
+
+func TestAddItemsDuplicatesWithinBatch(t *testing.T) {
+	d := setupTestDB(t)
+
+	created, err := AddItems(context.Background(), d, 1, 1, []string{"Eggs", "eggs", " EGGS ", "  ", ""})
+	if err != nil {
+		t.Fatalf("AddItems: %v", err)
+	}
+	if len(created) != 1 {
+		t.Fatalf("created %d items, want 1", len(created))
+	}
+	if created[0].Content != "Eggs" {
+		t.Errorf("kept %q, want the first spelling %q", created[0].Content, "Eggs")
+	}
+	if got := contents(t, d, 1); !equalStrings(got, []string{"Eggs"}) {
+		t.Errorf("list is %v, want [Eggs]", got)
+	}
+}
+
+func TestAddItemsEmptySlice(t *testing.T) {
+	d := setupTestDB(t)
+
+	if _, err := Add(d, GroceryItem{HouseholdID: 1, Content: "Milk", OriginalText: "Milk", AddedBy: 1}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	for _, names := range [][]string{nil, {}} {
+		created, err := AddItems(context.Background(), d, 1, 1, names)
+		if err != nil {
+			t.Fatalf("AddItems(%v): %v", names, err)
+		}
+		if len(created) != 0 {
+			t.Errorf("AddItems(%v) created %d items, want 0", names, len(created))
+		}
+	}
+
+	if got := contents(t, d, 1); !equalStrings(got, []string{"Milk"}) {
+		t.Errorf("list is %v, want [Milk]", got)
+	}
+}
+
+func TestAddItemsNamesAreTrimmedOnInsert(t *testing.T) {
+	d := setupTestDB(t)
+
+	created, err := AddItems(context.Background(), d, 1, 1, []string{"  Sour cream  "})
+	if err != nil {
+		t.Fatalf("AddItems: %v", err)
+	}
+	if len(created) != 1 || created[0].Content != "Sour cream" {
+		t.Fatalf("created %v, want one item with content %q", created, "Sour cream")
+	}
+	if got := contents(t, d, 1); !equalStrings(got, []string{"Sour cream"}) {
+		t.Errorf("list is %v, want [Sour cream]", got)
+	}
+}
+
+func TestAddItemsHouseholdIsolation(t *testing.T) {
+	d := setupTestDB(t)
+
+	if _, err := d.Exec(`INSERT INTO users (id, email, name, picture, google_id, created_at) VALUES (2, 'other@example.com', 'Other', '', 'g2', '')`); err != nil {
+		t.Fatalf("insert user 2: %v", err)
+	}
+	if _, err := Add(d, GroceryItem{HouseholdID: 2, Content: "Milk", OriginalText: "Milk", AddedBy: 2}); err != nil {
+		t.Fatalf("Add household 2: %v", err)
+	}
+
+	// Another household's identically named item must not suppress the insert.
+	created, err := AddItems(context.Background(), d, 1, 1, []string{"Milk"})
+	if err != nil {
+		t.Fatalf("AddItems: %v", err)
+	}
+	if len(created) != 1 {
+		t.Fatalf("created %d items, want 1", len(created))
+	}
+	if got := contents(t, d, 1); !equalStrings(got, []string{"Milk"}) {
+		t.Errorf("household 1 list is %v, want [Milk]", got)
+	}
+	if got := contents(t, d, 2); !equalStrings(got, []string{"Milk"}) {
+		t.Errorf("household 2 list is %v, want [Milk]", got)
+	}
+}
+
+func TestAddItemsContinuesSortOrderFromAdd(t *testing.T) {
+	d := setupTestDB(t)
+
+	first, err := Add(d, GroceryItem{HouseholdID: 1, Content: "Milk", OriginalText: "Milk", AddedBy: 1})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	created, err := AddItems(context.Background(), d, 1, 1, []string{"Eggs", "Bread"})
+	if err != nil {
+		t.Fatalf("AddItems: %v", err)
+	}
+	if len(created) != 2 {
+		t.Fatalf("created %d items, want 2", len(created))
+	}
+	if created[0].SortOrder != first.SortOrder+1 || created[1].SortOrder != first.SortOrder+2 {
+		t.Errorf("sort orders %d, %d after %d — want consecutive", created[0].SortOrder, created[1].SortOrder, first.SortOrder)
+	}
+
+	// Content must survive the encryption round-trip just like Add's does.
+	items, err := ListByHousehold(d, 1)
+	if err != nil {
+		t.Fatalf("ListByHousehold: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("got %d items, want 3", len(items))
+	}
+	for _, item := range items {
+		if item.Checked {
+			t.Errorf("item %q should not be checked", item.Content)
+		}
+		if item.CreatedAt.IsZero() {
+			t.Errorf("item %q has zero created_at", item.Content)
+		}
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Bulk add for grocery items with duplicate detection** - The grocery store can now add several items at once in a single transaction, skipping names already on the list and repeats within the batch (matching ignores case and surrounding whitespace). This is the groundwork for pushing recipe ingredients onto the grocery list. (Hytte-2m0ky)

## Original Issue (task): Grocery bulk add with case-insensitive de-duplication

Modify `internal/grocery/store.go` to add a bulk insert on the existing add-item path: `AddItems(ctx context.Context, userID string, names []string) error`. Because item names are stored encrypted, de-duplication cannot be done in SQL — load the user's current list items, decrypt each name, build a `map[string]struct{}` keyed on `strings.ToLower(strings.TrimSpace(name))`, and skip any incoming name that matches an existing item or an earlier name in the same batch. Insert the remainder in a single transaction reusing the existing single-item insert logic (encryption, ordering/position, timestamps) so behaviour stays identical to `AddItem`. Add `internal/grocery/store_test.go` cases: bulk insert of new names, mixed new/duplicate input, case- and whitespace-insensitive matching, duplicates within the same batch, and empty slice being a no-op. This sub-task is a prerequisite for the recipe grocery-push endpoint and is the only change outside `internal/recipes`.

---
Bead: Hytte-2m0ky | Branch: forge/Hytte-2m0ky
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->