### PR TITLE
Meal plan endpoints and recipe→grocery push endpoint (Hytte-580m2)

### DIFF
--- a/changelog.d/Hytte-580m2.md
+++ b/changelog.d/Hytte-580m2.md
@@ -1,0 +1,3 @@
+category: Added
+- **Meal plan endpoints** - `GET/PUT/DELETE /api/recipes/plan` schedule recipes into breakfast, lunch, dinner and snack slots. GET returns a full ISO week keyed by calendar day (defaulting to the week containing today), and PUT upserts on (day, slot) so repeated saves replace an entry instead of stacking duplicates. (Hytte-580m2)
+- **Push recipe ingredients to the grocery list** - `POST /api/recipes/{id}/grocery` takes a list of ingredient IDs from one of your recipes and adds them to your grocery list, skipping anything already on it (case-insensitively) and reporting how many were added versus skipped. (Hytte-580m2)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2127,7 +2127,12 @@ func createSchema(db *sql.DB) error {
 		created_at TEXT NOT NULL DEFAULT ''
 	);
 
-	CREATE INDEX IF NOT EXISTS idx_meal_plan_entries_user_date ON meal_plan_entries(user_id, plan_date);
+	-- One entry per user, day and slot: PUT /api/recipes/plan upserts on this
+	-- conflict target so repeated writes of the same slot stay idempotent. The
+	-- index also covers the (user_id, plan_date) week lookups, so the earlier
+	-- non-unique index on that prefix is redundant and gets dropped.
+	DROP INDEX IF EXISTS idx_meal_plan_entries_user_date;
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_meal_plan_entries_user_date_slot ON meal_plan_entries(user_id, plan_date, slot);
 
 	`
 

--- a/internal/recipes/handlers.go
+++ b/internal/recipes/handlers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/grocery"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -108,16 +109,70 @@ type CookedRequest struct {
 	CookedAt *time.Time `json:"cooked_at"`
 }
 
+// PlanEntryResponse is one scheduled meal. The day it falls on is the key it
+// is filed under in PlanWeekResponse.Days and is repeated here so an entry
+// stays self-describing once the client pulls it out of the map.
+type PlanEntryResponse struct {
+	ID          int64  `json:"id"`
+	Date        string `json:"date"`
+	Slot        string `json:"slot"`
+	RecipeID    int64  `json:"recipe_id"`
+	RecipeTitle string `json:"recipe_title"`
+}
+
+// PlanWeekResponse is the body of GET /api/recipes/plan: one ISO week, keyed
+// by calendar day. Days always holds all seven keys — an empty day is an empty
+// array rather than a missing key — so the client can render the grid straight
+// from the response.
+type PlanWeekResponse struct {
+	WeekStart string                         `json:"week_start"`
+	WeekEnd   string                         `json:"week_end"`
+	Days      map[string][]PlanEntryResponse `json:"days"`
+}
+
+// PlanEntryRequest is one entry of a PUT /api/recipes/plan body.
+type PlanEntryRequest struct {
+	Date     string `json:"date"` // YYYY-MM-DD
+	Slot     string `json:"slot"` // breakfast | lunch | dinner | snack
+	RecipeID int64  `json:"recipe_id"`
+}
+
+// UpdatePlanRequest is the body of PUT /api/recipes/plan. Several entries may
+// be sent at once so a whole week can be planned in one round trip; each one
+// replaces whatever occupied its day and slot.
+type UpdatePlanRequest struct {
+	Entries []PlanEntryRequest `json:"entries"`
+}
+
+// GroceryPushRequest is the body of POST /api/recipes/{id}/grocery: the subset
+// of the recipe's ingredients to put on the grocery list.
+type GroceryPushRequest struct {
+	IngredientIDs []int64 `json:"ingredient_ids"`
+}
+
+// GroceryPushResponse reports what the push did. Added counts the items that
+// reached the list; Skipped counts the requested ingredients that were already
+// on it (or repeated within the request), which the grocery store de-duplicates
+// case-insensitively.
+type GroceryPushResponse struct {
+	Added   int                   `json:"added"`
+	Skipped int                   `json:"skipped"`
+	Items   []grocery.GroceryItem `json:"items"`
+}
+
 // --- Handlers ---
 
-// Handlers serves the recipes REST API on top of the recipe Store.
+// Handlers serves the recipes REST API on top of the recipe Store. It keeps
+// the database handle as well: pushing ingredients onto the grocery list goes
+// through the grocery package, which owns that table.
 type Handlers struct {
 	store *Store
+	db    *sql.DB
 }
 
 // NewHandlers builds the recipe handlers around a database handle.
 func NewHandlers(db *sql.DB) *Handlers {
-	return &Handlers{store: NewStore(db)}
+	return &Handlers{store: NewStore(db), db: db}
 }
 
 // RegisterRoutes mounts every /api/recipes route on r behind the "recipes"
@@ -132,11 +187,15 @@ func RegisterRoutes(r chi.Router, db *sql.DB) {
 		// Registered before /recipes/{id} so the literal segment wins even if
 		// chi's static-over-wildcard preference ever changes.
 		r.Get("/recipes/cook-again", h.HandleCookAgain)
+		r.Get("/recipes/plan", h.HandlePlanGet)
+		r.Put("/recipes/plan", h.HandlePlanPut)
+		r.Delete("/recipes/plan", h.HandlePlanDelete)
 		r.Get("/recipes/{id}", h.HandleGet)
 		r.Put("/recipes/{id}", h.HandleUpdate)
 		r.Delete("/recipes/{id}", h.HandleDelete)
 		r.Post("/recipes/{id}/rating", h.HandleRate)
 		r.Post("/recipes/{id}/cooked", h.HandleCooked)
+		r.Post("/recipes/{id}/grocery", h.HandleGroceryPush)
 	})
 }
 
@@ -363,6 +422,188 @@ func (h *Handlers) HandleCookAgain(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"recipes": toRecipeResponses(recipes)})
 }
 
+// HandlePlanGet returns one ISO week of the caller's meal plan, keyed by
+// calendar day. ?week=YYYY-MM-DD selects the week containing that date — any
+// day of the week works, it is normalised to the Monday — and defaults to the
+// week containing today.
+func (h *Handlers) HandlePlanGet(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	day := time.Now()
+	if raw := r.URL.Query().Get("week"); raw != "" {
+		parsed, err := ParsePlanDate(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "week must be a YYYY-MM-DD date")
+			return
+		}
+		day = parsed
+	}
+	start := ISOWeekStart(day)
+	end := start.AddDate(0, 0, 6)
+
+	entries, err := h.store.ListPlanEntries(r.Context(), user.ID,
+		start.Format(PlanDateLayout), end.Format(PlanDateLayout))
+	if err != nil {
+		log.Printf("recipes: list plan entries: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to load meal plan")
+		return
+	}
+
+	// Seed all seven days so the client always gets a full week back, then file
+	// each entry under its own date.
+	days := make(map[string][]PlanEntryResponse, 7)
+	for i := 0; i < 7; i++ {
+		days[start.AddDate(0, 0, i).Format(PlanDateLayout)] = []PlanEntryResponse{}
+	}
+	for _, e := range entries {
+		days[e.PlanDate] = append(days[e.PlanDate], toPlanEntryResponse(e))
+	}
+
+	writeJSON(w, http.StatusOK, PlanWeekResponse{
+		WeekStart: start.Format(PlanDateLayout),
+		WeekEnd:   end.Format(PlanDateLayout),
+		Days:      days,
+	})
+}
+
+// HandlePlanPut schedules one or more recipes into meal slots. Each entry
+// replaces whatever occupied its (date, slot), so re-sending the same payload
+// is idempotent. The whole batch is rejected if any entry is malformed or names
+// a recipe the caller does not own.
+func (h *Handlers) HandlePlanPut(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	var body UpdatePlanRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if len(body.Entries) == 0 {
+		writeError(w, http.StatusBadRequest, "at least one entry is required")
+		return
+	}
+
+	entries := make([]PlanEntry, 0, len(body.Entries))
+	for _, in := range body.Entries {
+		entries = append(entries, PlanEntry{
+			RecipeID: in.RecipeID,
+			PlanDate: in.Date,
+			Slot:     in.Slot,
+		})
+	}
+
+	stored, err := h.store.UpsertPlanEntries(r.Context(), user.ID, entries)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidPlanDate):
+			writeError(w, http.StatusBadRequest, "date must be YYYY-MM-DD")
+		case errors.Is(err, ErrInvalidSlot):
+			writeError(w, http.StatusBadRequest, "slot must be breakfast, lunch, dinner or snack")
+		case errors.Is(err, sql.ErrNoRows):
+			// A recipe belonging to someone else is reported as missing rather
+			// than forbidden, matching the single-recipe routes.
+			writeError(w, http.StatusNotFound, "recipe not found")
+		default:
+			log.Printf("recipes: upsert plan entries: %v", err)
+			writeError(w, http.StatusInternalServerError, "failed to save meal plan")
+		}
+		return
+	}
+
+	out := make([]PlanEntryResponse, 0, len(stored))
+	for _, e := range stored {
+		out = append(out, toPlanEntryResponse(e))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"entries": out})
+}
+
+// HandlePlanDelete clears one meal slot, identified by ?date= and ?slot=.
+// An already-empty slot is a 404 so the client can tell a no-op from a delete.
+func (h *Handlers) HandlePlanDelete(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	query := r.URL.Query()
+	date, slot := query.Get("date"), query.Get("slot")
+	if date == "" || slot == "" {
+		writeError(w, http.StatusBadRequest, "date and slot are required")
+		return
+	}
+
+	if err := h.store.DeletePlanEntry(r.Context(), user.ID, date, slot); err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidPlanDate):
+			writeError(w, http.StatusBadRequest, "date must be YYYY-MM-DD")
+		case errors.Is(err, ErrInvalidSlot):
+			writeError(w, http.StatusBadRequest, "slot must be breakfast, lunch, dinner or snack")
+		case errors.Is(err, sql.ErrNoRows):
+			writeError(w, http.StatusNotFound, "meal plan entry not found")
+		default:
+			log.Printf("recipes: delete plan entry: %v", err)
+			writeError(w, http.StatusInternalServerError, "failed to clear meal plan entry")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// HandleGroceryPush puts the named ingredients of one of the caller's recipes
+// onto their grocery list. Ingredients already on the list are skipped rather
+// than duplicated, and the response says how many of each there were.
+//
+// The route sits behind the "recipes" gate only: it is a recipe action, and the
+// list it writes to is the caller's own.
+func (h *Handlers) HandleGroceryPush(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	id, ok := urlID(r)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid recipe ID")
+		return
+	}
+
+	var body GroceryPushRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if len(body.IngredientIDs) == 0 {
+		writeError(w, http.StatusBadRequest, "ingredient_ids is required")
+		return
+	}
+
+	names, err := h.store.IngredientNamesForRecipe(r.Context(), user.ID, id, body.IngredientIDs)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrIngredientNotInRecipe):
+			writeError(w, http.StatusBadRequest, "ingredient does not belong to this recipe")
+		case errors.Is(err, sql.ErrNoRows):
+			writeError(w, http.StatusNotFound, "recipe not found")
+		default:
+			log.Printf("recipes: resolve ingredient names: %v", err)
+			writeError(w, http.StatusInternalServerError, "failed to load ingredients")
+		}
+		return
+	}
+
+	// The grocery list is keyed by household, which is the user's own ID
+	// throughout the grocery package.
+	created, err := grocery.AddItems(r.Context(), h.db, user.ID, user.ID, names)
+	if err != nil {
+		log.Printf("recipes: push ingredients to grocery list: %v", err)
+		writeError(w, http.StatusInternalServerError, "failed to add items to the grocery list")
+		return
+	}
+	for _, item := range created {
+		grocery.DefaultBroker.Publish(user.ID, grocery.GroceryEvent{Type: grocery.EventItemAdded, Payload: item})
+	}
+
+	writeJSON(w, http.StatusOK, GroceryPushResponse{
+		Added:   len(created),
+		Skipped: len(names) - len(created),
+		Items:   created,
+	})
+}
+
 // respondWithRecipe re-reads a recipe and writes it as the response body. The
 // mutating endpoints use it so the client always gets the stored state back
 // rather than having to re-fetch.
@@ -472,6 +713,16 @@ func toRecipeResponse(r Recipe) RecipeResponse {
 		})
 	}
 	return resp
+}
+
+func toPlanEntryResponse(e PlanEntry) PlanEntryResponse {
+	return PlanEntryResponse{
+		ID:          e.ID,
+		Date:        e.PlanDate,
+		Slot:        e.Slot,
+		RecipeID:    e.RecipeID,
+		RecipeTitle: e.RecipeTitle,
+	}
 }
 
 func toRecipeResponses(recipes []Recipe) []RecipeResponse {

--- a/internal/recipes/handlers_test.go
+++ b/internal/recipes/handlers_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Robin831/Hytte/internal/auth"
+	"github.com/Robin831/Hytte/internal/grocery"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -516,6 +517,11 @@ func TestFeatureFlagGating(t *testing.T) {
 		{http.MethodDelete, fmt.Sprintf("/api/recipes/%d", created.ID), ""},
 		{http.MethodPost, fmt.Sprintf("/api/recipes/%d/rating", created.ID), `{"rating":3}`},
 		{http.MethodPost, fmt.Sprintf("/api/recipes/%d/cooked", created.ID), ""},
+		{http.MethodGet, "/api/recipes/plan", ""},
+		{http.MethodPut, "/api/recipes/plan",
+			fmt.Sprintf(`{"entries":[{"date":"2024-01-03","slot":"dinner","recipe_id":%d}]}`, created.ID)},
+		{http.MethodDelete, "/api/recipes/plan?date=2024-01-03&slot=dinner", ""},
+		{http.MethodPost, fmt.Sprintf("/api/recipes/%d/grocery", created.ID), `{"ingredient_ids":[1]}`},
 	}
 	for _, rt := range routes {
 		rec := env.do(t, otherID, rt.method, rt.path, rt.body)
@@ -548,5 +554,474 @@ func TestUnauthenticatedRequestsRejected(t *testing.T) {
 	env.router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// --- meal plan ---
+
+// 2024-01-01 is a Monday, so the fixed week below runs 2024-01-01 (Mon) to
+// 2024-01-07 (Sun) and the following week starts on 2024-01-08.
+const (
+	weekMonday    = "2024-01-01"
+	weekWednesday = "2024-01-03"
+	weekSunday    = "2024-01-07"
+	nextMonday    = "2024-01-08"
+)
+
+func decodePlanWeek(t *testing.T, rec *httptest.ResponseRecorder) PlanWeekResponse {
+	t.Helper()
+	var week PlanWeekResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &week); err != nil {
+		t.Fatalf("decode plan week response: %v (body: %s)", err, rec.Body.String())
+	}
+	return week
+}
+
+func decodePlanEntries(t *testing.T, rec *httptest.ResponseRecorder) []PlanEntryResponse {
+	t.Helper()
+	var env struct {
+		Entries []PlanEntryResponse `json:"entries"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode plan entries response: %v (body: %s)", err, rec.Body.String())
+	}
+	return env.Entries
+}
+
+// putPlan schedules one recipe and returns the recorded response.
+func (e *testEnv) putPlan(t *testing.T, userID int64, date, slot string, recipeID int64) *httptest.ResponseRecorder {
+	t.Helper()
+	body := fmt.Sprintf(`{"entries":[{"date":%q,"slot":%q,"recipe_id":%d}]}`, date, slot, recipeID)
+	return e.do(t, userID, http.MethodPut, "/api/recipes/plan", body)
+}
+
+// getPlanWeek fetches the week containing the given day.
+func (e *testEnv) getPlanWeek(t *testing.T, userID int64, week string) PlanWeekResponse {
+	t.Helper()
+	rec := e.do(t, userID, http.MethodGet, "/api/recipes/plan?week="+week, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get plan status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	return decodePlanWeek(t, rec)
+}
+
+// TestHandlePlanRoundTrip walks a plan entry through PUT, GET and DELETE and
+// checks it lands on — and leaves — the right day.
+func TestHandlePlanRoundTrip(t *testing.T) {
+	env := setupHandlerTest(t)
+	recipe := mustCreate(t, env.store, ownerID, Recipe{Title: "Fiskegrateng"})
+
+	// An untouched week comes back as seven empty days.
+	week := env.getPlanWeek(t, ownerID, weekWednesday)
+	if week.WeekStart != weekMonday || week.WeekEnd != weekSunday {
+		t.Fatalf("week = %s..%s, want %s..%s", week.WeekStart, week.WeekEnd, weekMonday, weekSunday)
+	}
+	if len(week.Days) != 7 {
+		t.Fatalf("week has %d days, want 7: %+v", len(week.Days), week.Days)
+	}
+	if entries, ok := week.Days[weekWednesday]; !ok || len(entries) != 0 {
+		t.Fatalf("empty week day %s = %+v (present: %t), want an empty list", weekWednesday, entries, ok)
+	}
+
+	rec := env.putPlan(t, ownerID, weekWednesday, "dinner", recipe.ID)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put plan status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	stored := decodePlanEntries(t, rec)
+	if len(stored) != 1 || stored[0].ID == 0 {
+		t.Fatalf("put returned %+v, want one entry with an ID", stored)
+	}
+	if stored[0].Date != weekWednesday || stored[0].Slot != "dinner" || stored[0].RecipeID != recipe.ID {
+		t.Errorf("stored entry = %+v, want %s/dinner/%d", stored[0], weekWednesday, recipe.ID)
+	}
+	if stored[0].RecipeTitle != "Fiskegrateng" {
+		t.Errorf("recipe_title = %q, want %q", stored[0].RecipeTitle, "Fiskegrateng")
+	}
+
+	week = env.getPlanWeek(t, ownerID, weekWednesday)
+	day := week.Days[weekWednesday]
+	if len(day) != 1 || day[0].ID != stored[0].ID {
+		t.Fatalf("%s = %+v, want the stored entry %d", weekWednesday, day, stored[0].ID)
+	}
+	if day[0].RecipeTitle != "Fiskegrateng" {
+		t.Errorf("recipe_title = %q, want the joined title", day[0].RecipeTitle)
+	}
+	if len(week.Days[weekMonday]) != 0 {
+		t.Errorf("%s = %+v, want no entries", weekMonday, week.Days[weekMonday])
+	}
+
+	rec = env.do(t, ownerID, http.MethodDelete, "/api/recipes/plan?date="+weekWednesday+"&slot=dinner", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete plan status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if week = env.getPlanWeek(t, ownerID, weekWednesday); len(week.Days[weekWednesday]) != 0 {
+		t.Errorf("%s after delete = %+v, want empty", weekWednesday, week.Days[weekWednesday])
+	}
+
+	// Deleting an already-empty slot is a 404, not a silent success.
+	rec = env.do(t, ownerID, http.MethodDelete, "/api/recipes/plan?date="+weekWednesday+"&slot=dinner", "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("second delete status = %d, want 404 (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandlePlanDefaultsToCurrentWeek checks that GET without ?week= returns
+// the week containing today, keyed by the local calendar day.
+func TestHandlePlanDefaultsToCurrentWeek(t *testing.T) {
+	env := setupHandlerTest(t)
+	recipe := mustCreate(t, env.store, ownerID, Recipe{Title: "Today's dinner"})
+
+	today := time.Now().Format(PlanDateLayout)
+	if rec := env.putPlan(t, ownerID, today, "dinner", recipe.ID); rec.Code != http.StatusOK {
+		t.Fatalf("put plan status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	rec := env.do(t, ownerID, http.MethodGet, "/api/recipes/plan", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get plan status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	week := decodePlanWeek(t, rec)
+	if len(week.Days[today]) != 1 {
+		t.Fatalf("today (%s) = %+v, want the entry just scheduled", today, week.Days[today])
+	}
+	if week.WeekStart > today || week.WeekEnd < today {
+		t.Errorf("week %s..%s does not contain today (%s)", week.WeekStart, week.WeekEnd, today)
+	}
+}
+
+// TestHandlePlanWeekBoundary asserts entries are filed by ISO week: the Sunday
+// of one week and the Monday of the next never show up together.
+func TestHandlePlanWeekBoundary(t *testing.T) {
+	env := setupHandlerTest(t)
+	sundayRecipe := mustCreate(t, env.store, ownerID, Recipe{Title: "Sunday roast"})
+	mondayRecipe := mustCreate(t, env.store, ownerID, Recipe{Title: "Monday soup"})
+
+	if rec := env.putPlan(t, ownerID, weekSunday, "dinner", sundayRecipe.ID); rec.Code != http.StatusOK {
+		t.Fatalf("put sunday status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if rec := env.putPlan(t, ownerID, nextMonday, "dinner", mondayRecipe.ID); rec.Code != http.StatusOK {
+		t.Fatalf("put monday status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	first := env.getPlanWeek(t, ownerID, weekWednesday)
+	if first.WeekEnd != weekSunday {
+		t.Fatalf("first week ends %s, want %s", first.WeekEnd, weekSunday)
+	}
+	if len(first.Days[weekSunday]) != 1 || first.Days[weekSunday][0].RecipeID != sundayRecipe.ID {
+		t.Errorf("%s = %+v, want the Sunday recipe", weekSunday, first.Days[weekSunday])
+	}
+	if _, leaked := first.Days[nextMonday]; leaked {
+		t.Errorf("first week leaked the next Monday: %+v", first.Days)
+	}
+
+	second := env.getPlanWeek(t, ownerID, nextMonday)
+	if second.WeekStart != nextMonday {
+		t.Fatalf("second week starts %s, want %s", second.WeekStart, nextMonday)
+	}
+	if len(second.Days[nextMonday]) != 1 || second.Days[nextMonday][0].RecipeID != mondayRecipe.ID {
+		t.Errorf("%s = %+v, want the Monday recipe", nextMonday, second.Days[nextMonday])
+	}
+	if _, leaked := second.Days[weekSunday]; leaked {
+		t.Errorf("second week leaked the previous Sunday: %+v", second.Days)
+	}
+}
+
+// TestHandlePlanPutIsIdempotent checks that re-sending the same slot replaces
+// it in place instead of stacking up rows, and that a different recipe in the
+// same slot takes it over.
+func TestHandlePlanPutIsIdempotent(t *testing.T) {
+	env := setupHandlerTest(t)
+	first := mustCreate(t, env.store, ownerID, Recipe{Title: "First"})
+	second := mustCreate(t, env.store, ownerID, Recipe{Title: "Second"})
+
+	rec := env.putPlan(t, ownerID, weekWednesday, "dinner", first.ID)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first put status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	original := decodePlanEntries(t, rec)[0]
+
+	rec = env.putPlan(t, ownerID, weekWednesday, "dinner", first.ID)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("repeat put status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if repeated := decodePlanEntries(t, rec)[0]; repeated.ID != original.ID {
+		t.Errorf("repeat put created entry %d, want the existing %d", repeated.ID, original.ID)
+	}
+
+	week := env.getPlanWeek(t, ownerID, weekWednesday)
+	if len(week.Days[weekWednesday]) != 1 {
+		t.Fatalf("%s = %+v, want exactly one entry after a repeated PUT", weekWednesday, week.Days[weekWednesday])
+	}
+
+	// The same slot with another recipe replaces rather than appends.
+	if rec = env.putPlan(t, ownerID, weekWednesday, "dinner", second.ID); rec.Code != http.StatusOK {
+		t.Fatalf("replace put status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	week = env.getPlanWeek(t, ownerID, weekWednesday)
+	if len(week.Days[weekWednesday]) != 1 || week.Days[weekWednesday][0].RecipeID != second.ID {
+		t.Fatalf("%s = %+v, want only the second recipe", weekWednesday, week.Days[weekWednesday])
+	}
+
+	// A different slot on the same day is its own entry.
+	if rec = env.putPlan(t, ownerID, weekWednesday, "lunch", first.ID); rec.Code != http.StatusOK {
+		t.Fatalf("lunch put status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	week = env.getPlanWeek(t, ownerID, weekWednesday)
+	day := week.Days[weekWednesday]
+	if len(day) != 2 {
+		t.Fatalf("%s = %+v, want lunch and dinner", weekWednesday, day)
+	}
+	// Days come back in the order the slots are eaten in.
+	if day[0].Slot != "lunch" || day[1].Slot != "dinner" {
+		t.Errorf("slot order = [%s %s], want [lunch dinner]", day[0].Slot, day[1].Slot)
+	}
+}
+
+// TestHandlePlanPutMultipleEntries checks a whole week can be planned in one
+// request.
+func TestHandlePlanPutMultipleEntries(t *testing.T) {
+	env := setupHandlerTest(t)
+	recipe := mustCreate(t, env.store, ownerID, Recipe{Title: "Batch"})
+
+	body := fmt.Sprintf(`{"entries":[
+		{"date":%q,"slot":"dinner","recipe_id":%d},
+		{"date":%q,"slot":"Breakfast","recipe_id":%d},
+		{"date":%q,"slot":"dinner","recipe_id":%d}
+	]}`, weekMonday, recipe.ID, weekWednesday, recipe.ID, weekSunday, recipe.ID)
+
+	rec := env.do(t, ownerID, http.MethodPut, "/api/recipes/plan", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if stored := decodePlanEntries(t, rec); len(stored) != 3 {
+		t.Fatalf("put returned %d entries, want 3", len(stored))
+	}
+
+	week := env.getPlanWeek(t, ownerID, weekMonday)
+	for _, date := range []string{weekMonday, weekWednesday, weekSunday} {
+		if len(week.Days[date]) != 1 {
+			t.Errorf("%s = %+v, want one entry", date, week.Days[date])
+		}
+	}
+	// Slot names are normalised on the way in.
+	if got := week.Days[weekWednesday][0].Slot; got != "breakfast" {
+		t.Errorf("slot = %q, want %q", got, "breakfast")
+	}
+}
+
+// TestHandlePlanValidation covers the malformed and out-of-range inputs the
+// plan routes must reject before touching the database.
+func TestHandlePlanValidation(t *testing.T) {
+	env := setupHandlerTest(t)
+	recipe := mustCreate(t, env.store, ownerID, Recipe{Title: "Valid"})
+	foreign := mustCreate(t, env.store, otherID, Recipe{Title: "Someone else's"})
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+		want   int
+	}{
+		{"malformed JSON", http.MethodPut, "/api/recipes/plan", `{"entries":`, http.StatusBadRequest},
+		{"no entries", http.MethodPut, "/api/recipes/plan", `{"entries":[]}`, http.StatusBadRequest},
+		{"bad date", http.MethodPut, "/api/recipes/plan",
+			fmt.Sprintf(`{"entries":[{"date":"03-01-2024","slot":"dinner","recipe_id":%d}]}`, recipe.ID), http.StatusBadRequest},
+		{"impossible date", http.MethodPut, "/api/recipes/plan",
+			fmt.Sprintf(`{"entries":[{"date":"2024-02-30","slot":"dinner","recipe_id":%d}]}`, recipe.ID), http.StatusBadRequest},
+		{"bad slot", http.MethodPut, "/api/recipes/plan",
+			fmt.Sprintf(`{"entries":[{"date":%q,"slot":"brunch","recipe_id":%d}]}`, weekWednesday, recipe.ID), http.StatusBadRequest},
+		{"missing recipe", http.MethodPut, "/api/recipes/plan",
+			fmt.Sprintf(`{"entries":[{"date":%q,"slot":"dinner","recipe_id":9999}]}`, weekWednesday), http.StatusNotFound},
+		{"foreign recipe", http.MethodPut, "/api/recipes/plan",
+			fmt.Sprintf(`{"entries":[{"date":%q,"slot":"dinner","recipe_id":%d}]}`, weekWednesday, foreign.ID), http.StatusNotFound},
+		{"bad week param", http.MethodGet, "/api/recipes/plan?week=2024", "", http.StatusBadRequest},
+		{"delete without params", http.MethodDelete, "/api/recipes/plan", "", http.StatusBadRequest},
+		{"delete without slot", http.MethodDelete, "/api/recipes/plan?date=" + weekWednesday, "", http.StatusBadRequest},
+		{"delete bad date", http.MethodDelete, "/api/recipes/plan?date=nope&slot=dinner", "", http.StatusBadRequest},
+		{"delete bad slot", http.MethodDelete, "/api/recipes/plan?date=" + weekWednesday + "&slot=brunch", "", http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := env.do(t, ownerID, tc.method, tc.path, tc.body)
+			if rec.Code != tc.want {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+
+	// A batch containing one bad entry writes none of them.
+	body := fmt.Sprintf(`{"entries":[
+		{"date":%q,"slot":"dinner","recipe_id":%d},
+		{"date":%q,"slot":"brunch","recipe_id":%d}
+	]}`, weekMonday, recipe.ID, weekWednesday, recipe.ID)
+	if rec := env.do(t, ownerID, http.MethodPut, "/api/recipes/plan", body); rec.Code != http.StatusBadRequest {
+		t.Fatalf("mixed batch status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if week := env.getPlanWeek(t, ownerID, weekMonday); len(week.Days[weekMonday]) != 0 {
+		t.Errorf("%s = %+v, want nothing written by the rejected batch", weekMonday, week.Days[weekMonday])
+	}
+}
+
+// TestHandlePlanUserIsolation asserts one user's plan is invisible and
+// untouchable from another account.
+func TestHandlePlanUserIsolation(t *testing.T) {
+	env := setupHandlerTest(t)
+	recipe := mustCreate(t, env.store, ownerID, Recipe{Title: "Owner's dinner"})
+
+	if rec := env.putPlan(t, ownerID, weekWednesday, "dinner", recipe.ID); rec.Code != http.StatusOK {
+		t.Fatalf("put status = %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	if week := env.getPlanWeek(t, otherID, weekWednesday); len(week.Days[weekWednesday]) != 0 {
+		t.Errorf("other user sees %+v, want an empty plan", week.Days[weekWednesday])
+	}
+
+	rec := env.do(t, otherID, http.MethodDelete, "/api/recipes/plan?date="+weekWednesday+"&slot=dinner", "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("other user's delete status = %d, want 404 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if week := env.getPlanWeek(t, ownerID, weekWednesday); len(week.Days[weekWednesday]) != 1 {
+		t.Errorf("owner's entry = %+v, want it untouched", week.Days[weekWednesday])
+	}
+}
+
+// --- grocery push ---
+
+// TestHandleGroceryPush pushes recipe ingredients onto the grocery list and
+// checks the added/skipped split, including de-duplication against items that
+// are already on the list.
+func TestHandleGroceryPush(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	created := decodeRecipe(t, env.do(t, ownerID, http.MethodPost, "/api/recipes", createBody))
+	torsk, melk := created.Ingredients[0].ID, created.Ingredients[1].ID
+
+	// "Torsk" is already on the list under a different casing.
+	if _, err := grocery.Add(env.db, grocery.GroceryItem{
+		HouseholdID:  ownerID,
+		Content:      "Torsk",
+		OriginalText: "Torsk",
+		AddedBy:      ownerID,
+	}); err != nil {
+		t.Fatalf("seed grocery item: %v", err)
+	}
+
+	path := fmt.Sprintf("/api/recipes/%d/grocery", created.ID)
+	rec := env.do(t, ownerID, http.MethodPost, path, fmt.Sprintf(`{"ingredient_ids":[%d,%d]}`, torsk, melk))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("push status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var push GroceryPushResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &push); err != nil {
+		t.Fatalf("decode push response: %v (body: %s)", err, rec.Body.String())
+	}
+	if push.Added != 1 || push.Skipped != 1 {
+		t.Errorf("added/skipped = %d/%d, want 1/1", push.Added, push.Skipped)
+	}
+	if len(push.Items) != 1 || push.Items[0].Content != "melk" {
+		t.Errorf("items = %+v, want only melk", push.Items)
+	}
+
+	items, err := grocery.ListByHousehold(env.db, ownerID)
+	if err != nil {
+		t.Fatalf("list grocery items: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("grocery list has %d items, want 2 (no duplicate torsk): %+v", len(items), items)
+	}
+
+	// Pushing the same ingredients again adds nothing.
+	rec = env.do(t, ownerID, http.MethodPost, path, fmt.Sprintf(`{"ingredient_ids":[%d,%d]}`, torsk, melk))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second push status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	push = GroceryPushResponse{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &push); err != nil {
+		t.Fatalf("decode second push response: %v", err)
+	}
+	if push.Added != 0 || push.Skipped != 2 {
+		t.Errorf("second push added/skipped = %d/%d, want 0/2", push.Added, push.Skipped)
+	}
+	if items, err = grocery.ListByHousehold(env.db, ownerID); err != nil || len(items) != 2 {
+		t.Errorf("grocery list = %+v (err %v), want the same 2 items", items, err)
+	}
+}
+
+// TestHandleGroceryPushUsesIngredientLineWhenUnparsed checks the fallback for
+// ingredients the client never parsed into a name.
+func TestHandleGroceryPushUsesIngredientLineWhenUnparsed(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	created := decodeRecipe(t, env.do(t, ownerID, http.MethodPost, "/api/recipes",
+		`{"title":"Unparsed","ingredients":[{"text":"En klype salt"}]}`))
+
+	rec := env.do(t, ownerID, http.MethodPost, fmt.Sprintf("/api/recipes/%d/grocery", created.ID),
+		fmt.Sprintf(`{"ingredient_ids":[%d]}`, created.Ingredients[0].ID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("push status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	items, err := grocery.ListByHousehold(env.db, ownerID)
+	if err != nil {
+		t.Fatalf("list grocery items: %v", err)
+	}
+	if len(items) != 1 || items[0].Content != "En klype salt" {
+		t.Errorf("grocery list = %+v, want the free-form ingredient line", items)
+	}
+}
+
+// TestHandleGroceryPushValidation checks the ownership and membership rules:
+// an ingredient from another recipe is a bad request, someone else's recipe is
+// simply not found, and neither writes to the list.
+func TestHandleGroceryPushValidation(t *testing.T) {
+	env := setupHandlerTest(t)
+
+	created := decodeRecipe(t, env.do(t, ownerID, http.MethodPost, "/api/recipes", createBody))
+	otherRecipe := decodeRecipe(t, env.do(t, ownerID, http.MethodPost, "/api/recipes",
+		`{"title":"Another","ingredients":[{"text":"1 løk","name":"løk"}]}`))
+	foreign := mustCreate(t, env.store, otherID, Recipe{
+		Title:       "Someone else's",
+		Ingredients: []Ingredient{{Text: "1 dl fløte", Name: "fløte"}},
+	})
+
+	path := fmt.Sprintf("/api/recipes/%d/grocery", created.ID)
+	cases := []struct {
+		name   string
+		caller int64
+		path   string
+		body   string
+		want   int
+	}{
+		{"malformed JSON", ownerID, path, `{"ingredient_ids":`, http.StatusBadRequest},
+		{"no ingredients", ownerID, path, `{"ingredient_ids":[]}`, http.StatusBadRequest},
+		{"invalid recipe id", ownerID, "/api/recipes/abc/grocery", `{"ingredient_ids":[1]}`, http.StatusBadRequest},
+		{"unknown ingredient", ownerID, path, `{"ingredient_ids":[999999]}`, http.StatusBadRequest},
+		{"ingredient from another recipe", ownerID, path,
+			fmt.Sprintf(`{"ingredient_ids":[%d]}`, otherRecipe.Ingredients[0].ID), http.StatusBadRequest},
+		{"missing recipe", ownerID, "/api/recipes/9999/grocery", `{"ingredient_ids":[1]}`, http.StatusNotFound},
+		{"another user's recipe", otherID, path,
+			fmt.Sprintf(`{"ingredient_ids":[%d]}`, created.Ingredients[0].ID), http.StatusNotFound},
+		{"owner reaching into a foreign recipe", ownerID,
+			fmt.Sprintf("/api/recipes/%d/grocery", foreign.ID),
+			fmt.Sprintf(`{"ingredient_ids":[%d]}`, foreign.Ingredients[0].ID), http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := env.do(t, tc.caller, http.MethodPost, tc.path, tc.body)
+			if rec.Code != tc.want {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+
+	for _, userID := range []int64{ownerID, otherID} {
+		items, err := grocery.ListByHousehold(env.db, userID)
+		if err != nil {
+			t.Fatalf("list grocery items for %d: %v", userID, err)
+		}
+		if len(items) != 0 {
+			t.Errorf("user %d's grocery list = %+v, want nothing written by rejected pushes", userID, items)
+		}
 	}
 }

--- a/internal/recipes/models.go
+++ b/internal/recipes/models.go
@@ -89,7 +89,8 @@ type Cook struct {
 	CookedAt time.Time `json:"cooked_at"`
 }
 
-// PlanEntry schedules a recipe into a meal slot on a given day.
+// PlanEntry schedules a recipe into a meal slot on a given day. At most one
+// entry exists per (user, day, slot) — the store upserts on that triple.
 type PlanEntry struct {
 	ID        int64     `json:"id"`
 	UserID    int64     `json:"user_id"`
@@ -97,6 +98,10 @@ type PlanEntry struct {
 	PlanDate  string    `json:"plan_date"` // YYYY-MM-DD, local calendar day
 	Slot      string    `json:"slot"`      // breakfast | lunch | dinner | snack
 	CreatedAt time.Time `json:"created_at"`
+	// RecipeTitle is the scheduled recipe's (decrypted) title, joined in on
+	// read so a plan week can be rendered without fetching every recipe. It is
+	// derived, never stored on the entry row.
+	RecipeTitle string `json:"recipe_title"`
 }
 
 // TagFilter narrows a recipe listing by tags. Any matches recipes carrying at

--- a/internal/recipes/store.go
+++ b/internal/recipes/store.go
@@ -17,6 +17,52 @@ import (
 // 0 clears an existing rating; 1-5 set one.
 var ErrInvalidRating = errors.New("rating must be between 0 and 5")
 
+// ErrInvalidSlot is returned for a meal slot outside the allowed set.
+var ErrInvalidSlot = errors.New("slot must be breakfast, lunch, dinner or snack")
+
+// ErrInvalidPlanDate is returned for a plan date that is not a YYYY-MM-DD
+// calendar day.
+var ErrInvalidPlanDate = errors.New("plan date must be YYYY-MM-DD")
+
+// ErrIngredientNotInRecipe is returned when an ingredient ID does not belong to
+// the recipe it was requested against.
+var ErrIngredientNotInRecipe = errors.New("ingredient does not belong to this recipe")
+
+// PlanDateLayout is the calendar-day format meal plan entries are stored and
+// exchanged in. Entries are days, not instants — no time zone is attached.
+const PlanDateLayout = "2006-01-02"
+
+// slotOrder ranks the meal slots for display: a day's entries come back in the
+// order they are eaten rather than in insertion order.
+var slotOrder = map[string]int{"breakfast": 0, "lunch": 1, "dinner": 2, "snack": 3}
+
+// NormalizeSlot trims and lowercases a slot name and reports whether it is one
+// of the four the schema allows.
+func NormalizeSlot(slot string) (string, bool) {
+	slot = strings.ToLower(strings.TrimSpace(slot))
+	_, ok := slotOrder[slot]
+	return slot, ok
+}
+
+// ParsePlanDate parses a YYYY-MM-DD calendar day, rejecting anything else
+// (including timestamps and out-of-range days such as 2026-02-30).
+func ParsePlanDate(s string) (time.Time, error) {
+	day, err := time.Parse(PlanDateLayout, strings.TrimSpace(s))
+	if err != nil {
+		return time.Time{}, ErrInvalidPlanDate
+	}
+	return day, nil
+}
+
+// ISOWeekStart returns the Monday of the ISO week containing day, keeping the
+// day's location so a week never shifts across a time-zone boundary.
+func ISOWeekStart(day time.Time) time.Time {
+	// time.Weekday counts from Sunday; ISO weeks start on Monday.
+	offset := (int(day.Weekday()) + 6) % 7
+	y, m, d := day.AddDate(0, 0, -offset).Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, day.Location())
+}
+
 // Store is the persistence layer for the recipes feature. It owns all
 // encryption and decryption of recipe text — callers above it only ever see
 // plaintext models.
@@ -433,6 +479,257 @@ func (s *Store) ListCooks(ctx context.Context, userID, recipeID int64) ([]Cook, 
 		cooks = append(cooks, c)
 	}
 	return cooks, rows.Err()
+}
+
+// --- Meal plan ---
+
+// ListPlanEntries returns the user's meal plan entries for the inclusive date
+// range [from, to], ordered by day and then by the order the slots are eaten
+// in (see slotOrder). Both bounds are YYYY-MM-DD; the lexicographic comparison
+// SQLite performs on that format is also the chronological one.
+func (s *Store) ListPlanEntries(ctx context.Context, userID int64, from, to string) ([]PlanEntry, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT p.id, p.user_id, p.recipe_id, p.plan_date, p.slot, p.created_at, r.title
+		FROM meal_plan_entries p
+		JOIN recipes r ON r.id = p.recipe_id
+		WHERE p.user_id = ? AND p.plan_date >= ? AND p.plan_date <= ?
+	`, userID, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("query meal plan entries: %w", err)
+	}
+	defer rows.Close()
+
+	entries := []PlanEntry{}
+	for rows.Next() {
+		var e PlanEntry
+		var createdAt string
+		if err := rows.Scan(&e.ID, &e.UserID, &e.RecipeID, &e.PlanDate, &e.Slot, &createdAt, &e.RecipeTitle); err != nil {
+			return nil, fmt.Errorf("scan meal plan entry: %w", err)
+		}
+		if e.RecipeTitle, err = encryption.DecryptField(e.RecipeTitle); err != nil {
+			return nil, fmt.Errorf("decrypt recipe title: %w", err)
+		}
+		e.CreatedAt = parseTime(createdAt)
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate meal plan entries: %w", err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].PlanDate != entries[j].PlanDate {
+			return entries[i].PlanDate < entries[j].PlanDate
+		}
+		return slotOrder[entries[i].Slot] < slotOrder[entries[j].Slot]
+	})
+	return entries, nil
+}
+
+// UpsertPlanEntries writes one or more plan entries for the user and returns
+// them as stored. Each entry replaces whatever occupied its (day, slot), so
+// sending the same payload twice is a no-op the second time rather than a
+// duplicate row. created_at is the moment the slot was first filled and is kept
+// across replacements.
+//
+// Every referenced recipe must belong to the user: a foreign or unknown recipe
+// ID fails the whole batch with sql.ErrNoRows and nothing is written. Invalid
+// dates and slots fail with ErrInvalidPlanDate / ErrInvalidSlot.
+func (s *Store) UpsertPlanEntries(ctx context.Context, userID int64, entries []PlanEntry) ([]PlanEntry, error) {
+	if len(entries) == 0 {
+		return []PlanEntry{}, nil
+	}
+
+	// Validate and normalise up front so a bad entry never opens a transaction.
+	normalized := make([]PlanEntry, len(entries))
+	recipeIDs := make([]any, 0, len(entries))
+	seenRecipe := make(map[int64]struct{}, len(entries))
+	for i, e := range entries {
+		day, err := ParsePlanDate(e.PlanDate)
+		if err != nil {
+			return nil, err
+		}
+		slot, ok := NormalizeSlot(e.Slot)
+		if !ok {
+			return nil, ErrInvalidSlot
+		}
+		if e.RecipeID <= 0 {
+			return nil, sql.ErrNoRows
+		}
+		normalized[i] = PlanEntry{
+			UserID:   userID,
+			RecipeID: e.RecipeID,
+			PlanDate: day.Format(PlanDateLayout),
+			Slot:     slot,
+		}
+		if _, dup := seenRecipe[e.RecipeID]; !dup {
+			seenRecipe[e.RecipeID] = struct{}{}
+			recipeIDs = append(recipeIDs, e.RecipeID)
+		}
+	}
+
+	titles, err := s.recipeTitles(ctx, userID, recipeIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	now := nowRFC3339()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin upsert plan entries: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for i := range normalized {
+		e := &normalized[i]
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO meal_plan_entries (user_id, recipe_id, plan_date, slot, created_at)
+			VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT (user_id, plan_date, slot) DO UPDATE SET recipe_id = excluded.recipe_id
+		`, userID, e.RecipeID, e.PlanDate, e.Slot, now); err != nil {
+			return nil, fmt.Errorf("upsert meal plan entry: %w", err)
+		}
+
+		// Read the row back rather than trusting LastInsertId, which reports the
+		// pre-existing row only on insert and not on the conflict path.
+		var createdAt string
+		if err := tx.QueryRowContext(ctx, `
+			SELECT id, created_at FROM meal_plan_entries
+			WHERE user_id = ? AND plan_date = ? AND slot = ?
+		`, userID, e.PlanDate, e.Slot).Scan(&e.ID, &createdAt); err != nil {
+			return nil, fmt.Errorf("reload meal plan entry: %w", err)
+		}
+		e.CreatedAt = parseTime(createdAt)
+		e.RecipeTitle = titles[e.RecipeID]
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit upsert plan entries: %w", err)
+	}
+	return normalized, nil
+}
+
+// DeletePlanEntry clears the entry occupying one (day, slot) for the user.
+// Returns sql.ErrNoRows when the slot was already empty.
+func (s *Store) DeletePlanEntry(ctx context.Context, userID int64, planDate, slot string) error {
+	day, err := ParsePlanDate(planDate)
+	if err != nil {
+		return err
+	}
+	normalizedSlot, ok := NormalizeSlot(slot)
+	if !ok {
+		return ErrInvalidSlot
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+		DELETE FROM meal_plan_entries WHERE user_id = ? AND plan_date = ? AND slot = ?
+	`, userID, day.Format(PlanDateLayout), normalizedSlot)
+	if err != nil {
+		return fmt.Errorf("delete meal plan entry: %w", err)
+	}
+	return requireRow(res)
+}
+
+// recipeTitles loads the decrypted titles of the given recipe IDs, scoped to
+// the user. Any ID that is missing or owned by someone else makes the lookup
+// fail with sql.ErrNoRows, so callers can treat foreign recipes as not found
+// without leaking that they exist.
+func (s *Store) recipeTitles(ctx context.Context, userID int64, ids []any) (map[int64]string, error) {
+	titles := make(map[int64]string, len(ids))
+	if len(ids) == 0 {
+		return titles, nil
+	}
+
+	args := append([]any{userID}, ids...)
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, title FROM recipes WHERE user_id = ? AND id IN (%s)
+	`, placeholders(len(ids))), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query recipe titles: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int64
+		var title string
+		if err := rows.Scan(&id, &title); err != nil {
+			return nil, fmt.Errorf("scan recipe title: %w", err)
+		}
+		if title, err = encryption.DecryptField(title); err != nil {
+			return nil, fmt.Errorf("decrypt recipe title: %w", err)
+		}
+		titles[id] = title
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recipe titles: %w", err)
+	}
+	if len(titles) != len(ids) {
+		return nil, sql.ErrNoRows
+	}
+	return titles, nil
+}
+
+// IngredientNamesForRecipe resolves ingredient IDs to the names a shopping list
+// should carry, in the order they were requested. The parsed Name is preferred;
+// ingredients that were never parsed fall back to their free-form line.
+//
+// Returns sql.ErrNoRows when the recipe is not the user's (or does not exist)
+// and ErrIngredientNotInRecipe when an ID is not one of that recipe's
+// ingredients, so a caller can tell "wrong recipe" from "wrong ingredient".
+func (s *Store) IngredientNamesForRecipe(ctx context.Context, userID, recipeID int64, ingredientIDs []int64) ([]string, error) {
+	var exists int
+	if err := s.db.QueryRowContext(ctx,
+		"SELECT 1 FROM recipes WHERE id = ? AND user_id = ?", recipeID, userID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("check recipe ownership: %w", err)
+	}
+	if len(ingredientIDs) == 0 {
+		return []string{}, nil
+	}
+
+	args := make([]any, 0, len(ingredientIDs)+1)
+	args = append(args, recipeID)
+	for _, id := range ingredientIDs {
+		args = append(args, id)
+	}
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, text, name FROM recipe_ingredients WHERE recipe_id = ? AND id IN (%s)
+	`, placeholders(len(ingredientIDs))), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query recipe ingredients: %w", err)
+	}
+	defer rows.Close()
+
+	byID := make(map[int64]string, len(ingredientIDs))
+	for rows.Next() {
+		var id int64
+		var text, name string
+		if err := rows.Scan(&id, &text, &name); err != nil {
+			return nil, fmt.Errorf("scan recipe ingredient: %w", err)
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			if text, err = encryption.DecryptField(text); err != nil {
+				return nil, fmt.Errorf("decrypt ingredient text: %w", err)
+			}
+			name = strings.TrimSpace(text)
+		}
+		byID[id] = name
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recipe ingredients: %w", err)
+	}
+
+	names := make([]string, 0, len(ingredientIDs))
+	for _, id := range ingredientIDs {
+		name, ok := byID[id]
+		if !ok {
+			return nil, ErrIngredientNotInRecipe
+		}
+		names = append(names, name)
+	}
+	return names, nil
 }
 
 // --- Scaling ---


### PR DESCRIPTION
## Changes

- **Meal plan endpoints** - `GET/PUT/DELETE /api/recipes/plan` schedule recipes into breakfast, lunch, dinner and snack slots. GET returns a full ISO week keyed by calendar day (defaulting to the week containing today), and PUT upserts on (day, slot) so repeated saves replace an entry instead of stacking duplicates. (Hytte-580m2)
- **Push recipe ingredients to the grocery list** - `POST /api/recipes/{id}/grocery` takes a list of ingredient IDs from one of your recipes and adds them to your grocery list, skipping anything already on it (case-insensitively) and reporting how many were added versus skipped. (Hytte-580m2)

## Original Issue (task): Meal plan endpoints and recipe→grocery push endpoint

Extend `internal/recipes/handlers.go` (routes registered by the same `Register` from the previous sub-task) with `GET /api/recipes/plan` (query param for the ISO week start date, returns entries keyed by day), `PUT /api/recipes/plan` (upsert one or more `meal_plan_entries` rows for a given ISO date + day slot, user-scoped), and `DELETE /api/recipes/plan` (clear an entry for a date/day). Persist via the store API from sub-task 1 against the `meal_plan_entries` table; use upsert-on-conflict for (user_id, date, day/slot) so repeated PUTs are idempotent. Also implement `POST /api/recipes/{id}/grocery` taking `{"ingredient_ids": [...]}`, verifying each ID belongs to the named recipe and the recipe belongs to the caller, resolving ingredient names, and calling `grocery.AddItems(ctx, userID, names)` from the grocery sub-task; return the count added vs skipped. Extend `internal/recipes/handlers_test.go` with plan persistence across GET/PUT/DELETE round-trips, week-boundary keying, idempotent PUT, grocery push de-duplication against pre-existing list items, and feature-flag gating on these routes. Depends on both prior sub-tasks.

---
Bead: Hytte-580m2 | Branch: forge/Hytte-580m2
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->