### PR TITLE
Extract shared Pokémon formatters and a card image with error fallback (Hytte-bij33)

### DIFF
--- a/changelog.d/Hytte-bij33.md
+++ b/changelog.d/Hytte-bij33.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Card images in the set grid fall back to the collector number** - When a pokemontcg.io image fails to load, the set-detail grid now shows the card's collector number instead of a broken-image icon, matching the behaviour of the set list and top-cards grids. (Hytte-bij33)

--- a/web/src/components/pokemon/AddCardPanel.tsx
+++ b/web/src/components/pokemon/AddCardPanel.tsx
@@ -4,7 +4,7 @@ import { Camera, LayoutGrid, Plus, Search, X } from 'lucide-react'
 import { Dialog } from '../ui/dialog'
 import ToastList from '../ToastList'
 import { useToast } from '../../hooks/useToast'
-import { formatNumber } from '../../utils/formatDate'
+import { formatNok } from './format'
 import CardScanner from './CardScanner'
 import PageScanner from './PageScanner'
 import CardLightbox from './CardLightbox'
@@ -35,18 +35,6 @@ interface Card {
 
 const DEBOUNCE_MS = 200
 const SEARCH_LIMIT = 20
-
-// 0 means "upstream price missing" rather than "this card is free" — see
-// CardLightbox.formatNok for the full reasoning.
-function formatNok(amount: number | null | undefined): string {
-  if (amount == null || amount === 0) return '—'
-  return formatNumber(amount, {
-    style: 'currency',
-    currency: 'NOK',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  })
-}
 
 interface AddCardPanelProps {
   onAdded?: () => void

--- a/web/src/components/pokemon/CardLightbox.tsx
+++ b/web/src/components/pokemon/CardLightbox.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { Check, ChevronLeft, ChevronRight } from 'lucide-react'
 import { formatNumber } from '../../utils/formatDate'
+import { formatNok } from './format'
 
 export interface LightboxVariant {
   price_eur?: number | null
@@ -58,22 +59,9 @@ function unlockBodyScroll() {
   }
 }
 
-// 0 is treated the same as missing in both formatters below — Cardmarket
-// never quotes a card at exactly €0,00 (the floor is €0,01), so amount===0
-// always means upstream hasn't priced this card yet (common for cards from
-// the new Mega Evolution series whose Cardmarket scraper bridge isn't wired
-// to pokemontcg.io's API yet). Showing "kr 0" makes the card look free;
-// "—" reads as unknown.
-function formatNok(amount: number | null | undefined): string {
-  if (amount == null || amount === 0) return '—'
-  return formatNumber(amount, {
-    style: 'currency',
-    currency: 'NOK',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  })
-}
-
+// 0 is treated the same as missing here, as in the shared formatNok — see
+// components/pokemon/format.ts for the full reasoning. This copy returns null
+// rather than "—" so callers can omit the secondary EUR line entirely.
 function formatEur(amount: number | null | undefined): string | null {
   if (amount == null || amount === 0) return null
   return formatNumber(amount, {

--- a/web/src/components/pokemon/PokemonImage.test.tsx
+++ b/web/src/components/pokemon/PokemonImage.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import PokemonImage from './PokemonImage'
+
+function renderImage(src: string | null | undefined) {
+  return render(
+    <PokemonImage
+      src={src}
+      alt="card"
+      className="object-contain"
+      fallback={<span>001</span>}
+    />,
+  )
+}
+
+describe('PokemonImage', () => {
+  it('renders the image when a URL is given', () => {
+    renderImage('https://example.com/a.png')
+    const img = screen.getByAltText('card')
+    expect(img).toHaveAttribute('src', 'https://example.com/a.png')
+    expect(img).toHaveAttribute('loading', 'lazy')
+    expect(screen.queryByText('001')).not.toBeInTheDocument()
+  })
+
+  it('renders the fallback when there is no URL', () => {
+    renderImage('')
+    expect(screen.getByText('001')).toBeInTheDocument()
+    expect(screen.queryByAltText('card')).not.toBeInTheDocument()
+  })
+
+  it('swaps in the fallback when the image fails to load', () => {
+    renderImage('https://example.com/missing.png')
+    fireEvent.error(screen.getByAltText('card'))
+    expect(screen.getByText('001')).toBeInTheDocument()
+    expect(screen.queryByAltText('card')).not.toBeInTheDocument()
+  })
+
+  it('clears the error state when src changes', () => {
+    const { rerender } = renderImage('https://example.com/missing.png')
+    fireEvent.error(screen.getByAltText('card'))
+    expect(screen.getByText('001')).toBeInTheDocument()
+
+    rerender(
+      <PokemonImage
+        src="https://example.com/working.png"
+        alt="card"
+        className="object-contain"
+        fallback={<span>001</span>}
+      />,
+    )
+    const img = screen.getByAltText('card')
+    expect(img).toHaveAttribute('src', 'https://example.com/working.png')
+    expect(screen.queryByText('001')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/pokemon/PokemonImage.tsx
+++ b/web/src/components/pokemon/PokemonImage.tsx
@@ -1,0 +1,36 @@
+import { useState, type ReactNode } from 'react'
+
+interface PokemonImageProps {
+  src: string | null | undefined
+  alt: string
+  className?: string
+  loading?: 'lazy' | 'eager'
+  // fallback renders in place of the <img> when there is no URL or the URL
+  // fails to load. It is a node rather than a string so all user-facing copy
+  // (and its i18n) stays with the caller.
+  fallback: ReactNode
+}
+
+// PokemonImage renders a remote pokemontcg.io image and swaps in `fallback`
+// when the image 404s or otherwise fails, so grids show readable text instead
+// of the browser's broken-image icon. The error flag resets during render when
+// `src` changes — a new URL deserves a fresh attempt, and doing it here rather
+// than in an effect avoids a frame where the stale fallback is still painted.
+export default function PokemonImage({ src, alt, className, loading = 'lazy', fallback }: PokemonImageProps) {
+  const [errored, setErrored] = useState(false)
+  const [prevUrl, setPrevUrl] = useState(src)
+  if (src !== prevUrl) {
+    setPrevUrl(src)
+    setErrored(false)
+  }
+  if (!src || errored) return <>{fallback}</>
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      loading={loading}
+      onError={() => setErrored(true)}
+    />
+  )
+}

--- a/web/src/components/pokemon/ScanDetailModal.tsx
+++ b/web/src/components/pokemon/ScanDetailModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronDown, ChevronUp, Search } from 'lucide-react'
 import { Dialog, DialogHeader, DialogBody, DialogFooter } from '../ui/dialog'
-import { formatNumber } from '../../utils/formatDate'
+import { formatNok } from './format'
 
 const SEARCH_DEBOUNCE_MS = 250
 const SEARCH_LIMIT = 20
@@ -55,18 +55,6 @@ interface ScanDetailModalProps {
   busy: boolean
   onClose: () => void
   onResolve: (body: ScanDetailResolveBody) => void | Promise<void>
-}
-
-// 0 means "upstream price missing" rather than "this card is free" — see
-// CardLightbox.formatNok for the full reasoning.
-function formatNok(amount: number | null | undefined): string {
-  if (amount == null || amount === 0) return '—'
-  return formatNumber(amount, {
-    style: 'currency',
-    currency: 'NOK',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  })
 }
 
 function confidencePercent(confidence: number | null | undefined): number | null {

--- a/web/src/components/pokemon/format.test.ts
+++ b/web/src/components/pokemon/format.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { formatNok, formatReleaseDate } from './format'
+
+// Mock the i18n instance the formatDate utility reads its locale from so the
+// tests don't pull in the HTTP backend.
+vi.mock('../../i18n', () => ({
+  default: { language: 'en' },
+}))
+
+describe('formatNok', () => {
+  it('renders an em dash for missing prices', () => {
+    expect(formatNok(null)).toBe('—')
+    expect(formatNok(undefined)).toBe('—')
+  })
+
+  it('treats 0 as unpriced rather than free', () => {
+    expect(formatNok(0)).toBe('—')
+  })
+
+  it('formats a positive amount as whole-krone currency', () => {
+    const expected = (1234).toLocaleString('en', {
+      style: 'currency',
+      currency: 'NOK',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })
+    expect(formatNok(1234)).toBe(expected)
+    // No fractional part regardless of the locale's currency conventions.
+    expect(formatNok(1234.6)).toBe(
+      (1235).toLocaleString('en', {
+        style: 'currency',
+        currency: 'NOK',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }),
+    )
+  })
+})
+
+describe('formatReleaseDate', () => {
+  it('localizes the "YYYY/MM/DD" format pokemontcg.io returns', () => {
+    const expected = new Date(2023, 2, 31).toLocaleDateString('en', { dateStyle: 'medium' })
+    expect(formatReleaseDate('2023/03/31')).toBe(expected)
+  })
+
+  it('localizes the dashed variant without UTC drift', () => {
+    const expected = new Date(2023, 2, 31).toLocaleDateString('en', { dateStyle: 'medium' })
+    expect(formatReleaseDate('2023-03-31')).toBe(expected)
+    // Parsing from local components keeps the day number intact.
+    expect(formatReleaseDate('2023-03-31')).toContain('31')
+  })
+
+  it('falls back to the raw string when the input is unparseable', () => {
+    expect(formatReleaseDate('coming soon')).toBe('coming soon')
+    expect(formatReleaseDate('')).toBe('')
+  })
+})

--- a/web/src/components/pokemon/format.ts
+++ b/web/src/components/pokemon/format.ts
@@ -1,0 +1,37 @@
+import { formatDate, formatNumber } from '../../utils/formatDate'
+
+// 0 is treated the same as missing — Cardmarket never quotes a card at
+// exactly €0,00 (the floor is €0,01), so amount===0 always means upstream
+// hasn't priced this card yet (common for cards from the new Mega Evolution
+// series whose Cardmarket scraper bridge isn't wired to pokemontcg.io's API
+// yet). Showing "kr 0" makes the card look free; "—" reads as unknown.
+export function formatNok(amount: number | null | undefined): string {
+  if (amount == null || amount === 0) return '—'
+  return formatNumber(amount, {
+    style: 'currency',
+    currency: 'NOK',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+export function formatReleaseDate(raw: string): string {
+  // pokemontcg.io releases dates as "YYYY/MM/DD". `new Date('YYYY-MM-DD')`
+  // parses as UTC midnight, which becomes the previous day in any negative-UTC
+  // timezone, so we construct the Date from local components instead. Fall
+  // back to the raw string when parsing fails so we never render
+  // "Invalid Date".
+  const m = raw.match(/^(\d{4})[/-](\d{1,2})[/-](\d{1,2})$/)
+  let d: Date
+  if (m) {
+    d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+  } else {
+    d = new Date(raw)
+  }
+  if (Number.isNaN(d.getTime())) return raw
+  try {
+    return formatDate(d, { dateStyle: 'medium' })
+  } catch {
+    return raw
+  }
+}

--- a/web/src/pages/PokemonSet.test.tsx
+++ b/web/src/pages/PokemonSet.test.tsx
@@ -669,3 +669,26 @@ describe('PokemonSet – variant filter chip', () => {
     })
   })
 })
+
+describe('PokemonSet – card image fallback', () => {
+  it('renders the collector number when a card image fails to load', async () => {
+    const set = makeSet({ total_cards: 1 })
+    const cards = [makeCard({ id: 'sv1-1', name: 'Pikachu', collector_no: '001' })]
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards }))
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    const tile = screen.getByTestId('card-tile-sv1-1')
+    const img = tile.querySelector('img')
+    expect(img).not.toBeNull()
+
+    fireEvent.error(img as HTMLImageElement)
+
+    // The broken <img> is replaced by the plain collector number, not left as
+    // a broken-image icon. (The tile's caption renders "#001" via mockT, so
+    // the bare "001" match is the fallback span.)
+    expect(tile.querySelector('img')).toBeNull()
+    expect(within(tile).getByText('001')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -7,8 +7,9 @@ import { Skeleton } from '../components/ui/skeleton'
 import ToastList from '../components/ToastList'
 import AddCardPanel from '../components/pokemon/AddCardPanel'
 import CardLightbox from '../components/pokemon/CardLightbox'
+import PokemonImage from '../components/pokemon/PokemonImage'
+import { formatNok, formatReleaseDate } from '../components/pokemon/format'
 import { useToast } from '../hooks/useToast'
-import { formatDate, formatNumber } from '../utils/formatDate'
 
 interface Variant {
   id: number
@@ -228,37 +229,6 @@ function variantCompletionLabelKey(filter: VariantFilter): string {
   return 'set.completion.kind'
 }
 
-// parseReleaseDate accepts the "YYYY/MM/DD" or "YYYY-MM-DD" formats returned
-// by pokemontcg.io and renders a localized date. Falls back to the raw string
-// when parsing fails so we never render "Invalid Date".
-function formatReleaseDate(raw: string): string {
-  const m = raw.match(/^(\d{4})[/-](\d{1,2})[/-](\d{1,2})$/)
-  let d: Date
-  if (m) {
-    d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
-  } else {
-    d = new Date(raw)
-  }
-  if (Number.isNaN(d.getTime())) return raw
-  try {
-    return formatDate(d, { dateStyle: 'medium' })
-  } catch {
-    return raw
-  }
-}
-
-// 0 means "upstream price missing" rather than "this card is free" — see
-// CardLightbox.formatNok for the full reasoning.
-function formatNok(amount: number | null | undefined): string {
-  if (amount == null || amount === 0) return '—'
-  return formatNumber(amount, {
-    style: 'currency',
-    currency: 'NOK',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  })
-}
-
 // defaultVariant returns the variant we display on a card tile. The backend
 // orders variants by kind, so "normal" precedes "reverse_holofoil"; we treat
 // the first variant as the canonical one. When a per-kind filter is active
@@ -310,16 +280,12 @@ function CardTile({ card, filter, onClick, t }: TileProps) {
       className={`flex flex-col gap-2 p-2 rounded-lg border bg-gray-800/40 transition-colors text-left cursor-pointer ${tileClass}`}
     >
       <div className="relative aspect-[5/7] flex items-center justify-center bg-gray-900/40 rounded overflow-hidden">
-        {card.image_small_url ? (
-          <img
-            src={card.image_small_url}
-            alt=""
-            loading="lazy"
-            className="max-h-full max-w-full object-contain"
-          />
-        ) : (
-          <span className="text-xs text-gray-500">{card.collector_no}</span>
-        )}
+        <PokemonImage
+          src={card.image_small_url}
+          alt=""
+          className="max-h-full max-w-full object-contain"
+          fallback={<span className="text-xs text-gray-500">{card.collector_no}</span>}
+        />
         {applicable && owned && (
           <span
             aria-hidden="true"

--- a/web/src/pages/PokemonSets.tsx
+++ b/web/src/pages/PokemonSets.tsx
@@ -8,7 +8,8 @@ import AddCardPanel from '../components/pokemon/AddCardPanel'
 import CardScanner from '../components/pokemon/CardScanner'
 import PageScanner from '../components/pokemon/PageScanner'
 import CollectionValueCard from '../components/pokemon/CollectionValueCard'
-import { formatDate } from '../utils/formatDate'
+import PokemonImage from '../components/pokemon/PokemonImage'
+import { formatReleaseDate } from '../components/pokemon/format'
 
 // PokemonSetsLocationState carries the optional "open AddCardPanel pre-filled
 // with this query" hint that the /pokemon/scanned page passes through
@@ -49,27 +50,6 @@ function eraSlug(era: string): string {
     .replace(/^-+|-+$/g, '')
 }
 
-function formatReleaseDate(raw: string): string {
-  // pokemontcg.io releases dates as "YYYY/MM/DD". `new Date('YYYY-MM-DD')`
-  // parses as UTC midnight, which becomes the previous day in any negative-UTC
-  // timezone, so we construct the Date from local components instead. Fall
-  // back to the raw string when parsing fails so we never render
-  // "Invalid Date".
-  const m = raw.match(/^(\d{4})[/-](\d{1,2})[/-](\d{1,2})$/)
-  let d: Date
-  if (m) {
-    d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
-  } else {
-    d = new Date(raw)
-  }
-  if (Number.isNaN(d.getTime())) return raw
-  try {
-    return formatDate(d, { dateStyle: 'medium' })
-  } catch {
-    return raw
-  }
-}
-
 function ownershipPercent(owned: number, total: number): number {
   if (total <= 0) return 0
   return Math.round((owned / total) * 100)
@@ -82,12 +62,6 @@ interface SetTileProps {
 
 function SetTile({ set, t }: SetTileProps) {
   const percent = ownershipPercent(set.owned_count, set.total_cards)
-  const [errored, setErrored] = useState(false)
-  const [prevUrl, setPrevUrl] = useState(set.logo_url)
-  if (set.logo_url !== prevUrl) {
-    setPrevUrl(set.logo_url)
-    setErrored(false)
-  }
   return (
     <Link
       to={`/pokemon/sets/${set.id}`}
@@ -96,17 +70,12 @@ function SetTile({ set, t }: SetTileProps) {
       data-testid={`set-tile-${set.id}`}
     >
       <div className="h-14 flex items-center justify-center">
-        {set.logo_url && !errored ? (
-          <img
-            src={set.logo_url}
-            alt=""
-            className="max-h-14 max-w-full object-contain"
-            loading="lazy"
-            onError={() => setErrored(true)}
-          />
-        ) : (
-          <span className="text-xs uppercase tracking-wide text-gray-500">{set.id}</span>
-        )}
+        <PokemonImage
+          src={set.logo_url}
+          alt=""
+          className="max-h-14 max-w-full object-contain"
+          fallback={<span className="text-xs uppercase tracking-wide text-gray-500">{set.id}</span>}
+        />
       </div>
       <div className="min-w-0">
         <p className="text-sm font-medium text-white truncate" title={set.name}>{set.name}</p>

--- a/web/src/pages/PokemonTop.tsx
+++ b/web/src/pages/PokemonTop.tsx
@@ -40,8 +40,10 @@ function filterToQuery(filter: Filter): string {
   return 'any'
 }
 
-// 0 means "upstream price missing" rather than "this card is free" — see
-// components/pokemon/format.ts for the full reasoning.
+// formatEur treats 0 as "upstream price missing" rather than "this card is
+// free", same as the shared formatNok — see components/pokemon/format.ts for
+// the full reasoning. This copy stays local because it renders "—" while
+// CardLightbox's formatEur returns null to drop the secondary price line.
 function formatEur(amount: number | null | undefined): string {
   if (amount == null || amount === 0) return '—'
   return formatNumber(amount, {

--- a/web/src/pages/PokemonTop.tsx
+++ b/web/src/pages/PokemonTop.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { ArrowLeft, Check, Trophy } from 'lucide-react'
 import { Skeleton } from '../components/ui/skeleton'
+import PokemonImage from '../components/pokemon/PokemonImage'
+import { formatNok } from '../components/pokemon/format'
 import { formatNumber } from '../utils/formatDate'
 
 interface Variant {
@@ -39,17 +41,7 @@ function filterToQuery(filter: Filter): string {
 }
 
 // 0 means "upstream price missing" rather than "this card is free" — see
-// CardLightbox.formatNok for the full reasoning.
-function formatNok(amount: number | null | undefined): string {
-  if (amount == null || amount === 0) return '—'
-  return formatNumber(amount, {
-    style: 'currency',
-    currency: 'NOK',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  })
-}
-
+// components/pokemon/format.ts for the full reasoning.
 function formatEur(amount: number | null | undefined): string {
   if (amount == null || amount === 0) return '—'
   return formatNumber(amount, {
@@ -122,12 +114,6 @@ function TopCardTile({ card, rank, onClick, t }: TileProps) {
   const variantLabel = card.top_variant_kind
     ? t(`variantKind.${card.top_variant_kind}`, { defaultValue: card.top_variant_kind })
     : ''
-  const [errored, setErrored] = useState(false)
-  const [prevUrl, setPrevUrl] = useState(card.image_small_url)
-  if (card.image_small_url !== prevUrl) {
-    setPrevUrl(card.image_small_url)
-    setErrored(false)
-  }
   return (
     <button
       type="button"
@@ -141,17 +127,12 @@ function TopCardTile({ card, rank, onClick, t }: TileProps) {
         }`}
     >
       <div className="relative aspect-[5/7] flex items-center justify-center bg-gray-900/40 rounded overflow-hidden">
-        {card.image_small_url && !errored ? (
-          <img
-            src={card.image_small_url}
-            alt=""
-            loading="lazy"
-            className="max-h-full max-w-full object-contain"
-            onError={() => setErrored(true)}
-          />
-        ) : (
-          <span className="text-xs text-gray-500">{card.collector_no}</span>
-        )}
+        <PokemonImage
+          src={card.image_small_url}
+          alt=""
+          className="max-h-full max-w-full object-contain"
+          fallback={<span className="text-xs text-gray-500">{card.collector_no}</span>}
+        />
         <span
           aria-hidden="true"
           className="absolute top-1 left-1 px-1.5 py-0.5 rounded bg-black/60 text-xs font-semibold text-amber-300"


### PR DESCRIPTION
## Changes

- **Card images in the set grid fall back to the collector number** - When a pokemontcg.io image fails to load, the set-detail grid now shows the card's collector number instead of a broken-image icon, matching the behaviour of the set list and top-cards grids. (Hytte-bij33)

## Original Issue (feature): Extract shared Pokémon formatters and a card image with error fallback

### Scope
Extract the duplicated Pokémon presentation helpers into one shared module and one shared image component under `web/src/components/pokemon/`, then replace every copy. Covers `formatNok` (5 identical copies), `formatReleaseDate` (2 near-identical copies), and the `errored`/`prevUrl` image-fallback pattern (currently in `SetTile` and `TopCardTile`), which also gets applied to `CardTile` in `PokemonSet.tsx` so the set-detail grid stops showing broken-image icons. Pure refactor plus that one behavioural fix — no visual or copy changes anywhere else.

### Files to touch
- `web/src/components/pokemon/format.ts` (new) — `formatNok`, `formatReleaseDate`, with the existing explanatory comments (zero-means-unpriced; local-components date parsing) carried over as the single canonical copy
- `web/src/components/pokemon/format.test.ts` (new) — unit tests for both helpers
- `web/src/components/pokemon/PokemonImage.tsx` (new) — `src` + fallback rendering, `onError` state, resets `errored` when `src` changes
- `web/src/pages/PokemonSet.tsx` — drop both local helpers; `CardTile` uses `PokemonImage`
- `web/src/pages/PokemonSets.tsx` — drop `formatReleaseDate`; `SetTile` uses `PokemonImage`
- `web/src/pages/PokemonTop.tsx` — drop `formatNok`; `TopCardTile` uses `PokemonImage`
- `web/src/components/pokemon/CardLightbox.tsx`, `AddCardPanel.tsx`, `ScanDetailModal.tsx` — drop local `formatNok`, import shared
- `changelog.d/` — one fragment (`Fixed`, since the grid fallback is user-visible)

### Acceptance criteria
- `grep -rn "function formatNok\|function formatReleaseDate" web/src` returns only `components/pokemon/format.ts` (plus the intentionally different `formatNok(amount, locale)` in `CollectionValueCard.tsx`, if left alone).
- A card image in the set-detail grid whose URL 404s renders the collector-number fallback text, not a broken-image icon — covered by a test in `PokemonSet.test.tsx` that fires `error` on a tile image.
- `PokemonImage` clears its error state when `src` changes: after a failed image, switching to a working URL renders the `<img>` again — covered by a component test.
- Rendered output is unchanged for the existing set/top/lightbox/panel views: prices still show `—` for `null`/`0`, release dates still localize via `formatDate` and fall back to the raw string on unparseable input.
- `npm run lint`, `npm run build`, and `npm test` all pass; no new `useState` copies of `errored`/`prevUrl` remain in `PokemonSets.tsx`, `PokemonSet.tsx`, `PokemonTop.tsx`.
- No new user-facing strings (component takes fallback content as a prop/child, so i18n stays in the callers).

### Non-goals
- `formatEur` — the copies in `PokemonTop.tsx` and `CardLightbox.tsx` have different return types (`string` vs `string | null`); leave both.
- `CollectionValueCard.formatNok` — deliberately renders `0 kr` rather than `—`; leave it or only unify behind an explicit option, not silently.
- `PokemonScanned.tsx` / `ScanPageGrid.tsx` — their `errored` flags gate on `has_image` with no URL to reset against; a different shape, out of scope.
- No changes to tile layout, ownership styling, filters, data fetching, or backend.
- No new shared "formatters" module outside `components/pokemon/` — this is not a general utils refactor.

## Source

Created from Suggestions page (suggestion id 363, page slug "pokemon", source=claude).

## Original suggestion

`formatNok` is copy-pasted across PokemonSet.tsx, PokemonTop.tsx and CardLightbox.tsx (one copy's comment literally points at another), `formatReleaseDate` is duplicated verbatim in PokemonSets.tsx and PokemonSet.tsx, and the `errored`/`prevUrl` image-fallback pattern from commit 07510f1 exists in SetTile and TopCardTile but was never applied to the card tiles in PokemonSet.tsx. Move the formatters into `web/src/components/pokemon/format.ts` and the fallback into a small `<PokemonImage>` component, then use them everywhere. Beyond removing four near-identical blocks, this fixes the set-detail grid — today's largest image grid — still rendering broken-image icons when pokemontcg.io images fail to load.


---
Bead: Hytte-bij33 | Branch: forge/Hytte-bij33
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->