### PR TITLE
Extract SSE stream/reconnect/backfill into useFamilyChatStream (Hytte-8rihl)

### DIFF
--- a/changelog.d/Hytte-8rihl.md
+++ b/changelog.d/Hytte-8rihl.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Family Chat streaming extracted into useFamilyChatStream** - The ~475-line SSE effect in ChatView (reader loop, reconnect backoff, backfill-since-lastId de-duplication, connection status, typing expiry, missed-call synthesis) now lives in a dedicated `useFamilyChatStream` hook with direct unit tests. Call signalling frames are forwarded to the voice/group call hooks through injected callbacks. No behavior change. (Hytte-8rihl)

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -21,7 +21,7 @@ import {
   Sparkles,
 } from 'lucide-react'
 import { Skeleton } from '../../components/ui/skeleton'
-import ConnectionStatus, { type ChatConnectionState } from '../../components/ConnectionStatus'
+import ConnectionStatus from '../../components/ConnectionStatus'
 import { useAuth } from '../../auth'
 import { useKeyboardInset } from '../../hooks/useKeyboardInset'
 import Composer from './Composer'
@@ -33,15 +33,20 @@ import {
   applyReactionEvent,
   editMessage,
   deleteMessage,
-  type ReactionMap,
 } from './api'
+import {
+  useFamilyChatStream,
+  reconcileMessage,
+  type ChatMessage,
+  type MissedCallEntry,
+} from './useFamilyChatStream'
 import { formatRelative } from './utils'
 import VoiceBubble from './voice/VoiceBubble'
 import { readCachedWaveform, parseWaveformJSON, DEFAULT_BAR_COUNT, type Waveform } from './voice/waveform'
 import * as voicePlayer from './voice/voicePlayer'
-import { useVoiceCall, type CallKind, type CallSignalEventName, type CallSignalPayload } from './voice/useVoiceCall'
+import { useVoiceCall, type CallKind } from './voice/useVoiceCall'
 import { supportedFilters, type FilterKind } from './voice/videoFilters'
-import { useGroupCall, type GroupSignalEventName } from './voice/useGroupCall'
+import { useGroupCall } from './voice/useGroupCall'
 import GroupCallOverlay from './GroupCallOverlay'
 
 interface ChatViewProps {
@@ -49,78 +54,9 @@ interface ChatViewProps {
   onBack: () => void
 }
 
-interface Conversation {
-  id: number
-  name: string
-  owner_user_id: number
-  created_at: string
-  last_message_at: string
-  unread_count: number
-  member_ids: number[]
-}
-
-export interface ChatMessage {
-  id: number
-  conversation_id: number
-  sender_user_id: number
-  body: string
-  attachment_path?: string
-  attachment_mime?: string
-  created_at: string
-  edited_at?: string | null
-  deleted_at?: string | null
-  deleted_by?: number | null
-  // meta_json is opaque client-controlled JSON the server stores verbatim.
-  // Voice notes use it to ship the precomputed waveform (see voice/waveform.ts).
-  meta_json?: string | null
-  reactions?: ReactionMap
-  // client_id is a client-generated correlation id for optimistic sends. It is
-  // present on the locally-rendered "sending" bubble and is echoed back by the
-  // server on the POST response and the SSE message_new event, so whichever
-  // arrives first reconciles the bubble. Kept on the message after reconciling
-  // so the React key stays stable (no remount/flicker). Absent on messages
-  // loaded from the server.
-  client_id?: string
-  // status drives the optimistic-send affordance: 'sending' while the POST is
-  // in flight, 'failed' once it errors (tap to retry). Absent for authoritative
-  // (reconciled or server-loaded) messages.
-  status?: 'sending' | 'failed'
-}
-
-// reconcileMessage merges an authoritative message into the list. When the
-// incoming message carries a client_id that matches a local optimistic bubble,
-// it replaces that bubble in place — preserving the client_id (so the React key
-// stays stable and the row doesn't remount/flicker) and dropping the optimistic
-// status. Otherwise it dedupes by id so a message delivered via both the POST
-// response and the SSE stream (or gap-fill) shows up exactly once, regardless of
-// arrival order.
-function reconcileMessage(
-  prev: ChatMessage[],
-  clientId: string | undefined,
-  incoming: ChatMessage,
-): ChatMessage[] {
-  if (clientId) {
-    const idx = prev.findIndex(m => m.client_id === clientId)
-    if (idx !== -1) {
-      const reconciled = { ...incoming, client_id: clientId, status: undefined }
-      // Replace the optimistic bubble in place, and drop any *other* row that
-      // already carries the same authoritative id. That second row appears when
-      // an SSE message_new for this same send lands before the POST response
-      // and gets appended separately (e.g. an event that omitted our
-      // client_id); without this filter the reconcile would leave two bubbles
-      // sharing one id.
-      const next: ChatMessage[] = []
-      prev.forEach((m, i) => {
-        if (i === idx) { next.push(reconciled); return }
-        if (m.id === incoming.id) return
-        next.push(m)
-      })
-      return next
-    }
-  }
-  if (prev.some(m => m.id === incoming.id)) return prev
-  return [...prev, incoming]
-}
+// ChatMessage is defined alongside the stream that produces it; re-exported
+// here because the composer and bubble components import it from this module.
+export type { ChatMessage }
 
 // parseVoiceMeta extracts a {bars, durationMs} pair from a meta_json blob.
 // Returns null when the field is absent, unparseable, or shaped wrong — the
@@ -134,15 +70,6 @@ function parseVoiceMeta(meta: string | null | undefined): Waveform | null {
 interface MemberInfo {
   label: string
   emoji: string
-}
-
-interface MissedCallEntry {
-  callId: string
-  fromUserId: number
-  receivedAt: string
-  // kind mirrors the call-kind from the original offer so call-back can
-  // match the modality (voice → voice, video → video).
-  kind: CallKind
 }
 
 interface FamilyChild {
@@ -167,25 +94,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const { t, i18n } = useTranslation('familyChat')
   const { user, familyStatus } = useAuth()
 
-  const [conversation, setConversation] = useState<Conversation | null>(null)
-  const [messages, setMessages] = useState<ChatMessage[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
   const [memberLookup, setMemberLookup] = useState<Map<number, MemberInfo>>(new Map())
   const [lightbox, setLightbox] = useState<{ url: string; alt: string } | null>(null)
-  // connStatus tracks the live state of the SSE stream so the header can show
-  // honest connectivity feedback:
-  //   'connecting'   — initial load, before the stream has ever opened
-  //   'live'         — stream is open and messages arrive in real time
-  //   'reconnecting' — the stream dropped after being live and a backoff retry
-  //                    is in flight
-  //   'offline'      — the browser reports no network connectivity
-  // The 'connecting' → 'reconnecting' distinction keeps the initial-load
-  // skeleton from being shadowed by a false "Reconnecting" badge.
-  const [connStatus, setConnStatus] = useState<ChatConnectionState>('connecting')
-  // justReconnected briefly flips true right after the stream recovers from a
-  // drop so the header can flash a "Connected" confirmation, then auto-clears.
-  const [justReconnected, setJustReconnected] = useState(false)
   // pickerForMsgId is the id of the bubble whose reaction picker is open, or
   // null when nothing is open. We only show one picker at a time.
   const [pickerForMsgId, setPickerForMsgId] = useState<number | null>(null)
@@ -205,15 +115,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const [deleteError, setDeleteError] = useState('')
   const deleteConfirmBtnRef = useRef<HTMLButtonElement>(null)
   const deletePrevFocusRef = useRef<Element | null>(null)
-  // missedCalls collects inbound calls the recipient never answered — surfaced
-  // as a tombstone row in the message list with a call-back button. Only
-  // populated for missed calls where the local user was the callee (we ignore
-  // missed calls that we initiated, since those aren't useful history for us).
-  const [missedCalls, setMissedCalls] = useState<MissedCallEntry[]>([])
-  // typingUsers maps a member's user id to the epoch-ms timestamp of their most
-  // recent typing signal. A sweep effect drops entries older than ~5s so the
-  // indicator clears on its own when the other side stops composing.
-  const [typingUsers, setTypingUsers] = useState<Map<number, number>>(new Map())
   // lastTypingSentRef throttles outbound typing POSTs to at most one per ~3s
   // while the local user is composing.
   const lastTypingSentRef = useRef(0)
@@ -245,8 +146,9 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const pipDragRef = useRef<{ offsetX: number; offsetY: number; pointerId: number } | null>(null)
 
   // Voice-call state machine. skipSignalSubscription is set so the hook
-  // doesn't open its own SSE stream — ChatView already owns one for messages
-  // and reactions, and routes call_* frames through handleSignalEvent below.
+  // doesn't open its own SSE stream — useFamilyChatStream below already owns
+  // one for messages and reactions, and forwards call_* frames into
+  // handleSignalEvent.
   const voiceCall = useVoiceCall({
     conversationId,
     userId: user?.id ?? null,
@@ -254,42 +156,53 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   })
 
   // Group-call mesh for conversations with 3+ members. Like voiceCall it does
-  // not open its own SSE stream — ChatView routes call_* / call_join /
-  // call_leave frames into it via groupCallSignalRef below.
+  // not open its own SSE stream — the shared stream below routes call_* /
+  // call_join / call_leave frames into it.
   const groupCall = useGroupCall({
     conversationId,
     userId: user?.id ?? null,
   })
 
-  const messagesEndRef = useRef<HTMLDivElement>(null)
-  // voiceCallSignalRef shadows handleSignalEvent so the long-lived SSE reader
-  // can dispatch into the latest hook state without re-running on every
-  // re-render the hook returns a new function reference for.
-  const voiceCallSignalRef = useRef(voiceCall.handleSignalEvent)
-  useEffect(() => {
-    voiceCallSignalRef.current = voiceCall.handleSignalEvent
+  // The conversation's data feed: initial load, the SSE reader with reconnect +
+  // gap-fill, connection status, typing indicators and missed-call synthesis.
+  // Call signalling frames are forwarded to the two call hooks above rather than
+  // handled inside the stream, so neither hook needs to know about transport.
+  const {
+    conversation,
+    messages,
+    setMessages,
+    loading,
+    error,
+    connStatus,
+    justReconnected,
+    typingUsers,
+    missedCalls,
+    setMissedCalls,
+  } = useFamilyChatStream({
+    conversationId,
+    userId: user?.id,
+    callKind: voiceCall.callKind,
+    onSignal: voiceCall.handleSignalEvent,
+    onGroupSignal: groupCall.handleSignalEvent,
+    onConversationOpen: () => {
+      setEndedCallSummary(null)
+      lastTypingSentRef.current = 0
+    },
+    onConversationClose: () => {
+      // Stop any voice-note playback owned by this conversation. Switching
+      // chats or unmounting must not leave a bubble in the prior conversation
+      // continuing to play in the background.
+      voicePlayer.stopAll()
+      setEndedCallSummary(null)
+    },
   })
+
+  const messagesEndRef = useRef<HTMLDivElement>(null)
   // voiceCallEndRef lets the conversationId-change cleanup end any active call
   // on the old conversation without re-subscribing on every voice-call state change.
   const voiceCallEndRef = useRef(voiceCall.endCall)
   useEffect(() => {
     voiceCallEndRef.current = voiceCall.endCall
-  })
-  // voiceCallKindRef shadows voiceCall.callKind so the long-lived SSE reader
-  // can capture the current call kind when recording missed calls — the hook
-  // resets callKind synchronously inside tearDown before the next render, so
-  // capturing it at the top of the SSE dispatch path preserves the correct
-  // value even when call_end arrives immediately after call_offer.
-  const voiceCallKindRef = useRef<CallKind>(voiceCall.callKind)
-  useEffect(() => {
-    voiceCallKindRef.current = voiceCall.callKind
-  })
-  // groupCallSignalRef shadows groupCall.handleSignalEvent so the long-lived
-  // SSE reader can dispatch group-call frames into the latest hook state without
-  // re-subscribing on every render.
-  const groupCallSignalRef = useRef(groupCall.handleSignalEvent)
-  useEffect(() => {
-    groupCallSignalRef.current = groupCall.handleSignalEvent
   })
   // groupCallLeaveRef lets the conversationId-change cleanup leave any active
   // group call on the old conversation.
@@ -314,10 +227,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       void groupCallLeaveRef.current()
     }
   }, [conversationId])
-  // currentUserIdRef shadows user?.id so the long-lived SSE reader closure
-  // (recreated only when conversationId changes) can read the most recent
-  // value without forcing the effect to re-run on auth changes.
-  const currentUserIdRef = useRef<number | undefined>(user?.id)
   // lastPointerTypeRef is set by onPointerDown so onContextMenu knows whether
   // it was triggered by a touch long-press (open picker, suppress native menu)
   // or a mouse right-click (leave native menu alone; picker is on hover button).
@@ -331,11 +240,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // the same click. NOT set on long-press (no toggle button exists there), so
   // tapping the bubble correctly closes the picker.
   const pickerGuardRef = useRef<HTMLElement | null>(null)
-  // conversationRef mirrors the conversation state for the long-lived SSE
-  // closure so call-event gating can check member count without re-running.
-  const conversationRef = useRef<Conversation | null>(null)
-  useEffect(() => { currentUserIdRef.current = user?.id }, [user?.id])
-  useEffect(() => { conversationRef.current = conversation }, [conversation])
 
   // Focus management + Escape handling for the delete confirmation modal,
   // matching the pattern used by ConfirmDialog.
@@ -419,484 +323,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     })()
     return () => { controller.abort() }
   }, [user, familyStatus, t])
-
-  // Load conversation metadata + initial messages, then subscribe to the SSE
-  // stream so new messages arrive without a refetch. The initial load and the
-  // SSE subscription share a single AbortController so switching conversation
-  // tears both down atomically; the SSE reader is also canceled explicitly so
-  // tests (and the rare browser that doesn't propagate abort to a streaming
-  // body) terminate the read loop deterministically.
-  useEffect(() => {
-    // When no conversation is selected, do nothing here — the previous
-    // non-null effect's cleanup (below) resets state when switching away.
-    // Calling setState directly in the guard body is flagged by
-    // react-hooks/set-state-in-effect; cleanup callbacks are not.
-    if (conversationId === null) return
-    const controller = new AbortController()
-    // lastId is the highest message id this client has rendered for the
-    // current conversation. It seeds gap-fill queries on reconnect and is
-    // updated by initial load, SSE events, and gap-fill responses.
-    let lastId = 0
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
-    // recoveredTimer clears the brief "Connected" confirmation after a drop.
-    let recoveredTimer: ReturnType<typeof setTimeout> | null = null
-    let reconnectAttempts = 0
-    let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null
-    let connectInFlight = false
-    // browserOffline mirrors navigator.onLine so scheduleReconnect can label a
-    // drop as "Offline" (no network) vs "Reconnecting" (server blip) without a
-    // separate stream or poll.
-    let browserOffline = typeof navigator !== 'undefined' && navigator.onLine === false
-
-    // Initialise loading state at the start of every new conversation fetch.
-    // setLoading(true) must live here (not in cleanup) because cleanup runs
-    // setLoading(false) to represent "no conversation selected", which is the
-    // correct value when conversationId is null. Cleanup callbacks are exempt
-    // from react-hooks/set-state-in-effect; the synchronous call here is
-    // intentional and safe — React 18 batches all these updates into one commit.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLoading(true)
-    setError('')
-    setMessages([])
-    setConversation(null)
-    setConnStatus(browserOffline ? 'offline' : 'connecting')
-    setJustReconnected(false)
-    setMissedCalls([])
-    setEndedCallSummary(null)
-    setTypingUsers(new Map())
-    lastTypingSentRef.current = 0
-
-    // appendIncoming deduplicates by id so a message that arrives via both
-    // SSE and the POST response (the sender path) or via SSE and gap-fill
-    // shows up exactly once.
-    const appendIncoming = (msg: ChatMessage) => {
-      if (msg.conversation_id !== conversationId) return
-      if (msg.id > lastId) lastId = msg.id
-      // A message from a member ends their typing state immediately, so the
-      // indicator doesn't linger after their reply lands.
-      setTypingUsers(prev => {
-        if (!prev.has(msg.sender_user_id)) return prev
-        const next = new Map(prev)
-        next.delete(msg.sender_user_id)
-        return next
-      })
-      // Reconcile against an optimistic bubble when the server echoed our
-      // client_id (the SSE-first arrival path); otherwise dedupe by id.
-      setMessages(prev => reconcileMessage(prev, msg.client_id, msg))
-    }
-
-    // applyReactionEventLocal merges an incoming reaction event into the
-    // open message list. We can't compute the recipient's `me` flag from
-    // the wire payload alone (the server broadcasts a single payload to
-    // every subscriber), so the comparison happens here against the
-    // current user's id.
-    const applyReactionEventLocal = (
-      payload: { message_id: number; user_id: number; emoji: string; count: number; conversation_id?: number },
-      removed: boolean,
-    ) => {
-      if (payload.conversation_id !== undefined && payload.conversation_id !== conversationId) return
-      setMessages(prev => {
-        let changed = false
-        const next = prev.map(m => {
-          if (m.id !== payload.message_id) return m
-          changed = true
-          return {
-            ...m,
-            reactions: applyReactionEvent(m.reactions, payload, currentUserIdRef.current, removed),
-          }
-        })
-        return changed ? next : prev
-      })
-    }
-
-    // applyMessageEdited overwrites the body + edited_at of the matching
-    // message. Keeps the existing reactions / attachment metadata intact.
-    const applyMessageEdited = (
-      payload: { message_id: number; body: string; edited_at: string; conversation_id?: number },
-    ) => {
-      if (payload.conversation_id !== undefined && payload.conversation_id !== conversationId) return
-      setMessages(prev => prev.map(m =>
-        m.id === payload.message_id
-          ? { ...m, body: payload.body, edited_at: payload.edited_at }
-          : m,
-      ))
-    }
-
-    // applyMessageDeleted converts the matching message into a tombstone.
-    // Body + attachment metadata are cleared so the bubble flips to the
-    // "Message deleted" placeholder; deleted_at + deleted_by drive that
-    // rendering and the timestamp tooltip.
-    const applyMessageDeleted = (
-      payload: { message_id: number; deleted_by: number; conversation_id?: number },
-    ) => {
-      if (payload.conversation_id !== undefined && payload.conversation_id !== conversationId) return
-      const now = new Date().toISOString()
-      setMessages(prev => prev.map(m =>
-        m.id === payload.message_id
-          ? {
-              ...m,
-              body: '',
-              attachment_path: '',
-              attachment_mime: '',
-              edited_at: null,
-              deleted_at: m.deleted_at ?? now,
-              deleted_by: payload.deleted_by,
-            }
-          : m,
-      ))
-    }
-
-    // recordTyping stamps a member's latest typing signal. We never record our
-    // own id (the hub fans the event back to every subscriber, including the
-    // sender) so the local user never sees their own indicator.
-    const recordTyping = (userId: number) => {
-      if (userId === currentUserIdRef.current) return
-      setTypingUsers(prev => {
-        const next = new Map(prev)
-        next.set(userId, Date.now())
-        return next
-      })
-    }
-
-    const fillGap = async () => {
-      if (controller.signal.aborted) return
-      try {
-        const url = lastId > 0
-          ? `/api/familychat/conversations/${conversationId}/messages?since=${lastId}`
-          : `/api/familychat/conversations/${conversationId}/messages`
-        const res = await fetch(url, { credentials: 'include', signal: controller.signal })
-        if (!res.ok) return
-        const data = await res.json()
-        const msgs: ChatMessage[] = data.messages ?? []
-        // API returns newest-first; sort ascending so lastId climbs
-        // monotonically as we replay the burst.
-        msgs.sort((a, b) => a.id - b.id)
-        for (const m of msgs) appendIncoming(m)
-      } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') return
-        // Non-fatal: the next reconnect attempt will retry.
-      }
-    }
-
-    const scheduleReconnect = () => {
-      if (controller.signal.aborted) return
-      if (browserOffline) {
-        setConnStatus('offline')
-        return
-      }
-      // Only surface the "Reconnecting" badge once we've actually been live —
-      // a failure on the very first connect keeps us in 'connecting' so the
-      // initial load never flashes a false "offline".
-      setConnStatus(prev => (prev === 'connecting' ? 'connecting' : 'reconnecting'))
-      reconnectAttempts += 1
-      // Exponential backoff capped at 30s to keep a server outage from
-      // hammering the endpoint while still recovering quickly from a
-      // transient blip.
-      const delay = Math.min(30000, 1000 * 2 ** Math.min(reconnectAttempts, 5))
-      reconnectTimer = setTimeout(() => {
-        reconnectTimer = null
-        void connect(false)
-      }, delay)
-    }
-
-    const connect = async (firstConnect: boolean) => {
-      if (controller.signal.aborted) return
-      connectInFlight = true
-      // Capture the resume point BEFORE fillGap runs. fillGap appends any new
-      // messages and bumps lastId; if we passed the post-fillGap lastId to the
-      // stream, the backfill watermark would advance past edits/deletes that
-      // happened mid-gap (older than the newest message but newer than where we
-      // actually left off), silently dropping them. The pre-gap id is the true
-      // "last seen while connected" point.
-      const resumeId = lastId
-      // Skip the gap-fill on the very first connect: the initial /messages
-      // fetch already covered everything up to lastId. On reconnects we
-      // re-issue it so a disconnect window can't lose messages.
-      if (!firstConnect) await fillGap()
-      if (controller.signal.aborted) return
-      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
-      try {
-        // On reconnect, pass the last-seen message id as since_message_id so the
-        // stream replays anything missed while we were gone — not just new
-        // messages (which fillGap above already covers) but edits and deletes of
-        // older messages too, which a plain id>since fetch can't see. A native
-        // EventSource would resend this via Last-Event-ID automatically; this
-        // fetch-based reader can't set that header, so the query param carries
-        // the resume point instead. All replayed events are applied idempotently
-        // below, so overlap with fillGap (or a never-dropped event) is a no-op.
-        const streamUrl = !firstConnect && resumeId > 0
-          ? `/api/familychat/conversations/${conversationId}/stream?since_message_id=${resumeId}`
-          : `/api/familychat/conversations/${conversationId}/stream`
-        const res = await fetch(
-          streamUrl,
-          { credentials: 'include', signal: controller.signal },
-        )
-        if (!res.ok || !res.body) {
-          scheduleReconnect()
-          return
-        }
-        reconnectAttempts = 0
-        reader = res.body.getReader()
-        activeReader = reader
-        // A non-first connect means the stream just recovered from a drop. The
-        // gap-fill above already backfilled any messages missed during the
-        // outage; flash a brief "Connected" confirmation so the user gets a
-        // visible signal that messages are arriving live again.
-        if (!firstConnect) {
-          setJustReconnected(true)
-          if (recoveredTimer !== null) clearTimeout(recoveredTimer)
-          recoveredTimer = setTimeout(() => {
-            recoveredTimer = null
-            setJustReconnected(false)
-          }, 3000)
-        }
-        setConnStatus('live')
-        const decoder = new TextDecoder()
-        let buffer = ''
-        let eventName = 'message'
-        let dataLines: string[] = []
-        while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-          buffer += decoder.decode(value, { stream: true })
-          let nl = buffer.indexOf('\n')
-          while (nl >= 0) {
-            let line = buffer.slice(0, nl)
-            buffer = buffer.slice(nl + 1)
-            if (line.endsWith('\r')) line = line.slice(0, -1)
-            if (line === '') {
-              if (dataLines.length > 0) {
-                try {
-                  const payload = JSON.parse(dataLines.join('\n'))
-                  if (eventName === 'message_new' && payload?.message) {
-                    appendIncoming(payload.message as ChatMessage)
-                  } else if (
-                    (eventName === 'reaction_added' || eventName === 'reaction_removed') &&
-                    payload?.message_id !== undefined &&
-                    payload?.emoji !== undefined
-                  ) {
-                    applyReactionEventLocal(payload, eventName === 'reaction_removed')
-                  } else if (
-                    eventName === 'message_edited' &&
-                    payload?.message_id !== undefined &&
-                    payload?.body !== undefined &&
-                    payload?.edited_at !== undefined
-                  ) {
-                    applyMessageEdited(payload)
-                  } else if (
-                    eventName === 'message_deleted' &&
-                    payload?.message_id !== undefined &&
-                    payload?.deleted_by !== undefined
-                  ) {
-                    applyMessageDeleted(payload)
-                  } else if (
-                    eventName === 'typing' &&
-                    payload?.user_id !== undefined
-                  ) {
-                    recordTyping(payload.user_id as number)
-                  } else if (
-                    eventName === 'call_join'
-                    || eventName === 'call_leave'
-                  ) {
-                    // Group-call lifecycle events only exist for 3+ member
-                    // conversations; route them straight into the mesh hook.
-                    if ((conversationRef.current?.member_ids.length ?? 0) >= 3) {
-                      void groupCallSignalRef.current(
-                        eventName as GroupSignalEventName,
-                        payload as CallSignalPayload,
-                      )
-                    }
-                  } else if (
-                    eventName === 'call_offer'
-                    || eventName === 'call_answer'
-                    || eventName === 'call_ice'
-                    || eventName === 'call_end'
-                  ) {
-                    // 3+ member conversations use the group mesh; 1:1 uses the
-                    // single-peer voice-call hook. Route by member count.
-                    if ((conversationRef.current?.member_ids.length ?? 0) >= 3) {
-                      void groupCallSignalRef.current(
-                        eventName as GroupSignalEventName,
-                        payload as CallSignalPayload,
-                      )
-                    } else if (conversationRef.current?.member_ids.length === 2) {
-                      // Route call signalling into the voice-call hook. We also
-                      // track missed calls locally so the bubble area can render
-                      // a tombstone-style row with a call-back button: a
-                      // call_end with status=missed from someone other than us
-                      // means we never picked up.
-                      const callPayload = payload as CallSignalPayload
-                      // Synchronously update voiceCallKindRef when we see a
-                      // call_offer so that a same-iteration call_end (e.g.
-                      // missed) captures the correct kind without waiting for
-                      // a React render to flush the useEffect above.
-                      if (eventName === 'call_offer' && callPayload?.kind) {
-                        voiceCallKindRef.current = callPayload.kind
-                      }
-                      if (
-                        eventName === 'call_end'
-                        && callPayload?.status === 'missed'
-                        && callPayload?.from_user_id !== undefined
-                        && callPayload.from_user_id !== currentUserIdRef.current
-                      ) {
-                        // Capture the call kind before voiceCallSignalRef fires
-                        // tearDown (which resets callKindRef synchronously). This
-                        // preserves video vs voice so call-back matches the modality.
-                        const capturedKind = voiceCallKindRef.current
-                        setMissedCalls(prev => {
-                          if (prev.some(m => m.callId === callPayload.call_id)) return prev
-                          return [
-                            ...prev,
-                            {
-                              callId: callPayload.call_id,
-                              fromUserId: callPayload.from_user_id,
-                              receivedAt: new Date().toISOString(),
-                              kind: capturedKind,
-                            },
-                          ]
-                        })
-                      }
-                      void voiceCallSignalRef.current(
-                        eventName as CallSignalEventName,
-                        callPayload,
-                      )
-                    }
-                  }
-                } catch {
-                  // Ignore a malformed payload; the server should never emit
-                  // one, but we don't want to tear down the whole stream over
-                  // a single bad frame.
-                }
-              }
-              eventName = 'message'
-              dataLines = []
-            } else if (line.startsWith(':')) {
-              // SSE comment / heartbeat — ignore.
-            } else if (line.startsWith('event:')) {
-              eventName = line.slice(6).trimStart()
-            } else if (line.startsWith('data:')) {
-              const v = line.slice(5)
-              dataLines.push(v.startsWith(' ') ? v.slice(1) : v)
-            }
-            nl = buffer.indexOf('\n')
-          }
-        }
-        if (!controller.signal.aborted) scheduleReconnect()
-      } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') return
-        if (!controller.signal.aborted) scheduleReconnect()
-      } finally {
-        connectInFlight = false
-        if (activeReader === reader) activeReader = null
-      }
-    }
-
-    // Reflect browser connectivity in the indicator. These only surface state
-    // the EventSource-style reader already drives — 'offline' is the honest
-    // label while there's no network, and coming back online retries at once
-    // instead of waiting out the remaining backoff.
-    const handleOffline = () => {
-      browserOffline = true
-      if (reconnectTimer !== null) {
-        clearTimeout(reconnectTimer)
-        reconnectTimer = null
-      }
-      setConnStatus('offline')
-    }
-    const handleOnline = () => {
-      browserOffline = false
-      if (controller.signal.aborted) return
-      // If a stream is already open/opening, leave it alone; otherwise surface
-      // 'reconnecting' and retry immediately, cancelling any pending backoff.
-      if (activeReader || connectInFlight) return
-      setConnStatus(prev => (prev === 'connecting' ? 'connecting' : 'reconnecting'))
-      if (reconnectTimer !== null) {
-        clearTimeout(reconnectTimer)
-        reconnectTimer = null
-      }
-      reconnectAttempts = 0
-      void connect(false)
-    }
-    if (typeof window !== 'undefined') {
-      window.addEventListener('offline', handleOffline)
-      window.addEventListener('online', handleOnline)
-    }
-
-    ;(async () => {
-      try {
-        const [convRes, msgRes] = await Promise.all([
-          fetch(`/api/familychat/conversations/${conversationId}`, {
-            credentials: 'include',
-            signal: controller.signal,
-          }),
-          fetch(`/api/familychat/conversations/${conversationId}/messages`, {
-            credentials: 'include',
-            signal: controller.signal,
-          }),
-        ])
-        if (!convRes.ok) throw new Error('conversation failed')
-        if (!msgRes.ok) throw new Error('messages failed')
-        const convData = await convRes.json()
-        const msgData = await msgRes.json()
-        if (controller.signal.aborted) return
-        setConversation(convData.conversation ?? null)
-        // The API returns newest-first; display oldest at top to bottom.
-        const sorted: ChatMessage[] = (msgData.messages ?? []).slice().reverse()
-        if (sorted.length > 0) lastId = sorted[sorted.length - 1].id
-        setMessages(sorted)
-        void connect(true)
-      } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') return
-        const key = err instanceof Error && err.message === 'conversation failed'
-          ? 'errors.failedToLoadConversation'
-          : 'errors.failedToLoadMessages'
-        setError(t(key))
-      } finally {
-        if (!controller.signal.aborted) setLoading(false)
-      }
-    })()
-
-    return () => {
-      controller.abort()
-      if (typeof window !== 'undefined') {
-        window.removeEventListener('offline', handleOffline)
-        window.removeEventListener('online', handleOnline)
-      }
-      if (reconnectTimer !== null) {
-        clearTimeout(reconnectTimer)
-        reconnectTimer = null
-      }
-      if (recoveredTimer !== null) {
-        clearTimeout(recoveredTimer)
-        recoveredTimer = null
-      }
-      // Cancel the reader so the read loop exits even when the fetch mock
-      // doesn't propagate abort to the body (notably in tests). The catch is
-      // intentional — cancel can throw if the reader is already detached.
-      if (activeReader) {
-        activeReader.cancel().catch(() => {})
-        activeReader = null
-      }
-      // Stop any voice-note playback owned by this conversation. Switching
-      // chats or unmounting must not leave a bubble in the prior conversation
-      // continuing to play in the background.
-      voicePlayer.stopAll()
-      // Reset conversation state when leaving (to null or another conversation)
-      // so the next render starts from a blank slate. State updates inside
-      // cleanup callbacks are not flagged by react-hooks/set-state-in-effect.
-      setConversation(null)
-      setMessages([])
-      setError('')
-      setLoading(false)
-      // Reset connection state so the indicator never stays stuck in
-      // 'reconnecting' after the view unmounts or switches conversation.
-      setConnStatus('connecting')
-      setJustReconnected(false)
-      setMissedCalls([])
-      setEndedCallSummary(null)
-      setTypingUsers(new Map())
-    }
-  }, [conversationId, t])
 
   const keyboardInset = useKeyboardInset()
 
@@ -1012,28 +438,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
 
   const effectiveFilterPickerOpen = filterPickerOpen && voiceCall.state === 'active'
 
-  // Sweep stale typing indicators: drop any member whose most recent signal is
-  // older than 5s so the row clears shortly after they stop composing. The
-  // interval only runs while at least one member is typing.
-  useEffect(() => {
-    if (typingUsers.size === 0) return
-    const interval = setInterval(() => {
-      setTypingUsers(prev => {
-        const now = Date.now()
-        let changed = false
-        const next = new Map(prev)
-        for (const [uid, ts] of next) {
-          if (now - ts > 5000) {
-            next.delete(uid)
-            changed = true
-          }
-        }
-        return changed ? next : prev
-      })
-    }, 1000)
-    return () => clearInterval(interval)
-  }, [typingUsers])
-
   // notifyTyping fires from the composer on each keystroke; it throttles the
   // outbound signal to at most one POST per ~3s so a fast typist doesn't flood
   // the endpoint. Best-effort: a failed POST just means no indicator shows.
@@ -1056,7 +460,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     // client_id (the POST-response path for text sends); otherwise dedupe by
     // id (voice notes and attachments, which are not rendered optimistically).
     setMessages(prev => reconcileMessage(prev, msg.client_id, msg))
-  }, [conversationId])
+  }, [conversationId, setMessages])
 
   // handleOptimisticMessage renders a just-typed text message immediately in a
   // 'sending' state, before any network round-trip. Scoped to the active
@@ -1064,7 +468,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const handleOptimisticMessage = useCallback((msg: ChatMessage) => {
     if (msg.conversation_id !== conversationId) return
     setMessages(prev => [...prev, msg])
-  }, [conversationId])
+  }, [conversationId, setMessages])
 
   // handleMessageFailed flips an optimistic bubble to the 'failed' state when
   // its POST errors, preserving the typed text so the user can tap to retry.
@@ -1074,7 +478,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     setMessages(prev => prev.map(m =>
       m.client_id === clientId ? { ...m, status: 'failed' as const } : m,
     ))
-  }, [])
+  }, [setMessages])
 
   // composerRetryRef holds the Composer's retry entry point. The failed bubble's
   // tap target calls it to re-POST the preserved text under the same client_id
@@ -1091,7 +495,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       m.client_id === clientId ? { ...m, status: 'sending' as const } : m,
     ))
     composerRetryRef.current?.(clientId, msg.body, msg.conversation_id)
-  }, [])
+  }, [setMessages])
 
   // toggleReaction applies the change optimistically (chips update before the
   // network round-trip) and rolls back on failure. The eventual SSE
@@ -1129,7 +533,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         ))
       }
     }
-  }, [conversationId, userId, messages])
+  }, [conversationId, userId, messages, setMessages])
 
   const handlePickFromPicker = useCallback((msgId: number, emoji: string) => {
     setPickerForMsgId(null)
@@ -1196,7 +600,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       setEditingError(t('edit.saveError'))
       setEditingSaving(false)
     }
-  }, [conversationId, editingDraft, messages, t])
+  }, [conversationId, editingDraft, messages, t, setMessages])
 
   const confirmDelete = useCallback(async (msgId: number) => {
     if (conversationId === null) return
@@ -1230,7 +634,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       }
       setDeleteError(t('edit.deleteError'))
     }
-  }, [conversationId, user?.id, t, messages])
+  }, [conversationId, user?.id, t, messages, setMessages])
 
   const memberChips = useMemo(() => {
     if (!conversation) return []
@@ -1331,11 +735,11 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     // Use the kind from the original missed call so a video call-back
     // correctly starts as video, not a downgraded voice call.
     handleStartCall(entry.kind)
-  }, [handleStartCall])
+  }, [handleStartCall, setMissedCalls])
 
   const dismissMissedCall = useCallback((callId: string) => {
     setMissedCalls(prev => prev.filter(m => m.callId !== callId))
-  }, [])
+  }, [setMissedCalls])
 
   // handleAcceptCall resets the PiP position before accepting so the local
   // preview always starts from the default top-right corner for incoming calls,

--- a/web/src/pages/familychat/useFamilyChatStream.test.ts
+++ b/web/src/pages/familychat/useFamilyChatStream.test.ts
@@ -1,0 +1,560 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import {
+  useFamilyChatStream,
+  type ChatMessage,
+  type Conversation,
+  type UseFamilyChatStreamOptions,
+} from './useFamilyChatStream'
+import type { CallSignalPayload } from './voice/useVoiceCall'
+
+// ── i18n mock ─────────────────────────────────────────────────────────────────
+// `t` must keep a stable identity across renders: it is a dependency of the
+// stream effect, so a fresh function per render would re-subscribe endlessly.
+const stableT = (key: string) => key
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: stableT, i18n: { language: 'en' } }),
+}))
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const encoder = new TextEncoder()
+
+function makeConversation(memberIds: number[] = [1, 2]): Conversation {
+  return {
+    id: 1,
+    name: 'Family Chat',
+    owner_user_id: 1,
+    created_at: '2026-05-01T00:00:00Z',
+    last_message_at: '2026-05-01T10:00:00Z',
+    unread_count: 0,
+    member_ids: memberIds,
+  }
+}
+
+function makeMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 1,
+    conversation_id: 1,
+    sender_user_id: 2,
+    body: 'Hello!',
+    created_at: '2026-05-01T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function convOk(conv: Conversation = makeConversation()) {
+  return { ok: true, json: () => Promise.resolve({ conversation: conv }) }
+}
+
+// msgsOk mirrors the API contract: newest-first.
+function msgsOk(messages: ChatMessage[] = []) {
+  return { ok: true, json: () => Promise.resolve({ messages }) }
+}
+
+// makeStream builds a Response-shaped object whose body the hook reads as SSE.
+// The handle lets a test push frames, end the stream cleanly, or fail it
+// mid-read.
+function makeStream() {
+  let ctrl!: ReadableStreamDefaultController<Uint8Array>
+  const body = new ReadableStream<Uint8Array>({ start(c) { ctrl = c } })
+  return {
+    response: { ok: true, body },
+    push(event: string, data: unknown) {
+      ctrl.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`))
+    },
+    // pushRaw writes an unencoded frame so a test can send malformed data.
+    pushRaw(text: string) { ctrl.enqueue(encoder.encode(text)) },
+    close() { ctrl.close() },
+    fail(err: Error) { ctrl.error(err) },
+  }
+}
+
+// openStream is a stream that stays open until the hook cancels it on cleanup.
+function openStream() {
+  return { ok: true, body: new ReadableStream<Uint8Array>({ start() { /* held open */ } }) }
+}
+
+type Overrides = Partial<UseFamilyChatStreamOptions>
+
+function renderStream(overrides: Overrides = {}) {
+  const onSignal = vi.fn()
+  const onGroupSignal = vi.fn()
+  const onConversationOpen = vi.fn()
+  const onConversationClose = vi.fn()
+  const view = renderHook(() => useFamilyChatStream({
+    conversationId: 1,
+    userId: 1,
+    callKind: 'voice',
+    onSignal,
+    onGroupSignal,
+    onConversationOpen,
+    onConversationClose,
+    ...overrides,
+  }))
+  return { ...view, onSignal, onGroupSignal, onConversationOpen, onConversationClose }
+}
+
+function fetchedUrls(mock: ReturnType<typeof vi.fn>): string[] {
+  return mock.mock.calls.map(call => String(call[0]))
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+// ── Initial load ──────────────────────────────────────────────────────────────
+
+describe('useFamilyChatStream – initial load', () => {
+  it('loads the conversation, sorts messages oldest-first and goes live', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([
+        makeMessage({ id: 3, body: 'Third' }),
+        makeMessage({ id: 2, body: 'Second' }),
+        makeMessage({ id: 1, body: 'First' }),
+      ]))
+      .mockResolvedValueOnce(openStream())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, onConversationOpen } = renderStream()
+
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+    expect(result.current.conversation?.name).toBe('Family Chat')
+    expect(result.current.messages.map(m => m.body)).toEqual(['First', 'Second', 'Third'])
+    expect(result.current.lastIdRef.current).toBe(3)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBe('')
+    expect(onConversationOpen).toHaveBeenCalled()
+    // The first connect must not issue a gap-fill: the initial /messages fetch
+    // already covered everything up to lastId.
+    expect(fetchedUrls(fetchMock).filter(u => u.includes('since='))).toHaveLength(0)
+  })
+
+  it('surfaces a translated error when the conversation request fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce(msgsOk())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+
+    await waitFor(() => expect(result.current.error).toBe('errors.failedToLoadConversation'))
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('does nothing when no conversation is selected', () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream({ conversationId: null })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.messages).toEqual([])
+  })
+})
+
+// ── Reconnect ─────────────────────────────────────────────────────────────────
+
+describe('useFamilyChatStream – reconnect', () => {
+  it('retries after the backoff delay and flashes justReconnected once', async () => {
+    // shouldAdvanceTime lets real time flow so waitFor retries work, while
+    // advanceTimersByTimeAsync can still fast-forward the reconnect delay.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const first = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([makeMessage({ id: 10, body: 'Before drop' })]))
+      .mockResolvedValueOnce(first.response)
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(openStream())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+    expect(result.current.justReconnected).toBe(false)
+
+    await act(async () => {
+      first.close()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(result.current.connStatus).toBe('reconnecting'))
+
+    // Attempt #1 waits 1000 * 2**1 = 2000 ms.
+    await act(async () => { await vi.advanceTimersByTimeAsync(1500) })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(1000) })
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+    expect(result.current.justReconnected).toBe(true)
+
+    // The confirmation clears itself after 3s.
+    await act(async () => { await vi.advanceTimersByTimeAsync(3100) })
+    await waitFor(() => expect(result.current.justReconnected).toBe(false))
+
+    // The reconnected stream resumes from the pre-gap watermark.
+    expect(fetchedUrls(fetchMock)).toContain(
+      '/api/familychat/conversations/1/stream?since_message_id=10',
+    )
+  }, 15000)
+
+  it('stays in connecting (not reconnecting) when the very first connect fails', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([makeMessage({ id: 7 })]))
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(openStream())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(result.current.connStatus).toBe('connecting')
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2500) })
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+  }, 15000)
+
+  it('recovers from a mid-stream reader error', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const first = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([makeMessage({ id: 4 })]))
+      .mockResolvedValueOnce(first.response)
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(openStream())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      first.fail(new Error('network blip'))
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(result.current.connStatus).toBe('reconnecting'))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2500) })
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+  }, 15000)
+
+  it('cancels a pending reconnect on unmount', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const first = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([makeMessage({ id: 2 })]))
+      .mockResolvedValueOnce(first.response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, unmount, onConversationClose } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      first.close()
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(result.current.connStatus).toBe('reconnecting'))
+
+    unmount()
+    expect(onConversationClose).toHaveBeenCalled()
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+    // No gap-fill and no re-connect after teardown.
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  }, 15000)
+})
+
+// ── Backfill ──────────────────────────────────────────────────────────────────
+
+describe('useFamilyChatStream – backfill', () => {
+  it('gap-fills from lastId and drops messages already in the list', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const first = makeStream()
+    const seen = makeMessage({ id: 10, body: 'Before drop' })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([seen]))
+      .mockResolvedValueOnce(first.response)
+      // The backfill window overlaps the message we already rendered.
+      .mockResolvedValueOnce(msgsOk([
+        makeMessage({ id: 12, body: 'Gap two' }),
+        makeMessage({ id: 11, body: 'Gap one' }),
+        seen,
+      ]))
+      .mockResolvedValueOnce(openStream())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      first.close()
+      await Promise.resolve()
+    })
+    await act(async () => { await vi.advanceTimersByTimeAsync(2500) })
+    await waitFor(() => expect(result.current.messages).toHaveLength(3))
+
+    expect(fetchedUrls(fetchMock)).toContain(
+      '/api/familychat/conversations/1/messages?since=10',
+    )
+    // Ascending order, one row per id — the overlapping id 10 is not duplicated.
+    expect(result.current.messages.map(m => m.id)).toEqual([10, 11, 12])
+    expect(result.current.lastIdRef.current).toBe(12)
+  }, 15000)
+
+  it('gap-fills without a since param when nothing has been rendered yet', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const first = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(first.response)
+      .mockResolvedValueOnce(msgsOk([makeMessage({ id: 1, body: 'Late arrival' })]))
+      .mockResolvedValueOnce(openStream())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      first.close()
+      await Promise.resolve()
+    })
+    await act(async () => { await vi.advanceTimersByTimeAsync(2500) })
+    await waitFor(() => expect(result.current.messages).toHaveLength(1))
+
+    const gapUrls = fetchedUrls(fetchMock).filter(u => u.includes('/messages'))
+    expect(gapUrls.every(u => !u.includes('since='))).toBe(true)
+    // Without a watermark the stream must not carry a resume marker either.
+    expect(fetchedUrls(fetchMock)).toContain('/api/familychat/conversations/1/stream')
+  }, 15000)
+
+  it('tolerates a failing gap-fill and still opens the stream', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const first = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([makeMessage({ id: 5 })]))
+      .mockResolvedValueOnce(first.response)
+      .mockRejectedValueOnce(new Error('gap-fill exploded'))
+      .mockResolvedValueOnce(openStream())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      first.close()
+      await Promise.resolve()
+    })
+    await act(async () => { await vi.advanceTimersByTimeAsync(2500) })
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+    expect(result.current.messages).toHaveLength(1)
+  }, 15000)
+})
+
+// ── Live frames ───────────────────────────────────────────────────────────────
+
+describe('useFamilyChatStream – live frames', () => {
+  it('appends new messages once and advances the watermark', async () => {
+    const stream = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(stream.response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    const msg = makeMessage({ id: 21, body: 'Live one' })
+    await act(async () => {
+      stream.push('message_new', { message: msg })
+      // The same frame replayed after a resume must not duplicate the row.
+      stream.push('message_new', { message: msg })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(1))
+    expect(result.current.messages[0].body).toBe('Live one')
+    expect(result.current.lastIdRef.current).toBe(21)
+  })
+
+  it('ignores messages addressed to another conversation and malformed frames', async () => {
+    const stream = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(stream.response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      stream.push('message_new', { message: makeMessage({ id: 99, conversation_id: 42 }) })
+      // A malformed payload must not tear the stream down…
+      stream.pushRaw('event: message_new\ndata: {not json\n\n')
+      // …the heartbeat comment is ignored…
+      stream.pushRaw(': keep-alive\n\n')
+      // …and the next well-formed frame still lands.
+      stream.push('message_new', { message: makeMessage({ id: 100 }) })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(1))
+    expect(result.current.messages[0].id).toBe(100)
+    expect(result.current.connStatus).toBe('live')
+  })
+})
+
+// ── Typing indicators ─────────────────────────────────────────────────────────
+
+describe('useFamilyChatStream – typing indicators', () => {
+  it('records a member typing and expires the entry after ~5s', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const stream = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(stream.response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      // Our own echo is ignored; the other member's signal is recorded.
+      stream.push('typing', { user_id: 1 })
+      stream.push('typing', { user_id: 2 })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(result.current.typingUsers.has(2)).toBe(true))
+    expect(result.current.typingUsers.has(1)).toBe(false)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(6000) })
+    await waitFor(() => expect(result.current.typingUsers.size).toBe(0))
+  }, 15000)
+
+  it('clears a member typing state as soon as their message lands', async () => {
+    const stream = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(stream.response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      stream.push('typing', { user_id: 2 })
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(result.current.typingUsers.has(2)).toBe(true))
+
+    await act(async () => {
+      stream.push('message_new', { message: makeMessage({ id: 31, sender_user_id: 2 }) })
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(result.current.typingUsers.size).toBe(0))
+  })
+})
+
+// ── Call signalling ───────────────────────────────────────────────────────────
+
+describe('useFamilyChatStream – call signalling', () => {
+  it('forwards 1:1 frames to onSignal without handling them internally', async () => {
+    const stream = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk(makeConversation([1, 2])))
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(stream.response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, onSignal, onGroupSignal } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    const offer: CallSignalPayload = {
+      conversation_id: 1,
+      call_id: 'call-1',
+      from_user_id: 2,
+      kind: 'video',
+    }
+    await act(async () => {
+      stream.push('call_offer', offer)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(onSignal).toHaveBeenCalledWith('call_offer', offer))
+    expect(onGroupSignal).not.toHaveBeenCalled()
+  })
+
+  it('routes frames to onGroupSignal for 3+ member conversations', async () => {
+    const stream = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk(makeConversation([1, 2, 3])))
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(stream.response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, onSignal, onGroupSignal } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      stream.push('call_join', { conversation_id: 1, call_id: 'g1', from_user_id: 3 })
+      stream.push('call_offer', { conversation_id: 1, call_id: 'g1', from_user_id: 3 })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(onGroupSignal).toHaveBeenCalledTimes(2))
+    expect(onGroupSignal.mock.calls.map(c => c[0])).toEqual(['call_join', 'call_offer'])
+    expect(onSignal).not.toHaveBeenCalled()
+  })
+
+  it('synthesises a missed-call entry with the offered kind, only for inbound calls', async () => {
+    const stream = makeStream()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk(makeConversation([1, 2])))
+      .mockResolvedValueOnce(msgsOk([]))
+      .mockResolvedValueOnce(stream.response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderStream()
+    await waitFor(() => expect(result.current.connStatus).toBe('live'))
+
+    await act(async () => {
+      // A video offer followed immediately by a missed end — the kind must
+      // survive even though no render happened in between.
+      stream.push('call_offer', { conversation_id: 1, call_id: 'c1', from_user_id: 2, kind: 'video' })
+      stream.push('call_end', { conversation_id: 1, call_id: 'c1', from_user_id: 2, status: 'missed' })
+      // A call we placed ourselves is not our missed-call history, and the same
+      // call_id must never be recorded twice.
+      stream.push('call_end', { conversation_id: 1, call_id: 'c2', from_user_id: 1, status: 'missed' })
+      stream.push('call_end', { conversation_id: 1, call_id: 'c1', from_user_id: 2, status: 'missed' })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(result.current.missedCalls).toHaveLength(1))
+    expect(result.current.missedCalls[0].callId).toBe('c1')
+    expect(result.current.missedCalls[0].fromUserId).toBe(2)
+    expect(result.current.missedCalls[0].kind).toBe('video')
+  })
+})

--- a/web/src/pages/familychat/useFamilyChatStream.ts
+++ b/web/src/pages/familychat/useFamilyChatStream.ts
@@ -1,0 +1,738 @@
+import { useEffect, useRef, useState, type Dispatch, type RefObject, type SetStateAction } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { ChatConnectionState } from '../../components/ConnectionStatus'
+import { applyReactionEvent, type ReactionMap } from './api'
+import type { CallKind, CallSignalEventName, CallSignalPayload } from './voice/useVoiceCall'
+import type { GroupSignalEventName } from './voice/useGroupCall'
+
+// useFamilyChatStream owns everything about a Family Chat conversation's data
+// feed: the initial conversation + message load, the long-lived SSE reader,
+// reconnect with exponential backoff, gap-fill (backfill-since-lastId) after a
+// drop, the connection-status flags, the typing-user map with its expiry sweep,
+// and missed-call synthesis.
+//
+// Voice/group call signalling is *not* handled here — call_* frames are routed
+// out through the injected onSignal / onGroupSignal callbacks (kept in refs so a
+// new callback identity never tears down the stream), which keeps useVoiceCall
+// and useGroupCall completely independent of the transport.
+
+export interface Conversation {
+  id: number
+  name: string
+  owner_user_id: number
+  created_at: string
+  last_message_at: string
+  unread_count: number
+  member_ids: number[]
+}
+
+export interface ChatMessage {
+  id: number
+  conversation_id: number
+  sender_user_id: number
+  body: string
+  attachment_path?: string
+  attachment_mime?: string
+  created_at: string
+  edited_at?: string | null
+  deleted_at?: string | null
+  deleted_by?: number | null
+  // meta_json is opaque client-controlled JSON the server stores verbatim.
+  // Voice notes use it to ship the precomputed waveform (see voice/waveform.ts).
+  meta_json?: string | null
+  reactions?: ReactionMap
+  // client_id is a client-generated correlation id for optimistic sends. It is
+  // present on the locally-rendered "sending" bubble and is echoed back by the
+  // server on the POST response and the SSE message_new event, so whichever
+  // arrives first reconciles the bubble. Kept on the message after reconciling
+  // so the React key stays stable (no remount/flicker). Absent on messages
+  // loaded from the server.
+  client_id?: string
+  // status drives the optimistic-send affordance: 'sending' while the POST is
+  // in flight, 'failed' once it errors (tap to retry). Absent for authoritative
+  // (reconciled or server-loaded) messages.
+  status?: 'sending' | 'failed'
+}
+
+// MissedCallEntry is an inbound call the recipient never answered — surfaced as
+// a tombstone row in the message list with a call-back button. Only synthesised
+// for calls where the local user was the callee (a missed call we placed
+// ourselves isn't useful history for us).
+export interface MissedCallEntry {
+  callId: string
+  fromUserId: number
+  receivedAt: string
+  // kind mirrors the call-kind from the original offer so call-back can
+  // match the modality (voice → voice, video → video).
+  kind: CallKind
+}
+
+// Wire shapes for the non-call SSE frames. They mirror what the server
+// broadcasts (see internal/familychat); conversation_id is optional because
+// older frames omitted it, in which case the frame is assumed to belong to the
+// subscribed conversation.
+interface ReactionEventPayload {
+  message_id: number
+  user_id: number
+  emoji: string
+  count: number
+  conversation_id?: number
+}
+
+interface MessageEditedPayload {
+  message_id: number
+  body: string
+  edited_at: string
+  conversation_id?: number
+}
+
+interface MessageDeletedPayload {
+  message_id: number
+  deleted_by: number
+  conversation_id?: number
+}
+
+// reconcileMessage merges an authoritative message into the list. When the
+// incoming message carries a client_id that matches a local optimistic bubble,
+// it replaces that bubble in place — preserving the client_id (so the React key
+// stays stable and the row doesn't remount/flicker) and dropping the optimistic
+// status. Otherwise it dedupes by id so a message delivered via both the POST
+// response and the SSE stream (or gap-fill) shows up exactly once, regardless of
+// arrival order.
+export function reconcileMessage(
+  prev: ChatMessage[],
+  clientId: string | undefined,
+  incoming: ChatMessage,
+): ChatMessage[] {
+  if (clientId) {
+    const idx = prev.findIndex(m => m.client_id === clientId)
+    if (idx !== -1) {
+      const reconciled = { ...incoming, client_id: clientId, status: undefined }
+      // Replace the optimistic bubble in place, and drop any *other* row that
+      // already carries the same authoritative id. That second row appears when
+      // an SSE message_new for this same send lands before the POST response
+      // and gets appended separately (e.g. an event that omitted our
+      // client_id); without this filter the reconcile would leave two bubbles
+      // sharing one id.
+      const next: ChatMessage[] = []
+      prev.forEach((m, i) => {
+        if (i === idx) { next.push(reconciled); return }
+        if (m.id === incoming.id) return
+        next.push(m)
+      })
+      return next
+    }
+  }
+  if (prev.some(m => m.id === incoming.id)) return prev
+  return [...prev, incoming]
+}
+
+export interface UseFamilyChatStreamOptions {
+  conversationId: number | null
+  // userId is the signed-in user's id. Used to compute the `me` flag on
+  // reactions, to ignore our own typing echo, and to decide whether a missed
+  // call was inbound.
+  userId: number | undefined
+  // callKind mirrors the 1:1 voice-call hook's current call kind so a missed
+  // call records the right modality. The stream also updates its own shadow of
+  // this value synchronously when a call_offer arrives, because a same-frame
+  // call_end (a missed call) lands before React can flush a render.
+  callKind: CallKind
+  // onSignal receives 1:1 call signalling frames (2-member conversations).
+  onSignal: (event: CallSignalEventName, payload: CallSignalPayload) => void | Promise<void>
+  // onGroupSignal receives mesh call signalling frames (3+ member conversations).
+  onGroupSignal: (event: GroupSignalEventName, payload: CallSignalPayload) => void | Promise<void>
+  // onConversationOpen fires when a conversation's stream starts, so the caller
+  // can clear per-conversation UI state it still owns.
+  onConversationOpen?: () => void
+  // onConversationClose fires from the teardown path (unmount or conversation
+  // switch), before the caller's own cleanup.
+  onConversationClose?: () => void
+}
+
+export interface UseFamilyChatStreamApi {
+  conversation: Conversation | null
+  messages: ChatMessage[]
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>
+  loading: boolean
+  error: string
+  connStatus: ChatConnectionState
+  justReconnected: boolean
+  // typingUsers maps a member's user id to the epoch-ms timestamp of their most
+  // recent typing signal. A sweep drops entries older than ~5s so the indicator
+  // clears on its own when the other side stops composing.
+  typingUsers: Map<number, number>
+  missedCalls: MissedCallEntry[]
+  setMissedCalls: Dispatch<SetStateAction<MissedCallEntry[]>>
+  // lastIdRef is the highest message id rendered for the current conversation.
+  // It seeds the gap-fill query on reconnect and is exposed so callers can read
+  // the resume watermark (tests assert on it).
+  lastIdRef: RefObject<number>
+}
+
+export function useFamilyChatStream(options: UseFamilyChatStreamOptions): UseFamilyChatStreamApi {
+  const { conversationId, userId, callKind } = options
+  const { t } = useTranslation('familyChat')
+
+  const [conversation, setConversation] = useState<Conversation | null>(null)
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  // connStatus tracks the live state of the SSE stream so the header can show
+  // honest connectivity feedback:
+  //   'connecting'   — initial load, before the stream has ever opened
+  //   'live'         — stream is open and messages arrive in real time
+  //   'reconnecting' — the stream dropped after being live and a backoff retry
+  //                    is in flight
+  //   'offline'      — the browser reports no network connectivity
+  // The 'connecting' → 'reconnecting' distinction keeps the initial-load
+  // skeleton from being shadowed by a false "Reconnecting" badge.
+  const [connStatus, setConnStatus] = useState<ChatConnectionState>('connecting')
+  // justReconnected briefly flips true right after the stream recovers from a
+  // drop so the header can flash a "Connected" confirmation, then auto-clears.
+  const [justReconnected, setJustReconnected] = useState(false)
+  const [missedCalls, setMissedCalls] = useState<MissedCallEntry[]>([])
+  const [typingUsers, setTypingUsers] = useState<Map<number, number>>(new Map())
+
+  // lastIdRef is the highest message id this client has rendered for the
+  // current conversation. It seeds gap-fill queries on reconnect and is updated
+  // by initial load, SSE events, and gap-fill responses.
+  const lastIdRef = useRef(0)
+
+  // The refs below shadow values the long-lived SSE reader closure (recreated
+  // only when conversationId changes) needs to read at their most recent value,
+  // without forcing the effect — and therefore the stream — to re-subscribe.
+  const currentUserIdRef = useRef<number | undefined>(userId)
+  const conversationRef = useRef<Conversation | null>(null)
+  const signalRef = useRef(options.onSignal)
+  const groupSignalRef = useRef(options.onGroupSignal)
+  const conversationOpenRef = useRef(options.onConversationOpen)
+  const conversationCloseRef = useRef(options.onConversationClose)
+  // callKindRef shadows the 1:1 hook's callKind — the hook resets it
+  // synchronously inside tearDown before the next render, so capturing it at
+  // the top of the SSE dispatch path preserves the correct value even when
+  // call_end arrives immediately after call_offer.
+  const callKindRef = useRef<CallKind>(callKind)
+  useEffect(() => { currentUserIdRef.current = userId }, [userId])
+  useEffect(() => { conversationRef.current = conversation }, [conversation])
+  useEffect(() => {
+    signalRef.current = options.onSignal
+    groupSignalRef.current = options.onGroupSignal
+    conversationOpenRef.current = options.onConversationOpen
+    conversationCloseRef.current = options.onConversationClose
+    callKindRef.current = callKind
+  })
+
+  // Load conversation metadata + initial messages, then subscribe to the SSE
+  // stream so new messages arrive without a refetch. The initial load and the
+  // SSE subscription share a single AbortController so switching conversation
+  // tears both down atomically; the SSE reader is also canceled explicitly so
+  // tests (and the rare browser that doesn't propagate abort to a streaming
+  // body) terminate the read loop deterministically.
+  useEffect(() => {
+    // When no conversation is selected, do nothing here — the previous
+    // non-null effect's cleanup (below) resets state when switching away.
+    // Calling setState directly in the guard body is flagged by
+    // react-hooks/set-state-in-effect; cleanup callbacks are not.
+    if (conversationId === null) return
+    const controller = new AbortController()
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    // recoveredTimer clears the brief "Connected" confirmation after a drop.
+    let recoveredTimer: ReturnType<typeof setTimeout> | null = null
+    let reconnectAttempts = 0
+    let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null
+    let connectInFlight = false
+    // browserOffline mirrors navigator.onLine so scheduleReconnect can label a
+    // drop as "Offline" (no network) vs "Reconnecting" (server blip) without a
+    // separate stream or poll.
+    let browserOffline = typeof navigator !== 'undefined' && navigator.onLine === false
+
+    // Initialise loading state at the start of every new conversation fetch.
+    // setLoading(true) must live here (not in cleanup) because cleanup runs
+    // setLoading(false) to represent "no conversation selected", which is the
+    // correct value when conversationId is null. Cleanup callbacks are exempt
+    // from react-hooks/set-state-in-effect; the synchronous call here is
+    // intentional and safe — React 18 batches all these updates into one commit.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true)
+    setError('')
+    setMessages([])
+    setConversation(null)
+    setConnStatus(browserOffline ? 'offline' : 'connecting')
+    setJustReconnected(false)
+    setMissedCalls([])
+    setTypingUsers(new Map())
+    lastIdRef.current = 0
+    conversationOpenRef.current?.()
+
+    // appendIncoming deduplicates by id so a message that arrives via both
+    // SSE and the POST response (the sender path) or via SSE and gap-fill
+    // shows up exactly once.
+    const appendIncoming = (msg: ChatMessage) => {
+      if (msg.conversation_id !== conversationId) return
+      if (msg.id > lastIdRef.current) lastIdRef.current = msg.id
+      // A message from a member ends their typing state immediately, so the
+      // indicator doesn't linger after their reply lands.
+      setTypingUsers(prev => {
+        if (!prev.has(msg.sender_user_id)) return prev
+        const next = new Map(prev)
+        next.delete(msg.sender_user_id)
+        return next
+      })
+      // Reconcile against an optimistic bubble when the server echoed our
+      // client_id (the SSE-first arrival path); otherwise dedupe by id.
+      setMessages(prev => reconcileMessage(prev, msg.client_id, msg))
+    }
+
+    // applyReactionEventLocal merges an incoming reaction event into the
+    // open message list. We can't compute the recipient's `me` flag from
+    // the wire payload alone (the server broadcasts a single payload to
+    // every subscriber), so the comparison happens here against the
+    // current user's id.
+    const applyReactionEventLocal = (
+      payload: ReactionEventPayload,
+      removed: boolean,
+    ) => {
+      if (payload.conversation_id !== undefined && payload.conversation_id !== conversationId) return
+      setMessages(prev => {
+        let changed = false
+        const next = prev.map(m => {
+          if (m.id !== payload.message_id) return m
+          changed = true
+          return {
+            ...m,
+            reactions: applyReactionEvent(m.reactions, payload, currentUserIdRef.current, removed),
+          }
+        })
+        return changed ? next : prev
+      })
+    }
+
+    // applyMessageEdited overwrites the body + edited_at of the matching
+    // message. Keeps the existing reactions / attachment metadata intact.
+    const applyMessageEdited = (payload: MessageEditedPayload) => {
+      if (payload.conversation_id !== undefined && payload.conversation_id !== conversationId) return
+      setMessages(prev => prev.map(m =>
+        m.id === payload.message_id
+          ? { ...m, body: payload.body, edited_at: payload.edited_at }
+          : m,
+      ))
+    }
+
+    // applyMessageDeleted converts the matching message into a tombstone.
+    // Body + attachment metadata are cleared so the bubble flips to the
+    // "Message deleted" placeholder; deleted_at + deleted_by drive that
+    // rendering and the timestamp tooltip.
+    const applyMessageDeleted = (payload: MessageDeletedPayload) => {
+      if (payload.conversation_id !== undefined && payload.conversation_id !== conversationId) return
+      const now = new Date().toISOString()
+      setMessages(prev => prev.map(m =>
+        m.id === payload.message_id
+          ? {
+              ...m,
+              body: '',
+              attachment_path: '',
+              attachment_mime: '',
+              edited_at: null,
+              deleted_at: m.deleted_at ?? now,
+              deleted_by: payload.deleted_by,
+            }
+          : m,
+      ))
+    }
+
+    // recordTyping stamps a member's latest typing signal. We never record our
+    // own id (the hub fans the event back to every subscriber, including the
+    // sender) so the local user never sees their own indicator.
+    const recordTyping = (typingUserId: number) => {
+      if (typingUserId === currentUserIdRef.current) return
+      setTypingUsers(prev => {
+        const next = new Map(prev)
+        next.set(typingUserId, Date.now())
+        return next
+      })
+    }
+
+    const fillGap = async () => {
+      if (controller.signal.aborted) return
+      try {
+        const url = lastIdRef.current > 0
+          ? `/api/familychat/conversations/${conversationId}/messages?since=${lastIdRef.current}`
+          : `/api/familychat/conversations/${conversationId}/messages`
+        const res = await fetch(url, { credentials: 'include', signal: controller.signal })
+        if (!res.ok) return
+        const data = await res.json()
+        const msgs: ChatMessage[] = data.messages ?? []
+        // API returns newest-first; sort ascending so lastId climbs
+        // monotonically as we replay the burst.
+        msgs.sort((a, b) => a.id - b.id)
+        for (const m of msgs) appendIncoming(m)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        // Non-fatal: the next reconnect attempt will retry.
+      }
+    }
+
+    const scheduleReconnect = () => {
+      if (controller.signal.aborted) return
+      if (browserOffline) {
+        setConnStatus('offline')
+        return
+      }
+      // Only surface the "Reconnecting" badge once we've actually been live —
+      // a failure on the very first connect keeps us in 'connecting' so the
+      // initial load never flashes a false "offline".
+      setConnStatus(prev => (prev === 'connecting' ? 'connecting' : 'reconnecting'))
+      reconnectAttempts += 1
+      // Exponential backoff capped at 30s to keep a server outage from
+      // hammering the endpoint while still recovering quickly from a
+      // transient blip.
+      const delay = Math.min(30000, 1000 * 2 ** Math.min(reconnectAttempts, 5))
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null
+        void connect(false)
+      }, delay)
+    }
+
+    // dispatchFrame applies one decoded SSE frame. Message/reaction/typing
+    // frames mutate local state; call_* frames are forwarded to the injected
+    // signalling callbacks (routed by member count: 3+ → mesh, 2 → 1:1).
+    const dispatchFrame = (eventName: string, payload: Record<string, unknown> | null) => {
+      if (eventName === 'message_new' && payload?.message) {
+        appendIncoming(payload.message as ChatMessage)
+      } else if (
+        (eventName === 'reaction_added' || eventName === 'reaction_removed') &&
+        payload?.message_id !== undefined &&
+        payload?.emoji !== undefined
+      ) {
+        applyReactionEventLocal(
+          payload as unknown as ReactionEventPayload,
+          eventName === 'reaction_removed',
+        )
+      } else if (
+        eventName === 'message_edited' &&
+        payload?.message_id !== undefined &&
+        payload?.body !== undefined &&
+        payload?.edited_at !== undefined
+      ) {
+        applyMessageEdited(payload as unknown as MessageEditedPayload)
+      } else if (
+        eventName === 'message_deleted' &&
+        payload?.message_id !== undefined &&
+        payload?.deleted_by !== undefined
+      ) {
+        applyMessageDeleted(payload as unknown as MessageDeletedPayload)
+      } else if (
+        eventName === 'typing' &&
+        payload?.user_id !== undefined
+      ) {
+        recordTyping(payload.user_id as number)
+      } else if (
+        eventName === 'call_join'
+        || eventName === 'call_leave'
+      ) {
+        // Group-call lifecycle events only exist for 3+ member
+        // conversations; route them straight into the mesh hook.
+        if ((conversationRef.current?.member_ids.length ?? 0) >= 3) {
+          void groupSignalRef.current(
+            eventName as GroupSignalEventName,
+            payload as unknown as CallSignalPayload,
+          )
+        }
+      } else if (
+        eventName === 'call_offer'
+        || eventName === 'call_answer'
+        || eventName === 'call_ice'
+        || eventName === 'call_end'
+      ) {
+        // 3+ member conversations use the group mesh; 1:1 uses the
+        // single-peer voice-call hook. Route by member count.
+        if ((conversationRef.current?.member_ids.length ?? 0) >= 3) {
+          void groupSignalRef.current(
+            eventName as GroupSignalEventName,
+            payload as unknown as CallSignalPayload,
+          )
+        } else if (conversationRef.current?.member_ids.length === 2) {
+          // Route call signalling into the voice-call hook. We also
+          // track missed calls locally so the bubble area can render
+          // a tombstone-style row with a call-back button: a
+          // call_end with status=missed from someone other than us
+          // means we never picked up.
+          const callPayload = payload as unknown as CallSignalPayload
+          // Synchronously update callKindRef when we see a call_offer so that
+          // a same-iteration call_end (e.g. missed) captures the correct kind
+          // without waiting for a React render to flush the effect above.
+          if (eventName === 'call_offer' && callPayload?.kind) {
+            callKindRef.current = callPayload.kind
+          }
+          if (
+            eventName === 'call_end'
+            && callPayload?.status === 'missed'
+            && callPayload?.from_user_id !== undefined
+            && callPayload.from_user_id !== currentUserIdRef.current
+          ) {
+            // Capture the call kind before the signal callback fires
+            // tearDown (which resets the hook's callKind synchronously). This
+            // preserves video vs voice so call-back matches the modality.
+            const capturedKind = callKindRef.current
+            setMissedCalls(prev => {
+              if (prev.some(m => m.callId === callPayload.call_id)) return prev
+              return [
+                ...prev,
+                {
+                  callId: callPayload.call_id,
+                  fromUserId: callPayload.from_user_id,
+                  receivedAt: new Date().toISOString(),
+                  kind: capturedKind,
+                },
+              ]
+            })
+          }
+          void signalRef.current(
+            eventName as CallSignalEventName,
+            callPayload,
+          )
+        }
+      }
+    }
+
+    const connect = async (firstConnect: boolean) => {
+      if (controller.signal.aborted) return
+      connectInFlight = true
+      // Capture the resume point BEFORE fillGap runs. fillGap appends any new
+      // messages and bumps lastId; if we passed the post-fillGap lastId to the
+      // stream, the backfill watermark would advance past edits/deletes that
+      // happened mid-gap (older than the newest message but newer than where we
+      // actually left off), silently dropping them. The pre-gap id is the true
+      // "last seen while connected" point.
+      const resumeId = lastIdRef.current
+      // Skip the gap-fill on the very first connect: the initial /messages
+      // fetch already covered everything up to lastId. On reconnects we
+      // re-issue it so a disconnect window can't lose messages.
+      if (!firstConnect) await fillGap()
+      if (controller.signal.aborted) return
+      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
+      try {
+        // On reconnect, pass the last-seen message id as since_message_id so the
+        // stream replays anything missed while we were gone — not just new
+        // messages (which fillGap above already covers) but edits and deletes of
+        // older messages too, which a plain id>since fetch can't see. A native
+        // EventSource would resend this via Last-Event-ID automatically; this
+        // fetch-based reader can't set that header, so the query param carries
+        // the resume point instead. All replayed events are applied idempotently
+        // below, so overlap with fillGap (or a never-dropped event) is a no-op.
+        const streamUrl = !firstConnect && resumeId > 0
+          ? `/api/familychat/conversations/${conversationId}/stream?since_message_id=${resumeId}`
+          : `/api/familychat/conversations/${conversationId}/stream`
+        const res = await fetch(
+          streamUrl,
+          { credentials: 'include', signal: controller.signal },
+        )
+        if (!res.ok || !res.body) {
+          scheduleReconnect()
+          return
+        }
+        reconnectAttempts = 0
+        reader = res.body.getReader()
+        activeReader = reader
+        // A non-first connect means the stream just recovered from a drop. The
+        // gap-fill above already backfilled any messages missed during the
+        // outage; flash a brief "Connected" confirmation so the user gets a
+        // visible signal that messages are arriving live again.
+        if (!firstConnect) {
+          setJustReconnected(true)
+          if (recoveredTimer !== null) clearTimeout(recoveredTimer)
+          recoveredTimer = setTimeout(() => {
+            recoveredTimer = null
+            setJustReconnected(false)
+          }, 3000)
+        }
+        setConnStatus('live')
+        const decoder = new TextDecoder()
+        let buffer = ''
+        let eventName = 'message'
+        let dataLines: string[] = []
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          let nl = buffer.indexOf('\n')
+          while (nl >= 0) {
+            let line = buffer.slice(0, nl)
+            buffer = buffer.slice(nl + 1)
+            if (line.endsWith('\r')) line = line.slice(0, -1)
+            if (line === '') {
+              if (dataLines.length > 0) {
+                try {
+                  dispatchFrame(eventName, JSON.parse(dataLines.join('\n')))
+                } catch {
+                  // Ignore a malformed payload; the server should never emit
+                  // one, but we don't want to tear down the whole stream over
+                  // a single bad frame.
+                }
+              }
+              eventName = 'message'
+              dataLines = []
+            } else if (line.startsWith(':')) {
+              // SSE comment / heartbeat — ignore.
+            } else if (line.startsWith('event:')) {
+              eventName = line.slice(6).trimStart()
+            } else if (line.startsWith('data:')) {
+              const v = line.slice(5)
+              dataLines.push(v.startsWith(' ') ? v.slice(1) : v)
+            }
+            nl = buffer.indexOf('\n')
+          }
+        }
+        if (!controller.signal.aborted) scheduleReconnect()
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        if (!controller.signal.aborted) scheduleReconnect()
+      } finally {
+        connectInFlight = false
+        if (activeReader === reader) activeReader = null
+      }
+    }
+
+    // Reflect browser connectivity in the indicator. These only surface state
+    // the EventSource-style reader already drives — 'offline' is the honest
+    // label while there's no network, and coming back online retries at once
+    // instead of waiting out the remaining backoff.
+    const handleOffline = () => {
+      browserOffline = true
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      setConnStatus('offline')
+    }
+    const handleOnline = () => {
+      browserOffline = false
+      if (controller.signal.aborted) return
+      // If a stream is already open/opening, leave it alone; otherwise surface
+      // 'reconnecting' and retry immediately, cancelling any pending backoff.
+      if (activeReader || connectInFlight) return
+      setConnStatus(prev => (prev === 'connecting' ? 'connecting' : 'reconnecting'))
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      reconnectAttempts = 0
+      void connect(false)
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('offline', handleOffline)
+      window.addEventListener('online', handleOnline)
+    }
+
+    ;(async () => {
+      try {
+        const [convRes, msgRes] = await Promise.all([
+          fetch(`/api/familychat/conversations/${conversationId}`, {
+            credentials: 'include',
+            signal: controller.signal,
+          }),
+          fetch(`/api/familychat/conversations/${conversationId}/messages`, {
+            credentials: 'include',
+            signal: controller.signal,
+          }),
+        ])
+        if (!convRes.ok) throw new Error('conversation failed')
+        if (!msgRes.ok) throw new Error('messages failed')
+        const convData = await convRes.json()
+        const msgData = await msgRes.json()
+        if (controller.signal.aborted) return
+        setConversation(convData.conversation ?? null)
+        // The API returns newest-first; display oldest at top to bottom.
+        const sorted: ChatMessage[] = (msgData.messages ?? []).slice().reverse()
+        if (sorted.length > 0) lastIdRef.current = sorted[sorted.length - 1].id
+        setMessages(sorted)
+        void connect(true)
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        const key = err instanceof Error && err.message === 'conversation failed'
+          ? 'errors.failedToLoadConversation'
+          : 'errors.failedToLoadMessages'
+        setError(t(key))
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    })()
+
+    return () => {
+      controller.abort()
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('offline', handleOffline)
+        window.removeEventListener('online', handleOnline)
+      }
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      if (recoveredTimer !== null) {
+        clearTimeout(recoveredTimer)
+        recoveredTimer = null
+      }
+      // Cancel the reader so the read loop exits even when the fetch mock
+      // doesn't propagate abort to the body (notably in tests). The catch is
+      // intentional — cancel can throw if the reader is already detached.
+      if (activeReader) {
+        activeReader.cancel().catch(() => {})
+        activeReader = null
+      }
+      // Let the caller tear down whatever it owns for this conversation (voice
+      // playback, transient banners) before the stream state is reset.
+      conversationCloseRef.current?.()
+      // Reset conversation state when leaving (to null or another conversation)
+      // so the next render starts from a blank slate. State updates inside
+      // cleanup callbacks are not flagged by react-hooks/set-state-in-effect.
+      setConversation(null)
+      setMessages([])
+      setError('')
+      setLoading(false)
+      // Reset connection state so the indicator never stays stuck in
+      // 'reconnecting' after the view unmounts or switches conversation.
+      setConnStatus('connecting')
+      setJustReconnected(false)
+      setMissedCalls([])
+      setTypingUsers(new Map())
+      lastIdRef.current = 0
+    }
+  }, [conversationId, t])
+
+  // Sweep stale typing indicators: drop any member whose most recent signal is
+  // older than 5s so the row clears shortly after they stop composing. The
+  // interval only runs while at least one member is typing.
+  useEffect(() => {
+    if (typingUsers.size === 0) return
+    const interval = setInterval(() => {
+      setTypingUsers(prev => {
+        const now = Date.now()
+        let changed = false
+        const next = new Map(prev)
+        for (const [uid, ts] of next) {
+          if (now - ts > 5000) {
+            next.delete(uid)
+            changed = true
+          }
+        }
+        return changed ? next : prev
+      })
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [typingUsers])
+
+  return {
+    conversation,
+    messages,
+    setMessages,
+    loading,
+    error,
+    connStatus,
+    justReconnected,
+    typingUsers,
+    missedCalls,
+    setMissedCalls,
+    lastIdRef,
+  }
+}


### PR DESCRIPTION
## Changes

- **Family Chat streaming extracted into useFamilyChatStream** - The ~475-line SSE effect in ChatView (reader loop, reconnect backoff, backfill-since-lastId de-duplication, connection status, typing expiry, missed-call synthesis) now lives in a dedicated `useFamilyChatStream` hook with direct unit tests. Call signalling frames are forwarded to the voice/group call hooks through injected callbacks. No behavior change. (Hytte-8rihl)

## Original Issue (task): Extract SSE stream/reconnect/backfill into useFamilyChatStream

Create `web/src/pages/familychat/useFamilyChatStream.ts` by lifting the ~475-line effect at ChatView.tsx lines ~429–903: the EventSource/fetch reader loop, reconnect with backoff, backfill-since-`lastId` de-duplication, `connStatus`/`justReconnected` flags, typing-user map with expiry timers, and missed-call entry synthesis. Signature roughly `useFamilyChatStream({ chatId, onSignal, onGroupSignal, ... }): { messages, setMessages, connStatus, justReconnected, typingUsers, lastIdRef }` — voice/group signalling frames are forwarded via injected dispatch callbacks so `useVoiceCall`/`useGroupCall` stay untouched. Do NOT name it `useChatStream`; `web/src/hooks/useChatStream.ts` already exists for the Claude AI chat page and is out of scope. Add `useFamilyChatStream.test.ts` with direct unit tests for reconnect, backfill-without-duplicates, and reader error paths. ChatView.tsx consumes the hook and drops the inline effect. This sub-task lands first: siblings 2 and 3 consume the `messages`/`setMessages` surface it defines.

---
Bead: Hytte-8rihl | Branch: forge/Hytte-8rihl
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->