### PR TITLE
Sync workout filters to the URL and restore them on return from a detail page (Hytte-c1srg)

### DIFF
--- a/changelog.d/Hytte-c1srg.md
+++ b/changelog.d/Hytte-c1srg.md
@@ -1,0 +1,3 @@
+category: Changed
+- **Training filters live in the URL** - Sport, tag and text filters are now query parameters, so `/training?sport=running&tag=long&q=intervals` is bookmarkable, survives a reload, and comes back when you navigate back to it. Typing in the search box replaces the history entry rather than pushing one, so a single Back press leaves the page instead of stepping through keystrokes. (Hytte-c1srg)
+- **Filtered workout lists restore their pages and scroll position** - The saved list snapshot is keyed by the active filters, so opening a workout from a filtered, scrolled list and pressing Back returns to exactly that view instead of resetting to page 1. Two filter combinations kept in one tab restore independently. (Hytte-c1srg)

--- a/web/src/hooks/useTrainingListCache.test.ts
+++ b/web/src/hooks/useTrainingListCache.test.ts
@@ -10,6 +10,7 @@ import {
   isReloadNavigation,
   TRAINING_LIST_CACHE_VERSION,
   TRAINING_LIST_CACHE_TTL_MS,
+  MAX_SNAPSHOTS_PER_USER,
   type TrainingListSnapshot,
 } from './useTrainingListCache'
 import type { Workout } from '../types/training'
@@ -36,17 +37,30 @@ const makeWorkout = (id: number): Workout => ({
   tags: [],
 })
 
-function primeRaw(userId: string, snapshot: Record<string, unknown> | string) {
+// A filter key is the serialized list query, so it carries the separators that
+// make key construction interesting.
+const RUNNING = 'sport=running&tag=long&q=intervals'
+
+function primeRaw(
+  userId: string,
+  snapshot: Record<string, unknown> | string,
+  filterKey = '',
+) {
   window.sessionStorage.setItem(
-    trainingListCacheKey(userId),
+    trainingListCacheKey(userId, filterKey),
     typeof snapshot === 'string' ? snapshot : JSON.stringify(snapshot),
   )
 }
 
-function validSnapshot(userId: string, overrides: Partial<TrainingListSnapshot> = {}) {
+function validSnapshot(
+  userId: string,
+  overrides: Partial<TrainingListSnapshot> = {},
+  filterKey = '',
+) {
   return {
     version: TRAINING_LIST_CACHE_VERSION,
     userId,
+    filterKey,
     savedAt: Date.now(),
     workouts: [makeWorkout(1)],
     nextCursor: 'cursor-1',
@@ -63,7 +77,7 @@ describe('useTrainingListCache', () => {
   })
 
   it('round-trips a snapshot', () => {
-    writeTrainingListCache('1', {
+    writeTrainingListCache('1', '', {
       workouts: [makeWorkout(1), makeWorkout(2)],
       nextCursor: 'cursor-2',
       latestWorkoutId: 2,
@@ -79,8 +93,8 @@ describe('useTrainingListCache', () => {
   })
 
   it('merges a partial write into the existing snapshot', () => {
-    writeTrainingListCache('1', { workouts: [makeWorkout(1)], nextCursor: 'c1', scrollY: 10 })
-    writeTrainingListCache('1', { scrollY: 900 })
+    writeTrainingListCache('1', '', { workouts: [makeWorkout(1)], nextCursor: 'c1', scrollY: 10 })
+    writeTrainingListCache('1', '', { scrollY: 900 })
 
     const snapshot = readTrainingListCache('1')
     expect(snapshot!.scrollY).toBe(900)
@@ -89,12 +103,45 @@ describe('useTrainingListCache', () => {
   })
 
   it('scopes snapshots per user', () => {
-    writeTrainingListCache('1', { workouts: [makeWorkout(1)] })
-    writeTrainingListCache('2', { workouts: [makeWorkout(7)] })
+    writeTrainingListCache('1', '', { workouts: [makeWorkout(1)] })
+    writeTrainingListCache('2', '', { workouts: [makeWorkout(7)] })
 
     expect(readTrainingListCache('1')!.workouts.map(w => w.id)).toEqual([1])
     expect(readTrainingListCache('2')!.workouts.map(w => w.id)).toEqual([7])
     expect(readTrainingListCache('3')).toBeNull()
+  })
+
+  it('round-trips a snapshot under a filter key', () => {
+    writeTrainingListCache('1', RUNNING, {
+      workouts: [makeWorkout(3)],
+      nextCursor: 'c3',
+      scrollY: 120,
+    })
+
+    const snapshot = readTrainingListCache('1', RUNNING)
+    expect(snapshot!.workouts.map(w => w.id)).toEqual([3])
+    expect(snapshot!.nextCursor).toBe('c3')
+    expect(snapshot!.scrollY).toBe(120)
+  })
+
+  it('keeps filter variants isolated from each other', () => {
+    writeTrainingListCache('1', '', { workouts: [makeWorkout(1)] })
+    writeTrainingListCache('1', 'sport=running', { workouts: [makeWorkout(2)] })
+    writeTrainingListCache('1', 'sport=cycling', { workouts: [makeWorkout(3)] })
+
+    expect(readTrainingListCache('1')!.workouts.map(w => w.id)).toEqual([1])
+    expect(readTrainingListCache('1', 'sport=running')!.workouts.map(w => w.id)).toEqual([2])
+    expect(readTrainingListCache('1', 'sport=cycling')!.workouts.map(w => w.id)).toEqual([3])
+    expect(readTrainingListCache('1', 'sport=swimming')).toBeNull()
+  })
+
+  it('does not let a user id containing the separator collide with a filter key', () => {
+    writeTrainingListCache('a:b', '', { workouts: [makeWorkout(1)] })
+    writeTrainingListCache('a', 'b', { workouts: [makeWorkout(2)] })
+
+    expect(trainingListCacheKey('a:b', '')).not.toBe(trainingListCacheKey('a', 'b'))
+    expect(readTrainingListCache('a:b')!.workouts.map(w => w.id)).toEqual([1])
+    expect(readTrainingListCache('a', 'b')!.workouts.map(w => w.id)).toEqual([2])
   })
 
   it('ignores a snapshot whose stored userId does not match the reader', () => {
@@ -104,9 +151,31 @@ describe('useTrainingListCache', () => {
     expect(window.sessionStorage.getItem(trainingListCacheKey('2'))).toBeNull()
   })
 
+  it('ignores a snapshot whose stored filterKey does not match the reader', () => {
+    primeRaw('1', validSnapshot('1', {}, 'sport=cycling'), RUNNING)
+    expect(readTrainingListCache('1', RUNNING)).toBeNull()
+    expect(window.sessionStorage.getItem(trainingListCacheKey('1', RUNNING))).toBeNull()
+  })
+
   it('ignores a snapshot written by a different cache version', () => {
     primeRaw('1', validSnapshot('1', { version: TRAINING_LIST_CACHE_VERSION + 1 }))
     expect(readTrainingListCache('1')).toBeNull()
+  })
+
+  it('never reads a snapshot left behind by the v1 key layout', () => {
+    // Exactly what the v1 build wrote: no filter segment, version 1.
+    window.sessionStorage.setItem('hytte:training-list:v1:1', JSON.stringify({
+      version: 1,
+      userId: '1',
+      savedAt: Date.now(),
+      workouts: [makeWorkout(1)],
+      nextCursor: null,
+      latestWorkoutId: 1,
+      scrollY: 42,
+    }))
+
+    expect(readTrainingListCache('1')).toBeNull()
+    expect(readTrainingListCache('1', RUNNING)).toBeNull()
   })
 
   it('ignores a snapshot older than the TTL', () => {
@@ -142,7 +211,7 @@ describe('useTrainingListCache', () => {
       throw new DOMException('quota', 'QuotaExceededError')
     })
 
-    expect(() => writeTrainingListCache('1', { workouts: [makeWorkout(1)] })).not.toThrow()
+    expect(() => writeTrainingListCache('1', '', { workouts: [makeWorkout(1)] })).not.toThrow()
     expect(setItem).toHaveBeenCalled()
     setItem.mockRestore()
     expect(readTrainingListCache('1')).toBeNull()
@@ -158,40 +227,121 @@ describe('useTrainingListCache', () => {
   })
 
   it('does nothing without a user id', () => {
-    writeTrainingListCache('', { workouts: [makeWorkout(1)] })
+    writeTrainingListCache('', '', { workouts: [makeWorkout(1)] })
     expect(window.sessionStorage.length).toBe(0)
     expect(readTrainingListCache('')).toBeNull()
   })
 
-  it('clears one user, or every user when called with no id', () => {
-    writeTrainingListCache('1', { workouts: [makeWorkout(1)] })
-    writeTrainingListCache('2', { workouts: [makeWorkout(2)] })
+  it('keeps only the newest snapshots per user once the cap is reached', () => {
+    const now = Date.now()
+    const nowSpy = vi.spyOn(Date, 'now')
+    // One write per filter, each a second newer than the last.
+    for (let i = 0; i < MAX_SNAPSHOTS_PER_USER; i++) {
+      nowSpy.mockReturnValue(now + i * 1000)
+      writeTrainingListCache('1', `sport=s${i}`, { workouts: [makeWorkout(i)] })
+    }
+    expect(readTrainingListCache('1', 'sport=s0')).not.toBeNull()
+
+    // One past the cap: the oldest entry goes, everything newer stays.
+    nowSpy.mockReturnValue(now + MAX_SNAPSHOTS_PER_USER * 1000)
+    writeTrainingListCache('1', 'sport=overflow', { workouts: [makeWorkout(99)] })
+
+    expect(readTrainingListCache('1', 'sport=s0')).toBeNull()
+    for (let i = 1; i < MAX_SNAPSHOTS_PER_USER; i++) {
+      expect(readTrainingListCache('1', `sport=s${i}`)).not.toBeNull()
+    }
+    expect(readTrainingListCache('1', 'sport=overflow')!.workouts.map(w => w.id)).toEqual([99])
+    nowSpy.mockRestore()
+  })
+
+  it('does not count another user\'s snapshots towards the cap', () => {
+    for (let i = 0; i < MAX_SNAPSHOTS_PER_USER; i++) {
+      writeTrainingListCache('2', `sport=s${i}`, { workouts: [makeWorkout(i)] })
+    }
+    writeTrainingListCache('1', '', { workouts: [makeWorkout(50)] })
+    writeTrainingListCache('1', 'sport=running', { workouts: [makeWorkout(51)] })
+
+    expect(readTrainingListCache('1')).not.toBeNull()
+    expect(readTrainingListCache('1', 'sport=running')).not.toBeNull()
+    // The other user is at its own cap, untouched by these writes.
+    for (let i = 0; i < MAX_SNAPSHOTS_PER_USER; i++) {
+      expect(readTrainingListCache('2', `sport=s${i}`)).not.toBeNull()
+    }
+  })
+
+  it('evicts an unparseable entry before a valid one', () => {
+    window.sessionStorage.setItem(trainingListCacheKey('1', 'sport=broken'), '{ not json')
+    for (let i = 0; i < MAX_SNAPSHOTS_PER_USER - 1; i++) {
+      writeTrainingListCache('1', `sport=s${i}`, { workouts: [makeWorkout(i)] })
+    }
+    writeTrainingListCache('1', 'sport=fresh', { workouts: [makeWorkout(99)] })
+
+    expect(window.sessionStorage.getItem(trainingListCacheKey('1', 'sport=broken'))).toBeNull()
+    for (let i = 0; i < MAX_SNAPSHOTS_PER_USER - 1; i++) {
+      expect(readTrainingListCache('1', `sport=s${i}`)).not.toBeNull()
+    }
+    expect(readTrainingListCache('1', 'sport=fresh')).not.toBeNull()
+  })
+
+  it('re-writing the same filter does not evict the other variants', () => {
+    for (let i = 0; i < MAX_SNAPSHOTS_PER_USER; i++) {
+      writeTrainingListCache('1', `sport=s${i}`, { workouts: [makeWorkout(i)] })
+    }
+    writeTrainingListCache('1', 'sport=s0', { scrollY: 10 })
+
+    for (let i = 0; i < MAX_SNAPSHOTS_PER_USER; i++) {
+      expect(readTrainingListCache('1', `sport=s${i}`)).not.toBeNull()
+    }
+  })
+
+  it('clears every filter variant for one user, or every user when called with no id', () => {
+    writeTrainingListCache('1', '', { workouts: [makeWorkout(1)] })
+    writeTrainingListCache('1', 'sport=running', { workouts: [makeWorkout(2)] })
+    writeTrainingListCache('1', RUNNING, { workouts: [makeWorkout(3)] })
+    writeTrainingListCache('2', '', { workouts: [makeWorkout(4)] })
+    writeTrainingListCache('2', 'sport=cycling', { workouts: [makeWorkout(5)] })
 
     clearTrainingListCache('1')
     expect(readTrainingListCache('1')).toBeNull()
+    expect(readTrainingListCache('1', 'sport=running')).toBeNull()
+    expect(readTrainingListCache('1', RUNNING)).toBeNull()
     expect(readTrainingListCache('2')).not.toBeNull()
+    expect(readTrainingListCache('2', 'sport=cycling')).not.toBeNull()
 
     clearTrainingListCache()
     expect(readTrainingListCache('2')).toBeNull()
+    expect(readTrainingListCache('2', 'sport=cycling')).toBeNull()
+  })
+
+  it('sweeps snapshots from older cache versions too', () => {
+    window.sessionStorage.setItem('hytte:training-list:v1:1', 'legacy')
+    writeTrainingListCache('1', 'sport=running', { workouts: [makeWorkout(1)] })
+
+    clearTrainingListCache()
+
+    expect(window.sessionStorage.getItem('hytte:training-list:v1:1')).toBeNull()
+    expect(readTrainingListCache('1', 'sport=running')).toBeNull()
   })
 
   it('leaves unrelated sessionStorage keys alone when sweeping', () => {
     window.sessionStorage.setItem('unrelated', 'keep me')
-    writeTrainingListCache('1', { workouts: [makeWorkout(1)] })
+    writeTrainingListCache('1', '', { workouts: [makeWorkout(1)] })
 
     clearTrainingListCache()
 
     expect(window.sessionStorage.getItem('unrelated')).toBe('keep me')
   })
 
-  it('binds the helpers to a user id through the hook', () => {
-    const { result } = renderHook(() => useTrainingListCache(1))
+  it('binds the helpers to a user id and filter key through the hook', () => {
+    const { result } = renderHook(() => useTrainingListCache(1, RUNNING))
 
     act(() => {
       result.current.write({ workouts: [makeWorkout(5)], nextCursor: 'c5', scrollY: 50 })
     })
     expect(result.current.read()!.workouts.map(w => w.id)).toEqual([5])
-    expect(readTrainingListCache('1')!.nextCursor).toBe('c5')
+    expect(readTrainingListCache('1', RUNNING)!.nextCursor).toBe('c5')
+    // The unfiltered list is a different snapshot entirely.
+    expect(readTrainingListCache('1')).toBeNull()
 
     act(() => {
       result.current.clear()
@@ -199,26 +349,48 @@ describe('useTrainingListCache', () => {
     expect(result.current.read()).toBeNull()
   })
 
-  it('returns a stable object for the same user and a new one when the user changes', () => {
-    const { result, rerender } = renderHook(({ id }: { id: number }) => useTrainingListCache(id), {
-      initialProps: { id: 1 },
+  it('clears all of the user\'s filter variants through the hook', () => {
+    writeTrainingListCache('1', '', { workouts: [makeWorkout(1)] })
+    writeTrainingListCache('1', 'sport=cycling', { workouts: [makeWorkout(2)] })
+    const { result } = renderHook(() => useTrainingListCache(1, 'sport=running'))
+    act(() => {
+      result.current.write({ workouts: [makeWorkout(3)] })
     })
+
+    act(() => {
+      result.current.clear()
+    })
+
+    expect(readTrainingListCache('1')).toBeNull()
+    expect(readTrainingListCache('1', 'sport=cycling')).toBeNull()
+    expect(readTrainingListCache('1', 'sport=running')).toBeNull()
+  })
+
+  it('returns a stable object for the same user and filter, and a new one when either changes', () => {
+    const { result, rerender } = renderHook(
+      ({ id, filter }: { id: number; filter: string }) => useTrainingListCache(id, filter),
+      { initialProps: { id: 1, filter: '' } },
+    )
     const first = result.current
-    rerender({ id: 1 })
+    rerender({ id: 1, filter: '' })
     expect(result.current).toBe(first)
 
-    rerender({ id: 2 })
+    rerender({ id: 1, filter: 'sport=running' })
     expect(result.current).not.toBe(first)
+    const filtered = result.current
+
+    rerender({ id: 2, filter: 'sport=running' })
+    expect(result.current).not.toBe(filtered)
 
     act(() => {
       result.current.write({ workouts: [makeWorkout(9)] })
     })
-    expect(readTrainingListCache('2')!.workouts.map(w => w.id)).toEqual([9])
-    expect(readTrainingListCache('1')).toBeNull()
+    expect(readTrainingListCache('2', 'sport=running')!.workouts.map(w => w.id)).toEqual([9])
+    expect(readTrainingListCache('1', 'sport=running')).toBeNull()
   })
 
   it('is a no-op for a null user', () => {
-    const { result } = renderHook(() => useTrainingListCache(null))
+    const { result } = renderHook(() => useTrainingListCache(null, 'sport=running'))
     act(() => {
       result.current.write({ workouts: [makeWorkout(1)] })
     })

--- a/web/src/hooks/useTrainingListCache.ts
+++ b/web/src/hooks/useTrainingListCache.ts
@@ -1,12 +1,16 @@
 import { useMemo } from 'react'
 import type { Workout } from '../types/training'
 
-// Snapshot of the paginated training list, kept per user and per tab so that
-// navigating into a workout detail and back restores the pages the user already
-// paged in instead of resetting to page 1.
+// Snapshot of the paginated training list, kept per user, per active filter and
+// per tab so that navigating into a workout detail and back restores the pages
+// the user already paged in instead of resetting to page 1. The filter key is
+// the serialized list query (`sport=running&tag=long&q=intervals`), which is
+// also what the URL carries, so a filtered list restores exactly like the
+// unfiltered one.
 export interface TrainingListSnapshot {
   version: number
   userId: string
+  filterKey: string
   savedAt: number
   workouts: Workout[]
   nextCursor: string | null
@@ -16,17 +20,32 @@ export interface TrainingListSnapshot {
 
 // Bumping the version retires every snapshot written by an older build: it is
 // part of the key (old entries are never read again) and is re-checked on read.
-export const TRAINING_LIST_CACHE_VERSION = 1
+// v2 added the per-filter key segment.
+export const TRAINING_LIST_CACHE_VERSION = 2
 
 // A snapshot older than this is discarded, so a tab left open for hours does not
 // present a stale list as if it were fresh. Every write refreshes the timestamp,
 // so the TTL measures idle time rather than session length.
 export const TRAINING_LIST_CACHE_TTL_MS = 5 * 60 * 1000
 
-const KEY_PREFIX = 'hytte:training-list:'
+// Filters are now part of the key, so one user can accumulate a snapshot per
+// filter combination they try. Cap how many are kept and evict the oldest, so a
+// session of filter-fiddling cannot fill sessionStorage with lists nobody will
+// come back to.
+export const MAX_SNAPSHOTS_PER_USER = 4
 
-export function trainingListCacheKey(userId: string): string {
-  return `${KEY_PREFIX}v${TRAINING_LIST_CACHE_VERSION}:${userId}`
+const KEY_PREFIX = 'hytte:training-list:'
+const VERSION_PREFIX = `${KEY_PREFIX}v${TRAINING_LIST_CACHE_VERSION}:`
+
+// Both segments are percent-encoded: a filter key is a query string full of `&`
+// and `=`, and encoding it (along with the user id) keeps `:` exclusively a
+// separator, so no combination of values can be read as a different key.
+function userKeyPrefix(userId: string): string {
+  return `${VERSION_PREFIX}${encodeURIComponent(userId)}:`
+}
+
+export function trainingListCacheKey(userId: string, filterKey = ''): string {
+  return `${userKeyPrefix(userId)}${encodeURIComponent(filterKey)}`
 }
 
 // getStorage returns sessionStorage, or null when it is unavailable — private
@@ -50,12 +69,34 @@ function removeKey(storage: Storage, key: string) {
   }
 }
 
-function isSnapshot(value: unknown, userId: string): value is TrainingListSnapshot {
+// keysWithPrefix lists the stored keys under a prefix. Enumeration itself can
+// throw on a hostile storage, in which case whatever was collected so far is
+// returned — the callers only ever remove keys, so a short list just means a
+// smaller sweep.
+function keysWithPrefix(storage: Storage, prefix: string): string[] {
+  const keys: string[] = []
+  try {
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i)
+      if (key && key.startsWith(prefix)) keys.push(key)
+    }
+  } catch {
+    // Fall through with what we have.
+  }
+  return keys
+}
+
+function isSnapshot(
+  value: unknown,
+  userId: string,
+  filterKey: string,
+): value is TrainingListSnapshot {
   if (!value || typeof value !== 'object') return false
   const s = value as Partial<TrainingListSnapshot>
   return (
     s.version === TRAINING_LIST_CACHE_VERSION &&
     s.userId === userId &&
+    s.filterKey === filterKey &&
     typeof s.savedAt === 'number' &&
     Array.isArray(s.workouts) &&
     (s.nextCursor === null || typeof s.nextCursor === 'string') &&
@@ -65,15 +106,19 @@ function isSnapshot(value: unknown, userId: string): value is TrainingListSnapsh
 }
 
 /**
- * readTrainingListCache returns the snapshot for a user, or null when there is
- * none, it belongs to another user or cache version, it is older than the TTL,
- * or the stored payload is unusable. Anything unusable is dropped on the way out
- * so a corrupt entry cannot keep failing every future read.
+ * readTrainingListCache returns the snapshot for a user and filter, or null when
+ * there is none, it belongs to another user, filter or cache version, it is
+ * older than the TTL, or the stored payload is unusable. Anything unusable is
+ * dropped on the way out so a corrupt entry cannot keep failing every future
+ * read.
  */
-export function readTrainingListCache(userId: string): TrainingListSnapshot | null {
+export function readTrainingListCache(
+  userId: string,
+  filterKey = '',
+): TrainingListSnapshot | null {
   const storage = getStorage()
   if (!storage || !userId) return null
-  const key = trainingListCacheKey(userId)
+  const key = trainingListCacheKey(userId, filterKey)
   let raw: string | null
   try {
     raw = storage.getItem(key)
@@ -83,7 +128,7 @@ export function readTrainingListCache(userId: string): TrainingListSnapshot | nu
   if (!raw) return null
   try {
     const parsed: unknown = JSON.parse(raw)
-    if (!isSnapshot(parsed, userId)) {
+    if (!isSnapshot(parsed, userId, filterKey)) {
       removeKey(storage, key)
       return null
     }
@@ -105,18 +150,55 @@ export type TrainingListSnapshotPatch = Partial<
   Pick<TrainingListSnapshot, 'workouts' | 'nextCursor' | 'latestWorkoutId' | 'scrollY'>
 >
 
+// savedAtOf reads just the timestamp off a stored entry, for ranking evictions.
+// An entry that cannot be parsed counts as infinitely old, so corrupt leftovers
+// are the first thing the cap throws away.
+function savedAtOf(storage: Storage, key: string): number {
+  try {
+    const raw = storage.getItem(key)
+    if (!raw) return Number.NEGATIVE_INFINITY
+    const parsed = JSON.parse(raw) as Partial<TrainingListSnapshot> | null
+    const savedAt = parsed?.savedAt
+    return typeof savedAt === 'number' ? savedAt : Number.NEGATIVE_INFINITY
+  } catch {
+    return Number.NEGATIVE_INFINITY
+  }
+}
+
+// evictOverCap makes room for the entry about to be written at `currentKey` by
+// dropping this user's least recently written snapshots until the cap would hold
+// with the new entry included. `currentKey` is excluded from the ranking whether
+// or not it already exists, since it always survives.
+function evictOverCap(storage: Storage, userId: string, currentKey: string): void {
+  const others = keysWithPrefix(storage, userKeyPrefix(userId)).filter(k => k !== currentKey)
+  const allowed = MAX_SNAPSHOTS_PER_USER - 1
+  if (others.length <= allowed) return
+  const ranked = others
+    .map(key => ({ key, savedAt: savedAtOf(storage, key) }))
+    // Not a subtraction: -Infinity - -Infinity is NaN, which would leave the
+    // corrupt entries in an arbitrary place in the order.
+    .sort((a, b) => (a.savedAt === b.savedAt ? 0 : a.savedAt < b.savedAt ? -1 : 1))
+  for (let i = 0; i < others.length - allowed; i++) removeKey(storage, ranked[i].key)
+}
+
 /**
- * writeTrainingListCache merges a patch into the stored snapshot, so the list
- * and the scroll offset can be persisted independently. Quota and serialization
- * failures are swallowed: the cache is an optimization, never a requirement.
+ * writeTrainingListCache merges a patch into the stored snapshot for a user and
+ * filter, so the list and the scroll offset can be persisted independently.
+ * Quota and serialization failures are swallowed: the cache is an optimization,
+ * never a requirement.
  */
-export function writeTrainingListCache(userId: string, patch: TrainingListSnapshotPatch): void {
+export function writeTrainingListCache(
+  userId: string,
+  filterKey: string,
+  patch: TrainingListSnapshotPatch,
+): void {
   const storage = getStorage()
   if (!storage || !userId) return
-  const current = readTrainingListCache(userId)
+  const current = readTrainingListCache(userId, filterKey)
   const next: TrainingListSnapshot = {
     version: TRAINING_LIST_CACHE_VERSION,
     userId,
+    filterKey,
     savedAt: Date.now(),
     workouts: patch.workouts ?? current?.workouts ?? [],
     nextCursor: patch.nextCursor !== undefined ? patch.nextCursor : current?.nextCursor ?? null,
@@ -124,7 +206,8 @@ export function writeTrainingListCache(userId: string, patch: TrainingListSnapsh
       patch.latestWorkoutId !== undefined ? patch.latestWorkoutId : current?.latestWorkoutId ?? null,
     scrollY: patch.scrollY ?? current?.scrollY ?? 0,
   }
-  const key = trainingListCacheKey(userId)
+  const key = trainingListCacheKey(userId, filterKey)
+  evictOverCap(storage, userId, key)
   try {
     storage.setItem(key, JSON.stringify(next))
   } catch {
@@ -135,28 +218,17 @@ export function writeTrainingListCache(userId: string, patch: TrainingListSnapsh
 }
 
 /**
- * clearTrainingListCache removes one user's snapshot, or — with no argument —
- * every training-list snapshot in the tab. The sweep is what logout uses, so
- * signing in as a different user in the same tab can never surface the previous
- * user's workouts.
+ * clearTrainingListCache removes every snapshot one user has across all their
+ * filter combinations, or — with no argument — every training-list snapshot in
+ * the tab, including ones left behind by older cache versions. The sweep is what
+ * logout uses, so signing in as a different user in the same tab can never
+ * surface the previous user's workouts.
  */
 export function clearTrainingListCache(userId?: string): void {
   const storage = getStorage()
   if (!storage) return
-  if (userId) {
-    removeKey(storage, trainingListCacheKey(userId))
-    return
-  }
-  try {
-    const keys: string[] = []
-    for (let i = 0; i < storage.length; i++) {
-      const key = storage.key(i)
-      if (key && key.startsWith(KEY_PREFIX)) keys.push(key)
-    }
-    for (const key of keys) removeKey(storage, key)
-  } catch {
-    // Storage unavailable — nothing was written either, so nothing to clear.
-  }
+  const prefix = userId ? userKeyPrefix(userId) : KEY_PREFIX
+  for (const key of keysWithPrefix(storage, prefix)) removeKey(storage, key)
 }
 
 /**
@@ -181,18 +253,23 @@ export interface TrainingListCache {
 }
 
 /**
- * useTrainingListCache binds the snapshot helpers to a user id. The returned
- * object is referentially stable for a given user, so it is safe to use as an
- * effect dependency.
+ * useTrainingListCache binds the snapshot helpers to a user id and a filter key.
+ * The returned object is referentially stable for a given pair, so it is safe to
+ * use as an effect dependency — and it changes identity when the filters change,
+ * which is exactly when the page must look at a different snapshot. `clear()`
+ * drops all of the user's snapshots, not just the current filter's.
  */
-export function useTrainingListCache(userId: string | number | null | undefined): TrainingListCache {
+export function useTrainingListCache(
+  userId: string | number | null | undefined,
+  filterKey = '',
+): TrainingListCache {
   const key = userId === null || userId === undefined ? '' : String(userId)
   return useMemo(
     () => ({
-      read: () => readTrainingListCache(key),
-      write: (patch: TrainingListSnapshotPatch) => writeTrainingListCache(key, patch),
+      read: () => readTrainingListCache(key, filterKey),
+      write: (patch: TrainingListSnapshotPatch) => writeTrainingListCache(key, filterKey, patch),
       clear: () => clearTrainingListCache(key),
     }),
-    [key],
+    [key, filterKey],
   )
 }

--- a/web/src/pages/Training.test.tsx
+++ b/web/src/pages/Training.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter, useLocation, useNavigate } from 'react-router'
 import Training from './Training'
 import type { Workout } from '../types/training'
 import {
@@ -210,12 +210,38 @@ function lastListRequest() {
   return new URL(all[all.length - 1], 'http://localhost')
 }
 
-function renderTraining() {
+// The filters live in the URL now, so the tests need to see where the router
+// actually is — and to be able to press Back.
+function LocationProbe() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  return (
+    <>
+      <span data-testid="location">{location.pathname + location.search}</span>
+      <button type="button" data-testid="history-back" onClick={() => navigate(-1)}>
+        history back
+      </button>
+    </>
+  )
+}
+
+function renderTraining(entries: string | string[] = '/training') {
+  const initialEntries = Array.isArray(entries) ? entries : [entries]
   return render(
-    <MemoryRouter initialEntries={['/training']}>
+    <MemoryRouter initialEntries={initialEntries}>
       <Training />
+      <LocationProbe />
     </MemoryRouter>,
   )
+}
+
+function currentLocation(): string {
+  return screen.getByTestId('location').textContent ?? ''
+}
+
+function currentParams(): URLSearchParams {
+  const [, search = ''] = currentLocation().split('?')
+  return new URLSearchParams(search)
 }
 
 function stubEventSource() {
@@ -410,6 +436,162 @@ describe('Training filter bar', () => {
   })
 })
 
+describe('Training filters in the URL', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    window.sessionStorage.clear()
+    requests = []
+    stubEventSource()
+    vi.stubGlobal('fetch', mockFetch(WORKOUTS))
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('hydrates the filter bar and the first request from the query string', async () => {
+    renderTraining('/training?sport=running&tag=easy&q=morning')
+
+    expect(await screen.findByText('Morning Run')).toBeInTheDocument()
+    expect((screen.getByLabelText('Filter by sport') as HTMLSelectElement).value).toBe('running')
+    expect(screen.getByRole('button', { name: 'easy' })).toHaveAttribute('aria-pressed', 'true')
+    expect((screen.getByPlaceholderText(/search by title/i) as HTMLInputElement).value).toBe('morning')
+
+    const req = lastListRequest()
+    expect(req.searchParams.get('sport')).toBe('running')
+    expect(req.searchParams.getAll('tag')).toEqual(['easy'])
+    expect(req.searchParams.get('q')).toBe('morning')
+    expect(screen.queryByText('Easy Spin')).not.toBeInTheDocument()
+    expect(screen.queryByText('Hill Intervals')).not.toBeInTheDocument()
+  })
+
+  it('does not refetch because the search box was seeded from the URL', async () => {
+    renderTraining('/training?q=morning')
+    await screen.findByText('Morning Run')
+
+    await new Promise(resolve => setTimeout(resolve, SEARCH_DEBOUNCE_MS + 100))
+    expect(listRequests().length).toBe(1)
+    expect(currentParams().get('q')).toBe('morning')
+  })
+
+  it('pushes the sport filter into the URL, so Back undoes it', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+    expect(currentLocation()).toBe('/training')
+
+    fireEvent.change(screen.getByLabelText('Filter by sport'), { target: { value: 'cycling' } })
+    expect(currentParams().get('sport')).toBe('cycling')
+    expect(await screen.findByText('Easy Spin')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('history-back'))
+    await waitFor(() => {
+      expect(currentLocation()).toBe('/training')
+    })
+    expect((screen.getByLabelText('Filter by sport') as HTMLSelectElement).value).toBe('')
+    expect(await screen.findByText('Morning Run')).toBeInTheDocument()
+  })
+
+  it('writes tag selections to the URL and removes them when toggled off', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    fireEvent.click(screen.getByRole('button', { name: 'easy' }))
+    expect(currentParams().getAll('tag')).toEqual(['easy'])
+
+    fireEvent.click(screen.getByRole('button', { name: 'ai:recovery' }))
+    expect(currentParams().getAll('tag')).toEqual(['easy', 'ai:recovery'])
+
+    fireEvent.click(screen.getByRole('button', { name: 'easy' }))
+    expect(currentParams().getAll('tag')).toEqual(['ai:recovery'])
+  })
+
+  it('leaves a bare /training when every filter is cleared', async () => {
+    renderTraining('/training?sport=running&tag=easy&q=morning')
+    await screen.findByText('Morning Run')
+
+    const clearBtn = screen.getAllByRole('button').find(b => b.textContent?.includes('Clear filters'))
+    expect(clearBtn).toBeTruthy()
+    fireEvent.click(clearBtn!)
+
+    await waitFor(() => {
+      expect(currentLocation()).toBe('/training')
+    })
+    expect((screen.getByPlaceholderText(/search by title/i) as HTMLInputElement).value).toBe('')
+    for (const w of WORKOUTS) {
+      expect(await screen.findByText(w.title)).toBeInTheDocument()
+    }
+  })
+
+  it('commits typing to the URL only after the debounce', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    const input = screen.getByPlaceholderText(/search by title/i)
+    fireEvent.change(input, { target: { value: 'p' } })
+    fireEvent.change(input, { target: { value: 'po' } })
+    fireEvent.change(input, { target: { value: 'pool' } })
+    // Still inside the debounce window — no keystroke has reached the URL.
+    expect(currentLocation()).toBe('/training')
+
+    await waitFor(() => {
+      expect(currentParams().get('q')).toBe('pool')
+    })
+  })
+
+  it('replaces the history entry for the debounced search, so one Back leaves the page', async () => {
+    renderTraining(['/training/9', '/training'])
+    await screen.findByText('Morning Run')
+
+    fireEvent.change(screen.getByPlaceholderText(/search by title/i), { target: { value: 'pool' } })
+    await waitFor(() => {
+      expect(currentParams().get('q')).toBe('pool')
+    })
+    expect(await screen.findByText('Pool Laps')).toBeInTheDocument()
+
+    // One press leaves for wherever the user came from rather than stepping
+    // back through "poo", "po", "p".
+    fireEvent.click(screen.getByTestId('history-back'))
+    await waitFor(() => {
+      expect(currentLocation()).toBe('/training/9')
+    })
+  })
+
+  it('syncs the search box back when the URL changes from outside', async () => {
+    renderTraining()
+    await screen.findByText('Morning Run')
+
+    fireEvent.change(screen.getByPlaceholderText(/search by title/i), { target: { value: 'pool' } })
+    await waitFor(() => {
+      expect(currentParams().get('q')).toBe('pool')
+    })
+    fireEvent.change(screen.getByLabelText('Filter by sport'), { target: { value: 'swimming' } })
+    await waitFor(() => {
+      expect(currentParams().get('sport')).toBe('swimming')
+    })
+
+    fireEvent.click(screen.getByTestId('history-back'))
+    await waitFor(() => {
+      expect(currentParams().get('sport')).toBeNull()
+    })
+    expect(currentParams().get('q')).toBe('pool')
+    expect((screen.getByPlaceholderText(/search by title/i) as HTMLInputElement).value).toBe('pool')
+  })
+
+  it('hydrates a tag chip as pressed and refetches when it is toggled off', async () => {
+    renderTraining('/training?tag=easy')
+    await screen.findByText('Morning Run')
+
+    expect(screen.getByRole('button', { name: 'easy' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.queryByText('Hill Intervals')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'easy' }))
+    await waitFor(() => {
+      expect(currentLocation()).toBe('/training')
+    })
+    expect(await screen.findByText('Hill Intervals')).toBeInTheDocument()
+  })
+})
+
 describe('Training filtered pagination', () => {
   // 30 runs and 30 rides, interleaved: a filtered page can only be assembled by
   // the backend, and paging must walk matches rather than raw history.
@@ -582,10 +764,11 @@ describe('Training list cache', () => {
   const CACHED = HISTORY.slice(0, 50)
   const CACHED_CURSOR = String(CACHED[CACHED.length - 1].id)
 
-  function primeCache(overrides: Record<string, unknown> = {}, userId = '1') {
-    window.sessionStorage.setItem(trainingListCacheKey(userId), JSON.stringify({
+  function primeCache(overrides: Record<string, unknown> = {}, userId = '1', filterKey = '') {
+    window.sessionStorage.setItem(trainingListCacheKey(userId, filterKey), JSON.stringify({
       version: TRAINING_LIST_CACHE_VERSION,
       userId,
+      filterKey,
       savedAt: Date.now(),
       workouts: CACHED,
       nextCursor: CACHED_CURSOR,
@@ -774,18 +957,118 @@ describe('Training list cache', () => {
     expect(snapshot!.scrollY).toBe(512)
   })
 
-  it('drops the snapshot while a filter is active, since filters are not restored', async () => {
+  it('restores a filtered list from the snapshot for that filter', () => {
+    primeCache({}, '1', 'sport=running')
+    const { container } = renderTraining('/training?sport=running')
+
+    // No await: the restored rows must be there before any request resolves.
+    expect(screen.getByText('History 0')).toBeInTheDocument()
+    expect(screen.getByText('History 49')).toBeInTheDocument()
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('restores the scroll offset of a filtered list', () => {
+    primeCache({ scrollY: 640 }, '1', 'sport=running')
+    renderTraining('/training?sport=running')
+
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 640, behavior: 'auto' })
+  })
+
+  it('never restores the unfiltered snapshot into a filtered view', async () => {
     primeCache()
-    renderTraining()
+    renderTraining('/training?sport=running')
+
+    // Only page 1 of the filtered request — the unfiltered snapshot's deeper
+    // pages belong to a different key and must not leak in.
+    expect(await screen.findByText('History 0')).toBeInTheDocument()
+    expect(screen.queryByText('History 49')).not.toBeInTheDocument()
+  })
+
+  it('does a fresh load after a reload navigation even under a filter', async () => {
+    vi.spyOn(performance, 'getEntriesByType').mockReturnValue([
+      { type: 'reload' } as unknown as PerformanceEntry,
+    ])
+    primeCache({}, '1', 'sport=running')
+    renderTraining('/training?sport=running')
 
     expect(await screen.findByText('History 0')).toBeInTheDocument()
-    fireEvent.change(screen.getByLabelText('Filter by sport'), { target: { value: 'cycling' } })
-
-    await waitFor(() => {
-      expect(readTrainingListCache('1')).toBeNull()
-    })
-    // A filtered load replaces the restored list rather than merging into it.
     expect(screen.queryByText('History 49')).not.toBeInTheDocument()
+  })
+
+  it('persists a filtered list under its own key, leaving the unfiltered one alone', async () => {
+    const { unmount } = renderTraining('/training?sport=running')
+    await screen.findByText('History 0')
+
+    fireEvent.click(await screen.findByRole('button', { name: /load more/i }))
+    expect(await screen.findByText('History 30')).toBeInTheDocument()
+
+    Object.defineProperty(window, 'scrollY', { value: 256, configurable: true })
+    unmount()
+
+    const snapshot = readTrainingListCache('1', 'sport=running')
+    expect(snapshot).not.toBeNull()
+    expect(snapshot!.workouts.length).toBe(50)
+    expect(snapshot!.scrollY).toBe(256)
+    // The unfiltered list was never loaded in this tab, so it has no snapshot.
+    expect(readTrainingListCache('1')).toBeNull()
+  })
+
+  it('restores the previous filter\'s pages when the user switches back to it', async () => {
+    renderTraining()
+    await screen.findByText('History 0')
+
+    // Two pages of the unfiltered list are loaded and snapshotted.
+    fireEvent.click(await screen.findByRole('button', { name: /load more/i }))
+    expect(await screen.findByText('History 30')).toBeInTheDocument()
+
+    // Narrow to a query with its own, much shorter result set.
+    fireEvent.change(screen.getByPlaceholderText(/search by title/i), {
+      target: { value: 'History 5' },
+    })
+    await waitFor(() => {
+      expect(lastListRequest().searchParams.get('q')).toBe('History 5')
+    })
+    await waitFor(() => {
+      expect(screen.queryByText('History 30')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('History 55')).toBeInTheDocument()
+
+    // Clearing goes back to the unfiltered snapshot, pages and all.
+    const clearBtn = screen.getAllByRole('button').find(b => b.textContent?.includes('Clear filters'))
+    expect(clearBtn).toBeTruthy()
+    fireEvent.click(clearBtn!)
+
+    expect(await screen.findByText('History 30')).toBeInTheDocument()
+    expect(screen.getByText('History 49')).toBeInTheDocument()
+    // Each filter kept its own entry.
+    expect(readTrainingListCache('1', 'q=History+5')).not.toBeNull()
+    expect(readTrainingListCache('1')!.workouts.length).toBe(50)
+
+    // The snapshot's cursor came back too, so paging on continues past the
+    // restored pages instead of re-serving them.
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }))
+    expect(await screen.findByText('History 59')).toBeInTheDocument()
+    expect(screen.getByText('History 49')).toBeInTheDocument()
+  })
+
+  it('does not write the previous filter\'s rows under the new filter key', async () => {
+    renderTraining()
+    await screen.findByText('History 0')
+    fireEvent.click(await screen.findByRole('button', { name: /load more/i }))
+    expect(await screen.findByText('History 30')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText(/search by title/i), {
+      target: { value: 'History 5' },
+    })
+    await waitFor(() => {
+      expect(screen.queryByText('History 30')).not.toBeInTheDocument()
+    })
+
+    // 11 titles contain "History 5" (5 and 50..59) — the filtered snapshot must
+    // hold those, not the 50 rows that were on screen when the filter changed.
+    const filtered = readTrainingListCache('1', 'q=History+5')
+    expect(filtered).not.toBeNull()
+    expect(filtered!.workouts.length).toBe(11)
   })
 
   it('falls back to a fresh load when sessionStorage throws', async () => {

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo } from 'react'
-import { Link } from 'react-router'
+import { Link, useSearchParams } from 'react-router'
 import { Dumbbell, Upload, TrendingUp, BarChart3, RefreshCw, X, Database } from 'lucide-react'
 import { useAuth } from '../auth'
 import { useTranslation } from 'react-i18next'
@@ -96,13 +96,39 @@ const sportIcons: Record<string, string> = {
 export default function Training() {
   const { user } = useAuth()
   const { t } = useTranslation(['training', 'common'])
-  const listCache = useTrainingListCache(user?.id)
+
+  // Filter state lives in the URL, so /training?sport=running&tag=long&q=intervals
+  // is bookmarkable, survives a reload, and comes back intact when the browser
+  // navigates back to it. These are request parameters, not a client-side
+  // narrowing of the loaded pages: changing any of them refetches page 1 from
+  // the backend so matches are drawn from the whole workout history.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const sportFilter = searchParams.get('sport') ?? ''
+  const query = searchParams.get('q') ?? ''
+  const selectedTags = useMemo(() => searchParams.getAll('tag'), [searchParams])
+
+  // Serialized filter params: the query string every workout-list request
+  // carries, and the per-filter suffix of the list snapshot key. Built from the
+  // individual values rather than taken from searchParams.toString() so the
+  // order is canonical however the params arrived, which keeps one filter
+  // combination on one cache key. Kept as a string so it can be a stable effect
+  // dependency despite selectedTags being a new array on each toggle.
+  const filterParams = useMemo(() => {
+    const params = new URLSearchParams()
+    if (sportFilter) params.set('sport', sportFilter)
+    for (const tag of selectedTags) params.append('tag', tag)
+    const q = query.trim()
+    if (q) params.set('q', q)
+    return params.toString()
+  }, [sportFilter, selectedTags, query])
+
+  const listCache = useTrainingListCache(user?.id, filterParams)
 
   // Snapshot of the list as it was when the user last left this page in this
-  // tab, read once before the first paint so a return from a workout detail
-  // renders the already-loaded pages immediately. A reload (F5) deliberately
-  // skips it: sessionStorage survives F5, but asking for the page again means
-  // asking for fresh data.
+  // tab under these filters, read once before the first paint so a return from a
+  // workout detail renders the already-loaded pages immediately. A reload (F5)
+  // deliberately skips it: sessionStorage survives F5, but asking for the page
+  // again means asking for fresh data.
   const [hydrated] = useState(() => {
     if (isReloadNavigation()) return null
     const snapshot = listCache.read()
@@ -139,20 +165,30 @@ export default function Training() {
   }, [workouts])
 
   // Armed while the restored list is still authoritative. The first page-1 load
-  // after a hydrated mount is a background refresh that merges into the restored
-  // pages; any filter change or explicit refresh disarms it, because those own
-  // the list outright and must replace it.
+  // after a hydrated mount — or after a filter change that restored that
+  // filter's snapshot — is a background refresh that merges into the restored
+  // pages; a filter change with nothing cached, or an explicit refresh, disarms
+  // it because those own the list outright and must replace it.
   const mergeArmedRef = useRef(hydrated !== null)
 
-  // Filter state. These are request parameters, not a client-side narrowing of
-  // the loaded pages: changing any of them refetches page 1 from the backend so
-  // matches are drawn from the whole workout history.
-  const [sportFilter, setSportFilter] = useState('')
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
-  // queryInput is what the user sees; query is its debounced counterpart and is
-  // the value that actually reaches the request.
-  const [queryInput, setQueryInput] = useState('')
-  const [query, setQuery] = useState('')
+  // The filter and refresh generation the last page-1 effect run started a load
+  // for, used to tell a filter change from a re-run for some other reason.
+  const requestedFilterRef = useRef(filterParams)
+  const requestedRefreshTickRef = useRef(0)
+  // The filter the rows currently on screen were loaded for. Guards the snapshot
+  // write, so the render between a filter change and its page 1 landing cannot
+  // store the previous filter's rows under the new key.
+  const loadedFilterRef = useRef(filterParams)
+
+  // queryInput is what the user sees; the URL's ?q is its debounced counterpart
+  // and is the value that actually reaches the request.
+  const [queryInput, setQueryInput] = useState(query)
+
+  // The last ?q this page wrote itself. The sync-back effect uses it to tell an
+  // outside change — Back/forward, a pasted link — which must overwrite the
+  // input, from the echo of our own debounced commit, which must not (it would
+  // eat a trailing space the user is still typing past).
+  const committedQueryRef = useRef(query)
 
   // Generation counter for page-1 loads (mount, filter change, refresh). Only
   // those bump it; "load more" captures the current value and drops its response
@@ -160,27 +196,60 @@ export default function Training() {
   // filter therefore can never overwrite — or append to — a newer one's results.
   const listRequestIdRef = useRef(0)
 
+  // setFilters rewrites the whole filter query string, omitting empty values so
+  // clearing every filter leaves a bare /training. Sport and tag changes push a
+  // history entry; the debounced search commits with replace, so one Back press
+  // leaves the page instead of stepping back through keystrokes.
+  const setFilters = useCallback(
+    (next: { sport?: string; tags?: string[]; q?: string }, opts?: { replace?: boolean }) => {
+      const params = new URLSearchParams()
+      const sport = next.sport ?? sportFilter
+      const tags = next.tags ?? selectedTags
+      const q = (next.q ?? query).trim()
+      if (sport) params.set('sport', sport)
+      for (const tag of tags) params.append('tag', tag)
+      if (q) params.set('q', q)
+      setSearchParams(params, { replace: opts?.replace ?? false })
+    },
+    [sportFilter, selectedTags, query, setSearchParams],
+  )
+
   useEffect(() => {
-    // Nothing to debounce while the committed query already matches the input,
-    // so mount (and the settle after each commit) schedules no timer at all —
+    // Nothing to debounce while the URL already carries what the box holds, so
+    // mount (and the settle after each commit) schedules no timer at all —
     // page 1 is fetched once, not once more 300 ms later.
-    if (queryInput === query) return
-    const timer = setTimeout(() => setQuery(queryInput), SEARCH_DEBOUNCE_MS)
+    const trimmed = queryInput.trim()
+    if (trimmed === query) return
+    const timer = setTimeout(() => {
+      committedQueryRef.current = trimmed
+      setFilters({ q: trimmed }, { replace: true })
+    }, SEARCH_DEBOUNCE_MS)
     return () => clearTimeout(timer)
-  }, [queryInput, query])
+  }, [queryInput, query, setFilters])
+
+  // Adopt a ?q that came from outside this page (Back/forward, a shared link)
+  // into the search box.
+  useEffect(() => {
+    if (query === committedQueryRef.current) return
+    committedQueryRef.current = query
+    setQueryInput(query)
+  }, [query])
+
+  const setSportFilter = useCallback((sport: string) => { setFilters({ sport }) }, [setFilters])
 
   const toggleTag = useCallback((tag: string) => {
-    setSelectedTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
-    )
-  }, [])
+    setFilters({
+      tags: selectedTags.includes(tag)
+        ? selectedTags.filter((selected) => selected !== tag)
+        : [...selectedTags, tag],
+    })
+  }, [selectedTags, setFilters])
 
   const clearFilters = useCallback(() => {
-    setSportFilter('')
-    setSelectedTags([])
+    committedQueryRef.current = ''
     setQueryInput('')
-    setQuery('')
-  }, [])
+    setFilters({ sport: '', tags: [], q: '' })
+  }, [setFilters])
 
   const filtersActive = sportFilter !== '' || selectedTags.length > 0 || query.trim() !== ''
 
@@ -200,18 +269,6 @@ export default function Training() {
     return [...tags].sort((a, b) => a.localeCompare(b))
   }, [availableTags, selectedTags, workouts])
 
-  // Serialized filter params shared by every workout-list request. Kept as a
-  // string so it can be a stable effect dependency despite selectedTags being
-  // a new array on each toggle.
-  const filterParams = useMemo(() => {
-    const params = new URLSearchParams()
-    if (sportFilter) params.set('sport', sportFilter)
-    for (const tag of selectedTags) params.append('tag', tag)
-    const q = query.trim()
-    if (q) params.set('q', q)
-    return params.toString()
-  }, [sportFilter, selectedTags, query])
-
   const workoutsUrl = useCallback(
     (cursor: string | null) => {
       let url = `/api/training/workouts?limit=${PAGE_SIZE}`
@@ -230,26 +287,61 @@ export default function Training() {
     const requestId = ++listRequestIdRef.current
     let cancelled = false
     const isCurrent = () => !cancelled && requestId === listRequestIdRef.current
-    // Merge only while the restored list is untouched by a filter or a refresh.
-    // The check itself disarms: once a filter has been applied, later loads
-    // replace even after the filters are cleared again. A merge-armed load still
-    // replaces when the page comes back detached from the restored rows.
-    const merge = mergeArmedRef.current && filterParams === '' && refreshTick === 0
-    if (!merge) mergeArmedRef.current = false
+
+    const filterChanged = requestedFilterRef.current !== filterParams
+    requestedFilterRef.current = filterParams
+    const refreshed = refreshTick !== requestedRefreshTickRef.current
+    requestedRefreshTickRef.current = refreshTick
+
+    // Switching filters looks for the snapshot belonging to the filters being
+    // switched *to*, and page 1 folds into it exactly the way it folds into the
+    // rows a hydrated mount restored — so the pages and the cursor the user had
+    // under that filter come back rather than a bare page 1. The snapshot is
+    // applied when the response lands rather than up front, so the previous
+    // filter's rows are replaced once instead of flickering through a stale
+    // intermediate list.
+    const cached = filterChanged && !refreshed && !isReloadNavigation() ? listCache.read() : null
+    const restored = cached && cached.workouts.length > 0 ? cached : null
+    // Merge only while the list page 1 would fold into belongs to these exact
+    // filters: the restored snapshot above, or — when nothing about the request
+    // changed — the rows already on screen. A filter change with nothing cached,
+    // or an explicit refresh (which owns the list outright), replaces instead. A
+    // merge-armed load still replaces when the page comes back detached from the
+    // rows it would fold into.
+    const merge = restored !== null || (mergeArmedRef.current && !filterChanged && !refreshed)
+    mergeArmedRef.current = merge
     ;(async () => {
       // Drop the previous filter's cursor up front: it points into a different
       // result set, so "Load more" must not stay clickable with it while page 1
       // of the new filter is in flight. A background refresh keeps its cursor —
       // the restored pages it points past are still on screen.
-      if (!merge) setNextCursor(null)
+      if (restored !== null || !merge) setNextCursor(null)
+
+      // showRestored puts the snapshot on screen when the request for the newly
+      // selected filters does not come back. It is that filter's own last-seen
+      // list, which beats both an empty page and the previous filter's rows.
+      const showRestored = () => {
+        if (!restored) return
+        setWorkouts(restored.workouts)
+        setNextCursor(restored.nextCursor)
+        setHasAnyWorkouts(true)
+        loadedFilterRef.current = filterParams
+      }
+
       try {
         const res = await fetch(workoutsUrl(null), { credentials: 'include' })
         if (!isCurrent()) return
         if (!res.ok) {
-          // A failed background refresh leaves the restored list alone: it is
-          // the last thing the user actually saw, and dropping it would be a
-          // worse answer than showing it alongside the error.
-          if (!merge) setWorkouts([])
+          // A failed background refresh leaves the list on screen alone, and a
+          // failed switch falls back to that filter's snapshot: both are the
+          // last thing the user actually saw under these filters, and dropping
+          // them would be a worse answer than showing them with the error.
+          if (restored) {
+            showRestored()
+          } else if (!merge) {
+            setWorkouts([])
+            loadedFilterRef.current = filterParams
+          }
           setError(t('errors.failedToLoadWorkouts'))
           return
         }
@@ -257,8 +349,17 @@ export default function Training() {
         if (!isCurrent()) return
         const list: Workout[] = data.workouts || []
         const exhausted = (data.next_cursor ?? null) === null
-        if (merge && !firstPageDetached(workoutsRef.current, list, exhausted)) {
-          setWorkouts(prev => mergeFirstPage(prev, list, exhausted))
+        const base = restored ? restored.workouts : workoutsRef.current
+        loadedFilterRef.current = filterParams
+        if (merge && !firstPageDetached(base, list, exhausted)) {
+          if (restored) {
+            // The snapshot's cursor comes back with it: it points past the pages
+            // being restored, which is where "Load more" must continue from.
+            setWorkouts(mergeFirstPage(restored.workouts, list, exhausted))
+            setNextCursor(restored.nextCursor)
+          } else {
+            setWorkouts(prev => mergeFirstPage(prev, list, exhausted))
+          }
           setHasAnyWorkouts(list.length > 0 || filtersActive)
         } else {
           setWorkouts(list)
@@ -266,13 +367,16 @@ export default function Training() {
           setHasAnyWorkouts(list.length > 0 || filtersActive)
         }
       } catch {
-        if (isCurrent()) setError(t('errors.failedToLoadWorkouts'))
+        if (isCurrent()) {
+          showRestored()
+          setError(t('errors.failedToLoadWorkouts'))
+        }
       } finally {
         if (isCurrent()) setLoading(false)
       }
     })()
     return () => { cancelled = true }
-  }, [user, refreshTick, workoutsUrl, filterParams, filtersActive, t])
+  }, [user, refreshTick, workoutsUrl, filterParams, filtersActive, listCache, t])
 
   // Filter-independent page data: weekly summaries, the tag chip source, and
   // the new-workout baseline. The baseline comes from the cheap /latest
@@ -316,16 +420,14 @@ export default function Training() {
   }, [user, refreshTick, t])
 
   // Persist the loaded pages so leaving for a workout detail and coming back
-  // restores them. Only the unfiltered list is cached — filter state is not
-  // restored, so a snapshot taken under a filter would come back as a silently
-  // narrowed history. While a filter is active the snapshot is dropped instead,
-  // which just means the next mount does a normal fresh load.
+  // restores them. The snapshot is keyed by the active filters, which the URL
+  // now carries, so a filtered list comes back as the same filtered view rather
+  // than as a silently narrowed history. The loadedFilterRef guard covers the
+  // renders between a filter change and its page 1 landing, when `workouts`
+  // still holds the previous filter's rows.
   useEffect(() => {
     if (!user) return
-    if (filterParams !== '') {
-      listCache.clear()
-      return
-    }
+    if (loadedFilterRef.current !== filterParams) return
     if (loading || workouts.length === 0) return
     listCache.write({
       workouts,


### PR DESCRIPTION
## Changes

- **Training filters live in the URL** - Sport, tag and text filters are now query parameters, so `/training?sport=running&tag=long&q=intervals` is bookmarkable, survives a reload, and comes back when you navigate back to it. Typing in the search box replaces the history entry rather than pushing one, so a single Back press leaves the page instead of stepping through keystrokes. (Hytte-c1srg)
- **Filtered workout lists restore their pages and scroll position** - The saved list snapshot is keyed by the active filters, so opening a workout from a filtered, scrolled list and pressing Back returns to exactly that view instead of resetting to page 1. Two filter combinations kept in one tab restore independently. (Hytte-c1srg)

## Original Issue (feature): Sync workout filters to the URL and restore them on return from a detail page

### Scope
Move the Training list's sport, tag, and text filters out of `useState` and into the URL query string (`useSearchParams`), and re-key the sessionStorage list snapshot by the serialized filter params so a filtered list restores its pages and scroll offset the same way the unfiltered list already does. No backend or API changes — `filterParams` is already the exact request query string, so it doubles as the URL state and the cache key suffix.

### Files to touch
- `web/src/pages/Training.tsx` — read/write the three filters via `useSearchParams`; derive `filterParams` from the URL; drop the `filterParams !== ''` guard that clears the snapshot; seed `queryInput` from `?q`.
- `web/src/hooks/useTrainingListCache.ts` — add a filter-key segment to `trainingListCacheKey`, bump `TRAINING_LIST_CACHE_VERSION` to 2, make `useTrainingListCache(userId, filterKey)` bind both, make per-user `clear()` sweep every filter variant, and evict oldest entries past a small per-user cap.
- `web/src/hooks/useTrainingListCache.test.ts` — cases for filter-keyed reads/writes, isolation between filter keys, per-user sweep, cap eviction.
- `web/src/pages/Training.test.tsx` — cases for URL→filter hydration, filter→URL writes, replace-vs-push history, and restore under an active filter.
- `changelog.d/<bead-id>.md` (new) — `category: Changed` fragment.

### Acceptance criteria
- Loading `/training?sport=running&tag=long&q=intervals` renders with the sport select, the `long` tag chip, and the search box already populated, and the list request carries those params.
- Changing the sport select or toggling a tag updates the URL immediately; clearing filters removes the params (`/training` with no query).
- Typing in the search box updates the URL only after the existing debounce and uses `replace`, so one Back press from `/training?q=intervals` leaves the page rather than replaying keystrokes.
- Scrolling a filtered list, opening a workout, and pressing Back restores the same loaded pages and scroll position — no reset to page 1.
- Two different filter combinations kept in one tab restore independently; neither returns the other's workouts.
- Switching filters, then returning to the previous filter within the TTL, restores that filter's snapshot.
- Logout still clears every training snapshot in the tab, across all filter keys and users.
- A reload (`isReloadNavigation()`) still bypasses restore and does a fresh load, filtered or not.
- Snapshots written by the v1 build are never read; existing TTL and quota fallbacks are unchanged.
- `npm run lint`, `npm run build`, and the web test suite pass.

### Non-goals
- No changes to `/api/training` handlers, query params, or pagination.
- No URL state for TrainingTrends, TrainingCompare, or TrainingDetail.
- No new filter dimensions (date range, distance, etc.) and no redesign of `WorkoutFilterBar`.
- No move from sessionStorage to another persistence layer, and no change to the TTL or scroll-debounce constants.
- No server-side persistence of filters as a user preference.

## Source

Created from Suggestions page (suggestion id 350, page slug "training", source=claude).

## Original suggestion

Sport, tag, and text filters live only in component state, so a reload, a shared link, or the browser back button from /training/123 all drop them; useTrainingListCache deliberately refuses to snapshot a filtered list, which means a filtered view also loses its loaded pages and scroll position on return. Move the three filters into useSearchParams so /training?sport=running&tag=long&q=intervals is bookmarkable and survives reload, and key the session snapshot by the serialized filter params so a filtered list restores like the unfiltered one does. Debounced search should replace rather than push history entries, so back still exits the page rather than stepping through keystrokes. The user-visible win is that narrowing to a sport or tag, opening a workout, and pressing back returns exactly where they left off.


---
Bead: Hytte-c1srg | Branch: forge/Hytte-c1srg
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->