### PR TITLE
Recipe CRUD, rating, cooked and cook-again handlers (Hytte-q7q57)

### DIFF
--- a/changelog.d/Hytte-q7q57.md
+++ b/changelog.d/Hytte-q7q57.md
@@ -1,0 +1,2 @@
+category: Added
+- **Recipe API: CRUD, rating, cooking log and cook-again suggestions** - `/api/recipes` now supports listing (with tag filters), creating, reading, updating and deleting recipes, plus `POST /api/recipes/{id}/rating`, `POST /api/recipes/{id}/cooked` for logging a cook, and `GET /api/recipes/cook-again` for suggestions ranked by season and time since last cooked. Every route is scoped to the signed-in user and gated by the `recipes` feature flag. (Hytte-q7q57)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Robin831/Hytte/internal/notes"
 	"github.com/Robin831/Hytte/internal/pokemon"
 	"github.com/Robin831/Hytte/internal/push"
+	"github.com/Robin831/Hytte/internal/recipes"
 	"github.com/Robin831/Hytte/internal/settings"
 	"github.com/Robin831/Hytte/internal/skywatch"
 	"github.com/Robin831/Hytte/internal/stars"
@@ -942,12 +943,8 @@ func NewRouter(db *sql.DB) http.Handler {
 				r.With(auth.RequireAdmin()).Post("/offers/refresh", offers.HandleRefresh(db))
 			})
 
-			// Recipes — gated by "recipes" feature. The store landed in
-			// Hytte-evi4c; the /api/recipes/* handlers are wired into this
-			// group by the follow-up sub-task.
-			r.Group(func(r chi.Router) {
-				r.Use(auth.RequireFeature(db, "recipes"))
-			})
+			// Recipes — gated by "recipes" feature (routes in recipes.RegisterRoutes).
+			recipes.RegisterRoutes(r, db)
 
 			// Infrastructure monitoring — gated by "infra" feature.
 			r.Group(func(r chi.Router) {

--- a/internal/recipes/handlers.go
+++ b/internal/recipes/handlers.go
@@ -1,0 +1,506 @@
+package recipes
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+// defaultCookAgainLimit is how many suggestions GET /api/recipes/cook-again
+// returns when the caller does not ask for a specific number.
+const defaultCookAgainLimit = 5
+
+// maxCookAgainLimit caps the ?limit= query parameter so a stray large value
+// cannot ask the server to rank and serialise an unbounded list.
+const maxCookAgainLimit = 100
+
+// --- DTOs ---
+
+// RecipeResponse is the JSON shape the frontend consumes for a single recipe.
+// It deliberately omits user_id: every route is already scoped to the caller,
+// so the owner is implicit. Nullable fields are emitted as null rather than
+// dropped so the client can rely on the keys being present.
+type RecipeResponse struct {
+	ID           int64                `json:"id"`
+	Title        string               `json:"title"`
+	Notes        string               `json:"notes"`
+	Servings     int                  `json:"servings"`
+	Rating       *int                 `json:"rating"`
+	RatedAt      *time.Time           `json:"rated_at"`
+	LastCookedAt *time.Time           `json:"last_cooked_at"`
+	CreatedAt    time.Time            `json:"created_at"`
+	UpdatedAt    time.Time            `json:"updated_at"`
+	Ingredients  []IngredientResponse `json:"ingredients"`
+	Steps        []StepResponse       `json:"steps"`
+	Tags         []string             `json:"tags"`
+}
+
+// IngredientResponse is one ingredient line of a RecipeResponse.
+type IngredientResponse struct {
+	ID       int64   `json:"id"`
+	Position int     `json:"position"`
+	Text     string  `json:"text"`
+	Quantity float64 `json:"quantity"`
+	Unit     string  `json:"unit"`
+	Name     string  `json:"name"`
+}
+
+// StepResponse is one method step of a RecipeResponse.
+type StepResponse struct {
+	ID              int64  `json:"id"`
+	Position        int    `json:"position"`
+	Text            string `json:"text"`
+	DurationSeconds int    `json:"duration_seconds"`
+}
+
+// CreateRecipeRequest is the body of POST /api/recipes. Ingredient and step
+// order is taken from the array order — the store rewrites Position from it.
+type CreateRecipeRequest struct {
+	Title       string              `json:"title"`
+	Notes       string              `json:"notes"`
+	Servings    int                 `json:"servings"`
+	Ingredients []IngredientRequest `json:"ingredients"`
+	Steps       []StepRequest       `json:"steps"`
+	Tags        []string            `json:"tags"`
+}
+
+// UpdateRecipeRequest is the body of PUT /api/recipes/{id}. PUT replaces the
+// whole recipe — including its ingredient, step and tag lists — so the shape is
+// identical to create.
+type UpdateRecipeRequest = CreateRecipeRequest
+
+// IngredientRequest is one submitted ingredient line. Text is the free-form
+// line the user typed; Quantity/Unit/Name are the parsed triple the client
+// sends alongside it so scaling and grocery matching stay possible without
+// re-parsing server-side.
+type IngredientRequest struct {
+	Text     string  `json:"text"`
+	Quantity float64 `json:"quantity"`
+	Unit     string  `json:"unit"`
+	Name     string  `json:"name"`
+}
+
+// StepRequest is one submitted method step.
+type StepRequest struct {
+	Text            string `json:"text"`
+	DurationSeconds int    `json:"duration_seconds"`
+}
+
+// RateRecipeRequest is the body of POST /api/recipes/{id}/rating. Rating is a
+// pointer so an omitted field is rejected rather than silently read as 0,
+// which would clear an existing rating.
+type RateRecipeRequest struct {
+	Rating *int `json:"rating"`
+}
+
+// CookedRequest is the body of POST /api/recipes/{id}/cooked. CookedAt is
+// optional — omit it (or send an empty body) to log the cook as happening now.
+type CookedRequest struct {
+	CookedAt *time.Time `json:"cooked_at"`
+}
+
+// --- Handlers ---
+
+// Handlers serves the recipes REST API on top of the recipe Store.
+type Handlers struct {
+	store *Store
+}
+
+// NewHandlers builds the recipe handlers around a database handle.
+func NewHandlers(db *sql.DB) *Handlers {
+	return &Handlers{store: NewStore(db)}
+}
+
+// RegisterRoutes mounts every /api/recipes route on r behind the "recipes"
+// feature gate. Production and tests both call this, so the middleware chain
+// under test is the one that actually runs.
+func RegisterRoutes(r chi.Router, db *sql.DB) {
+	h := NewHandlers(db)
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireFeature(db, "recipes"))
+		r.Get("/recipes", h.HandleList)
+		r.Post("/recipes", h.HandleCreate)
+		// Registered before /recipes/{id} so the literal segment wins even if
+		// chi's static-over-wildcard preference ever changes.
+		r.Get("/recipes/cook-again", h.HandleCookAgain)
+		r.Get("/recipes/{id}", h.HandleGet)
+		r.Put("/recipes/{id}", h.HandleUpdate)
+		r.Delete("/recipes/{id}", h.HandleDelete)
+		r.Post("/recipes/{id}/rating", h.HandleRate)
+		r.Post("/recipes/{id}/cooked", h.HandleCooked)
+	})
+}
+
+// HandleList returns the caller's recipes, newest first. Optional repeated
+// query parameters narrow the list by tag: ?tag=dinner&tag=fish matches
+// recipes carrying at least one of them, ?tag_all=dinner&tag_all=fish matches
+// only recipes carrying all of them.
+func (h *Handlers) HandleList(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	query := r.URL.Query()
+	filter := TagFilter{Any: query["tag"], All: query["tag_all"]}
+
+	recipes, err := h.store.ListRecipes(r.Context(), user.ID, filter)
+	if err != nil {
+		log.Printf("recipes: list: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to list recipes")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"recipes": toRecipeResponses(recipes)})
+}
+
+// HandleCreate stores a new recipe with its ingredients, steps and tags.
+func (h *Handlers) HandleCreate(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	var body CreateRecipeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	recipe, errMsg := recipeFromRequest(body)
+	if errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	created, err := h.store.CreateRecipe(r.Context(), user.ID, recipe)
+	if err != nil {
+		log.Printf("recipes: create: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to create recipe")
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{"recipe": toRecipeResponse(created)})
+}
+
+// HandleGet returns one recipe. A recipe owned by another user is reported as
+// missing rather than forbidden so the API does not confirm it exists.
+func (h *Handlers) HandleGet(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	id, ok := urlID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid recipe ID")
+		return
+	}
+
+	recipe, err := h.store.GetRecipe(r.Context(), user.ID, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "recipe not found")
+			return
+		}
+		log.Printf("recipes: get: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to load recipe")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"recipe": toRecipeResponse(recipe)})
+}
+
+// HandleUpdate replaces a recipe's editable fields and its child lists. Rating
+// and cooking history are owned by their own endpoints and are left alone.
+func (h *Handlers) HandleUpdate(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	id, ok := urlID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid recipe ID")
+		return
+	}
+
+	var body UpdateRecipeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	recipe, errMsg := recipeFromRequest(body)
+	if errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+	recipe.ID = id
+
+	updated, err := h.store.UpdateRecipe(r.Context(), user.ID, recipe)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "recipe not found")
+			return
+		}
+		log.Printf("recipes: update: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to update recipe")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"recipe": toRecipeResponse(updated)})
+}
+
+// HandleDelete removes a recipe; its ingredients, steps, tags, cooking log and
+// meal-plan entries cascade.
+func (h *Handlers) HandleDelete(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	id, ok := urlID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid recipe ID")
+		return
+	}
+
+	if err := h.store.DeleteRecipe(r.Context(), user.ID, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "recipe not found")
+			return
+		}
+		log.Printf("recipes: delete: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to delete recipe")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// HandleRate sets a recipe's 1-5 star rating. A rating of 0 clears it.
+func (h *Handlers) HandleRate(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	id, ok := urlID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid recipe ID")
+		return
+	}
+
+	var body RateRecipeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if body.Rating == nil {
+		writeError(w, http.StatusBadRequest, "rating is required")
+		return
+	}
+
+	if err := h.store.SetRating(r.Context(), user.ID, id, *body.Rating); err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidRating):
+			writeError(w, http.StatusBadRequest, "rating must be between 0 and 5")
+		case errors.Is(err, sql.ErrNoRows):
+			writeError(w, http.StatusNotFound, "recipe not found")
+		default:
+			log.Printf("recipes: set rating: %v", err)
+			writeError(w, http.StatusInternalServerError, "failed to set rating")
+		}
+		return
+	}
+
+	h.respondWithRecipe(w, r, user.ID, id, "failed to load recipe")
+}
+
+// HandleCooked appends an entry to a recipe's cooking log. The client may send
+// the moment it was cooked (to backfill); an omitted or empty body logs now.
+func (h *Handlers) HandleCooked(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	id, ok := urlID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid recipe ID")
+		return
+	}
+
+	var body CookedRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	cookedAt := time.Now().UTC()
+	if body.CookedAt != nil {
+		cookedAt = body.CookedAt.UTC()
+	}
+
+	if err := h.store.RecordCook(r.Context(), user.ID, id, cookedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "recipe not found")
+			return
+		}
+		log.Printf("recipes: record cook: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to record cook")
+		return
+	}
+
+	h.respondWithRecipe(w, r, user.ID, id, "failed to load recipe")
+}
+
+// HandleCookAgain suggests recipes worth making again: in-season tags first,
+// then whatever was cooked longest ago. ?limit=0 returns every candidate.
+func (h *Handlers) HandleCookAgain(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	limit := defaultCookAgainLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 || parsed > maxCookAgainLimit {
+			writeError(w, http.StatusBadRequest, "invalid limit")
+			return
+		}
+		limit = parsed
+	}
+
+	recipes, err := h.store.CookAgain(r.Context(), user.ID, time.Now(), limit)
+	if err != nil {
+		log.Printf("recipes: cook again: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to load suggestions")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"recipes": toRecipeResponses(recipes)})
+}
+
+// respondWithRecipe re-reads a recipe and writes it as the response body. The
+// mutating endpoints use it so the client always gets the stored state back
+// rather than having to re-fetch.
+func (h *Handlers) respondWithRecipe(w http.ResponseWriter, r *http.Request, userID, id int64, failMsg string) {
+	recipe, err := h.store.GetRecipe(r.Context(), userID, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "recipe not found")
+			return
+		}
+		log.Printf("recipes: reload recipe: %v", err)
+		writeError(w, http.StatusInternalServerError, failMsg)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"recipe": toRecipeResponse(recipe)})
+}
+
+// --- mapping and validation ---
+
+// recipeFromRequest validates a create/update body and converts it into a
+// store model. It returns a non-empty message when the body is unusable; the
+// caller turns that into a 400. Blank ingredient and step rows are dropped
+// rather than rejected — form UIs routinely submit a trailing empty row.
+func recipeFromRequest(body CreateRecipeRequest) (Recipe, string) {
+	title := strings.TrimSpace(body.Title)
+	if title == "" {
+		return Recipe{}, "title is required"
+	}
+	if body.Servings < 0 {
+		return Recipe{}, "servings cannot be negative"
+	}
+
+	recipe := Recipe{
+		Title:       title,
+		Notes:       strings.TrimSpace(body.Notes),
+		Servings:    body.Servings,
+		Ingredients: make([]Ingredient, 0, len(body.Ingredients)),
+		Steps:       make([]Step, 0, len(body.Steps)),
+		Tags:        body.Tags,
+	}
+
+	for _, in := range body.Ingredients {
+		text := strings.TrimSpace(in.Text)
+		name := strings.TrimSpace(in.Name)
+		if text == "" && name == "" {
+			continue
+		}
+		if in.Quantity < 0 {
+			return Recipe{}, "ingredient quantity cannot be negative"
+		}
+		recipe.Ingredients = append(recipe.Ingredients, Ingredient{
+			Text:     text,
+			Quantity: in.Quantity,
+			Unit:     strings.TrimSpace(in.Unit),
+			Name:     name,
+		})
+	}
+
+	for _, in := range body.Steps {
+		text := strings.TrimSpace(in.Text)
+		if text == "" {
+			continue
+		}
+		if in.DurationSeconds < 0 {
+			return Recipe{}, "step duration cannot be negative"
+		}
+		recipe.Steps = append(recipe.Steps, Step{Text: text, DurationSeconds: in.DurationSeconds})
+	}
+
+	return recipe, ""
+}
+
+func toRecipeResponse(r Recipe) RecipeResponse {
+	resp := RecipeResponse{
+		ID:           r.ID,
+		Title:        r.Title,
+		Notes:        r.Notes,
+		Servings:     r.Servings,
+		Rating:       r.Rating,
+		RatedAt:      r.RatedAt,
+		LastCookedAt: r.LastCook,
+		CreatedAt:    r.CreatedAt,
+		UpdatedAt:    r.UpdatedAt,
+		Ingredients:  make([]IngredientResponse, 0, len(r.Ingredients)),
+		Steps:        make([]StepResponse, 0, len(r.Steps)),
+		Tags:         r.Tags,
+	}
+	if resp.Tags == nil {
+		resp.Tags = []string{}
+	}
+	for _, ing := range r.Ingredients {
+		resp.Ingredients = append(resp.Ingredients, IngredientResponse{
+			ID:       ing.ID,
+			Position: ing.Position,
+			Text:     ing.Text,
+			Quantity: ing.Quantity,
+			Unit:     ing.Unit,
+			Name:     ing.Name,
+		})
+	}
+	for _, step := range r.Steps {
+		resp.Steps = append(resp.Steps, StepResponse{
+			ID:              step.ID,
+			Position:        step.Position,
+			Text:            step.Text,
+			DurationSeconds: step.DurationSeconds,
+		})
+	}
+	return resp
+}
+
+func toRecipeResponses(recipes []Recipe) []RecipeResponse {
+	out := make([]RecipeResponse, 0, len(recipes))
+	for _, r := range recipes {
+		out = append(out, toRecipeResponse(r))
+	}
+	return out
+}
+
+// --- HTTP helpers ---
+
+// urlID parses the {id} path parameter.
+func urlID(r *http.Request) (int64, bool) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("recipes: encode response: %v", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/internal/recipes/handlers_test.go
+++ b/internal/recipes/handlers_test.go
@@ -1,0 +1,552 @@
+package recipes
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/go-chi/chi/v5"
+)
+
+// ownerID and otherID are the two users seeded by setupTestDB. otherID is used
+// to prove every route is scoped to the caller.
+const (
+	ownerID = int64(1)
+	otherID = int64(2)
+)
+
+// testEnv wires the real router chain — RequireAuth, WithFeatures and the
+// "recipes" feature gate from RegisterRoutes — around an in-memory database so
+// the tests exercise the middleware that actually runs in production.
+type testEnv struct {
+	db     *sql.DB
+	store  *Store
+	router http.Handler
+	tokens map[int64]string
+}
+
+func setupHandlerTest(t *testing.T) *testEnv {
+	t.Helper()
+	database := setupTestDB(t)
+
+	env := &testEnv{
+		db:     database,
+		store:  NewStore(database),
+		tokens: map[int64]string{},
+	}
+	for _, id := range []int64{ownerID, otherID} {
+		if err := auth.SetUserFeature(database, id, "recipes", true); err != nil {
+			t.Fatalf("enable recipes for user %d: %v", id, err)
+		}
+		token, _, err := auth.CreateSession(database, id)
+		if err != nil {
+			t.Fatalf("create session for user %d: %v", id, err)
+		}
+		env.tokens[id] = token
+	}
+
+	r := chi.NewRouter()
+	r.Route("/api", func(r chi.Router) {
+		r.Use(auth.RequireAuth(database))
+		r.Use(auth.WithFeatures(database))
+		RegisterRoutes(r, database)
+	})
+	env.router = r
+	return env
+}
+
+// do issues a request as the given user and returns the recorded response.
+// Pass an empty body for requests without one.
+func (e *testEnv) do(t *testing.T, userID int64, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, path, nil)
+	} else {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.AddCookie(&http.Cookie{Name: "session", Value: e.tokens[userID]})
+	rec := httptest.NewRecorder()
+	e.router.ServeHTTP(rec, req)
+	return rec
+}
+
+type recipeEnvelope struct {
+	Recipe RecipeResponse `json:"recipe"`
+}
+
+type recipeListEnvelope struct {
+	Recipes []RecipeResponse `json:"recipes"`
+}
+
+func decodeRecipe(t *testing.T, rec *httptest.ResponseRecorder) RecipeResponse {
+	t.Helper()
+	var env recipeEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode recipe response: %v (body: %s)", err, rec.Body.String())
+	}
+	return env.Recipe
+}
+
+func decodeRecipes(t *testing.T, rec *httptest.ResponseRecorder) []RecipeResponse {
+	t.Helper()
+	var env recipeListEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode recipe list response: %v (body: %s)", err, rec.Body.String())
+	}
+	return env.Recipes
+}
+
+// createBody is a valid POST /api/recipes payload.
+const createBody = `{
+	"title": "Fiskegrateng",
+	"notes": "Grandmother's version.",
+	"servings": 4,
+	"ingredients": [
+		{"text": "400 g torsk", "quantity": 400, "unit": "g", "name": "torsk"},
+		{"text": "3 dl melk", "quantity": 3, "unit": "dl", "name": "melk"}
+	],
+	"steps": [
+		{"text": "Kok makaronien.", "duration_seconds": 480},
+		{"text": "Stek i ovnen.", "duration_seconds": 1800}
+	],
+	"tags": ["Dinner", "fish"]
+}`
+
+func TestHandleCreateAndList(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	rec := env.do(t, ownerID, http.MethodPost, "/api/recipes", createBody)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want %d (body: %s)", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	created := decodeRecipe(t, rec)
+	if created.ID == 0 {
+		t.Fatal("created recipe has no ID")
+	}
+	if created.Title != "Fiskegrateng" {
+		t.Errorf("title = %q, want %q", created.Title, "Fiskegrateng")
+	}
+	if created.Servings != 4 {
+		t.Errorf("servings = %d, want 4", created.Servings)
+	}
+	if len(created.Ingredients) != 2 || created.Ingredients[0].Name != "torsk" {
+		t.Errorf("unexpected ingredients: %+v", created.Ingredients)
+	}
+	if len(created.Steps) != 2 || created.Steps[1].DurationSeconds != 1800 {
+		t.Errorf("unexpected steps: %+v", created.Steps)
+	}
+	// Tags are normalised (lowercased, sorted) by the store.
+	if len(created.Tags) != 2 || created.Tags[0] != "dinner" || created.Tags[1] != "fish" {
+		t.Errorf("tags = %v, want [dinner fish]", created.Tags)
+	}
+	if created.Rating != nil || created.LastCookedAt != nil {
+		t.Errorf("new recipe should have no rating or cook history: %+v", created)
+	}
+
+	rec = env.do(t, ownerID, http.MethodGet, "/api/recipes", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	list := decodeRecipes(t, rec)
+	if len(list) != 1 {
+		t.Fatalf("list returned %d recipes, want 1", len(list))
+	}
+	if list[0].ID != created.ID {
+		t.Errorf("list returned recipe %d, want %d", list[0].ID, created.ID)
+	}
+	if len(list[0].Ingredients) != 2 {
+		t.Errorf("list entry should carry its ingredients, got %d", len(list[0].Ingredients))
+	}
+}
+
+func TestHandleListFiltersByTag(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	dinner := mustCreate(t, env.store, ownerID, Recipe{Title: "Dinner one", Tags: []string{"dinner", "fish"}})
+	lunch := mustCreate(t, env.store, ownerID, Recipe{Title: "Lunch one", Tags: []string{"lunch"}})
+
+	rec := env.do(t, ownerID, http.MethodGet, "/api/recipes?tag=dinner", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	list := decodeRecipes(t, rec)
+	if len(list) != 1 || list[0].ID != dinner.ID {
+		t.Fatalf("?tag=dinner returned %+v, want only recipe %d", list, dinner.ID)
+	}
+
+	rec = env.do(t, ownerID, http.MethodGet, "/api/recipes?tag_all=dinner&tag_all=fish", "")
+	list = decodeRecipes(t, rec)
+	if len(list) != 1 || list[0].ID != dinner.ID {
+		t.Fatalf("tag_all returned %+v, want only recipe %d", list, dinner.ID)
+	}
+
+	rec = env.do(t, ownerID, http.MethodGet, "/api/recipes?tag=lunch", "")
+	if list = decodeRecipes(t, rec); len(list) != 1 || list[0].ID != lunch.ID {
+		t.Fatalf("?tag=lunch returned %+v, want only recipe %d", list, lunch.ID)
+	}
+
+	rec = env.do(t, ownerID, http.MethodGet, "/api/recipes?tag_all=dinner&tag_all=lunch", "")
+	if list = decodeRecipes(t, rec); len(list) != 0 {
+		t.Fatalf("tag_all with no common recipe returned %+v, want empty", list)
+	}
+}
+
+func TestHandleCreateValidation(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"missing title", `{"title": "  ", "servings": 2}`},
+		{"malformed JSON", `{"title": `},
+		{"negative servings", `{"title": "X", "servings": -1}`},
+		{"negative quantity", `{"title": "X", "ingredients": [{"text": "salt", "quantity": -2}]}`},
+		{"negative step duration", `{"title": "X", "steps": [{"text": "Bake", "duration_seconds": -5}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := env.do(t, ownerID, http.MethodPost, "/api/recipes", tc.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandleCreateDropsBlankRows checks that a trailing empty ingredient or
+// step row — routine in form UIs — is dropped rather than rejected or stored.
+func TestHandleCreateDropsBlankRows(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	body := `{"title": "Simple", "ingredients": [{"text": "salt"}, {"text": "  "}], "steps": [{"text": "Mix"}, {"text": ""}]}`
+	rec := env.do(t, ownerID, http.MethodPost, "/api/recipes", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	created := decodeRecipe(t, rec)
+	if len(created.Ingredients) != 1 || len(created.Steps) != 1 {
+		t.Fatalf("blank rows not dropped: %d ingredients, %d steps", len(created.Ingredients), len(created.Steps))
+	}
+}
+
+func TestHandleGetUpdateDelete(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	created := decodeRecipe(t, env.do(t, ownerID, http.MethodPost, "/api/recipes", createBody))
+	path := fmt.Sprintf("/api/recipes/%d", created.ID)
+
+	rec := env.do(t, ownerID, http.MethodGet, path, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeRecipe(t, rec); got.Title != "Fiskegrateng" || len(got.Steps) != 2 {
+		t.Errorf("unexpected recipe: %+v", got)
+	}
+
+	update := `{"title": "Fiskegrateng v2", "notes": "Less dill.", "servings": 6,
+		"ingredients": [{"text": "500 g torsk", "quantity": 500, "unit": "g", "name": "torsk"}],
+		"steps": [{"text": "Stek.", "duration_seconds": 1200}], "tags": ["Dinner"]}`
+	rec = env.do(t, ownerID, http.MethodPut, path, update)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	updated := decodeRecipe(t, rec)
+	if updated.Title != "Fiskegrateng v2" || updated.Servings != 6 {
+		t.Errorf("update did not apply: %+v", updated)
+	}
+	if len(updated.Ingredients) != 1 || len(updated.Steps) != 1 || len(updated.Tags) != 1 {
+		t.Errorf("child lists not replaced: %+v", updated)
+	}
+	if updated.ID != created.ID {
+		t.Errorf("update changed the ID: %d != %d", updated.ID, created.ID)
+	}
+
+	rec = env.do(t, ownerID, http.MethodDelete, path, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if rec = env.do(t, ownerID, http.MethodGet, path, ""); rec.Code != http.StatusNotFound {
+		t.Errorf("get after delete status = %d, want 404", rec.Code)
+	}
+	if rec = env.do(t, ownerID, http.MethodDelete, path, ""); rec.Code != http.StatusNotFound {
+		t.Errorf("second delete status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleInvalidAndMissingIDs(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+		want   int
+	}{
+		{"non-numeric get", http.MethodGet, "/api/recipes/abc", "", http.StatusBadRequest},
+		{"zero id", http.MethodGet, "/api/recipes/0", "", http.StatusBadRequest},
+		{"non-numeric rating", http.MethodPost, "/api/recipes/abc/rating", `{"rating":4}`, http.StatusBadRequest},
+		{"missing recipe get", http.MethodGet, "/api/recipes/9999", "", http.StatusNotFound},
+		{"missing recipe update", http.MethodPut, "/api/recipes/9999", `{"title":"X"}`, http.StatusNotFound},
+		{"missing recipe delete", http.MethodDelete, "/api/recipes/9999", "", http.StatusNotFound},
+		{"missing recipe rating", http.MethodPost, "/api/recipes/9999/rating", `{"rating":4}`, http.StatusNotFound},
+		{"missing recipe cooked", http.MethodPost, "/api/recipes/9999/cooked", "", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := env.do(t, ownerID, tc.method, tc.path, tc.body)
+			if rec.Code != tc.want {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleRate(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	created := decodeRecipe(t, env.do(t, ownerID, http.MethodPost, "/api/recipes", createBody))
+	path := fmt.Sprintf("/api/recipes/%d/rating", created.ID)
+
+	rec := env.do(t, ownerID, http.MethodPost, path, `{"rating": 4}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("rate status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	rated := decodeRecipe(t, rec)
+	if rated.Rating == nil || *rated.Rating != 4 {
+		t.Fatalf("rating = %v, want 4", rated.Rating)
+	}
+	if rated.RatedAt == nil {
+		t.Error("rated_at should be set alongside a rating")
+	}
+
+	// 0 clears the rating.
+	rec = env.do(t, ownerID, http.MethodPost, path, `{"rating": 0}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear rating status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if cleared := decodeRecipe(t, rec); cleared.Rating != nil {
+		t.Errorf("rating = %v, want nil after clearing", *cleared.Rating)
+	}
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"too high", `{"rating": 6}`},
+		{"negative", `{"rating": -1}`},
+		{"missing field", `{}`},
+		{"malformed", `{"rating":`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := env.do(t, ownerID, http.MethodPost, path, tc.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleCooked(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	created := decodeRecipe(t, env.do(t, ownerID, http.MethodPost, "/api/recipes", createBody))
+	path := fmt.Sprintf("/api/recipes/%d/cooked", created.ID)
+
+	before := time.Now().UTC().Add(-time.Second)
+	rec := env.do(t, ownerID, http.MethodPost, path, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cooked status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	cooked := decodeRecipe(t, rec)
+	if cooked.LastCookedAt == nil {
+		t.Fatal("last_cooked_at should be set after logging a cook")
+	}
+	if cooked.LastCookedAt.Before(before) {
+		t.Errorf("last_cooked_at = %v, want at/after %v", cooked.LastCookedAt, before)
+	}
+
+	// An explicit older timestamp is logged, but last_cooked_at keeps the most
+	// recent cook rather than the most recently logged one.
+	rec = env.do(t, ownerID, http.MethodPost, path, `{"cooked_at": "2024-01-02T10:00:00Z"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("backfill status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	backfilled := decodeRecipe(t, rec)
+	if backfilled.LastCookedAt == nil || !backfilled.LastCookedAt.Equal(*cooked.LastCookedAt) {
+		t.Errorf("last_cooked_at = %v, want unchanged %v", backfilled.LastCookedAt, cooked.LastCookedAt)
+	}
+
+	cooks, err := env.store.ListCooks(context.Background(), ownerID, created.ID)
+	if err != nil {
+		t.Fatalf("list cooks: %v", err)
+	}
+	if len(cooks) != 2 {
+		t.Fatalf("cooking log has %d entries, want 2", len(cooks))
+	}
+
+	if rec := env.do(t, ownerID, http.MethodPost, path, `{"cooked_at": "not-a-time"}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed timestamp status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleCookAgain(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	now := time.Now()
+	seasonal := ""
+	for tag := range seasonTags[seasonOf(now)] {
+		seasonal = tag
+		break
+	}
+
+	// Cooked yesterday but tagged for the current season — should outrank the
+	// never-cooked recipe that isn't in season.
+	inSeason := mustCreate(t, env.store, ownerID, Recipe{Title: "In season", Tags: []string{seasonal}})
+	if err := env.store.RecordCook(context.Background(), ownerID, inSeason.ID, now.Add(-24*time.Hour)); err != nil {
+		t.Fatalf("record cook: %v", err)
+	}
+	neverCooked := mustCreate(t, env.store, ownerID, Recipe{Title: "Never cooked", Tags: []string{"anytime"}})
+
+	rec := env.do(t, ownerID, http.MethodGet, "/api/recipes/cook-again", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cook-again status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	list := decodeRecipes(t, rec)
+	if len(list) != 2 {
+		t.Fatalf("cook-again returned %d recipes, want 2", len(list))
+	}
+	if list[0].ID != inSeason.ID || list[1].ID != neverCooked.ID {
+		t.Errorf("cook-again order = [%d %d], want [%d %d]", list[0].ID, list[1].ID, inSeason.ID, neverCooked.ID)
+	}
+
+	rec = env.do(t, ownerID, http.MethodGet, "/api/recipes/cook-again?limit=1", "")
+	if list = decodeRecipes(t, rec); len(list) != 1 || list[0].ID != inSeason.ID {
+		t.Fatalf("limit=1 returned %+v, want only recipe %d", list, inSeason.ID)
+	}
+
+	rec = env.do(t, ownerID, http.MethodGet, "/api/recipes/cook-again?limit=0", "")
+	if list = decodeRecipes(t, rec); len(list) != 2 {
+		t.Fatalf("limit=0 returned %d recipes, want all 2", len(list))
+	}
+
+	for _, raw := range []string{"abc", "-1", "1000"} {
+		rec := env.do(t, ownerID, http.MethodGet, "/api/recipes/cook-again?limit="+raw, "")
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("limit=%s status = %d, want 400", raw, rec.Code)
+		}
+	}
+}
+
+// TestUserScopingIsolation asserts a second user can neither see nor touch the
+// owner's recipes, and gets 404 (not 403) so the API never confirms that
+// someone else's recipe exists.
+func TestUserScopingIsolation(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	created := decodeRecipe(t, env.do(t, ownerID, http.MethodPost, "/api/recipes", createBody))
+	id := created.ID
+
+	if list := decodeRecipes(t, env.do(t, otherID, http.MethodGet, "/api/recipes", "")); len(list) != 0 {
+		t.Errorf("other user's list = %+v, want empty", list)
+	}
+	if list := decodeRecipes(t, env.do(t, otherID, http.MethodGet, "/api/recipes/cook-again", "")); len(list) != 0 {
+		t.Errorf("other user's cook-again = %+v, want empty", list)
+	}
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"get", http.MethodGet, fmt.Sprintf("/api/recipes/%d", id), ""},
+		{"update", http.MethodPut, fmt.Sprintf("/api/recipes/%d", id), `{"title":"Stolen"}`},
+		{"delete", http.MethodDelete, fmt.Sprintf("/api/recipes/%d", id), ""},
+		{"rating", http.MethodPost, fmt.Sprintf("/api/recipes/%d/rating", id), `{"rating":1}`},
+		{"cooked", http.MethodPost, fmt.Sprintf("/api/recipes/%d/cooked", id), ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := env.do(t, otherID, tc.method, tc.path, tc.body)
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("status = %d, want 404 (body: %s)", rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// The owner's recipe is untouched by all of the above.
+	owned := decodeRecipe(t, env.do(t, ownerID, http.MethodGet, fmt.Sprintf("/api/recipes/%d", id), ""))
+	if owned.Title != "Fiskegrateng" || owned.Rating != nil || owned.LastCookedAt != nil {
+		t.Errorf("owner's recipe was modified by the other user: %+v", owned)
+	}
+}
+
+// TestFeatureFlagGating asserts every route is behind the "recipes" flag: a
+// non-admin without it gets 403 (the sibling convention from RequireFeature),
+// while an admin bypasses the check entirely.
+func TestFeatureFlagGating(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	created := mustCreate(t, env.store, otherID, Recipe{Title: "Admin visible"})
+	if err := auth.SetUserFeature(env.db, otherID, "recipes", false); err != nil {
+		t.Fatalf("disable recipes: %v", err)
+	}
+
+	routes := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodGet, "/api/recipes", ""},
+		{http.MethodPost, "/api/recipes", createBody},
+		{http.MethodGet, "/api/recipes/cook-again", ""},
+		{http.MethodGet, fmt.Sprintf("/api/recipes/%d", created.ID), ""},
+		{http.MethodPut, fmt.Sprintf("/api/recipes/%d", created.ID), `{"title":"X"}`},
+		{http.MethodDelete, fmt.Sprintf("/api/recipes/%d", created.ID), ""},
+		{http.MethodPost, fmt.Sprintf("/api/recipes/%d/rating", created.ID), `{"rating":3}`},
+		{http.MethodPost, fmt.Sprintf("/api/recipes/%d/cooked", created.ID), ""},
+	}
+	for _, rt := range routes {
+		rec := env.do(t, otherID, rt.method, rt.path, rt.body)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s %s without the flag: status = %d, want 403 (body: %s)",
+				rt.method, rt.path, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Admins bypass the feature check even with the flag off.
+	if _, err := env.db.Exec("UPDATE users SET is_admin = 1 WHERE id = ?", otherID); err != nil {
+		t.Fatalf("promote user to admin: %v", err)
+	}
+	rec := env.do(t, otherID, http.MethodGet, "/api/recipes", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin list status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if list := decodeRecipes(t, rec); len(list) != 1 || list[0].ID != created.ID {
+		t.Errorf("admin list = %+v, want the admin's own recipe %d", list, created.ID)
+	}
+}
+
+// TestUnauthenticatedRequestsRejected guards the auth layer in front of the
+// group: no session cookie means no access to any recipe route.
+func TestUnauthenticatedRequestsRejected(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/recipes", nil)
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (body: %s)", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Changes

- **Recipe API: CRUD, rating, cooking log and cook-again suggestions** - `/api/recipes` now supports listing (with tag filters), creating, reading, updating and deleting recipes, plus `POST /api/recipes/{id}/rating`, `POST /api/recipes/{id}/cooked` for logging a cook, and `GET /api/recipes/cook-again` for suggestions ranked by season and time since last cooked. Every route is scoped to the signed-in user and gated by the `recipes` feature flag. (Hytte-q7q57)

## Original Issue (task): Recipe CRUD, rating, cooked and cook-again handlers

Create `internal/recipes/handlers.go` with a `Handlers` struct holding the store from sub-task 1 (and grocery store + feature-flag checker) and a `Register(g *echo/chi group)`-style function that mounts routes on the existing `/api/recipes` group. Implement `GET /api/recipes` (list), `POST /api/recipes` (create), `GET/PUT/DELETE /api/recipes/{id}`, `POST /api/recipes/{id}/rating`, `POST /api/recipes/{id}/cooked` (records a cook event with timestamp), and `GET /api/recipes/cook-again`. Follow sibling packages (e.g. `internal/grocery`) exactly for auth: resolve the authenticated user from context, scope every query by user ID, return 404 rather than 403 on cross-user access. Add a shared feature-flag middleware/guard on the group that returns 404 (or 403 for authenticated non-admin per the sibling convention) when the recipes flag is off and the user is not admin. Define request/response DTOs in this file matching the JSON shapes the frontend (sub-tasks 4 and 5 of the parent epic) consumes. Tests in `internal/recipes/handlers_test.go`: happy path per endpoint, validation errors, user-scoping isolation, and feature-flag gating.

---
Bead: Hytte-q7q57 | Branch: forge/Hytte-q7q57
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->