### PR TITLE
LocationSearch renders hardcoded English placeholder/aria-label defaults (Hytte-5x5pk)

### DIFF
--- a/changelog.d/Hytte-5x5pk.md
+++ b/changelog.d/Hytte-5x5pk.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Translated location search strings** - The location search box on the weather page now shows its placeholder, accessible label and failure message in the selected language instead of hardcoded English. (Hytte-5x5pk)

--- a/web/public/locales/en/weather.json
+++ b/web/public/locales/en/weather.json
@@ -18,6 +18,11 @@
     "attribution": "Weather data from",
     "windFromDirectionAria": "Wind from {{degrees}}°"
   },
+  "locationSearch": {
+    "placeholder": "Search location…",
+    "ariaLabel": "Search for a location",
+    "error": "Search failed"
+  },
   "geolocation": {
     "button": "Use my location",
     "buttonAria": "Use my current location for the forecast",

--- a/web/public/locales/nb/weather.json
+++ b/web/public/locales/nb/weather.json
@@ -18,6 +18,11 @@
     "attribution": "Værdata fra",
     "windFromDirectionAria": "Vind fra {{degrees}}°"
   },
+  "locationSearch": {
+    "placeholder": "Søk etter sted…",
+    "ariaLabel": "Søk etter et sted",
+    "error": "Søket mislyktes"
+  },
   "geolocation": {
     "button": "Bruk posisjonen min",
     "buttonAria": "Bruk nåværende posisjon for varselet",

--- a/web/public/locales/th/weather.json
+++ b/web/public/locales/th/weather.json
@@ -18,6 +18,11 @@
     "attribution": "ข้อมูลสภาพอากาศจาก",
     "windFromDirectionAria": "ลมจากทิศ {{degrees}}°"
   },
+  "locationSearch": {
+    "placeholder": "ค้นหาสถานที่…",
+    "ariaLabel": "ค้นหาสถานที่",
+    "error": "การค้นหาล้มเหลว"
+  },
   "geolocation": {
     "button": "ใช้ตำแหน่งของฉัน",
     "buttonAria": "ใช้ตำแหน่งปัจจุบันสำหรับพยากรณ์อากาศ",

--- a/web/src/components/LocationSearch.tsx
+++ b/web/src/components/LocationSearch.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, type KeyboardEvent } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Search } from 'lucide-react'
 
 interface SearchResult {
@@ -12,16 +13,21 @@ interface SearchResult {
 interface LocationSearchProps {
   onSelect: (result: { name: string; country: string; lat: number; lon: number }) => void
   inputClassName?: string
+  /** Optional override; defaults to the translated placeholder. */
   placeholder?: string
+  /** Optional override; defaults to the translated aria-label. */
   ariaLabel?: string
   inputId?: string
 }
 
-export default function LocationSearch({ onSelect, inputClassName = 'w-44', placeholder = 'Search location…', ariaLabel = 'Search for a location', inputId }: LocationSearchProps) {
+export default function LocationSearch({ onSelect, inputClassName = 'w-44', placeholder, ariaLabel, inputId }: LocationSearchProps) {
+  const { t } = useTranslation('weather')
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  // Search failures show a single translated message; the underlying error is
+  // logged instead of rendered, since the API returns untranslated detail.
+  const [failed, setFailed] = useState(false)
   const [open, setOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(-1)
 
@@ -48,23 +54,24 @@ export default function LocationSearch({ onSelect, inputClassName = 'w-44', plac
       if (trimmed.length < 2) {
         setResults([])
         setOpen(false)
-        setError(null)
+        setFailed(false)
         return
       }
       setLoading(true)
-      setError(null)
+      setFailed(false)
       try {
         const res = await fetch(`/api/weather/search?q=${encodeURIComponent(trimmed)}`)
         if (!res.ok) {
           const body = await res.json().catch(() => ({}))
-          throw new Error((body as { error?: string }).error || 'Search failed')
+          throw new Error((body as { error?: string }).error || `Search request failed with status ${res.status}`)
         }
         const data = await res.json() as { results: SearchResult[] }
         setResults(data.results ?? [])
         setOpen(true)
         setActiveIndex(-1)
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Search failed')
+        console.warn('Location search failed:', err)
+        setFailed(true)
         setResults([])
         setOpen(false)
       } finally {
@@ -125,8 +132,8 @@ export default function LocationSearch({ onSelect, inputClassName = 'w-44', plac
           onFocus={() => {
             if (results.length > 0) setOpen(true)
           }}
-          placeholder={placeholder}
-          aria-label={ariaLabel}
+          placeholder={placeholder ?? t('locationSearch.placeholder')}
+          aria-label={ariaLabel ?? t('locationSearch.ariaLabel')}
           className={`pl-8 pr-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-sm text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 ${inputClassName}`}
         />
         {loading && (
@@ -134,8 +141,8 @@ export default function LocationSearch({ onSelect, inputClassName = 'w-44', plac
         )}
       </div>
 
-      {error && (
-        <p className="mt-1 text-xs text-red-400">{error}</p>
+      {failed && (
+        <p role="alert" className="mt-1 text-xs text-red-400">{t('locationSearch.error')}</p>
       )}
 
       {open && results.length > 0 && (


### PR DESCRIPTION
## Changes

- **Translated location search strings** - The location search box on the weather page now shows its placeholder, accessible label and failure message in the selected language instead of hardcoded English. (Hytte-5x5pk)

## Original Issue (bug): LocationSearch renders hardcoded English placeholder/aria-label defaults

web/src/components/LocationSearch.tsx defaults placeholder='Search location…' and ariaLabel='Search for a location', and its inline error strings ('Search failed') are hardcoded English. web/src/pages/Weather.tsx:557 renders <LocationSearch onSelect={...} /> with no overrides, so those strings never translate. Violates the repo i18n rule (all user-facing strings via react-i18next). Fix: use useTranslation inside the component with keys in weather.json (en/nb/th), keeping the props as optional overrides.

---
Bead: Hytte-5x5pk | Branch: forge/Hytte-5x5pk
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->