### PR TITLE
Remove unused annuityPayment365 helper in internal/budget/loans.go (Hytte-xe0z2)

### DIFF
--- a/changelog.d/Hytte-xe0z2.md
+++ b/changelog.d/Hytte-xe0z2.md
@@ -1,0 +1,2 @@
+category: Removed
+- **Removed unused annuityPayment365 helper** - Deleted the dead actual/365 annuity solver in the budget loan engine; the amortization schedule already uses the inline r/12 annuity formula, so the unused helper only invited confusion about which payment formula applies. (Hytte-xe0z2)

--- a/internal/budget/loans.go
+++ b/internal/budget/loans.go
@@ -191,47 +191,6 @@ func daysIn(from, to time.Time) int {
 	return int(to.Sub(from).Hours() / 24)
 }
 
-// annuityPayment365 calculates the annuity payment using actual/365 day-count.
-// It iterates to find the fixed payment that amortises `balance` over `nMonths`.
-// `accrualStart` is the date interest starts accruing for the first period
-// (e.g. the first_payment_date after a partial period). `payDay` determines
-// the day of month for each payment. The first payment date is the next
-// occurrence of `payDay` after accrualStart.
-func annuityPayment365(balance, annualRate float64, nMonths int, accrualStart time.Time, payDay int) float64 {
-	// Use r/12 as initial estimate, then refine iteratively.
-	r12 := annualRate / 12.0
-	payment := balance * r12 / (1 - math.Pow(1+r12, -float64(nMonths)))
-
-	baseYear, baseMonth, _ := accrualStart.Date()
-	loc := accrualStart.Location()
-
-	// Refine: iterate the schedule with the candidate payment and adjust.
-	for iter := 0; iter < 10; iter++ {
-		bal := balance
-		// Interest accrues from the actual accrual start, not the pay-day-snapped date.
-		prevDate := accrualStart
-		for m := 1; m <= nMonths && bal > 0.005; m++ {
-			tm := int(baseMonth) - 1 + m
-			curDate := time.Date(baseYear+tm/12, time.Month(tm%12+1), payDay, 0, 0, 0, 0, loc)
-			days := daysIn(prevDate, curDate)
-			interest := bal * annualRate * float64(days) / 365.0
-			principal := payment - interest
-			if principal > bal {
-				principal = bal
-			}
-			bal -= principal
-			prevDate = curDate
-		}
-		// bal is the residual. Spread it across remaining payments.
-		if math.Abs(bal) < 0.01 {
-			break
-		}
-		// Adjust payment proportionally.
-		payment *= balance / (balance - bal)
-	}
-	return payment
-}
-
 // BuildAmortization computes the amortization schedule for a loan.
 // It generates rows starting from the loan's start_date using the original principal,
 // capping at maxRows (0 = use term_months). current_balance is informational only


### PR DESCRIPTION
## Changes

- **Removed unused annuityPayment365 helper** - Deleted the dead actual/365 annuity solver in the budget loan engine; the amortization schedule already uses the inline r/12 annuity formula, so the unused helper only invited confusion about which payment formula applies. (Hytte-xe0z2)

## Original Issue (task): Remove unused annuityPayment365 helper in internal/budget/loans.go

internal/budget/loans.go:200 defines annuityPayment365(), a ~35-line iterative annuity solver using actual/365 day-count. It has no callers anywhere in the repo (BuildAmortization uses the simple r/12 annuity formula inline instead). Dead code that invites confusion about which payment formula the engine uses. Either delete it or wire it up if the actual/365 payment calculation was the intent.

---
Bead: Hytte-xe0z2 | Branch: forge/Hytte-xe0z2
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->