### PR TITLE
Persist unsent message drafts per conversation across switches (Hytte-3tafy)

### DIFF
--- a/changelog.d/Hytte-3tafy.md
+++ b/changelog.d/Hytte-3tafy.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Family Chat keeps unsent message drafts per conversation** - Switching to another thread no longer discards a half-typed message: the composer text is saved per conversation and restored when you come back, and it survives a page reload. Drafts are stored locally in the browser, kept isolated per thread, and cleared as soon as the message is sent. (Hytte-3tafy)

--- a/web/src/auth.tsx
+++ b/web/src/auth.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react'
 import { clearTrainingListCache } from './hooks/useTrainingListCache'
+import { clearAllDrafts } from './pages/familychat/drafts'
 
 interface User {
   id: number
@@ -73,6 +74,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async () => {
     await fetch('/api/auth/logout', { method: 'POST' })
+    clearAllDrafts()
     setUser(null)
     setFamilyStatus(null)
     // Drop every cached training list in this tab, so signing in as a different

--- a/web/src/pages/familychat/Composer.test.tsx
+++ b/web/src/pages/familychat/Composer.test.tsx
@@ -333,7 +333,7 @@ describe('Composer – per-conversation drafts', () => {
 
   it('restores a stored draft on mount', () => {
     vi.stubGlobal('fetch', vi.fn())
-    setDraft(3, 'half typed message')
+    setDraft(1, 3, 'half typed message')
     renderComposer(3)
     expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('half typed message')
   })
@@ -347,12 +347,12 @@ describe('Composer – per-conversation drafts', () => {
 
     rerender(composerFor(2))
     expect(textarea.value).toBe('')
-    expect(getDraft(1)).toBe('a long unfinished thought')
+    expect(getDraft(1, 1)).toBe('a long unfinished thought')
 
     fireEvent.change(textarea, { target: { value: 'for the other thread' } })
     rerender(composerFor(1))
     expect(textarea.value).toBe('a long unfinished thought')
-    expect(getDraft(2)).toBe('for the other thread')
+    expect(getDraft(1, 2)).toBe('for the other thread')
   })
 
   it('persists the draft on unmount', () => {
@@ -360,23 +360,23 @@ describe('Composer – per-conversation drafts', () => {
     const { unmount } = renderComposer(4)
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'saved for later' } })
     unmount()
-    expect(getDraft(4)).toBe('saved for later')
+    expect(getDraft(1, 4)).toBe('saved for later')
   })
 
   it('stores no draft for a whitespace-only composer and drops a previous one', () => {
     vi.stubGlobal('fetch', vi.fn())
-    setDraft(5, 'previously typed')
+    setDraft(1, 5, 'previously typed')
     const { unmount } = renderComposer(5)
     fireEvent.change(screen.getByRole('textbox'), { target: { value: '   ' } })
     unmount()
-    expect(getDraft(5)).toBe('')
-    expect(localStorage.getItem(draftKey(5))).toBeNull()
+    expect(getDraft(1, 5)).toBe('')
+    expect(localStorage.getItem(draftKey(1, 5))).toBeNull()
   })
 
   it('clears the stored draft after a successful send', async () => {
     const msg = makeMessage({ id: 12, conversation_id: 6, body: 'Sent for real' })
     vi.stubGlobal('fetch', vi.fn(() => sendOk(msg)))
-    setDraft(6, 'an older draft')
+    setDraft(1, 6, 'an older draft')
     const { unmount } = renderComposer(6)
 
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
@@ -385,11 +385,11 @@ describe('Composer – per-conversation drafts', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
 
     await waitFor(() => { expect(textarea.value).toBe('') })
-    expect(getDraft(6)).toBe('')
+    expect(getDraft(1, 6)).toBe('')
 
     // The unmount persist must not resurrect the just-sent text.
     unmount()
-    expect(getDraft(6)).toBe('')
+    expect(getDraft(1, 6)).toBe('')
   })
 
   it('clears the stored draft after a successful attachment send', async () => {
@@ -416,9 +416,9 @@ describe('Composer – per-conversation drafts', () => {
     await waitFor(() => {
       expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('')
     })
-    expect(getDraft(7)).toBe('')
+    expect(getDraft(1, 7)).toBe('')
     unmount()
-    expect(getDraft(7)).toBe('')
+    expect(getDraft(1, 7)).toBe('')
   })
 
   it('still aborts in-flight sends, resets error/attachment state and focuses the input on a switch', async () => {

--- a/web/src/pages/familychat/Composer.test.tsx
+++ b/web/src/pages/familychat/Composer.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import Composer, { type RetryHandle } from './Composer'
 import type { ChatMessage } from './ChatView'
+import { getDraft, setDraft, draftKey, __resetDrafts } from './drafts'
 
 // ── Translation mock ──────────────────────────────────────────────────────────
 
@@ -64,6 +65,10 @@ function renderComposer(conversationId = 1, onMessageCreated = vi.fn(), extra: E
     />,
   )
 }
+
+// Drafts outlive a render (that is the point of them), so wipe the store
+// before every test to keep suites independent.
+beforeEach(() => { __resetDrafts() })
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -306,5 +311,157 @@ describe('Composer – attachments', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent('File is too large (max 10 MB)')
     })
+  })
+})
+
+describe('Composer – per-conversation drafts', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  // composerFor builds the element so a test can rerender the same component
+  // under a different conversation id — the switch the drafts protect.
+  function composerFor(conversationId: number, onMessageCreated = vi.fn()) {
+    return (
+      <Composer
+        conversationId={conversationId}
+        currentUserId={1}
+        onMessageCreated={onMessageCreated}
+        onOptimisticMessage={vi.fn()}
+        onMessageFailed={vi.fn()}
+      />
+    )
+  }
+
+  it('restores a stored draft on mount', () => {
+    vi.stubGlobal('fetch', vi.fn())
+    setDraft(3, 'half typed message')
+    renderComposer(3)
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('half typed message')
+  })
+
+  it('persists the draft when switching conversations and restores it on return', () => {
+    vi.stubGlobal('fetch', vi.fn())
+    const { rerender } = render(composerFor(1))
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    fireEvent.change(textarea, { target: { value: 'a long unfinished thought' } })
+
+    rerender(composerFor(2))
+    expect(textarea.value).toBe('')
+    expect(getDraft(1)).toBe('a long unfinished thought')
+
+    fireEvent.change(textarea, { target: { value: 'for the other thread' } })
+    rerender(composerFor(1))
+    expect(textarea.value).toBe('a long unfinished thought')
+    expect(getDraft(2)).toBe('for the other thread')
+  })
+
+  it('persists the draft on unmount', () => {
+    vi.stubGlobal('fetch', vi.fn())
+    const { unmount } = renderComposer(4)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'saved for later' } })
+    unmount()
+    expect(getDraft(4)).toBe('saved for later')
+  })
+
+  it('stores no draft for a whitespace-only composer and drops a previous one', () => {
+    vi.stubGlobal('fetch', vi.fn())
+    setDraft(5, 'previously typed')
+    const { unmount } = renderComposer(5)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '   ' } })
+    unmount()
+    expect(getDraft(5)).toBe('')
+    expect(localStorage.getItem(draftKey(5))).toBeNull()
+  })
+
+  it('clears the stored draft after a successful send', async () => {
+    const msg = makeMessage({ id: 12, conversation_id: 6, body: 'Sent for real' })
+    vi.stubGlobal('fetch', vi.fn(() => sendOk(msg)))
+    setDraft(6, 'an older draft')
+    const { unmount } = renderComposer(6)
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(textarea.value).toBe('an older draft')
+    fireEvent.change(textarea, { target: { value: 'Sent for real' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    await waitFor(() => { expect(textarea.value).toBe('') })
+    expect(getDraft(6)).toBe('')
+
+    // The unmount persist must not resurrect the just-sent text.
+    unmount()
+    expect(getDraft(6)).toBe('')
+  })
+
+  it('clears the stored draft after a successful attachment send', async () => {
+    const newMsg = makeMessage({ id: 13, conversation_id: 7, body: 'With a file' })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ upload_id: 'a'.repeat(32), mime: 'image/png', size: 12 }),
+      })
+      .mockResolvedValueOnce(sendOk(newMsg))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container, unmount } = renderComposer(7)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'With a file' } })
+    const file = new File([new Uint8Array([0x89, 0x50])], 'pic.png', { type: 'image/png' })
+    fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, {
+      target: { files: [file] },
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('family-chat-attachment-chip')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+    await waitFor(() => {
+      expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('')
+    })
+    expect(getDraft(7)).toBe('')
+    unmount()
+    expect(getDraft(7)).toBe('')
+  })
+
+  it('still aborts in-flight sends, resets error/attachment state and focuses the input on a switch', async () => {
+    // The message POST never resolves so its abort is observable; the upload
+    // succeeds so the attachment chip is on screen at switch time.
+    const sendSignals: AbortSignal[] = []
+    vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) => {
+      if (init?.body instanceof FormData) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ upload_id: 'b'.repeat(32), mime: 'image/png', size: 12 }),
+        })
+      }
+      if (init?.signal) sendSignals.push(init.signal)
+      return new Promise(() => {})
+    }))
+
+    const { container, rerender } = render(composerFor(8))
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: 'In flight' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+    expect(sendSignals).toHaveLength(1)
+    expect(sendSignals[0].aborted).toBe(false)
+
+    const file = new File([new Uint8Array([0x89, 0x50])], 'pic.png', { type: 'image/png' })
+    fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, {
+      target: { files: [file] },
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('family-chat-attachment-chip')).toBeInTheDocument()
+    })
+
+    // An over-long body raises the inline error without any network call.
+    fireEvent.change(textarea, { target: { value: 'x'.repeat(8001) } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+    expect(screen.getByRole('alert')).toHaveTextContent('Message is too long')
+
+    rerender(composerFor(9))
+
+    expect(sendSignals[0].aborted).toBe(true)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('family-chat-attachment-chip')).not.toBeInTheDocument()
+    expect(textarea.value).toBe('')
+    expect(document.activeElement).toBe(textarea)
   })
 })

--- a/web/src/pages/familychat/Composer.tsx
+++ b/web/src/pages/familychat/Composer.tsx
@@ -111,6 +111,12 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
   const bodyRef = useRef(body)
   useEffect(() => { bodyRef.current = body })
 
+  function resetComposerText(targetConversationId: number) {
+    bodyRef.current = ''
+    clearDraft(currentUserId, targetConversationId)
+    setBody('')
+  }
+
   // Swap in the stored draft + focus the textarea when the conversation
   // changes so the composer never carries a half-typed message into a
   // different chat, while the outgoing chat's text is kept for later. Also
@@ -118,7 +124,8 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
   // the newly selected conversation. The cleanup also runs on unmount.
   useEffect(() => {
     const id = conversationId
-    const draft = getDraft(id)
+    const uid = currentUserId
+    const draft = getDraft(uid, id)
     // Seed the mirror as well: a cleanup that runs before the next render
     // (React StrictMode's double-mount, or a very fast switch) would otherwise
     // persist a stale empty body and wipe the draft we just restored.
@@ -139,10 +146,13 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
     if (rs === 'recording' || rs === 'starting' || rs === 'processing') {
       recorderRef.current.cancel()
     }
+    const persistDraft = () => { setDraft(uid, id, bodyRef.current) }
+    window.addEventListener('pagehide', persistDraft)
     return () => {
+      window.removeEventListener('pagehide', persistDraft)
       // Keep the outgoing conversation's half-typed message so coming back
       // restores it. A blank body clears the stored draft instead.
-      setDraft(id, bodyRef.current)
+      setDraft(uid, id, bodyRef.current)
       abortRef.current?.abort()
       abortRef.current = null
       uploadAbortRef.current?.abort()
@@ -154,7 +164,7 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
       for (const c of sendAbortsRef.current) c.abort()
       sendAbortsRef.current.clear()
     }
-  }, [conversationId])
+  }, [conversationId, currentUserId])
 
   // Auto-grow the textarea up to a max height; collapse back when emptied.
   useEffect(() => {
@@ -306,11 +316,7 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
         throw new Error(t('composer.errors.send'))
       }
       onMessageCreated(msg)
-      // Update the ref before the state so a conversation switch racing this
-      // cleanup cannot re-persist the text we just sent.
-      bodyRef.current = ''
-      clearDraft(targetConversationId)
-      setBody('')
+      resetComposerText(targetConversationId)
       setAttachment(null)
       textareaRef.current?.focus()
     } catch (err) {
@@ -355,11 +361,7 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
     }
     tempIdRef.current -= 1
     onOptimisticMessage(optimistic)
-    // Update the ref before the state so a conversation switch racing this
-    // cleanup cannot re-persist the text we just sent.
-    bodyRef.current = ''
-    clearDraft(targetConversationId)
-    setBody('')
+    resetComposerText(targetConversationId)
     setError('')
     textareaRef.current?.focus()
     void postText(targetConversationId, clientId, trimmed)

--- a/web/src/pages/familychat/Composer.tsx
+++ b/web/src/pages/familychat/Composer.tsx
@@ -7,6 +7,7 @@ import { uploadAttachment, UploadError } from './api'
 import { useVoiceRecorder } from './voice/useVoiceRecorder'
 import { trimLeadingTrailingSilence } from './voice/silenceTrim'
 import { computeWaveform, writeCachedWaveform } from './voice/waveform'
+import { clearDraft, getDraft, setDraft } from './drafts'
 
 // RetryHandle re-POSTs a failed optimistic message, reusing its original
 // client_id so a successful retry reconciles the existing bubble in place.
@@ -105,13 +106,25 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
   const recorderRef = useRef(recorder)
   useEffect(() => { recorderRef.current = recorder })
 
-  // Clear draft + focus the textarea when the conversation changes so the
-  // composer doesn't carry a half-typed message to a different chat. Also
+  // bodyRef mirrors the current text so the conversation-change cleanup can
+  // persist it — the cleanup closure captures a stale `body` otherwise.
+  const bodyRef = useRef(body)
+  useEffect(() => { bodyRef.current = body })
+
+  // Swap in the stored draft + focus the textarea when the conversation
+  // changes so the composer never carries a half-typed message into a
+  // different chat, while the outgoing chat's text is kept for later. Also
   // abort any in-flight send so its response cannot leak the message into
   // the newly selected conversation. The cleanup also runs on unmount.
   useEffect(() => {
+    const id = conversationId
+    const draft = getDraft(id)
+    // Seed the mirror as well: a cleanup that runs before the next render
+    // (React StrictMode's double-mount, or a very fast switch) would otherwise
+    // persist a stale empty body and wipe the draft we just restored.
+    bodyRef.current = draft
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setBody('')
+    setBody(draft)
     setError('')
     setSending(false)
     setUploading(false)
@@ -127,6 +140,9 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
       recorderRef.current.cancel()
     }
     return () => {
+      // Keep the outgoing conversation's half-typed message so coming back
+      // restores it. A blank body clears the stored draft instead.
+      setDraft(id, bodyRef.current)
       abortRef.current?.abort()
       abortRef.current = null
       uploadAbortRef.current?.abort()
@@ -290,6 +306,10 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
         throw new Error(t('composer.errors.send'))
       }
       onMessageCreated(msg)
+      // Update the ref before the state so a conversation switch racing this
+      // cleanup cannot re-persist the text we just sent.
+      bodyRef.current = ''
+      clearDraft(targetConversationId)
       setBody('')
       setAttachment(null)
       textareaRef.current?.focus()
@@ -335,6 +355,10 @@ export default function Composer({ conversationId, currentUserId, onMessageCreat
     }
     tempIdRef.current -= 1
     onOptimisticMessage(optimistic)
+    // Update the ref before the state so a conversation switch racing this
+    // cleanup cannot re-persist the text we just sent.
+    bodyRef.current = ''
+    clearDraft(targetConversationId)
     setBody('')
     setError('')
     textareaRef.current?.focus()

--- a/web/src/pages/familychat/drafts.test.ts
+++ b/web/src/pages/familychat/drafts.test.ts
@@ -1,75 +1,106 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { getDraft, setDraft, clearDraft, draftKey, DRAFT_KEY_PREFIX, __resetDrafts } from './drafts'
+import { getDraft, setDraft, clearDraft, clearAllDrafts, draftKey, DRAFT_KEY_PREFIX, __resetDrafts } from './drafts'
+
+const U = 1
 
 describe('familychat drafts', () => {
   beforeEach(() => { __resetDrafts() })
   afterEach(() => { vi.restoreAllMocks(); __resetDrafts() })
 
   it('round-trips a draft for a conversation', () => {
-    setDraft(1, 'half typed')
-    expect(getDraft(1)).toBe('half typed')
+    setDraft(U, 1, 'half typed')
+    expect(getDraft(U, 1)).toBe('half typed')
   })
 
   it('keeps drafts isolated per conversation id', () => {
-    setDraft(1, 'for one')
-    setDraft(2, 'for two')
-    expect(getDraft(1)).toBe('for one')
-    expect(getDraft(2)).toBe('for two')
-    expect(getDraft(3)).toBe('')
+    setDraft(U, 1, 'for one')
+    setDraft(U, 2, 'for two')
+    expect(getDraft(U, 1)).toBe('for one')
+    expect(getDraft(U, 2)).toBe('for two')
+    expect(getDraft(U, 3)).toBe('')
   })
 
   it('preserves the exact text, including surrounding whitespace', () => {
-    setDraft(1, '  padded text  ')
-    expect(getDraft(1)).toBe('  padded text  ')
+    setDraft(U, 1, '  padded text  ')
+    expect(getDraft(U, 1)).toBe('  padded text  ')
   })
 
-  it('namespaces the localStorage key per conversation', () => {
-    setDraft(42, 'stored')
-    expect(draftKey(42)).toBe(`${DRAFT_KEY_PREFIX}42`)
-    expect(localStorage.getItem(draftKey(42))).toBe('stored')
+  it('namespaces the localStorage key per user and conversation', () => {
+    setDraft(U, 42, 'stored')
+    expect(draftKey(U, 42)).toBe(`${DRAFT_KEY_PREFIX}${U}:42`)
+    expect(localStorage.getItem(draftKey(U, 42))).toBe('stored')
+  })
+
+  it('isolates drafts by user id', () => {
+    setDraft(1, 5, 'user one draft')
+    setDraft(2, 5, 'user two draft')
+    expect(getDraft(1, 5)).toBe('user one draft')
+    expect(getDraft(2, 5)).toBe('user two draft')
   })
 
   it('survives a reload — a draft written earlier is read back from storage', () => {
-    setDraft(7, 'still here')
+    setDraft(U, 7, 'still here')
     // __resetDrafts drops the in-memory mirror but we re-seed storage to
     // stand in for a fresh page load with the same localStorage.
-    const stored = localStorage.getItem(draftKey(7))
+    const stored = localStorage.getItem(draftKey(U, 7))
     __resetDrafts()
-    localStorage.setItem(draftKey(7), stored!)
-    expect(getDraft(7)).toBe('still here')
+    localStorage.setItem(draftKey(U, 7), stored!)
+    expect(getDraft(U, 7)).toBe('still here')
   })
 
   it('removes a stored draft when the body becomes empty or whitespace-only', () => {
-    setDraft(1, 'something')
-    setDraft(1, '   ')
-    expect(getDraft(1)).toBe('')
-    expect(localStorage.getItem(draftKey(1))).toBeNull()
+    setDraft(U, 1, 'something')
+    setDraft(U, 1, '   ')
+    expect(getDraft(U, 1)).toBe('')
+    expect(localStorage.getItem(draftKey(U, 1))).toBeNull()
 
-    setDraft(2, 'something else')
-    setDraft(2, '')
-    expect(getDraft(2)).toBe('')
-    expect(localStorage.getItem(draftKey(2))).toBeNull()
+    setDraft(U, 2, 'something else')
+    setDraft(U, 2, '')
+    expect(getDraft(U, 2)).toBe('')
+    expect(localStorage.getItem(draftKey(U, 2))).toBeNull()
   })
 
   it('stores nothing for a blank body', () => {
-    setDraft(1, '  ')
-    expect(localStorage.getItem(draftKey(1))).toBeNull()
-    expect(getDraft(1)).toBe('')
+    setDraft(U, 1, '  ')
+    expect(localStorage.getItem(draftKey(U, 1))).toBeNull()
+    expect(getDraft(U, 1)).toBe('')
   })
 
   it('clearDraft removes the draft from storage and memory', () => {
-    setDraft(1, 'to be sent')
-    clearDraft(1)
-    expect(getDraft(1)).toBe('')
-    expect(localStorage.getItem(draftKey(1))).toBeNull()
+    setDraft(U, 1, 'to be sent')
+    clearDraft(U, 1)
+    expect(getDraft(U, 1)).toBe('')
+    expect(localStorage.getItem(draftKey(U, 1))).toBeNull()
   })
 
   it('ignores a falsy conversation id', () => {
-    setDraft(0, 'nowhere')
-    expect(getDraft(0)).toBe('')
-    expect(localStorage.getItem(draftKey(0))).toBeNull()
-    expect(() => clearDraft(0)).not.toThrow()
+    setDraft(U, 0, 'nowhere')
+    expect(getDraft(U, 0)).toBe('')
+    expect(() => clearDraft(U, 0)).not.toThrow()
+  })
+
+  it('ignores a falsy user id', () => {
+    setDraft(0, 1, 'nowhere')
+    expect(getDraft(0, 1)).toBe('')
+    expect(() => clearDraft(0, 1)).not.toThrow()
+  })
+
+  it('clearAllDrafts wipes all user drafts from storage', () => {
+    setDraft(1, 10, 'user one')
+    setDraft(2, 20, 'user two')
+    clearAllDrafts()
+    expect(getDraft(1, 10)).toBe('')
+    expect(getDraft(2, 20)).toBe('')
+    expect(localStorage.getItem(draftKey(1, 10))).toBeNull()
+    expect(localStorage.getItem(draftKey(2, 20))).toBeNull()
+  })
+
+  it('prefers storage over memory so cross-tab writes are visible', () => {
+    setDraft(U, 1, 'tab A')
+    // Simulate tab B writing a newer value directly to storage.
+    localStorage.setItem(draftKey(U, 1), 'tab B newer')
+    expect(getDraft(U, 1)).toBe('tab B newer')
   })
 
   it('falls back to memory when localStorage throws', () => {
@@ -86,12 +117,12 @@ describe('familychat drafts', () => {
     const original = Object.getOwnPropertyDescriptor(window, 'localStorage')
     Object.defineProperty(window, 'localStorage', { configurable: true, get: () => throwing })
     try {
-      expect(() => setDraft(1, 'private mode')).not.toThrow()
-      expect(getDraft(1)).toBe('private mode')
+      expect(() => setDraft(U, 1, 'private mode')).not.toThrow()
+      expect(getDraft(U, 1)).toBe('private mode')
       // No memory entry for 2 — the throwing read is swallowed.
-      expect(getDraft(2)).toBe('')
-      expect(() => clearDraft(1)).not.toThrow()
-      expect(getDraft(1)).toBe('')
+      expect(getDraft(U, 2)).toBe('')
+      expect(() => clearDraft(U, 1)).not.toThrow()
+      expect(getDraft(U, 1)).toBe('')
       expect(() => __resetDrafts()).not.toThrow()
 
       expect(throwing.setItem).toHaveBeenCalled()

--- a/web/src/pages/familychat/drafts.test.ts
+++ b/web/src/pages/familychat/drafts.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getDraft, setDraft, clearDraft, draftKey, DRAFT_KEY_PREFIX, __resetDrafts } from './drafts'
+
+describe('familychat drafts', () => {
+  beforeEach(() => { __resetDrafts() })
+  afterEach(() => { vi.restoreAllMocks(); __resetDrafts() })
+
+  it('round-trips a draft for a conversation', () => {
+    setDraft(1, 'half typed')
+    expect(getDraft(1)).toBe('half typed')
+  })
+
+  it('keeps drafts isolated per conversation id', () => {
+    setDraft(1, 'for one')
+    setDraft(2, 'for two')
+    expect(getDraft(1)).toBe('for one')
+    expect(getDraft(2)).toBe('for two')
+    expect(getDraft(3)).toBe('')
+  })
+
+  it('preserves the exact text, including surrounding whitespace', () => {
+    setDraft(1, '  padded text  ')
+    expect(getDraft(1)).toBe('  padded text  ')
+  })
+
+  it('namespaces the localStorage key per conversation', () => {
+    setDraft(42, 'stored')
+    expect(draftKey(42)).toBe(`${DRAFT_KEY_PREFIX}42`)
+    expect(localStorage.getItem(draftKey(42))).toBe('stored')
+  })
+
+  it('survives a reload — a draft written earlier is read back from storage', () => {
+    setDraft(7, 'still here')
+    // __resetDrafts drops the in-memory mirror but we re-seed storage to
+    // stand in for a fresh page load with the same localStorage.
+    const stored = localStorage.getItem(draftKey(7))
+    __resetDrafts()
+    localStorage.setItem(draftKey(7), stored!)
+    expect(getDraft(7)).toBe('still here')
+  })
+
+  it('removes a stored draft when the body becomes empty or whitespace-only', () => {
+    setDraft(1, 'something')
+    setDraft(1, '   ')
+    expect(getDraft(1)).toBe('')
+    expect(localStorage.getItem(draftKey(1))).toBeNull()
+
+    setDraft(2, 'something else')
+    setDraft(2, '')
+    expect(getDraft(2)).toBe('')
+    expect(localStorage.getItem(draftKey(2))).toBeNull()
+  })
+
+  it('stores nothing for a blank body', () => {
+    setDraft(1, '  ')
+    expect(localStorage.getItem(draftKey(1))).toBeNull()
+    expect(getDraft(1)).toBe('')
+  })
+
+  it('clearDraft removes the draft from storage and memory', () => {
+    setDraft(1, 'to be sent')
+    clearDraft(1)
+    expect(getDraft(1)).toBe('')
+    expect(localStorage.getItem(draftKey(1))).toBeNull()
+  })
+
+  it('ignores a falsy conversation id', () => {
+    setDraft(0, 'nowhere')
+    expect(getDraft(0)).toBe('')
+    expect(localStorage.getItem(draftKey(0))).toBeNull()
+    expect(() => clearDraft(0)).not.toThrow()
+  })
+
+  it('falls back to memory when localStorage throws', () => {
+    // Stands in for private mode / a blocked or full storage: every operation
+    // throws. The composer must keep working for the current session.
+    const throwing = {
+      length: 0,
+      getItem: vi.fn(() => { throw new Error('storage disabled') }),
+      setItem: vi.fn(() => { throw new Error('quota exceeded') }),
+      removeItem: vi.fn(() => { throw new Error('storage disabled') }),
+      key: vi.fn(() => { throw new Error('storage disabled') }),
+      clear: vi.fn(() => { throw new Error('storage disabled') }),
+    }
+    const original = Object.getOwnPropertyDescriptor(window, 'localStorage')
+    Object.defineProperty(window, 'localStorage', { configurable: true, get: () => throwing })
+    try {
+      expect(() => setDraft(1, 'private mode')).not.toThrow()
+      expect(getDraft(1)).toBe('private mode')
+      // No memory entry for 2 — the throwing read is swallowed.
+      expect(getDraft(2)).toBe('')
+      expect(() => clearDraft(1)).not.toThrow()
+      expect(getDraft(1)).toBe('')
+      expect(() => __resetDrafts()).not.toThrow()
+
+      expect(throwing.setItem).toHaveBeenCalled()
+      expect(throwing.getItem).toHaveBeenCalled()
+      expect(throwing.removeItem).toHaveBeenCalled()
+    } finally {
+      if (original) Object.defineProperty(window, 'localStorage', original)
+      else Reflect.deleteProperty(window, 'localStorage')
+    }
+  })
+})

--- a/web/src/pages/familychat/drafts.ts
+++ b/web/src/pages/familychat/drafts.ts
@@ -1,0 +1,91 @@
+// Per-conversation composer drafts for Family Chat.
+//
+// ChatView is remounted on every conversation switch (see the
+// key={selectedConversationId} in FamilyChat.tsx), which used to discard a
+// half-typed message. The composer now saves its text here when the
+// conversation changes (or on unmount) and restores it on mount.
+//
+// localStorage is the persistence layer so a draft survives a full reload; an
+// in-memory Map mirrors every write so private-mode/quota failures degrade
+// silently instead of breaking the composer. The Map is read first — within a
+// session it is always at least as fresh as storage.
+
+export const DRAFT_KEY_PREFIX = 'hytte.familychat.draft.'
+
+const memoryDrafts = new Map<string, string>()
+
+export function draftKey(conversationId: number | string): string {
+  return `${DRAFT_KEY_PREFIX}${conversationId}`
+}
+
+// Conversation ids are positive row ids, so any falsy value (0, NaN, '')
+// means "no conversation selected" and is not worth a storage round-trip.
+
+// getDraft returns the stored draft for a conversation, or '' when there is
+// none. Never throws — storage failures fall back to the in-memory mirror.
+export function getDraft(conversationId: number | string): string {
+  if (!conversationId) return ''
+  const key = draftKey(conversationId)
+  const cached = memoryDrafts.get(key)
+  if (cached !== undefined) return cached
+  if (typeof window === 'undefined') return ''
+  try {
+    return window.localStorage?.getItem(key) ?? ''
+  } catch {
+    // Storage disabled (private mode, blocked cookies) — nothing cached.
+    return ''
+  }
+}
+
+// setDraft persists the composer text for a conversation. A blank (or
+// whitespace-only) body removes any previously stored draft instead of
+// writing an empty one, so stale keys don't accumulate.
+export function setDraft(conversationId: number | string, body: string): void {
+  if (!conversationId) return
+  if (!body.trim()) {
+    clearDraft(conversationId)
+    return
+  }
+  const key = draftKey(conversationId)
+  memoryDrafts.set(key, body)
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage?.setItem(key, body)
+  } catch {
+    // Quota exhausted or storage disabled — the in-memory mirror still serves
+    // this session's switches, the draft just won't survive a reload.
+  }
+}
+
+// clearDraft drops a conversation's draft from both storage layers. Called
+// after a successful send.
+export function clearDraft(conversationId: number | string): void {
+  if (!conversationId) return
+  const key = draftKey(conversationId)
+  memoryDrafts.delete(key)
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage?.removeItem(key)
+  } catch {
+    // Ignore storage errors.
+  }
+}
+
+// __resetDrafts wipes every draft from both layers. Test-only helper — the app
+// never needs it, since drafts are cleared per conversation on send.
+export function __resetDrafts(): void {
+  memoryDrafts.clear()
+  if (typeof window === 'undefined') return
+  try {
+    const storage = window.localStorage
+    if (!storage) return
+    const stale: string[] = []
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i)
+      if (key?.startsWith(DRAFT_KEY_PREFIX)) stale.push(key)
+    }
+    for (const key of stale) storage.removeItem(key)
+  } catch {
+    // Ignore storage errors.
+  }
+}

--- a/web/src/pages/familychat/drafts.ts
+++ b/web/src/pages/familychat/drafts.ts
@@ -3,50 +3,58 @@
 // ChatView is remounted on every conversation switch (see the
 // key={selectedConversationId} in FamilyChat.tsx), which used to discard a
 // half-typed message. The composer now saves its text here when the
-// conversation changes (or on unmount) and restores it on mount.
+// conversation changes, on unmount, and on pagehide so a draft survives a full
+// reload.
 //
-// localStorage is the persistence layer so a draft survives a full reload; an
-// in-memory Map mirrors every write so private-mode/quota failures degrade
-// silently instead of breaking the composer. The Map is read first — within a
-// session it is always at least as fresh as storage.
+// localStorage is the persistence layer; an in-memory Map acts as a fallback
+// when storage is unavailable (private mode, quota errors). Storage is read
+// first — the mirror only serves when the read throws.
+//
+// Keys are namespaced by user id so drafts never leak across accounts on a
+// shared device, and clearAllDrafts() is called on logout as a second line
+// of defence.
 
-export const DRAFT_KEY_PREFIX = 'hytte.familychat.draft.'
+export const DRAFT_KEY_PREFIX = 'familychat-draft:'
 
 const memoryDrafts = new Map<string, string>()
 
-export function draftKey(conversationId: number | string): string {
-  return `${DRAFT_KEY_PREFIX}${conversationId}`
+export function draftKey(userId: number, conversationId: number | string): string {
+  return `${DRAFT_KEY_PREFIX}${userId}:${conversationId}`
 }
 
 // Conversation ids are positive row ids, so any falsy value (0, NaN, '')
 // means "no conversation selected" and is not worth a storage round-trip.
 
 // getDraft returns the stored draft for a conversation, or '' when there is
-// none. Never throws — storage failures fall back to the in-memory mirror.
-export function getDraft(conversationId: number | string): string {
-  if (!conversationId) return ''
-  const key = draftKey(conversationId)
-  const cached = memoryDrafts.get(key)
-  if (cached !== undefined) return cached
-  if (typeof window === 'undefined') return ''
-  try {
-    return window.localStorage?.getItem(key) ?? ''
-  } catch {
-    // Storage disabled (private mode, blocked cookies) — nothing cached.
-    return ''
+// none. Never throws — reads storage first, then the in-memory mirror;
+// storage errors fall back to the mirror.
+export function getDraft(userId: number, conversationId: number | string): string {
+  if (!conversationId || !userId) return ''
+  const key = draftKey(userId, conversationId)
+  if (typeof window !== 'undefined') {
+    try {
+      const stored = window.localStorage?.getItem(key)
+      if (stored !== null) {
+        memoryDrafts.set(key, stored)
+        return stored
+      }
+    } catch {
+      // Storage disabled — fall back to the in-memory mirror.
+    }
   }
+  return memoryDrafts.get(key) ?? ''
 }
 
 // setDraft persists the composer text for a conversation. A blank (or
 // whitespace-only) body removes any previously stored draft instead of
 // writing an empty one, so stale keys don't accumulate.
-export function setDraft(conversationId: number | string, body: string): void {
-  if (!conversationId) return
+export function setDraft(userId: number, conversationId: number | string, body: string): void {
+  if (!conversationId || !userId) return
   if (!body.trim()) {
-    clearDraft(conversationId)
+    clearDraft(userId, conversationId)
     return
   }
-  const key = draftKey(conversationId)
+  const key = draftKey(userId, conversationId)
   memoryDrafts.set(key, body)
   if (typeof window === 'undefined') return
   try {
@@ -59,9 +67,9 @@ export function setDraft(conversationId: number | string, body: string): void {
 
 // clearDraft drops a conversation's draft from both storage layers. Called
 // after a successful send.
-export function clearDraft(conversationId: number | string): void {
-  if (!conversationId) return
-  const key = draftKey(conversationId)
+export function clearDraft(userId: number, conversationId: number | string): void {
+  if (!conversationId || !userId) return
+  const key = draftKey(userId, conversationId)
   memoryDrafts.delete(key)
   if (typeof window === 'undefined') return
   try {
@@ -71,9 +79,9 @@ export function clearDraft(conversationId: number | string): void {
   }
 }
 
-// __resetDrafts wipes every draft from both layers. Test-only helper — the app
-// never needs it, since drafts are cleared per conversation on send.
-export function __resetDrafts(): void {
+// clearAllDrafts wipes every draft from both layers. Called on logout to
+// prevent draft leakage across user sessions on shared devices.
+export function clearAllDrafts(): void {
   memoryDrafts.clear()
   if (typeof window === 'undefined') return
   try {
@@ -89,3 +97,6 @@ export function __resetDrafts(): void {
     // Ignore storage errors.
   }
 }
+
+// __resetDrafts is a test-only alias for clearAllDrafts.
+export const __resetDrafts = clearAllDrafts


### PR DESCRIPTION
## Original Issue (feature): Persist unsent message drafts per conversation across switches

### Scope
Persist the Family Chat composer's text draft per conversation so switching threads (which remounts `ChatView` via the `key={selectedConversationId}` in `FamilyChat.tsx:65`) no longer discards a half-typed message. Today `Composer.tsx:108-114` deliberately calls `setBody('')` on every `conversationId` change; that effect becomes a save-then-restore instead of a clear. Frontend-only — no backend, no schema, no new API.

### Files to touch
- `web/src/pages/familychat/drafts.ts` (new) — tiny draft store: `getDraft(conversationId)`, `setDraft(conversationId, body)`, `clearDraft(conversationId)`. Back it with `localStorage` under a namespaced key per conversation (e.g. `hytte.familychat.draft.<id>`), wrapped in try/catch with an in-memory `Map` fallback so private-mode/quota failures degrade silently rather than breaking the composer.
- `web/src/pages/familychat/drafts.test.ts` (new) — unit tests for the store, including the localStorage-throws fallback path.
- `web/src/pages/familychat/Composer.tsx` — restore the stored draft on mount/conversation change; persist the current body when the conversation changes or the component unmounts (read the latest body from a ref, since the effect cleanup closes over stale state); clear the stored draft on successful send (the existing `setBody('')` sites at ~lines 293 and 338).
- `web/src/pages/familychat/Composer.test.tsx` — cover restore, persist-on-switch, and clear-on-send.
- `changelog.d/<slug>.md` (new) — `category: Fixed` fragment referencing the bead id.

### Acceptance criteria
- Typing in conversation A, switching to B, and returning to A restores the exact text in A's composer; B's composer is empty (or shows B's own draft).
- Drafts are isolated per conversation id — no bleed between threads.
- Sending a message clears both the composer and that conversation's stored draft; returning later shows an empty composer.
- A whitespace-only or empty composer stores no draft (and removes any previously stored one), so stale empty keys don't accumulate.
- Drafts survive a full page reload for the same logged-in browser.
- The existing safety behaviour of the conversation-change effect is preserved: in-flight sends are still aborted, errors/sending/uploading/attachment state still reset, active voice recordings are still discarded, and the textarea is still focused.
- `npm run lint`, `npm run build`, and `npm test` pass; new tests fail if the restore logic is reverted.

### Non-goals
- No server-side draft sync or cross-device drafts.
- No persistence of pending attachments, voice recordings, or in-progress message *edits* (`editingDraft` in `ChatView.tsx`).
- No draft indicator in `ConversationList.tsx` (no "Draft:" badge on the thread preview).
- No draft expiry/GC policy or cleanup of drafts for deleted conversations.
- No change to `internal/familychat/*` or to how `FamilyChat.tsx` keys `ChatView`.
- No new i18n keys (no user-facing strings introduced).

## Source

Created from Suggestions page (suggestion id 242, page slug "family-chat", source=claude).

## Original suggestion

The chat view is fully remounted whenever the user switches conversations (ChatView is keyed on the conversation id in FamilyChat.tsx), so any half-typed message in the composer is silently discarded when you tap another conversation and come back. Persist the composer draft per conversation id (in a ref/map held above ChatView or in localStorage keyed by conversation) and restore it on mount, clearing it only once the message is actually sent. This prevents the frustrating and easy-to-hit loss of a long message when a user glances at another thread, and it mirrors the draft behavior people expect from every other messaging app.


---
Bead: Hytte-3tafy | Branch: forge/Hytte-3tafy
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->