### PR TITLE
RecipeCookMode: single-step stepper with per-step countdown timer (Hytte-toiak)

### DIFF
--- a/changelog.d/Hytte-toiak.md
+++ b/changelog.d/Hytte-toiak.md
@@ -1,0 +1,2 @@
+category: Added
+- **Cook mode for recipes** - Walk a recipe one step at a time with a large, readable step view, next/previous controls and a step position indicator. Timed steps get a countdown with start, pause and reset that starts fresh on every step, the ingredient list stays on screen scaled to the portions chosen on the recipe page, and the screen is kept awake while you cook. (Hytte-toiak)

--- a/web/public/locales/en/recipes.json
+++ b/web/public/locales/en/recipes.json
@@ -141,6 +141,7 @@
     "exit": "Exit cook mode",
     "ingredientsHere": "Ingredients for this step",
     "timerStart": "Start timer",
+    "timeRemaining": "Time remaining",
     "timerPause": "Pause timer",
     "timerResume": "Resume timer",
     "timerReset": "Reset timer",

--- a/web/public/locales/nb/recipes.json
+++ b/web/public/locales/nb/recipes.json
@@ -141,6 +141,7 @@
     "exit": "Avslutt kokemodus",
     "ingredientsHere": "Ingredienser til dette steget",
     "timerStart": "Start tidtaker",
+    "timeRemaining": "Tid igjen",
     "timerPause": "Pause tidtaker",
     "timerResume": "Fortsett tidtaker",
     "timerReset": "Nullstill tidtaker",

--- a/web/public/locales/th/recipes.json
+++ b/web/public/locales/th/recipes.json
@@ -141,6 +141,7 @@
     "exit": "ออกจากโหมดทำอาหาร",
     "ingredientsHere": "วัตถุดิบสำหรับขั้นตอนนี้",
     "timerStart": "เริ่มจับเวลา",
+    "timeRemaining": "เวลาที่เหลือ",
     "timerPause": "หยุดจับเวลาชั่วคราว",
     "timerResume": "จับเวลาต่อ",
     "timerReset": "รีเซ็ตการจับเวลา",

--- a/web/src/pages/RecipeCookMode.test.tsx
+++ b/web/src/pages/RecipeCookMode.test.tsx
@@ -1,0 +1,294 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import RecipeCookMode from './RecipeCookMode'
+import type { Recipe } from '../types/recipes'
+
+// ── Translation mock ──────────────────────────────────────────────────────────
+// `mockT` must be a stable reference: the recipe hook has `t` in its effect
+// dependencies, so a fresh function per render would re-fetch forever.
+
+const TRANSLATIONS: Record<string, string> = {
+  'cook.title': 'Cook mode',
+  'cook.step': 'Step {{current}} of {{total}}',
+  'cook.next': 'Next step',
+  'cook.prev': 'Previous step',
+  'cook.finish': 'Done cooking',
+  'cook.exit': 'Exit cook mode',
+  'cook.timeRemaining': 'Time remaining',
+  'cook.timerStart': 'Start timer',
+  'cook.timerPause': 'Pause timer',
+  'cook.timerResume': 'Resume timer',
+  'cook.timerReset': 'Reset timer',
+  'cook.timerDone': 'Time is up',
+  'cook.noSteps': 'This recipe has no steps to cook through',
+  'detail.ingredients': 'Ingredients',
+  'detail.scaledFrom': 'Scaled from {{count}} servings',
+  'detail.loading': 'Loading recipe…',
+  'errors.notFound': 'That recipe does not exist',
+  'errors.failedToLoadRecipe': 'Could not load this recipe',
+  'errors.retry': 'Try again',
+}
+
+function mockT(key: string, opts?: Record<string, string | number>): string {
+  const raw = TRANSLATIONS[key]
+  if (raw === undefined) return key
+  return raw.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(opts?.[name] ?? ''))
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockT,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+/**
+ * Three steps: an untimed one, then two timed ones so a timer can be started on
+ * one step and asserted to be gone from the next. Four servings, so a portion
+ * override lands on whole numbers.
+ */
+const RECIPE: Recipe = {
+  id: 1,
+  title: 'Fish gratin',
+  notes: '',
+  servings: 4,
+  rating: null,
+  rated_at: null,
+  last_cooked_at: null,
+  created_at: '2026-01-01T12:00:00Z',
+  updated_at: '2026-01-01T12:00:00Z',
+  ingredients: [
+    { id: 11, position: 1, text: '400 g cod, cubed', quantity: 400, unit: 'g', name: 'cod' },
+    { id: 12, position: 2, text: '2 dl cream', quantity: 2, unit: 'dl', name: 'cream' },
+  ],
+  steps: [
+    { id: 21, position: 1, text: 'Cube the cod.', duration_seconds: 0 },
+    { id: 22, position: 2, text: 'Bake until golden.', duration_seconds: 1800 },
+    { id: 23, position: 3, text: 'Rest before serving.', duration_seconds: 300 },
+  ],
+  tags: [],
+}
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+function jsonResponse(body: unknown, status = 200) {
+  return { ok: status < 400, status, json: () => Promise.resolve(body) }
+}
+
+function mockFetch(recipe: Recipe = RECIPE) {
+  const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({ recipe })))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+interface RenderOptions {
+  recipe?: Recipe
+  /** Appended to the cook-mode URL, e.g. `?portions=8`. */
+  search?: string
+  /** Router state, the way the detail page's "start cooking" link passes it. */
+  state?: unknown
+}
+
+async function renderCookMode(options: RenderOptions = {}) {
+  const { recipe = RECIPE, search = '', state } = options
+  mockFetch(recipe)
+  const view = render(
+    <MemoryRouter initialEntries={[{ pathname: '/recipes/1/cook', search, state }]}>
+      <Routes>
+        <Route path="/recipes/:id/cook" element={<RecipeCookMode />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+  await screen.findByRole('heading', { name: 'Fish gratin' })
+  return view
+}
+
+function prevButton() {
+  return screen.getByRole('button', { name: 'Previous step' })
+}
+
+function nextButton() {
+  return screen.getByRole('button', { name: 'Next step' })
+}
+
+/** The countdown display, or null when the current step is untimed. */
+function timerDisplay() {
+  return screen.queryByRole('timer', { name: 'Time remaining' })
+}
+
+/** Runs the fake clock forward inside `act` so React flushes the tick. */
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms)
+  })
+}
+
+afterEach(() => {
+  // Restore spies before the clock: `clearInterval` is spied on *after* the
+  // fake timers are installed, so restoring it later would put the fake
+  // implementation back over the real one.
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('RecipeCookMode', () => {
+  it('shows one step at a time with its position', async () => {
+    await renderCookMode()
+
+    expect(screen.getByText('Cube the cod.')).toBeInTheDocument()
+    expect(screen.queryByText('Bake until golden.')).toBeNull()
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument()
+
+    fireEvent.click(nextButton())
+    expect(screen.getByText('Bake until golden.')).toBeInTheDocument()
+    expect(screen.getByText('Step 2 of 3')).toBeInTheDocument()
+    expect(screen.queryByText('Cube the cod.')).toBeNull()
+
+    fireEvent.click(prevButton())
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument()
+  })
+
+  it('bounds navigation at the first and last step', async () => {
+    await renderCookMode()
+
+    expect(prevButton()).toBeDisabled()
+    expect(nextButton()).toBeEnabled()
+
+    fireEvent.click(nextButton())
+    fireEvent.click(nextButton())
+    expect(screen.getByText('Step 3 of 3')).toBeInTheDocument()
+    expect(nextButton()).toBeDisabled()
+    expect(prevButton()).toBeEnabled()
+
+    // Clicking through a disabled button changes nothing.
+    fireEvent.click(nextButton())
+    expect(screen.getByText('Step 3 of 3')).toBeInTheDocument()
+
+    fireEvent.click(prevButton())
+    fireEvent.click(prevButton())
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument()
+    fireEvent.click(prevButton())
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument()
+  })
+
+  it('only offers a timer on steps that carry a duration', async () => {
+    await renderCookMode()
+
+    expect(timerDisplay()).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Start timer' })).toBeNull()
+
+    fireEvent.click(nextButton())
+    expect(timerDisplay()).toHaveTextContent('30:00')
+    expect(screen.getByRole('button', { name: 'Start timer' })).toBeInTheDocument()
+  })
+
+  it('counts down, pauses and resets the step timer', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    await renderCookMode()
+
+    fireEvent.click(nextButton())
+    expect(timerDisplay()).toHaveTextContent('30:00')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start timer' }))
+    advance(3000)
+    expect(timerDisplay()).toHaveTextContent('29:57')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pause timer' }))
+    const paused = timerDisplay()?.textContent
+    advance(5000)
+    expect(timerDisplay()).toHaveTextContent(String(paused))
+    // Paused mid-count, the primary action resumes rather than restarts.
+    expect(screen.getByRole('button', { name: 'Resume timer' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resume timer' }))
+    advance(2000)
+    expect(timerDisplay()).toHaveTextContent('29:55')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset timer' }))
+    expect(timerDisplay()).toHaveTextContent('30:00')
+    advance(4000)
+    expect(timerDisplay()).toHaveTextContent('30:00')
+  })
+
+  it('stops at zero and announces that the time is up', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    await renderCookMode()
+
+    // Step 3 is the short one — five minutes.
+    fireEvent.click(nextButton())
+    fireEvent.click(nextButton())
+    expect(timerDisplay()).toHaveTextContent('5:00')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start timer' }))
+    advance(300_000)
+    expect(timerDisplay()).toHaveTextContent('0:00')
+    expect(screen.getByRole('status')).toHaveTextContent('Time is up')
+
+    // The interval is cleared once it hits zero; the clock cannot go negative.
+    advance(10_000)
+    expect(timerDisplay()).toHaveTextContent('0:00')
+  })
+
+  it('clears the interval on unmount and starts each step’s timer fresh', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    const { unmount } = await renderCookMode()
+
+    fireEvent.click(nextButton())
+    fireEvent.click(screen.getByRole('button', { name: 'Start timer' }))
+    advance(3000)
+    expect(timerDisplay()).toHaveTextContent('29:57')
+
+    // Moving on while the timer runs tears it down and mounts the next step's
+    // timer paused at its own full duration.
+    clearIntervalSpy.mockClear()
+    fireEvent.click(nextButton())
+    expect(clearIntervalSpy).toHaveBeenCalled()
+    expect(timerDisplay()).toHaveTextContent('5:00')
+    expect(screen.getByRole('button', { name: 'Start timer' })).toBeInTheDocument()
+
+    // Coming back finds the earlier step's timer reset too — nothing kept running.
+    fireEvent.click(prevButton())
+    expect(timerDisplay()).toHaveTextContent('30:00')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start timer' }))
+    clearIntervalSpy.mockClear()
+    unmount()
+    expect(clearIntervalSpy).toHaveBeenCalled()
+  })
+
+  it('scales the ingredient list to portions passed as router state', async () => {
+    await renderCookMode({ state: { portions: 8 } })
+
+    expect(screen.getByText('800 g cod, cubed')).toBeInTheDocument()
+    expect(screen.getByText('4 dl cream')).toBeInTheDocument()
+    expect(screen.getByText('Scaled from 4 servings')).toBeInTheDocument()
+  })
+
+  it('falls back to the portions query param, then to the recipe’s own yield', async () => {
+    const { unmount } = await renderCookMode({ search: '?portions=2' })
+    expect(screen.getByText('200 g cod, cubed')).toBeInTheDocument()
+    unmount()
+
+    await renderCookMode({ search: '?portions=nonsense' })
+    expect(screen.getByText('400 g cod, cubed')).toBeInTheDocument()
+    expect(screen.queryByText('Scaled from 4 servings')).toBeNull()
+  })
+
+  it('says so when the recipe has no steps to cook through', async () => {
+    await renderCookMode({ recipe: { ...RECIPE, steps: [] } })
+
+    expect(screen.getByText('This recipe has no steps to cook through')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Next step' })).toBeNull()
+  })
+})

--- a/web/src/pages/RecipeCookMode.test.tsx
+++ b/web/src/pages/RecipeCookMode.test.tsx
@@ -123,6 +123,22 @@ function timerDisplay() {
   return screen.queryByRole('timer', { name: 'Time remaining' })
 }
 
+/**
+ * Installs a fake `navigator.wakeLock` and returns a teardown that removes it
+ * again. happy-dom has no Wake Lock API of its own, so without this the hook
+ * takes its feature-detect branch and never calls anything.
+ */
+function stubWakeLock(request: () => Promise<unknown>) {
+  Object.defineProperty(navigator, 'wakeLock', {
+    value: { request },
+    configurable: true,
+    writable: true,
+  })
+  return () => {
+    Reflect.deleteProperty(navigator as unknown as object, 'wakeLock')
+  }
+}
+
 /** Runs the fake clock forward inside `act` so React flushes the tick. */
 function advance(ms: number) {
   act(() => {
@@ -220,6 +236,27 @@ describe('RecipeCookMode', () => {
     expect(timerDisplay()).toHaveTextContent('30:00')
   })
 
+  it('keeps the part-second already spent across a pause', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    await renderCookMode()
+
+    fireEvent.click(nextButton())
+    fireEvent.click(screen.getByRole('button', { name: 'Start timer' }))
+
+    // Two pauses landing mid-second. Rounding the remainder up at each pause
+    // would hand a whole second back to the cook, so 30 seconds of running
+    // would show as 29:31 instead of 29:30.
+    advance(500)
+    fireEvent.click(screen.getByRole('button', { name: 'Pause timer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Resume timer' }))
+    advance(500)
+    fireEvent.click(screen.getByRole('button', { name: 'Pause timer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Resume timer' }))
+    advance(29_000)
+
+    expect(timerDisplay()).toHaveTextContent('29:30')
+  })
+
   it('stops at zero and announces that the time is up', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     await renderCookMode()
@@ -283,6 +320,40 @@ describe('RecipeCookMode', () => {
     await renderCookMode({ search: '?portions=nonsense' })
     expect(screen.getByText('400 g cod, cubed')).toBeInTheDocument()
     expect(screen.queryByText('Scaled from 4 servings')).toBeNull()
+  })
+
+  it('holds a screen wake lock while cooking and releases it on exit', async () => {
+    const release = vi.fn(() => Promise.resolve())
+    const request = vi.fn(() => Promise.resolve({ released: false, release }))
+    const restoreWakeLock = stubWakeLock(request)
+
+    try {
+      const { unmount } = await renderCookMode()
+      // Let the request promise settle so the sentinel is stored before unmount.
+      await act(async () => {})
+      expect(request).toHaveBeenCalledWith('screen')
+
+      unmount()
+      expect(release).toHaveBeenCalled()
+    } finally {
+      restoreWakeLock()
+    }
+  })
+
+  it('cooks on when the browser refuses the wake lock', async () => {
+    const request = vi.fn(() => Promise.reject(new Error('denied')))
+    const restoreWakeLock = stubWakeLock(request)
+
+    try {
+      await renderCookMode()
+      await act(async () => {})
+
+      expect(request).toHaveBeenCalled()
+      expect(screen.getByText('Cube the cod.')).toBeInTheDocument()
+      expect(nextButton()).toBeEnabled()
+    } finally {
+      restoreWakeLock()
+    }
   })
 
   it('says so when the recipe has no steps to cook through', async () => {

--- a/web/src/pages/RecipeCookMode.tsx
+++ b/web/src/pages/RecipeCookMode.tsx
@@ -1,18 +1,369 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { Check, ChevronLeft, ChevronRight, Pause, Play, RotateCcw, X } from 'lucide-react'
+import { useRecipe } from '../hooks/useRecipes'
+import { useWakeLock } from '../hooks/useWakeLock'
+import { ingredientLine, type Recipe, type RecipeStep } from '../types/recipes'
 
 /**
- * Full-screen cook mode: one step at a time, with per-step timers.
+ * Full-screen cook mode: one step at a time, with a per-step countdown.
  *
- * Placeholder shell — the sibling sub-task for cook mode fills it in using the
- * `recipes:cook.*` keys and `useRecipe` from `hooks/useRecipes.ts`.
+ * The recipe is read through the same `useRecipe` hook the detail page uses, so
+ * cook mode never holds its own copy of the data. The portion count comes from
+ * whatever the detail page was showing — passed as router state by its "start
+ * cooking" link, or as a `?portions=` query so a bookmarked cook-mode URL keeps
+ * the scaling — falling back to the recipe's own yield. Only the ingredient
+ * list is scaled; step text is shown exactly as written.
+ *
+ * Each step's timer lives in {@link StepTimer}, keyed by step ID. Keying it
+ * means moving between steps unmounts the timer rather than reconfiguring it,
+ * so the interval is always cleared and the next step starts fresh and paused.
  */
+
+/**
+ * How often the countdown recomputes. The remaining time is derived from a
+ * deadline rather than decremented per tick, so the tick rate only controls how
+ * quickly the display catches up (after a resume, say) and never accumulates
+ * drift. A quarter second keeps the seconds digit honest without busy-looping.
+ */
+const TICK_MS = 250
+
+/** `m:ss`, counting minutes past an hour rather than showing an hours field. */
+function formatRemaining(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds))
+  const minutes = Math.floor(safe / 60)
+  const seconds = safe % 60
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
+
+/** Reads a portion count from router state or a query param; null when it is not a usable one. */
+function positivePortions(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+interface Countdown {
+  /** Whole seconds left. */
+  remaining: number
+  running: boolean
+  /** True once a timed step has run out — the caller shows "time is up". */
+  done: boolean
+  start: () => void
+  pause: () => void
+  reset: () => void
+}
+
+/**
+ * A pausable countdown over `durationSeconds`.
+ *
+ * The interval only exists while the timer runs, and its effect cleanup clears
+ * it — on pause, on completion and on unmount — so no timer outlives the step
+ * that started it. `remaining` is computed from a deadline on every tick, which
+ * keeps a backgrounded tab (where intervals are throttled) honest.
+ */
+function useCountdown(durationSeconds: number): Countdown {
+  const [remaining, setRemaining] = useState(durationSeconds)
+  const [running, setRunning] = useState(false)
+  const deadlineRef = useRef(0)
+  // Mirrors `remaining` so start/pause can read the current value without
+  // depending on it (a state updater must stay free of side effects).
+  const remainingRef = useRef(durationSeconds)
+
+  const applyRemaining = useCallback((seconds: number) => {
+    remainingRef.current = seconds
+    setRemaining(seconds)
+  }, [])
+
+  /** Whole seconds between now and the deadline, never below zero. */
+  const secondsLeft = useCallback(
+    () => Math.max(0, Math.ceil((deadlineRef.current - Date.now()) / 1000)),
+    [],
+  )
+
+  useEffect(() => {
+    if (!running) return
+
+    const tick = () => {
+      const left = secondsLeft()
+      applyRemaining(left)
+      if (left === 0) setRunning(false)
+    }
+
+    tick()
+    const interval = setInterval(tick, TICK_MS)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [running, applyRemaining, secondsLeft])
+
+  const start = useCallback(() => {
+    // Starting from zero restarts the whole duration; otherwise it resumes.
+    const from = remainingRef.current > 0 ? remainingRef.current : durationSeconds
+    if (from <= 0) return
+    deadlineRef.current = Date.now() + from * 1000
+    applyRemaining(from)
+    setRunning(true)
+  }, [durationSeconds, applyRemaining])
+
+  const pause = useCallback(() => {
+    if (running) applyRemaining(secondsLeft())
+    setRunning(false)
+  }, [running, applyRemaining, secondsLeft])
+
+  const reset = useCallback(() => {
+    setRunning(false)
+    applyRemaining(durationSeconds)
+  }, [durationSeconds, applyRemaining])
+
+  return {
+    remaining,
+    running,
+    done: durationSeconds > 0 && remaining === 0,
+    start,
+    pause,
+    reset,
+  }
+}
+
+/** The countdown for one timed step. Mount it keyed by step so it resets on navigation. */
+function StepTimer({ durationSeconds }: { durationSeconds: number }) {
+  const { t } = useTranslation('recipes')
+  const { remaining, running, done, start, pause, reset } = useCountdown(durationSeconds)
+
+  // Started once and now paused mid-way — the primary action reads "resume".
+  const resumable = !running && remaining > 0 && remaining < durationSeconds
+
+  return (
+    <div className="mt-6 rounded-2xl bg-gray-800/60 border border-gray-700 p-4">
+      <p
+        role="timer"
+        aria-label={t('cook.timeRemaining')}
+        className={`text-center tabular-nums text-5xl sm:text-6xl font-semibold ${
+          done ? 'text-amber-300' : 'text-white'
+        }`}
+      >
+        {formatRemaining(remaining)}
+      </p>
+
+      {done && (
+        <p role="status" className="mt-2 text-center text-amber-300 font-medium">
+          {t('cook.timerDone')}
+        </p>
+      )}
+
+      <div className="mt-4 flex items-center justify-center gap-3">
+        <button
+          type="button"
+          onClick={running ? pause : start}
+          className="flex items-center justify-center gap-2 min-h-12 min-w-[7.5rem] px-5 py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-white transition-colors cursor-pointer"
+        >
+          {running ? (
+            <Pause size={20} aria-hidden="true" />
+          ) : (
+            <Play size={20} aria-hidden="true" />
+          )}
+          {running
+            ? t('cook.timerPause')
+            : resumable
+              ? t('cook.timerResume')
+              : t('cook.timerStart')}
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          disabled={!running && remaining === durationSeconds}
+          className="flex items-center justify-center gap-2 min-h-12 px-5 py-3 rounded-xl bg-gray-700 hover:bg-gray-600 text-gray-100 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <RotateCcw size={20} aria-hidden="true" />
+          {t('cook.timerReset')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/** The scaled ingredient list, kept on screen so a step never sends the cook back. */
+function CookIngredients({ recipe, portions }: { recipe: Recipe; portions: number }) {
+  const { t } = useTranslation('recipes')
+  if (recipe.ingredients.length === 0) return null
+
+  return (
+    <section aria-labelledby="cook-ingredients-heading" className="mt-6">
+      <h2 id="cook-ingredients-heading" className="text-base font-semibold text-gray-300">
+        {t('detail.ingredients')}
+      </h2>
+      {portions !== recipe.servings && recipe.servings > 0 && (
+        <p className="text-sm text-gray-500">{t('detail.scaledFrom', { count: recipe.servings })}</p>
+      )}
+      <ul className="mt-2 space-y-1 text-gray-300">
+        {recipe.ingredients.map(ing => (
+          <li key={ing.id} className="break-words">
+            {ingredientLine(ing, recipe.servings, portions)}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
 export default function RecipeCookMode() {
   const { t } = useTranslation('recipes')
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+  const { recipe, loading, error, notFound, refresh } = useRecipe(id)
+  const [stepIndex, setStepIndex] = useState(0)
+
+  // Cooking means wet hands and long pauses; the screen must not sleep.
+  useWakeLock()
+
+  const steps: RecipeStep[] = recipe?.steps ?? []
+  const lastIndex = steps.length - 1
+  // Clamped rather than trusted: a refresh that returns a shorter method must
+  // not leave the view pointing past the end of the list.
+  const safeIndex = Math.min(Math.max(stepIndex, 0), Math.max(lastIndex, 0))
+  const step = steps[safeIndex]
+  const isFirst = safeIndex === 0
+  const isLast = safeIndex === lastIndex
+
+  const goPrev = useCallback(() => {
+    setStepIndex(index => Math.max(0, index - 1))
+  }, [])
+
+  const goNext = useCallback(() => {
+    setStepIndex(index => Math.min(steps.length - 1, index + 1))
+  }, [steps.length])
+
+  const backTo = id ? `/recipes/${id}` : '/recipes'
+
+  const exitLink = (
+    <Link
+      to={backTo}
+      className="inline-flex items-center gap-2 min-h-11 px-3 py-2 -ml-3 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+    >
+      <X size={16} aria-hidden="true" />
+      {t('cook.exit')}
+    </Link>
+  )
+
+  if (loading) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-6">
+        {exitLink}
+        <p role="status" aria-busy="true" className="mt-4 text-gray-400">
+          {t('detail.loading')}
+        </p>
+      </div>
+    )
+  }
+
+  if (notFound) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-6">
+        {exitLink}
+        <p className="mt-4 text-gray-400">{t('errors.notFound')}</p>
+      </div>
+    )
+  }
+
+  if (!recipe) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-6">
+        {exitLink}
+        <div className="mt-4 px-4 py-2 bg-red-900/50 border border-red-800 rounded-lg text-red-300 text-sm">
+          {error || t('errors.failedToLoadRecipe')}
+        </div>
+        <button
+          type="button"
+          onClick={refresh}
+          className="mt-3 min-h-11 px-4 py-2 bg-gray-800 hover:bg-gray-700 rounded-lg transition-colors cursor-pointer text-sm"
+        >
+          {t('errors.retry')}
+        </button>
+      </div>
+    )
+  }
+
+  const routePortions = positivePortions((location.state as { portions?: unknown } | null)?.portions)
+  const portions = routePortions ?? positivePortions(searchParams.get('portions')) ?? recipe.servings
+
+  if (steps.length === 0) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-6">
+        {exitLink}
+        <h1 className="mt-3 text-xl font-semibold break-words">{recipe.title}</h1>
+        <p className="mt-4 text-gray-400">{t('cook.noSteps')}</p>
+        <CookIngredients recipe={recipe} portions={portions} />
+      </div>
+    )
+  }
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-6">
-      <h1 className="text-2xl font-bold mb-2">{t('cook.title')}</h1>
-      <p className="text-gray-400">{t('detail.loading')}</p>
+      {exitLink}
+
+      <h1 className="mt-3 text-xl font-semibold break-words">{recipe.title}</h1>
+      <p className="mt-1 text-sm text-gray-400">
+        {t('cook.step', { current: safeIndex + 1, total: steps.length })}
+      </p>
+
+      {/* Progress across the method, so the position is readable at a glance. */}
+      <ol aria-hidden="true" className="mt-2 flex gap-1">
+        {steps.map((s, index) => (
+          <li
+            key={s.id}
+            className={`h-1.5 flex-1 rounded-full ${
+              index <= safeIndex ? 'bg-blue-500' : 'bg-gray-700'
+            }`}
+          />
+        ))}
+      </ol>
+
+      <p className="mt-6 text-2xl sm:text-3xl leading-relaxed break-words whitespace-pre-wrap">
+        {step.text}
+      </p>
+
+      {step.duration_seconds > 0 && (
+        <StepTimer key={step.id} durationSeconds={step.duration_seconds} />
+      )}
+
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={goPrev}
+          disabled={isFirst}
+          aria-disabled={isFirst}
+          className="flex flex-1 items-center justify-center gap-2 min-h-14 px-4 py-3 rounded-xl bg-gray-800 hover:bg-gray-700 text-gray-100 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <ChevronLeft size={20} aria-hidden="true" />
+          {t('cook.prev')}
+        </button>
+        <button
+          type="button"
+          onClick={goNext}
+          disabled={isLast}
+          aria-disabled={isLast}
+          className="flex flex-1 items-center justify-center gap-2 min-h-14 px-4 py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-white transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {t('cook.next')}
+          <ChevronRight size={20} aria-hidden="true" />
+        </button>
+      </div>
+
+      {isLast && (
+        <button
+          type="button"
+          onClick={() => navigate(backTo)}
+          className="mt-3 flex w-full items-center justify-center gap-2 min-h-14 px-4 py-3 rounded-xl bg-green-700 hover:bg-green-600 text-white transition-colors cursor-pointer"
+        >
+          <Check size={20} aria-hidden="true" />
+          {t('cook.finish')}
+        </button>
+      )}
+
+      <CookIngredients recipe={recipe} portions={portions} />
     </div>
   )
 }

--- a/web/src/pages/RecipeCookMode.tsx
+++ b/web/src/pages/RecipeCookMode.tsx
@@ -44,11 +44,15 @@ function positivePortions(value: unknown): number | null {
 }
 
 interface Countdown {
-  /** Whole seconds left. */
+  /** Whole seconds left, rounded up so the display only reads 0:00 at the end. */
   remaining: number
   running: boolean
   /** True once a timed step has run out — the caller shows "time is up". */
   done: boolean
+  /** Paused part-way through: the primary action resumes rather than restarts. */
+  resumable: boolean
+  /** Untouched, or reset back to the full duration — nothing to reset. */
+  pristine: boolean
   start: () => void
   pause: () => void
   reset: () => void
@@ -59,33 +63,37 @@ interface Countdown {
  *
  * The interval only exists while the timer runs, and its effect cleanup clears
  * it — on pause, on completion and on unmount — so no timer outlives the step
- * that started it. `remaining` is computed from a deadline on every tick, which
- * keeps a backgrounded tab (where intervals are throttled) honest.
+ * that started it. The time left is computed from a deadline on every tick,
+ * which keeps a backgrounded tab (where intervals are throttled) honest.
+ *
+ * It is tracked in milliseconds rather than whole seconds: rounding at pause
+ * would hand back the part-second already spent, so a timer paused and resumed
+ * often enough would gain minutes. Rounding happens only on the way to the
+ * display.
  */
 function useCountdown(durationSeconds: number): Countdown {
-  const [remaining, setRemaining] = useState(durationSeconds)
+  const durationMs = durationSeconds * 1000
+  const [remainingMs, setRemainingMs] = useState(durationMs)
   const [running, setRunning] = useState(false)
   const deadlineRef = useRef(0)
-  // Mirrors `remaining` so start/pause can read the current value without
+  // Mirrors `remainingMs` so start/pause can read the current value without
   // depending on it (a state updater must stay free of side effects).
-  const remainingRef = useRef(durationSeconds)
+  const remainingRef = useRef(durationMs)
 
-  const applyRemaining = useCallback((seconds: number) => {
-    remainingRef.current = seconds
-    setRemaining(seconds)
+  const applyRemaining = useCallback((ms: number) => {
+    const clamped = Math.max(0, ms)
+    remainingRef.current = clamped
+    setRemainingMs(clamped)
   }, [])
 
-  /** Whole seconds between now and the deadline, never below zero. */
-  const secondsLeft = useCallback(
-    () => Math.max(0, Math.ceil((deadlineRef.current - Date.now()) / 1000)),
-    [],
-  )
+  /** Milliseconds between now and the deadline, never below zero. */
+  const msLeft = useCallback(() => Math.max(0, deadlineRef.current - Date.now()), [])
 
   useEffect(() => {
     if (!running) return
 
     const tick = () => {
-      const left = secondsLeft()
+      const left = msLeft()
       applyRemaining(left)
       if (left === 0) setRunning(false)
     }
@@ -95,31 +103,33 @@ function useCountdown(durationSeconds: number): Countdown {
     return () => {
       clearInterval(interval)
     }
-  }, [running, applyRemaining, secondsLeft])
+  }, [running, applyRemaining, msLeft])
 
   const start = useCallback(() => {
     // Starting from zero restarts the whole duration; otherwise it resumes.
-    const from = remainingRef.current > 0 ? remainingRef.current : durationSeconds
+    const from = remainingRef.current > 0 ? remainingRef.current : durationMs
     if (from <= 0) return
-    deadlineRef.current = Date.now() + from * 1000
+    deadlineRef.current = Date.now() + from
     applyRemaining(from)
     setRunning(true)
-  }, [durationSeconds, applyRemaining])
+  }, [durationMs, applyRemaining])
 
   const pause = useCallback(() => {
-    if (running) applyRemaining(secondsLeft())
+    if (running) applyRemaining(msLeft())
     setRunning(false)
-  }, [running, applyRemaining, secondsLeft])
+  }, [running, applyRemaining, msLeft])
 
   const reset = useCallback(() => {
     setRunning(false)
-    applyRemaining(durationSeconds)
-  }, [durationSeconds, applyRemaining])
+    applyRemaining(durationMs)
+  }, [durationMs, applyRemaining])
 
   return {
-    remaining,
+    remaining: Math.ceil(remainingMs / 1000),
     running,
-    done: durationSeconds > 0 && remaining === 0,
+    done: durationMs > 0 && remainingMs === 0,
+    resumable: !running && remainingMs > 0 && remainingMs < durationMs,
+    pristine: !running && remainingMs === durationMs,
     start,
     pause,
     reset,
@@ -129,10 +139,8 @@ function useCountdown(durationSeconds: number): Countdown {
 /** The countdown for one timed step. Mount it keyed by step so it resets on navigation. */
 function StepTimer({ durationSeconds }: { durationSeconds: number }) {
   const { t } = useTranslation('recipes')
-  const { remaining, running, done, start, pause, reset } = useCountdown(durationSeconds)
-
-  // Started once and now paused mid-way — the primary action reads "resume".
-  const resumable = !running && remaining > 0 && remaining < durationSeconds
+  const { remaining, running, done, resumable, pristine, start, pause, reset } =
+    useCountdown(durationSeconds)
 
   return (
     <div className="mt-6 rounded-2xl bg-gray-800/60 border border-gray-700 p-4">
@@ -172,7 +180,7 @@ function StepTimer({ durationSeconds }: { durationSeconds: number }) {
         <button
           type="button"
           onClick={reset}
-          disabled={!running && remaining === durationSeconds}
+          disabled={pristine}
           className="flex items-center justify-center gap-2 min-h-12 px-5 py-3 rounded-xl bg-gray-700 hover:bg-gray-600 text-gray-100 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <RotateCcw size={20} aria-hidden="true" />
@@ -216,7 +224,10 @@ export default function RecipeCookMode() {
   const { recipe, loading, error, notFound, refresh } = useRecipe(id)
   const [stepIndex, setStepIndex] = useState(0)
 
-  // Cooking means wet hands and long pauses; the screen must not sleep.
+  // Cooking means wet hands and long pauses; the screen must not sleep. The
+  // hook feature-detects the Wake Lock API and swallows a refused request, so
+  // there is nothing to handle here — an unsupported or locked-down browser
+  // just cooks with the screen timeout it already had.
   useWakeLock()
 
   const steps: RecipeStep[] = recipe?.steps ?? []

--- a/web/src/pages/RecipeDetail.tsx
+++ b/web/src/pages/RecipeDetail.tsx
@@ -429,8 +429,10 @@ function RecipeDetailInner() {
           <Check size={16} aria-hidden="true" />
           {cookLogged ? t('detail.markedCooked') : t('detail.markCooked')}
         </button>
+        {/* Cook mode scales its ingredient list for whatever is on screen here. */}
         <Link
           to={`/recipes/${recipe.id}/cook`}
+          state={{ portions }}
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors text-sm"
         >
           <Utensils size={16} aria-hidden="true" />


### PR DESCRIPTION
## Changes

- **Cook mode for recipes** - Walk a recipe one step at a time with a large, readable step view, next/previous controls and a step position indicator. Timed steps get a countdown with start, pause and reset that starts fresh on every step, the ingredient list stays on screen scaled to the portions chosen on the recipe page, and the screen is kept awake while you cook. (Hytte-toiak)

## Original Issue (task): RecipeCookMode: single-step stepper with per-step countdown timer

Create `web/src/pages/RecipeCookMode.tsx`. Render one step at a time with next/prev controls and a step position indicator, reading the recipe via the API client from sub-task 1 (and honouring the portion count if passed through route state/query from RecipeDetail). For any step carrying a duration, show a running countdown timer with start/pause/reset, driven by a `setInterval`/`requestAnimationFrame` effect that is cleaned up on unmount and on step change so timers don't leak between steps. Keep the screen readable at 375px with large touch targets. All strings from the `recipes` namespace. Add a focused test for timer countdown and cleanup, and step navigation bounds (no prev on first step, no next past last). Depends on sub-task 1 for the route and i18n namespace; consumes the same recipe shape as sub-task 3.

---
Bead: Hytte-toiak | Branch: forge/Hytte-toiak
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->