### PR TITLE
Extract the location resolution and persistence state machine into hooks (Hytte-c1x77)

### DIFF
--- a/changelog.d/Hytte-c1x77.md
+++ b/changelog.d/Hytte-c1x77.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Weather page split into hooks and components** - The location resolution and persistence state machine, the forecast fetch/auto-refresh loop and the sun-times fetch now live in `useWeatherLocation`, `useForecast` and `useSunTimes`, with the page reduced to layout. Behaviour is unchanged; the auth-timing logic is now unit-tested and reusable by the dashboard widgets. (Hytte-c1x77)

--- a/web/src/components/weather/CurrentConditionsCard.tsx
+++ b/web/src/components/weather/CurrentConditionsCard.tsx
@@ -1,0 +1,169 @@
+import { useTranslation } from 'react-i18next'
+import { ArrowUp, Droplets, Sunrise, Sunset, Thermometer, Wind } from 'lucide-react'
+import type { TimeseriesEntry } from '../../lib/weatherForecast'
+import type { SunTimes } from '../../hooks/useSunTimes'
+import { getWeatherDescription, getWeatherIcon } from '../../weatherUtils'
+import { formatTime } from '../../utils/formatDate'
+
+/** Split a daylight duration in seconds into whole hours and minutes. */
+function splitDaylight(seconds: number): { hours: number; minutes: number } {
+  const totalMinutes = Math.max(0, Math.round(seconds / 60))
+  return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60 }
+}
+
+/**
+ * Calculate feels-like temperature.
+ * Uses wind chill when temp ≤ 10°C and wind ≥ 1.3 m/s (Environment Canada formula),
+ * or heat index when temp ≥ 27°C and humidity ≥ 40% (Rothfusz regression).
+ * Returns null when actual temperature already represents perceived comfort.
+ */
+function calculateFeelsLike(temp: number, windSpeed: number, humidity: number): number | null {
+  if (temp <= 10 && windSpeed >= 1.3) {
+    const v = windSpeed * 3.6 // m/s to km/h
+    const wc = 13.12 + 0.6215 * temp - 11.37 * Math.pow(v, 0.16) + 0.3965 * temp * Math.pow(v, 0.16)
+    const rounded = Math.round(wc)
+    return rounded !== Math.round(temp) ? rounded : null
+  }
+  if (temp >= 27 && humidity >= 40) {
+    // Rothfusz regression (Fahrenheit), then convert back
+    const tf = temp * 9 / 5 + 32
+    const hi =
+      -42.379 + 2.04901523 * tf + 10.14333127 * humidity
+      - 0.22475541 * tf * humidity - 0.00683783 * tf * tf
+      - 0.05481717 * humidity * humidity + 0.00122874 * tf * tf * humidity
+      + 0.00085282 * tf * humidity * humidity - 0.00000199 * tf * tf * humidity * humidity
+    const rounded = Math.round((hi - 32) * 5 / 9)
+    return rounded !== Math.round(temp) ? rounded : null
+  }
+  return null
+}
+
+/**
+ * Wind direction arrow rotation in degrees (CSS clockwise).
+ * wind_from_direction = 180 (from south) → arrow points north (0°).
+ */
+function windArrowRotation(windFromDirection: number): number {
+  return (windFromDirection + 180) % 360
+}
+
+interface CurrentConditionsCardProps {
+  current: TimeseriesEntry
+  /** Symbol code for the current hour, already resolved with a fallback. */
+  symbolCode: string
+  locationName?: string
+  sun: SunTimes | null
+  /** Pre-formatted "Updated X min ago" text, or empty when nothing has loaded. */
+  timeAgo: string
+}
+
+export default function CurrentConditionsCard({
+  current,
+  symbolCode,
+  locationName,
+  sun,
+  timeAgo,
+}: CurrentConditionsCardProps) {
+  const { t } = useTranslation('weather')
+  const details = current.data.instant.details
+  const feelsLike = calculateFeelsLike(
+    details.air_temperature,
+    details.wind_speed,
+    details.relative_humidity,
+  )
+
+  return (
+    <section className="bg-gray-800 rounded-xl p-6 mb-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm text-gray-400 mb-1">{t('page.rightNowIn', { location: locationName })}</p>
+          <div className="flex items-end gap-3">
+            <span className="text-5xl font-bold">{Math.round(details.air_temperature)}°</span>
+            {feelsLike !== null && (
+              <span className="text-sm text-gray-400 mb-2">
+                {t('page.feelsLike', { temp: feelsLike })}
+              </span>
+            )}
+            <span className="text-lg text-gray-300 mb-1">
+              {getWeatherDescription(symbolCode, t)}
+            </span>
+          </div>
+          {sun && (
+            <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-300">
+              {sun.polarDay ? (
+                <span className="flex items-center gap-1.5">
+                  <Sunrise size={16} className="text-amber-400 shrink-0" />
+                  {t('sun.polarDay')}
+                </span>
+              ) : sun.polarNight ? (
+                <span className="flex items-center gap-1.5">
+                  <Sunset size={16} className="text-indigo-400 shrink-0" />
+                  {t('sun.polarNight')}
+                </span>
+              ) : sun.sunrise && sun.sunset ? (
+                <>
+                  <span
+                    className="flex items-center gap-1.5"
+                    aria-label={`${t('sun.sunrise')} ${formatTime(sun.sunrise, { hour: '2-digit', minute: '2-digit' })}`}
+                  >
+                    <Sunrise size={16} className="text-amber-400 shrink-0" />
+                    {formatTime(sun.sunrise, { hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                  <span
+                    className="flex items-center gap-1.5"
+                    aria-label={`${t('sun.sunset')} ${formatTime(sun.sunset, { hour: '2-digit', minute: '2-digit' })}`}
+                  >
+                    <Sunset size={16} className="text-orange-400 shrink-0" />
+                    {formatTime(sun.sunset, { hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                  <span className="text-gray-400">
+                    {t('sun.daylight', splitDaylight(sun.daylightSeconds))}
+                  </span>
+                </>
+              ) : null}
+            </div>
+          )}
+        </div>
+        <div className="text-blue-400">{getWeatherIcon(symbolCode, 56)}</div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mt-6 pt-4 border-t border-gray-700">
+        <div className="flex items-center gap-2">
+          <Wind size={16} className="text-gray-400" />
+          <div>
+            <p className="text-xs text-gray-400">{t('page.wind')}</p>
+            <p className="text-sm font-medium flex items-center gap-1">
+              {details.wind_speed} m/s
+              {details.wind_from_direction !== undefined && (
+                <ArrowUp
+                  size={14}
+                  className="text-gray-400 shrink-0"
+                  style={{ transform: `rotate(${windArrowRotation(details.wind_from_direction)}deg)` }}
+                  aria-label={t('page.windFromDirectionAria', { degrees: Math.round(details.wind_from_direction) })}
+                />
+              )}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Droplets size={16} className="text-gray-400" />
+          <div>
+            <p className="text-xs text-gray-400">{t('page.humidity')}</p>
+            <p className="text-sm font-medium">{Math.round(details.relative_humidity)}%</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Thermometer size={16} className="text-gray-400" />
+          <div>
+            <p className="text-xs text-gray-400">{t('page.pressure')}</p>
+            <p className="text-sm font-medium">
+              {details.air_pressure_at_sea_level
+                ? `${Math.round(details.air_pressure_at_sea_level)} hPa`
+                : '—'}
+            </p>
+          </div>
+        </div>
+      </div>
+      {timeAgo && <p className="text-xs text-gray-500 mt-4">{timeAgo}</p>}
+    </section>
+  )
+}

--- a/web/src/components/weather/DailyForecastList.tsx
+++ b/web/src/components/weather/DailyForecastList.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next'
+import { Droplets, Wind } from 'lucide-react'
+import type { DayForecast } from '../../lib/weatherForecast'
+import { getWeatherIcon } from '../../weatherUtils'
+
+/** Seven-day outlook, one row per day. */
+export default function DailyForecastList({ days }: { days: DayForecast[] }) {
+  const { t } = useTranslation('weather')
+
+  return (
+    <section className="bg-gray-800 rounded-xl p-6">
+      <h2 className="text-lg font-semibold mb-4">{t('page.sevenDayForecast')}</h2>
+      <div className="space-y-3">
+        {days.map((day) => (
+          <div
+            key={day.date}
+            className="flex items-center justify-between bg-gray-700/50 rounded-lg px-4 py-3"
+          >
+            <div className="flex items-center gap-3 w-24">
+              <span className="text-sm font-medium">{day.dayName}</span>
+            </div>
+            <div className="flex items-center gap-2 text-blue-400">
+              {getWeatherIcon(day.symbolCode, 20)}
+            </div>
+            <div className="flex items-center gap-1 w-16 justify-end">
+              <Droplets size={12} className="text-blue-400" />
+              <span className="text-xs text-gray-400">{day.precipitation} mm</span>
+            </div>
+            <div className="flex items-center gap-1 w-16 justify-end">
+              <Wind size={12} className="text-gray-400" />
+              <span className="text-xs text-gray-400">{day.windSpeed} m/s</span>
+            </div>
+            <div className="flex items-center gap-2 w-20 justify-end">
+              <span className="text-sm text-gray-400">{day.tempMin}°</span>
+              <span className="text-sm font-medium">{day.tempMax}°</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/weather/HourlyStrip.tsx
+++ b/web/src/components/weather/HourlyStrip.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { TimeseriesEntry } from '../../lib/weatherForecast'
+import { getWeatherIcon } from '../../weatherUtils'
+import { formatDate, formatTime } from '../../utils/formatDate'
+
+type HourlyRange = 12 | 24 | 48
+
+const RANGES: HourlyRange[] = [12, 24, 48]
+
+/** Horizontally scrolling hour-by-hour preview with a 12/24/48-hour range toggle. */
+export default function HourlyStrip({ timeseries }: { timeseries: TimeseriesEntry[] }) {
+  const { t } = useTranslation('weather')
+  const [hourlyRange, setHourlyRange] = useState<HourlyRange>(12)
+
+  return (
+    <section className="bg-gray-800 rounded-xl p-6 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold">{t('page.nextHours', { count: hourlyRange })}</h2>
+        <div className="flex rounded-lg overflow-hidden border border-gray-600 text-xs">
+          {RANGES.map((range) => (
+            <button
+              key={range}
+              onClick={() => setHourlyRange(range)}
+              className={`px-3 py-1 transition-colors ${
+                hourlyRange === range
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              }`}
+              aria-label={t('page.showNextHours', { count: range })}
+              aria-pressed={hourlyRange === range}
+            >
+              {range}h
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex gap-4 overflow-x-auto pb-2">
+        {timeseries.slice(0, hourlyRange).map((entry, index) => {
+          const dt = new Date(entry.time)
+          const hour = formatTime(dt, { hour: 'numeric', hour12: false })
+          const sym =
+            entry.data.next_1_hours?.summary.symbol_code ||
+            entry.data.next_6_hours?.summary.symbol_code ||
+            'cloudy'
+          // Show date separator when crossing midnight (hour 0) after the first entry
+          const showDateSep = index > 0 && dt.getHours() === 0
+          const dateLabel = formatDate(dt, { weekday: 'short', month: 'short', day: 'numeric' })
+          return (
+            <div key={entry.time} className="flex items-start gap-4">
+              {showDateSep && (
+                <div className="flex flex-col items-center self-stretch">
+                  <div className="w-px bg-gray-600 flex-1" />
+                  <span className="text-xs text-gray-400 whitespace-nowrap rotate-0 py-1 px-1 bg-gray-700 rounded text-center leading-tight">
+                    {dateLabel}
+                  </span>
+                  <div className="w-px bg-gray-600 flex-1" />
+                </div>
+              )}
+              <div className="flex flex-col items-center gap-1 min-w-[3.5rem]">
+                <span className="text-xs text-gray-400">{hour}</span>
+                <span className="text-blue-400">{getWeatherIcon(sym, 20)}</span>
+                <span className="text-sm font-medium">
+                  {Math.round(entry.data.instant.details.air_temperature)}°
+                </span>
+                {entry.data.next_1_hours?.details.precipitation_amount ? (
+                  <span className="text-xs text-blue-400">
+                    {entry.data.next_1_hours.details.precipitation_amount} mm
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/web/src/hooks/useForecast.test.ts
+++ b/web/src/hooks/useForecast.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
-import { useForecast, clearForecastCache } from './useForecast'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useForecast, clearForecastCache, AUTO_REFRESH_MS } from './useForecast'
 
 const mockLocation = { lat: 59.91, lon: 10.75, name: 'Oslo' }
+const BERGEN = { name: 'Bergen', lat: 60.39, lon: 5.32 }
 
 vi.mock('../usePreferredLocation', () => ({
   usePreferredLocation: () => mockLocation,
@@ -25,8 +26,19 @@ const fakeForecast = {
 
 beforeEach(() => {
   clearForecastCache()
+  localStorage.clear()
   vi.restoreAllMocks()
 })
+
+afterEach(() => {
+  vi.useRealTimers()
+  Reflect.deleteProperty(document, 'hidden')
+})
+
+/** Override `document.hidden` for visibility-driven behaviour. */
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+}
 
 describe('useForecast', () => {
   it('fetches forecast and returns data on success', async () => {
@@ -111,5 +123,164 @@ describe('useForecast', () => {
     await waitFor(() => expect(b.current.loading).toBe(false))
     expect(a.current.data).toEqual(fakeForecast)
     expect(b.current.data).toEqual(fakeForecast)
+  })
+})
+
+describe('useForecast with an explicit location', () => {
+  it('fetches the given location instead of the preferred one', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeForecast),
+    } as Response)
+
+    const { result } = renderHook(() => useForecast(BERGEN))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/weather/forecast?lat=60.39&lon=5.32&location=Bergen',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+    expect(result.current.lastUpdated).toBeInstanceOf(Date)
+  })
+
+  it('does not fetch while the location is unresolved', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeForecast),
+    } as Response)
+
+    const { result } = renderHook(() => useForecast(null))
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('does not fetch until enabled', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeForecast),
+    } as Response)
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useForecast(BERGEN, { enabled }),
+      { initialProps: { enabled: false } },
+    )
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    rerender({ enabled: true })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes an error message alongside the error flag', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    const { result } = renderHook(() => useForecast(BERGEN))
+
+    await waitFor(() => expect(result.current.error).toBe(true))
+    expect(result.current.errorMessage).toBe('Failed to fetch forecast')
+  })
+
+  it('refetches on refresh(), bypassing the cache', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeForecast),
+    } as Response)
+
+    const { result } = renderHook(() => useForecast(BERGEN))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    act(() => result.current.refresh())
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2))
+  })
+
+  it('seeds from the persisted cache and revalidates', async () => {
+    localStorage.setItem(
+      'weather:forecastCache:anon',
+      JSON.stringify([{ key: '60.39,5.32', response: fakeForecast, lastUpdated: 1_700_000_000_000 }]),
+    )
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeForecast),
+    } as Response)
+
+    const { result } = renderHook(() => useForecast(BERGEN, { persist: true }))
+
+    // Cached numbers render immediately; a fresh request is still in flight.
+    expect(result.current.data).toEqual(fakeForecast)
+    expect(result.current.loading).toBe(true)
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useForecast auto-refresh', () => {
+  it('refreshes on an interval, pauses while hidden, and resumes on re-show', async () => {
+    setHidden(false)
+    vi.useFakeTimers()
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeForecast),
+    } as Response)
+
+    renderHook(() => useForecast(BERGEN, { autoRefresh: true }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    // The 10-minute interval fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTO_REFRESH_MS)
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+
+    // Hiding the tab stops the interval entirely.
+    setHidden(true)
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+      await vi.advanceTimersByTimeAsync(AUTO_REFRESH_MS * 3)
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+
+    // Re-showing refreshes immediately and restarts the interval.
+    setHidden(false)
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTO_REFRESH_MS)
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not start the interval when the tab is hidden on mount', async () => {
+    setHidden(true)
+    vi.useFakeTimers()
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeForecast),
+    } as Response)
+
+    renderHook(() => useForecast(BERGEN, { autoRefresh: true }))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(AUTO_REFRESH_MS * 2)
+    })
+    // Only the initial load — no interval ticks while hidden.
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/hooks/useForecast.test.ts
+++ b/web/src/hooks/useForecast.test.ts
@@ -202,6 +202,78 @@ describe('useForecast with an explicit location', () => {
     await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2))
   })
 
+  it('deduplicates a persisted and an in-memory caller on the same location', async () => {
+    let resolveFetch!: (v: Response) => void
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockReturnValue(
+      new Promise((r) => { resolveFetch = r }),
+    )
+
+    const { result: page } = renderHook(() => useForecast(BERGEN, { persist: true }))
+    const { result: widget } = renderHook(() => useForecast(BERGEN))
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    resolveFetch({ ok: true, json: () => Promise.resolve(fakeForecast) } as Response)
+
+    await waitFor(() => expect(page.current.loading).toBe(false))
+    await waitFor(() => expect(widget.current.loading).toBe(false))
+    expect(page.current.data).toEqual(fakeForecast)
+    expect(widget.current.data).toEqual(fakeForecast)
+  })
+
+  it('unmounting one caller does not fail a shared request', async () => {
+    let resolveFetch!: (v: Response) => void
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(
+      new Promise((r) => { resolveFetch = r }),
+    )
+
+    const first = renderHook(() => useForecast(BERGEN, { persist: true }))
+    const { result: second } = renderHook(() => useForecast(BERGEN))
+    first.unmount()
+
+    resolveFetch({ ok: true, json: () => Promise.resolve(fakeForecast) } as Response)
+
+    await waitFor(() => expect(second.current.loading).toBe(false))
+    expect(second.current.data).toEqual(fakeForecast)
+    expect(second.current.error).toBe(false)
+  })
+
+  it('refetches over the network on refresh() when persisting', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeForecast),
+    } as Response)
+
+    const { result } = renderHook(() => useForecast(BERGEN, { persist: true }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    // The persisted cache written by the first fetch must not satisfy the refresh.
+    act(() => result.current.refresh())
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.data).toEqual(fakeForecast)
+  })
+
+  it('keeps the displayed forecast when a background refresh fails', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeForecast),
+    } as Response)
+
+    const { result } = renderHook(() => useForecast(BERGEN, { persist: true }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const firstLoad = result.current.lastUpdated
+
+    fetchSpy.mockRejectedValue(new Error('network'))
+    act(() => result.current.refresh())
+
+    await waitFor(() => expect(result.current.error).toBe(true))
+    // Non-blocking: the previous forecast and its timestamp stay on screen.
+    expect(result.current.data).toEqual(fakeForecast)
+    expect(result.current.lastUpdated).toEqual(firstLoad)
+    expect(result.current.loading).toBe(false)
+  })
+
   it('seeds from the persisted cache and revalidates', async () => {
     localStorage.setItem(
       'weather:forecastCache:anon',

--- a/web/src/hooks/useForecast.ts
+++ b/web/src/hooks/useForecast.ts
@@ -1,35 +1,62 @@
-import { useEffect, useReducer, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react'
 import { usePreferredLocation } from '../usePreferredLocation'
+import type { RecentLocation } from '../recentLocations'
+import type { TimeseriesEntry } from '../lib/weatherForecast'
+import { readForecastCache, writeForecastCache } from '../lib/weatherCache'
 
-export interface TimeseriesEntry {
-  time: string
-  data: {
-    instant: {
-      details: {
-        air_temperature: number
-      }
-    }
-    next_1_hours?: { summary: { symbol_code: string } }
-    next_6_hours?: { summary: { symbol_code: string } }
-  }
-}
+export type { TimeseriesEntry }
 
 export interface ForecastResponse {
   properties: { timeseries: TimeseriesEntry[] }
 }
 
-type State = { loading: boolean; error: boolean; data: ForecastResponse | null }
-type Action = { type: 'start' } | { type: 'done'; data: ForecastResponse } | { type: 'error' }
+/** Auto-refresh cadence for long-lived weather surfaces. */
+export const AUTO_REFRESH_MS = 10 * 60 * 1000 // 10 minutes
+
+export interface ForecastState {
+  loading: boolean
+  /** True when the most recent request failed. */
+  error: boolean
+  /** Message from the most recent failure, for surfaces that render the reason. */
+  errorMessage: string | null
+  data: ForecastResponse | null
+  /** When `data` was fetched (or cached), or null when nothing has loaded. */
+  lastUpdated: Date | null
+  /** Force a fresh fetch, bypassing any cached response. */
+  refresh: () => void
+}
+
+type State = Omit<ForecastState, 'refresh'>
+type Action =
+  | { type: 'start' }
+  | { type: 'done'; data: ForecastResponse; at: Date }
+  | { type: 'error'; message: string }
+  // Show a cached response while a fresh one loads (stale-while-revalidate).
+  | { type: 'seed'; data: ForecastResponse; at: Date }
+  // Clear displayed data so skeletons show (location with no cached forecast).
+  | { type: 'reset' }
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
-    case 'start': return { loading: true, error: false, data: state.data }
-    case 'done': return { loading: false, error: false, data: action.data }
-    case 'error': return { loading: false, error: true, data: state.data }
+    case 'start':
+      return { ...state, loading: true, error: false, errorMessage: null }
+    case 'done':
+      return { loading: false, error: false, errorMessage: null, data: action.data, lastUpdated: action.at }
+    case 'error':
+      return { ...state, loading: false, error: true, errorMessage: action.message }
+    case 'seed':
+      return { loading: true, error: false, errorMessage: null, data: action.data, lastUpdated: action.at }
+    case 'reset':
+      return { loading: true, error: false, errorMessage: null, data: null, lastUpdated: null }
   }
 }
 
-const cache = new Map<string, ForecastResponse>()
+interface CacheEntry {
+  data: ForecastResponse
+  at: Date
+}
+
+const cache = new Map<string, CacheEntry>()
 const inflight = new Map<string, Promise<ForecastResponse>>()
 
 export function cacheKey(lat: number, lon: number, name: string) {
@@ -41,52 +68,200 @@ export function clearForecastCache() {
   inflight.clear()
 }
 
-export function useForecast(): State {
-  const location = usePreferredLocation()
-  const key = cacheKey(location.lat, location.lon, location.name)
-  const [state, dispatch] = useReducer(reducer, {
-    loading: !cache.has(key),
-    error: false,
-    data: cache.get(key) ?? null,
-  })
+export interface UseForecastOptions {
+  /**
+   * Seed from and write to the per-user localStorage forecast cache instead of the
+   * in-memory one, and always revalidate on mount. Suits a full page that must show
+   * fresh data; the default in-memory cache suits short-lived widgets.
+   */
+  persist?: boolean
+  /** User id scoping the persisted cache. Undefined uses the anonymous namespace. */
+  userId?: number
+  /** Refresh every {@link AUTO_REFRESH_MS}, pausing while the tab is hidden. */
+  autoRefresh?: boolean
+  /** Hold off fetching until the caller knows the location is final. */
+  enabled?: boolean
+}
+
+function initState(
+  { location, persist, userId }: { location: RecentLocation | null; persist: boolean; userId?: number },
+): State {
+  const empty: State = { loading: true, error: false, errorMessage: null, data: null, lastUpdated: null }
+  if (!location) return empty
+
+  if (persist) {
+    // Seed from the per-location cache so a revisit renders real numbers on first
+    // paint (no skeleton flash) while a fresh forecast loads in the background.
+    const cached = readForecastCache<ForecastResponse>(location.lat, location.lon, userId)
+    if (!cached) return empty
+    return { ...empty, data: cached.response, lastUpdated: new Date(cached.lastUpdated) }
+  }
+
+  const cached = cache.get(cacheKey(location.lat, location.lon, location.name))
+  if (!cached) return empty
+  return { loading: false, error: false, errorMessage: null, data: cached.data, lastUpdated: cached.at }
+}
+
+function forecastUrl(location: RecentLocation): string {
+  return `/api/weather/forecast?lat=${location.lat}&lon=${location.lon}&location=${encodeURIComponent(location.name)}`
+}
+
+/**
+ * Fetch the forecast for a location.
+ *
+ * Called with no arguments it resolves the location from {@link usePreferredLocation}
+ * and reads through a shared in-memory cache, which is what the compact Today
+ * widgets want. Pass an explicit location (or `null` while one is still being
+ * resolved) plus options to opt into localStorage-backed stale-while-revalidate
+ * and periodic auto-refresh.
+ */
+export function useForecast(
+  location?: RecentLocation | null,
+  options: UseForecastOptions = {},
+): ForecastState {
+  const { persist = false, userId, autoRefresh = false, enabled = true } = options
+  // Whether the caller supplies its own location is fixed per call site, so gating
+  // the preferred-location lookup on it never changes hook order.
+  const usePreferred = location === undefined
+  const preferred = usePreferredLocation(usePreferred)
+  const active = usePreferred ? preferred : location
+
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [state, dispatch] = useReducer(reducer, { location: active, persist, userId }, initState)
   const mountedRef = useRef(true)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const lat = active?.lat
+  const lon = active?.lon
+  const name = active?.name
+  const key = active ? cacheKey(active.lat, active.lon, active.name) : null
 
   useEffect(() => {
     mountedRef.current = true
-    return () => { mountedRef.current = false }
+    return () => {
+      mountedRef.current = false
+    }
   }, [])
 
+  const stopInterval = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  // Held in a ref so the auto-refresh effect never has to restart just because
+  // `refresh` was re-created (which happens whenever the location changes).
+  const refreshRef = useRef<() => void>(() => {})
+
+  const startInterval = useCallback(() => {
+    stopInterval()
+    timerRef.current = setInterval(() => refreshRef.current(), AUTO_REFRESH_MS)
+  }, [stopInterval])
+
+  const refresh = useCallback(() => {
+    if (!persist && key) {
+      cache.delete(key)
+      inflight.delete(key)
+    }
+    setRefreshKey((k) => k + 1)
+    // Restart the countdown so a manual refresh gets a full interval rather than
+    // whatever remained of the previous one.
+    if (timerRef.current !== null) startInterval()
+  }, [persist, key, startInterval])
+
   useEffect(() => {
-    const cached = cache.get(key)
+    refreshRef.current = refresh
+  }, [refresh])
+
+  // Re-seed displayed data when the active location changes: show that location's
+  // cached forecast instantly, or clear to skeletons when it was never viewed.
+  // useLayoutEffect runs before paint, preventing a brief flash of the previous
+  // location's forecast under the newly selected location name.
+  useLayoutEffect(() => {
+    if (!persist || lat === undefined || lon === undefined) return
+    const cached = readForecastCache<ForecastResponse>(lat, lon, userId)
     if (cached) {
-      dispatch({ type: 'done', data: cached })
-      return
+      dispatch({ type: 'seed', data: cached.response, at: new Date(cached.lastUpdated) })
+    } else {
+      dispatch({ type: 'reset' })
+    }
+  }, [persist, lat, lon, userId])
+
+  useEffect(() => {
+    if (!enabled || key === null || lat === undefined || lon === undefined || name === undefined) return
+
+    if (!persist) {
+      const cached = cache.get(key)
+      if (cached) {
+        dispatch({ type: 'done', data: cached.data, at: cached.at })
+        return
+      }
     }
 
     const controller = new AbortController()
     dispatch({ type: 'start' })
 
-    let promise = inflight.get(key)
+    let promise = persist ? undefined : inflight.get(key)
     if (!promise) {
-      promise = fetch(
-        `/api/weather/forecast?lat=${location.lat}&lon=${location.lon}&location=${encodeURIComponent(location.name)}`,
-        { signal: controller.signal, credentials: 'include' },
-      ).then((r) => (r.ok ? (r.json() as Promise<ForecastResponse>) : Promise.reject()))
-      inflight.set(key, promise)
+      promise = fetch(forecastUrl({ lat, lon, name }), {
+        signal: controller.signal,
+        credentials: 'include',
+      }).then((r) => {
+        if (!r.ok) throw new Error('Failed to fetch forecast')
+        return r.json() as Promise<ForecastResponse>
+      })
+      if (!persist) inflight.set(key, promise)
     }
 
     promise
-      .then((d) => {
-        cache.set(key, d)
-        inflight.delete(key)
-        if (mountedRef.current) dispatch({ type: 'done', data: d })
+      .then((data) => {
+        if (persist) {
+          writeForecastCache(lat, lon, data, userId)
+        } else {
+          cache.set(key, { data, at: new Date() })
+          inflight.delete(key)
+        }
+        if (!controller.signal.aborted && mountedRef.current) {
+          dispatch({ type: 'done', data, at: new Date() })
+        }
       })
-      .catch(() => {
-        inflight.delete(key)
-        if (!controller.signal.aborted && mountedRef.current) dispatch({ type: 'error' })
+      .catch((err: unknown) => {
+        if (!persist) inflight.delete(key)
+        if (!controller.signal.aborted && mountedRef.current) {
+          dispatch({
+            type: 'error',
+            message: err instanceof Error ? err.message : 'Failed to fetch forecast',
+          })
+        }
       })
-    return () => controller.abort()
-  }, [key, location.lat, location.lon, location.name])
 
-  return state
+    return () => controller.abort()
+  }, [enabled, persist, userId, key, lat, lon, name, refreshKey])
+
+  // Auto-refresh on a fixed cadence, pausing while the tab is hidden and
+  // refreshing immediately when it becomes visible again.
+  useEffect(() => {
+    if (!autoRefresh) return
+
+    function handleVisibilityChange() {
+      if (document.hidden) {
+        stopInterval()
+      } else {
+        refreshRef.current()
+        startInterval()
+      }
+    }
+
+    // Don't start the interval if the tab is already hidden on mount.
+    if (!document.hidden) startInterval()
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      stopInterval()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [autoRefresh, startInterval, stopInterval])
+
+  return { ...state, refresh }
 }

--- a/web/src/hooks/useForecast.ts
+++ b/web/src/hooks/useForecast.ts
@@ -107,6 +107,34 @@ function forecastUrl(location: RecentLocation): string {
 }
 
 /**
+ * Request a forecast, reusing any request already in flight for the same location.
+ *
+ * The guard is shared by every caller regardless of `persist`, so a page and a
+ * widget mounted on the same location issue one request between them. The request
+ * is deliberately not tied to any single caller's lifetime — cancelling a consumer
+ * must not abort a request other consumers are still awaiting.
+ */
+function fetchForecast(location: RecentLocation, key: string): Promise<ForecastResponse> {
+  const shared = inflight.get(key)
+  if (shared) return shared
+
+  const promise = fetch(forecastUrl(location), { credentials: 'include' }).then((r) => {
+    if (!r.ok) throw new Error('Failed to fetch forecast')
+    return r.json() as Promise<ForecastResponse>
+  })
+  inflight.set(key, promise)
+
+  // Clear only our own entry: refresh() may already have replaced it with a newer
+  // request, and deleting that one would defeat the guard for its consumers.
+  const clear = () => {
+    if (inflight.get(key) === promise) inflight.delete(key)
+  }
+  promise.then(clear, clear)
+
+  return promise
+}
+
+/**
  * Fetch the forecast for a location.
  *
  * Called with no arguments it resolves the location from {@link usePreferredLocation}
@@ -128,20 +156,12 @@ export function useForecast(
 
   const [refreshKey, setRefreshKey] = useState(0)
   const [state, dispatch] = useReducer(reducer, { location: active, persist, userId }, initState)
-  const mountedRef = useRef(true)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const lat = active?.lat
   const lon = active?.lon
   const name = active?.name
   const key = active ? cacheKey(active.lat, active.lon, active.name) : null
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
 
   const stopInterval = useCallback(() => {
     if (timerRef.current !== null) {
@@ -160,15 +180,23 @@ export function useForecast(
   }, [stopInterval])
 
   const refresh = useCallback(() => {
-    if (!persist && key) {
+    if (key) {
+      // Drop the in-memory entry and any shared in-flight request so the fetch
+      // effect issues a genuinely fresh request instead of replaying the previous
+      // one. Both maps are cleared whether or not this caller persists, since a
+      // persisted caller can be sharing an in-flight request with a widget.
+      // The localStorage copy is intentionally kept: it only seeds first paint
+      // and is overwritten as soon as the new response lands.
       cache.delete(key)
       inflight.delete(key)
     }
+    // Bumping the key re-runs the fetch effect below for every caller, persisted
+    // or not — the effect never short-circuits on the persisted cache.
     setRefreshKey((k) => k + 1)
     // Restart the countdown so a manual refresh gets a full interval rather than
     // whatever remained of the previous one.
     if (timerRef.current !== null) startInterval()
-  }, [persist, key, startInterval])
+  }, [key, startInterval])
 
   useEffect(() => {
     refreshRef.current = refresh
@@ -191,6 +219,9 @@ export function useForecast(
   useEffect(() => {
     if (!enabled || key === null || lat === undefined || lon === undefined || name === undefined) return
 
+    // Only the in-memory cache can satisfy a request outright. The persisted cache
+    // is a first-paint seed, never a substitute for revalidating, so a persisted
+    // caller always reaches the network here — including on refresh().
     if (!persist) {
       const cached = cache.get(key)
       if (cached) {
@@ -199,36 +230,26 @@ export function useForecast(
       }
     }
 
-    const controller = new AbortController()
+    let cancelled = false
     dispatch({ type: 'start' })
 
-    let promise = persist ? undefined : inflight.get(key)
-    if (!promise) {
-      promise = fetch(forecastUrl({ lat, lon, name }), {
-        signal: controller.signal,
-        credentials: 'include',
-      }).then((r) => {
-        if (!r.ok) throw new Error('Failed to fetch forecast')
-        return r.json() as Promise<ForecastResponse>
-      })
-      if (!persist) inflight.set(key, promise)
-    }
-
-    promise
+    fetchForecast({ lat, lon, name }, key)
       .then((data) => {
+        const at = new Date()
+        // Cache regardless of who is still listening — the response is already paid for.
         if (persist) {
           writeForecastCache(lat, lon, data, userId)
         } else {
-          cache.set(key, { data, at: new Date() })
-          inflight.delete(key)
+          cache.set(key, { data, at })
         }
-        if (!controller.signal.aborted && mountedRef.current) {
-          dispatch({ type: 'done', data, at: new Date() })
+        if (!cancelled) {
+          dispatch({ type: 'done', data, at })
         }
       })
       .catch((err: unknown) => {
-        if (!persist) inflight.delete(key)
-        if (!controller.signal.aborted && mountedRef.current) {
+        // Keeps whatever data is already on screen: a failed background refresh
+        // must not blank out a forecast the user is looking at.
+        if (!cancelled) {
           dispatch({
             type: 'error',
             message: err instanceof Error ? err.message : 'Failed to fetch forecast',
@@ -236,7 +257,9 @@ export function useForecast(
         }
       })
 
-    return () => controller.abort()
+    return () => {
+      cancelled = true
+    }
   }, [enabled, persist, userId, key, lat, lon, name, refreshKey])
 
   // Auto-refresh on a fixed cadence, pausing while the tab is hidden and

--- a/web/src/hooks/useSunTimes.test.ts
+++ b/web/src/hooks/useSunTimes.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useSunTimes, type SunTimes } from './useSunTimes'
+
+const OSLO = { name: 'Oslo', lat: 59.9139, lon: 10.7522 }
+const BERGEN = { name: 'Bergen', lat: 60.3913, lon: 5.3221 }
+
+const osloSun: SunTimes = {
+  sunrise: '2026-06-02T03:55:00Z',
+  sunset: '2026-06-02T20:45:00Z',
+  daylightSeconds: 60_600,
+  polarDay: false,
+  polarNight: false,
+}
+
+const bergenSun: SunTimes = { ...osloSun, daylightSeconds: 61_200 }
+
+function json(data: unknown): Response {
+  return { ok: true, json: () => Promise.resolve(data) } as unknown as Response
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useSunTimes', () => {
+  it('fetches sun data for the given location', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(osloSun))
+
+    const { result } = renderHook(() => useSunTimes(OSLO))
+
+    await waitFor(() => expect(result.current).toEqual(osloSun))
+    expect(fetchSpy).toHaveBeenCalledWith('/api/weather/sun?lat=59.9139&lon=10.7522')
+  })
+
+  it('does not fetch without a location', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(osloSun))
+
+    const { result } = renderHook(() => useSunTimes(null))
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(result.current).toBeNull()
+  })
+
+  it('does not fetch until enabled', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(json(osloSun))
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useSunTimes(OSLO, enabled),
+      { initialProps: { enabled: false } },
+    )
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    rerender({ enabled: true })
+    await waitFor(() => expect(result.current).toEqual(osloSun))
+  })
+
+  it('refetches when the location changes and never shows the previous times', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input) =>
+      Promise.resolve(json(String(input).includes('5.3221') ? bergenSun : osloSun)),
+    )
+
+    const { result, rerender } = renderHook(({ loc }) => useSunTimes(loc), {
+      initialProps: { loc: OSLO },
+    })
+    await waitFor(() => expect(result.current).toEqual(osloSun))
+
+    rerender({ loc: BERGEN })
+    // The stale Oslo entry is tagged with Oslo's coordinates, so it is discarded
+    // rather than rendered under Bergen while the new request is in flight.
+    expect(result.current).toBeNull()
+
+    await waitFor(() => expect(result.current).toEqual(bergenSun))
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null when the request fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve(null),
+    } as Response)
+
+    const { result } = renderHook(() => useSunTimes(OSLO))
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when the network fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'))
+
+    const { result } = renderHook(() => useSunTimes(OSLO))
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    expect(result.current).toBeNull()
+  })
+})

--- a/web/src/hooks/useSunTimes.ts
+++ b/web/src/hooks/useSunTimes.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import type { RecentLocation } from '../recentLocations'
+
+export interface SunTimes {
+  /** RFC3339 timestamp, absent on polar day/night. */
+  sunrise?: string
+  /** RFC3339 timestamp, absent on polar day/night. */
+  sunset?: string
+  daylightSeconds: number
+  polarDay: boolean
+  polarNight: boolean
+}
+
+/**
+ * Fetch sunrise/sunset/daylight for a location.
+ *
+ * The backend computes these locally and caches them per day, so this is cheap
+ * and only re-runs when the location changes. Results are tagged with the
+ * location they belong to, so the previous location's times are never shown
+ * under a newly selected one while its request is still in flight.
+ */
+export function useSunTimes(location: RecentLocation | null, enabled = true): SunTimes | null {
+  const [entry, setEntry] = useState<{ data: SunTimes; locationKey: string } | null>(null)
+
+  const lat = location?.lat
+  const lon = location?.lon
+  const locationKey = lat !== undefined && lon !== undefined ? `${lat},${lon}` : null
+
+  useEffect(() => {
+    if (!enabled || locationKey === null) return
+
+    let cancelled = false
+    fetch(`/api/weather/sun?lat=${lat}&lon=${lon}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled) setEntry(data ? { data: data as SunTimes, locationKey } : null)
+      })
+      .catch((err: unknown) => {
+        console.warn('Failed to fetch sun data:', err)
+        if (!cancelled) setEntry(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, locationKey, lat, lon])
+
+  return entry && entry.locationKey === locationKey ? entry.data : null
+}

--- a/web/src/hooks/useWeatherLocation.test.ts
+++ b/web/src/hooks/useWeatherLocation.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useWeatherLocation } from './useWeatherLocation'
+
+let mockAuth: { user: { id: number } | null; loading: boolean } = { user: null, loading: false }
+
+vi.mock('../auth', () => ({
+  useAuth: () => mockAuth,
+}))
+
+const OSLO = { name: 'Oslo', lat: 59.9139, lon: 10.7522 }
+const BERGEN = { name: 'Bergen', lat: 60.3913, lon: 5.3221 }
+const TRONDHEIM = { name: 'Trondheim', lat: 63.4305, lon: 10.3951 }
+// Returned unsorted so the reducer's name sort is exercised.
+const LOCATIONS = [TRONDHEIM, OSLO, BERGEN]
+
+function json(data: unknown): Response {
+  return { ok: true, json: () => Promise.resolve(data) } as unknown as Response
+}
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = () => r()
+  })
+  return { promise, resolve }
+}
+
+interface Routes {
+  /** Resolved value of GET /api/weather/locations, gated behind `locationsGate`. */
+  locations?: unknown
+  locationsGate?: Promise<void>
+  /** Resolved value of GET /api/settings/preferences, gated behind `prefsGate`. */
+  prefs?: unknown
+  prefsGate?: Promise<void>
+}
+
+/** Route fetch by URL, so tests only describe the responses they care about. */
+function routeFetch(routes: Routes) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const url = String(input)
+    if (url.startsWith('/api/weather/locations')) {
+      const body = json({ locations: routes.locations ?? [] })
+      return routes.locationsGate ? routes.locationsGate.then(() => body) : Promise.resolve(body)
+    }
+    if (url.startsWith('/api/settings/preferences')) {
+      if (init?.method === 'PUT') return Promise.resolve(json({}))
+      const body = json(routes.prefs ?? { preferences: {} })
+      return routes.prefsGate ? routes.prefsGate.then(() => body) : Promise.resolve(body)
+    }
+    return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve(null) } as Response)
+  })
+}
+
+/** Let every queued promise callback and effect flush. */
+async function flush() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0))
+  })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  mockAuth = { user: null, loading: false }
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useWeatherLocation', () => {
+  it('retries a preference that arrived before the locations list', async () => {
+    mockAuth = { user: { id: 1 }, loading: false }
+    const gate = deferred()
+    routeFetch({
+      locations: LOCATIONS,
+      locationsGate: gate.promise,
+      prefs: { preferences: { weather_location: 'Bergen' } },
+    })
+
+    const { result } = renderHook(() => useWeatherLocation())
+
+    // Preferences settle first. Bergen cannot be resolved against an empty
+    // locations list, so it is parked rather than dropped.
+    await flush()
+    expect(result.current.location).toBeNull()
+    expect(result.current.locationResolved).toBe(false)
+
+    gate.resolve()
+    await flush()
+
+    expect(result.current.location).toEqual(BERGEN)
+    expect(result.current.locationResolved).toBe(true)
+  })
+
+  it('falls back to the localStorage location when logged out', async () => {
+    localStorage.setItem('recent_locations', JSON.stringify([OSLO, BERGEN]))
+    localStorage.setItem('weather_location', JSON.stringify(BERGEN))
+    const fetchSpy = routeFetch({ locations: LOCATIONS })
+
+    const { result } = renderHook(() => useWeatherLocation())
+
+    // Resolved from localStorage on the very first render — no waiting on the API.
+    expect(result.current.location).toEqual(BERGEN)
+    expect(result.current.locationResolved).toBe(true)
+
+    await flush()
+    expect(result.current.location).toEqual(BERGEN)
+    // A logged-out visitor must never hit the preferences endpoint.
+    expect(fetchSpy.mock.calls.every(([url]) => !String(url).startsWith('/api/settings/preferences')))
+      .toBe(true)
+  })
+
+  it('persists a logged-out selection to localStorage', async () => {
+    localStorage.setItem('recent_locations', JSON.stringify([OSLO]))
+    routeFetch({ locations: LOCATIONS })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await flush()
+
+    act(() => result.current.selectByName('Bergen'))
+    await flush()
+
+    expect(result.current.location).toEqual(BERGEN)
+    expect(JSON.parse(localStorage.getItem('weather_location')!)).toEqual(BERGEN)
+    expect(JSON.parse(localStorage.getItem('recent_locations')!)[0]).toEqual(BERGEN)
+  })
+
+  it('persists a logged-in selection to preferences and not localStorage', async () => {
+    mockAuth = { user: { id: 7 }, loading: false }
+    const fetchSpy = routeFetch({ locations: LOCATIONS, prefs: { preferences: {} } })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await waitFor(() => expect(result.current.locationResolved).toBe(true))
+
+    act(() => result.current.selectByName('Bergen'))
+    await flush()
+
+    expect(result.current.location).toEqual(BERGEN)
+
+    const put = fetchSpy.mock.calls.find(([, init]) => init?.method === 'PUT')
+    expect(put).toBeDefined()
+    const body = JSON.parse(String(put![1]!.body)) as {
+      preferences: { weather_location: string; recent_locations: string }
+    }
+    expect(body.preferences.weather_location).toBe('Bergen')
+    expect(JSON.parse(body.preferences.recent_locations)[0]).toEqual(BERGEN)
+
+    // Authenticated users store recents server-side only — nothing may leak to
+    // localStorage, where a different account on the same browser would read it.
+    expect(localStorage.getItem('weather_location')).toBeNull()
+    expect(localStorage.getItem('recent_locations')).toBeNull()
+  })
+
+  it('keeps an explicit selection when a stored preference arrives later', async () => {
+    mockAuth = { user: { id: 7 }, loading: false }
+    const gate = deferred()
+    const fetchSpy = routeFetch({
+      locations: LOCATIONS,
+      prefs: { preferences: { weather_location: 'Bergen' } },
+      prefsGate: gate.promise,
+    })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await waitFor(() => expect(result.current.knownLocations).toHaveLength(3))
+
+    act(() => result.current.selectByName('Trondheim'))
+    expect(result.current.location).toEqual(TRONDHEIM)
+
+    gate.resolve()
+    await flush()
+
+    expect(result.current.location).toEqual(TRONDHEIM)
+    expect(result.current.userHasSelected).toBe(true)
+    // The late-arriving sync pushes the user's choice back to the server.
+    const put = fetchSpy.mock.calls.find(([, init]) => init?.method === 'PUT')
+    expect(put).toBeDefined()
+  })
+
+  it('falls back safely when the stored location is invalid', async () => {
+    // lat/lon out of range — rejected by isValidRecentLocation.
+    localStorage.setItem('recent_locations', JSON.stringify([OSLO, BERGEN]))
+    localStorage.setItem('weather_location', JSON.stringify({ name: 'Nowhere', lat: 999, lon: 999 }))
+    routeFetch({ locations: LOCATIONS })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await flush()
+
+    expect(result.current.location).toEqual(OSLO)
+  })
+
+  it('falls back to the first recent when the stored name is unknown', async () => {
+    localStorage.setItem('recent_locations', JSON.stringify([BERGEN, OSLO]))
+    localStorage.setItem('weather_location', 'Atlantis')
+    routeFetch({ locations: LOCATIONS })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await flush()
+
+    expect(result.current.location).toEqual(BERGEN)
+  })
+
+  it('builds defaults from the API on a first visit with no stored data', async () => {
+    routeFetch({ locations: LOCATIONS })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    expect(result.current.location).toBeNull()
+
+    await flush()
+
+    expect(result.current.location).toEqual(OSLO)
+    expect(result.current.recents.map((l) => l.name)).toEqual(['Oslo', 'Bergen', 'Trondheim'])
+    expect(result.current.knownLocations.map((l) => l.name)).toEqual(['Bergen', 'Oslo', 'Trondheim'])
+  })
+
+  it('keeps the active location in the dropdown even when it is not a recent', async () => {
+    mockAuth = { user: { id: 7 }, loading: false }
+    localStorage.setItem('recent_locations', JSON.stringify([OSLO]))
+    routeFetch({ locations: LOCATIONS, prefs: { preferences: { weather_location: 'Bergen' } } })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await flush()
+
+    // Bergen came from the preference and is not in the recents list, but must
+    // still appear as the selected dropdown option rather than an empty select.
+    expect(result.current.location).toEqual(BERGEN)
+    expect(result.current.recents.map((l) => l.name)).toEqual(['Oslo'])
+    expect(result.current.displayRecents.map((l) => l.name)).toEqual(['Bergen', 'Oslo'])
+    expect(result.current.otherCities.map((l) => l.name)).toEqual(['Trondheim'])
+  })
+
+  it('adds a searched location to the front of recents', async () => {
+    routeFetch({ locations: LOCATIONS })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await flush()
+
+    act(() => result.current.selectLocation({ name: 'Reykjavík', lat: 64.14, lon: -21.94 }))
+    await flush()
+
+    expect(result.current.location).toEqual({ name: 'Reykjavík', lat: 64.14, lon: -21.94 })
+    expect(result.current.recents[0].name).toBe('Reykjavík')
+  })
+
+  it('still resolves a location when the locations request fails', async () => {
+    localStorage.setItem('recent_locations', JSON.stringify([BERGEN]))
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'))
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await flush()
+
+    expect(result.current.location).toEqual(BERGEN)
+    expect(result.current.locationResolved).toBe(true)
+  })
+
+  it('ignores a selection for a name that resolves to nothing', async () => {
+    localStorage.setItem('recent_locations', JSON.stringify([OSLO]))
+    routeFetch({ locations: [] })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await flush()
+
+    act(() => result.current.selectByName('Atlantis'))
+    await flush()
+
+    expect(result.current.location).toEqual(OSLO)
+  })
+})

--- a/web/src/hooks/useWeatherLocation.ts
+++ b/web/src/hooks/useWeatherLocation.ts
@@ -1,0 +1,356 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import { useAuth } from '../auth'
+import {
+  type RecentLocation,
+  isValidRecentLocation,
+  loadRecentLocations,
+  saveRecentLocations,
+  addRecentLocation,
+  parseRecentLocationsPreference,
+  buildDefaultLocations,
+} from '../recentLocations'
+
+/** Resolve a location name, checking recents first then the fetched known locations. */
+function findLocation(
+  name: string,
+  recents: RecentLocation[],
+  knownLocations?: RecentLocation[],
+): RecentLocation | undefined {
+  const fromRecents = recents.find((l) => l.name === name)
+  if (fromRecents) return fromRecents
+  return knownLocations?.find((l) => l.name === name)
+}
+
+interface LocationState {
+  /** The active location, or null before anything has been resolved. */
+  selected: RecentLocation | null
+  /** Recently used locations, most recent first. */
+  recents: RecentLocation[]
+  /** Canonical city list from /api/weather/locations, sorted by name. */
+  known: RecentLocation[]
+  /** True once the locations request has settled (successfully or not). */
+  locationsLoaded: boolean
+  /** True once the preferences request has settled (successfully or not). */
+  prefsFetched: boolean
+  /**
+   * A saved preference name that could not be resolved yet because the known
+   * locations list had not arrived. Retried once the list settles.
+   */
+  pendingPreferenceName: string | null
+  /** True once the user has explicitly picked a location this session. */
+  userHasSelected: boolean
+  /** Set when a selection needs to be written to localStorage or the server. */
+  pendingSave: { location: RecentLocation; recents: RecentLocation[] } | null
+}
+
+type LocationAction =
+  | { type: 'locationsResolved'; locations: RecentLocation[] }
+  | { type: 'locationsSettled' }
+  | { type: 'preferencesResolved'; serverRecents: RecentLocation[] | null; savedName: string | null }
+  | { type: 'preferencesSettled' }
+  | { type: 'selectByName'; name: string }
+  | { type: 'select'; location: RecentLocation }
+  | { type: 'saved' }
+
+/**
+ * Read the initial location and recents from localStorage.
+ * Returns a null location on first visit — coordinates then come from the API.
+ */
+function initLocationState(): LocationState {
+  const base: LocationState = {
+    selected: null,
+    recents: [],
+    known: [],
+    locationsLoaded: false,
+    prefsFetched: false,
+    pendingPreferenceName: null,
+    userHasSelected: false,
+    pendingSave: null,
+  }
+
+  const recents = loadRecentLocations()
+  if (!recents) return base
+
+  try {
+    const stored = localStorage.getItem('weather_location')
+    if (stored) {
+      // Prefer full-JSON storage with lat+lon matching (avoids duplicate-name collisions)
+      try {
+        const parsed = JSON.parse(stored) as unknown
+        if (isValidRecentLocation(parsed)) {
+          const found = recents.find((l) => l.lat === parsed.lat && l.lon === parsed.lon) ?? parsed
+          return { ...base, selected: found, recents }
+        }
+      } catch {
+        // Not JSON — fall through to legacy name matching
+      }
+      const loc = findLocation(stored, recents)
+      if (loc) return { ...base, selected: loc, recents }
+    }
+  } catch {
+    // localStorage may be unavailable.
+  }
+  return { ...base, selected: recents[0] ?? null, recents }
+}
+
+/**
+ * Resolve a preference name that arrived before the known locations list.
+ * A no-op unless a name is pending, the list has settled, and the user has not
+ * already made an explicit choice (which always wins over a stored preference).
+ */
+function applyPendingPreference(state: LocationState): LocationState {
+  if (!state.pendingPreferenceName || !state.locationsLoaded || state.userHasSelected) return state
+  const loc = findLocation(state.pendingPreferenceName, state.recents, state.known)
+  if (!loc) return state
+  return { ...state, selected: loc, pendingPreferenceName: null }
+}
+
+function locationReducer(state: LocationState, action: LocationAction): LocationState {
+  switch (action.type) {
+    case 'locationsResolved': {
+      const locs = [...action.locations].sort((a, b) => a.name.localeCompare(b.name))
+      const locMap = new Map(locs.map((l) => [l.name, l]))
+      const defaults = buildDefaultLocations(locs)
+      return applyPendingPreference({
+        ...state,
+        known: locs,
+        // First visit — build defaults from API data (no hardcoded coordinates).
+        // Otherwise reconcile stored locations with canonical API coordinates.
+        recents:
+          state.recents.length === 0 ? defaults : state.recents.map((r) => locMap.get(r.name) ?? r),
+        selected: state.selected ?? defaults[0] ?? locs[0] ?? null,
+      })
+    }
+
+    case 'locationsSettled':
+      return applyPendingPreference({ ...state, locationsLoaded: true })
+
+    case 'preferencesResolved': {
+      const { serverRecents, savedName } = action
+      // Recents captured before the server sync — they carry a selection the user
+      // may have made while the preferences request was still in flight.
+      const priorRecents = state.recents
+      const recents = serverRecents && serverRecents.length > 0 ? serverRecents : priorRecents
+
+      if (state.userHasSelected) {
+        // User interacted before prefs loaded; push their choice server-side.
+        return state.selected
+          ? { ...state, recents, pendingSave: { location: state.selected, recents: priorRecents } }
+          : { ...state, recents }
+      }
+      if (!savedName) return { ...state, recents }
+
+      // Resolve from server recents first, then known cities from the API.
+      const loc = findLocation(savedName, serverRecents ?? priorRecents, state.known)
+      if (loc) return { ...state, recents, selected: loc }
+      // Known locations may not be loaded yet; store the name and retry when they arrive.
+      return applyPendingPreference({ ...state, recents, pendingPreferenceName: savedName })
+    }
+
+    case 'preferencesSettled':
+      return applyPendingPreference({ ...state, prefsFetched: true })
+
+    case 'selectByName': {
+      const loc = findLocation(action.name, state.recents, state.known)
+      if (!loc) return { ...state, userHasSelected: true }
+      const recents = addRecentLocation(state.recents, loc)
+      return {
+        ...state,
+        userHasSelected: true,
+        selected: loc,
+        recents,
+        pendingSave: { location: loc, recents },
+      }
+    }
+
+    case 'select': {
+      const recents = addRecentLocation(state.recents, action.location)
+      return {
+        ...state,
+        userHasSelected: true,
+        selected: action.location,
+        recents,
+        pendingSave: { location: action.location, recents },
+      }
+    }
+
+    case 'saved':
+      return { ...state, pendingSave: null }
+
+    default:
+      return state
+  }
+}
+
+export interface WeatherLocationState {
+  /** The active location, or null until one has been resolved. */
+  location: RecentLocation | null
+  /** Recently used locations, most recent first. */
+  recents: RecentLocation[]
+  /** Canonical city list from the API, sorted by name. */
+  knownLocations: RecentLocation[]
+  /** Recents for the dropdown, always including the active location. */
+  displayRecents: RecentLocation[]
+  /** Known cities not already present in `displayRecents`. */
+  otherCities: RecentLocation[]
+  /**
+   * True once the active location is known to be final: auth has settled, any
+   * stored preference has been read, and the locations list (or recents) exists.
+   * Fetching a forecast before this would hit the wrong location first.
+   */
+  locationResolved: boolean
+  /** True once the user has explicitly picked a location this session. */
+  userHasSelected: boolean
+  /** Select a location from the dropdown by city name. */
+  selectByName: (name: string) => void
+  /** Select an arbitrary location from search or geolocation. */
+  selectLocation: (result: { name: string; lat: number; lon: number }) => void
+}
+
+/**
+ * Owns the weather page's location state machine: selection, recents, and the
+ * localStorage-vs-preferences split.
+ *
+ * Anonymous visitors persist to localStorage; authenticated users persist to
+ * `/api/settings/preferences` only, so recents never leak across accounts on a
+ * shared browser. A preference that arrives before the canonical locations list
+ * is parked in `pendingPreferenceName` and retried once the list settles, and an
+ * explicit user selection always wins over a later-arriving stored preference.
+ */
+export function useWeatherLocation(): WeatherLocationState {
+  const { user, loading: authLoading } = useAuth()
+  const [state, dispatch] = useReducer(locationReducer, undefined, initLocationState)
+
+  // Fetch available locations from the backend (single source of truth for coordinates).
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/weather/locations')
+      .then((r) => {
+        if (!r.ok) throw new Error('Failed to fetch locations')
+        return r.json()
+      })
+      .then((data) => {
+        if (cancelled) return
+        dispatch({ type: 'locationsResolved', locations: (data.locations ?? []) as RecentLocation[] })
+      })
+      .catch((err: unknown) => {
+        // Best-effort: the dropdown still shows recent locations from localStorage.
+        console.warn('Failed to fetch locations:', err)
+      })
+      .finally(() => {
+        if (!cancelled) dispatch({ type: 'locationsSettled' })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Load the user's preferred location and recents once auth settles.
+  useEffect(() => {
+    if (authLoading || !user) return
+
+    let cancelled = false
+    fetch('/api/settings/preferences', { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return
+        const raw = data?.preferences?.recent_locations
+        dispatch({
+          type: 'preferencesResolved',
+          serverRecents: raw ? parseRecentLocationsPreference(raw) : null,
+          savedName: data?.preferences?.weather_location || data?.preferences?.home_location || null,
+        })
+      })
+      .catch((err: unknown) => {
+        // Preference load is best-effort; localStorage values are used as fallback.
+        console.warn('Failed to fetch preferences:', err)
+      })
+      .finally(() => {
+        if (!cancelled) dispatch({ type: 'preferencesSettled' })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, authLoading])
+
+  // Persist recent locations to localStorage — only for unauthenticated users after
+  // auth settles. Authenticated users store recents server-side only to prevent
+  // cross-account leakage.
+  const { recents, pendingSave } = state
+  useEffect(() => {
+    if (authLoading || user) return
+    saveRecentLocations(recents)
+  }, [recents, user, authLoading])
+
+  // Flush a queued selection to its persistence target.
+  useEffect(() => {
+    if (!pendingSave) return
+    dispatch({ type: 'saved' })
+
+    if (!user) {
+      try {
+        localStorage.setItem('weather_location', JSON.stringify(pendingSave.location))
+      } catch {
+        // localStorage may be unavailable.
+      }
+      saveRecentLocations(pendingSave.recents)
+      return
+    }
+
+    fetch('/api/settings/preferences', {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        preferences: {
+          weather_location: pendingSave.location.name,
+          recent_locations: JSON.stringify(pendingSave.recents),
+        },
+      }),
+    }).catch((err: unknown) => {
+      // Best-effort save; localStorage is used as local fallback.
+      console.warn('Failed to save preferences:', err)
+    })
+  }, [pendingSave, user])
+
+  const selectByName = useCallback((name: string) => {
+    dispatch({ type: 'selectByName', name })
+  }, [])
+
+  const selectLocation = useCallback((result: { name: string; lat: number; lon: number }) => {
+    dispatch({ type: 'select', location: { name: result.name, lat: result.lat, lon: result.lon } })
+  }, [])
+
+  // Build dropdown options: recent locations, then remaining known cities not in
+  // recents. The active location is always present so the dropdown never renders
+  // empty or mismatched while loading.
+  const { selected, known } = state
+  const displayRecents = useMemo(() => {
+    if (!selected || recents.some((l) => l.name === selected.name)) return recents
+    return [selected, ...recents]
+  }, [selected, recents])
+
+  const otherCities = useMemo(() => {
+    const recentNames = new Set(displayRecents.map((l) => l.name))
+    return known.filter((l) => !recentNames.has(l.name))
+  }, [displayRecents, known])
+
+  const locationResolved =
+    selected !== null &&
+    !authLoading &&
+    (!user || state.prefsFetched) &&
+    (recents.length > 0 || state.locationsLoaded)
+
+  return {
+    location: selected,
+    recents,
+    knownLocations: known,
+    displayRecents,
+    otherCities,
+    locationResolved,
+    userHasSelected: state.userHasSelected,
+    selectByName,
+    selectLocation,
+  }
+}

--- a/web/src/pages/Weather.tsx
+++ b/web/src/pages/Weather.tsx
@@ -114,6 +114,11 @@ export default function Weather() {
         </div>
       )}
 
+      {/*
+        Only surface the error when there is nothing to show. A failed background
+        refresh (interval tick, tab re-show, manual refresh) leaves the previous
+        forecast on screen untouched rather than replacing it with a banner.
+      */}
       {errorMessage && !forecast && (
         <div className="bg-red-900/30 border border-red-800 rounded-xl p-4 mb-6">
           <p className="text-red-400 text-sm">{errorMessage}</p>

--- a/web/src/pages/Weather.tsx
+++ b/web/src/pages/Weather.tsx
@@ -1,91 +1,22 @@
-import { useState, useEffect, useLayoutEffect, useReducer, useCallback, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
+import { MapPin, RefreshCw } from 'lucide-react'
 import { useAuth } from '../auth'
 import { Skeleton } from '../components/ui/skeleton'
-import {
-  type RecentLocation,
-  isValidRecentLocation,
-  loadRecentLocations,
-  saveRecentLocations,
-  addRecentLocation,
-  parseRecentLocationsPreference,
-  buildDefaultLocations,
-} from '../recentLocations'
 import LocationSearch from '../components/LocationSearch'
 import UseMyLocationButton from '../components/UseMyLocationButton'
 import HourlyChart from '../components/HourlyChart'
-import { readForecastCache, writeForecastCache } from '../lib/weatherCache'
-import { buildDailyForecasts, type TimeseriesEntry } from '../lib/weatherForecast'
-import { getWeatherIcon, getWeatherDescription } from '../weatherUtils'
-import { formatDate, formatTime } from '../utils/formatDate'
-import {
-  ArrowUp,
-  Droplets,
-  Wind,
-  MapPin,
-  Thermometer,
-  RefreshCw,
-  Sunrise,
-  Sunset,
-} from 'lucide-react'
+import CurrentConditionsCard from '../components/weather/CurrentConditionsCard'
+import HourlyStrip from '../components/weather/HourlyStrip'
+import DailyForecastList from '../components/weather/DailyForecastList'
+import { useWeatherLocation } from '../hooks/useWeatherLocation'
+import { useForecast } from '../hooks/useForecast'
+import { useSunTimes } from '../hooks/useSunTimes'
+import { buildDailyForecasts } from '../lib/weatherForecast'
 
-
-
-interface ForecastResponse {
-  properties: {
-    timeseries: TimeseriesEntry[]
-  }
-}
-
-interface SunResponse {
-  sunrise?: string
-  sunset?: string
-  daylightSeconds: number
-  polarDay: boolean
-  polarNight: boolean
-}
-
-/** Split a daylight duration in seconds into whole hours and minutes. */
-function splitDaylight(seconds: number): { hours: number; minutes: number } {
-  const totalMinutes = Math.max(0, Math.round(seconds / 60))
-  return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60 }
-}
-
-
-type FetchState = { loading: boolean; error: string | null; forecast: ForecastResponse | null; lastUpdated: Date | null }
-type FetchAction =
-  | { type: 'start' }
-  | { type: 'success'; data: ForecastResponse }
-  | { type: 'error'; message: string }
-  // Seed displayed data from a cached response (stale-while-revalidate).
-  | { type: 'seed'; data: ForecastResponse; lastUpdated: Date }
-  // Clear displayed data so skeletons show (location with no cached forecast).
-  | { type: 'reset' }
-
-function fetchReducer(state: FetchState, action: FetchAction): FetchState {
-  switch (action.type) {
-    case 'start': return { ...state, loading: true, error: null }
-    case 'success': return { loading: false, error: null, forecast: action.data, lastUpdated: new Date() }
-    case 'error': return { loading: false, error: action.message, forecast: state.forecast, lastUpdated: state.lastUpdated }
-    case 'seed': return { loading: true, error: null, forecast: action.data, lastUpdated: action.lastUpdated }
-    case 'reset': return { loading: true, error: null, forecast: null, lastUpdated: null }
-    default: return state
-  }
-}
-
-/** Build the initial fetch state, seeding from the per-location cache when available. */
-function initFetchState({ loc, userId }: { loc: RecentLocation | null; userId?: number }): FetchState {
-  if (loc) {
-    const cached = readForecastCache<ForecastResponse>(loc.lat, loc.lon, userId)
-    if (cached) {
-      return { loading: true, error: null, forecast: cached.response, lastUpdated: new Date(cached.lastUpdated) }
-    }
-  }
-  return { loading: true, error: null, forecast: null, lastUpdated: null }
-}
-
-const AUTO_REFRESH_MS = 10 * 60 * 1000 // 10 minutes
+/** How often the "Updated X min ago" label is recomputed. */
+const TIME_AGO_TICK_MS = 30_000
 
 function formatTimeAgo(date: Date, t: TFunction<'weather'>): string {
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
@@ -95,458 +26,41 @@ function formatTimeAgo(date: Date, t: TFunction<'weather'>): string {
   return t('updated.minutesAgo', { count: minutes })
 }
 
-/**
- * Calculate feels-like temperature.
- * Uses wind chill when temp ≤ 10°C and wind ≥ 1.3 m/s (Environment Canada formula),
- * or heat index when temp ≥ 27°C and humidity ≥ 40% (Rothfusz regression).
- * Returns null when actual temperature already represents perceived comfort.
- */
-function calculateFeelsLike(temp: number, windSpeed: number, humidity: number): number | null {
-  if (temp <= 10 && windSpeed >= 1.3) {
-    const v = windSpeed * 3.6 // m/s to km/h
-    const wc = 13.12 + 0.6215 * temp - 11.37 * Math.pow(v, 0.16) + 0.3965 * temp * Math.pow(v, 0.16)
-    const rounded = Math.round(wc)
-    return rounded !== Math.round(temp) ? rounded : null
-  }
-  if (temp >= 27 && humidity >= 40) {
-    // Rothfusz regression (Fahrenheit), then convert back
-    const tf = temp * 9 / 5 + 32
-    const hi =
-      -42.379 + 2.04901523 * tf + 10.14333127 * humidity
-      - 0.22475541 * tf * humidity - 0.00683783 * tf * tf
-      - 0.05481717 * humidity * humidity + 0.00122874 * tf * tf * humidity
-      + 0.00085282 * tf * humidity * humidity - 0.00000199 * tf * tf * humidity * humidity
-    const rounded = Math.round((hi - 32) * 5 / 9)
-    return rounded !== Math.round(temp) ? rounded : null
-  }
-  return null
-}
-
-/**
- * Wind direction arrow rotation in degrees (CSS clockwise).
- * wind_from_direction = 180 (from south) → arrow points north (0°).
- */
-function windArrowRotation(windFromDirection: number): number {
-  return (windFromDirection + 180) % 360
-}
-
-/** Resolve a location name, checking recents first then the fetched known locations. */
-function resolveLocation(
-  name: string,
-  recents: RecentLocation[],
-  knownLocations?: RecentLocation[],
-): RecentLocation | undefined {
-  const fromRecents = recents.find((l) => l.name === name)
-  if (fromRecents) return fromRecents
-  return knownLocations?.find((l) => l.name === name)
-}
-
-function getInitialState(): { location: RecentLocation | null; recents: RecentLocation[] } {
-  const recents = loadRecentLocations()
-  if (!recents) {
-    // First visit — no localStorage data. Coordinates will come from the API.
-    return { location: null, recents: [] }
-  }
-  // Try to restore the last selected location from localStorage.
-  try {
-    const stored = localStorage.getItem('weather_location')
-    if (stored) {
-      // Prefer full-JSON storage with lat+lon matching (avoids duplicate-name collisions)
-      try {
-        const parsed = JSON.parse(stored) as unknown
-        if (isValidRecentLocation(parsed)) {
-          const loc = parsed as RecentLocation
-          const found = recents.find((l) => l.lat === loc.lat && l.lon === loc.lon) ?? loc
-          return { location: found, recents }
-        }
-      } catch {
-        // Not JSON — fall through to legacy name matching
-      }
-      const loc = resolveLocation(stored, recents)
-      if (loc) return { location: loc, recents }
-    }
-  } catch {
-    // localStorage may be unavailable.
-  }
-  return { location: recents[0] ?? null, recents }
-}
-
-/** Build the forecast API URL for a location, always using lat/lon. */
-function forecastUrl(loc: RecentLocation): string {
-  return `/api/weather/forecast?lat=${loc.lat}&lon=${loc.lon}&location=${encodeURIComponent(loc.name)}`
-}
-
-
-type HourlyRange = 12 | 24 | 48
-
 export default function Weather() {
   const { t } = useTranslation('weather')
-  const { user, loading: authLoading } = useAuth()
-  const [initialState] = useState(getInitialState)
-  const [selectedLocation, setSelectedLocation] = useState<RecentLocation | null>(initialState.location)
-  const [hourlyRange, setHourlyRange] = useState<HourlyRange>(12)
-  const [recentLocations, setRecentLocations] = useState<RecentLocation[]>(initialState.recents)
-  const [knownLocations, setKnownLocations] = useState<RecentLocation[]>([])
-  const [locationsLoaded, setLocationsLoaded] = useState(false)
-  const [prefsFetched, setPrefsFetched] = useState(false)
-  const [pendingPreferenceName, setPendingPreferenceName] = useState<string | null>(null)
-  const locationResolved =
-    selectedLocation !== null && !authLoading && (!user || prefsFetched) && (recentLocations.length > 0 || locationsLoaded)
-  const [refreshKey, setRefreshKey] = useState(0)
-  const [intervalResetKey, setIntervalResetKey] = useState(0)
-  const userHasSelected = useRef(false)
-  const selectedLocationRef = useRef(selectedLocation)
-  const recentLocationsRef = useRef(recentLocations)
-  const knownLocationsRef = useRef(knownLocations)
-  useEffect(() => {
-    selectedLocationRef.current = selectedLocation
-  }, [selectedLocation])
-  useEffect(() => {
-    recentLocationsRef.current = recentLocations
-  }, [recentLocations])
-  useEffect(() => {
-    knownLocationsRef.current = knownLocations
-  }, [knownLocations])
+  const { user } = useAuth()
+  const {
+    location,
+    displayRecents,
+    otherCities,
+    locationResolved,
+    selectByName,
+    selectLocation,
+  } = useWeatherLocation()
 
-  // Persist recent locations to localStorage — only for unauthenticated users after auth settles.
-  // Authenticated users store recents server-side only to prevent cross-account leakage.
-  useEffect(() => {
-    if (authLoading || user) return
-    saveRecentLocations(recentLocations)
-  }, [recentLocations, user, authLoading])
+  const { data: forecast, loading, errorMessage, lastUpdated, refresh } = useForecast(location, {
+    persist: true,
+    userId: user?.id,
+    autoRefresh: true,
+    enabled: locationResolved,
+  })
+  const sun = useSunTimes(location, locationResolved)
 
-  // Fetch available locations from the backend (single source of truth for coordinates).
-  useEffect(() => {
-    let cancelled = false
-    fetch('/api/weather/locations')
-      .then((r) => {
-        if (!r.ok) throw new Error('Failed to fetch locations')
-        return r.json()
-      })
-      .then((data) => {
-        if (cancelled) return
-        const locs = (data.locations ?? []) as RecentLocation[]
-        locs.sort((a, b) => a.name.localeCompare(b.name))
-        setKnownLocations(locs)
-        // Reconcile recent locations with canonical coordinates from API.
-        const locMap = new Map(locs.map((l) => [l.name, l]))
-        setRecentLocations((prev) => {
-          if (prev.length === 0) {
-            // First visit — build defaults from API data (no hardcoded coordinates).
-            return buildDefaultLocations(locs)
-          }
-          // Reconcile stored locations with canonical coordinates from the API.
-          return prev.map((r) => locMap.get(r.name) ?? r)
-        })
-        // Set initial selected location if not yet set (first visit).
-        setSelectedLocation((prev) => {
-          if (prev !== null) return prev
-          const defaults = buildDefaultLocations(locs)
-          return defaults[0] ?? locs[0] ?? null
-        })
-      })
-      .catch((err) => {
-        // Best-effort: dropdown will still show recent locations from localStorage.
-        console.warn('Failed to fetch locations:', err)
-      })
-      .finally(() => {
-        if (!cancelled) setLocationsLoaded(true)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-  // Seed the reducer from the per-location cache so a revisit renders real numbers
-  // on first paint (no skeleton flash) while a fresh forecast loads in the background.
-  const [{ forecast, loading, error, lastUpdated }, dispatch] = useReducer(
-    fetchReducer,
-    { loc: initialState.location, userId: user?.id },
-    initFetchState,
-  )
-  const [sunEntry, setSunEntry] = useState<{ data: SunResponse; locationKey: string } | null>(null)
-  const currentLocKey = selectedLocation ? `${selectedLocation.lat},${selectedLocation.lon}` : null
-  const sun = sunEntry && sunEntry.locationKey === currentLocKey ? sunEntry.data : null
+  // Tick periodically to keep the "Updated X min ago" text current.
   const [, setTick] = useState(0)
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
-
-  // Load user's preferred location and recents once auth settles.
   useEffect(() => {
-    if (authLoading) return
-
-    if (!user) return
-
-    let cancelled = false
-    fetch('/api/settings/preferences', { credentials: 'include' })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (cancelled) return
-
-        // Sync recent locations from backend.
-        const serverRecentsRaw = data?.preferences?.recent_locations
-        if (serverRecentsRaw) {
-          const serverRecents = parseRecentLocationsPreference(serverRecentsRaw)
-          if (serverRecents && serverRecents.length > 0) {
-            setRecentLocations(serverRecents)
-            // Do NOT write to localStorage here — authenticated users store recents server-side only.
-          }
-        }
-
-        if (userHasSelected.current) {
-          // User interacted before prefs loaded; persist their choice server-side.
-          const currentRecents = recentLocationsRef.current
-          fetch('/api/settings/preferences', {
-            method: 'PUT',
-            credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              preferences: {
-                weather_location: selectedLocationRef.current?.name ?? '',
-                recent_locations: JSON.stringify(currentRecents),
-              },
-            }),
-          }).catch((err: unknown) => {
-            console.warn('Failed to push user selection to server:', err)
-          })
-          return
-        }
-
-        const savedName = data?.preferences?.weather_location || data?.preferences?.home_location
-        if (savedName) {
-          // Resolve from server recents first, then known cities from API.
-          const serverRecents = serverRecentsRaw
-            ? parseRecentLocationsPreference(serverRecentsRaw)
-            : null
-          const loc = resolveLocation(
-            savedName,
-            serverRecents ?? recentLocationsRef.current,
-            knownLocationsRef.current,
-          )
-          if (loc) {
-            setSelectedLocation(loc)
-          } else {
-            // Known locations may not be loaded yet; store the name and retry when they arrive.
-            setPendingPreferenceName(savedName)
-          }
-        }
-      })
-      .catch((err: unknown) => {
-        // Preference load is best-effort; localStorage values are used as fallback.
-        console.warn('Failed to fetch preferences:', err)
-      })
-      .finally(() => {
-        if (!cancelled) setPrefsFetched(true)
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [user, authLoading])
-
-  // Retry resolving the pending preference name once knownLocations becomes available.
-  useEffect(() => {
-    if (!pendingPreferenceName || !locationsLoaded || userHasSelected.current) return
-    const loc = resolveLocation(pendingPreferenceName, recentLocationsRef.current, knownLocations)
-    if (loc) {
-      setSelectedLocation(loc)
-      setPendingPreferenceName(null)
-    }
-  }, [pendingPreferenceName, locationsLoaded, knownLocations])
-
-  const triggerRefresh = useCallback(() => {
-    setRefreshKey((k) => k + 1)
-    setIntervalResetKey((k) => k + 1)
-  }, [])
-
-  // Persist location and recents whenever they change.
-  const saveState = useCallback(
-    (loc: RecentLocation, updatedRecents: RecentLocation[]) => {
-      if (!user) {
-        try {
-          localStorage.setItem('weather_location', JSON.stringify(loc))
-        } catch {
-          // localStorage may be unavailable.
-        }
-        saveRecentLocations(updatedRecents)
-      }
-      if (user) {
-        fetch('/api/settings/preferences', {
-          method: 'PUT',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            preferences: {
-              weather_location: loc.name,
-              recent_locations: JSON.stringify(updatedRecents),
-            },
-          }),
-        }).catch((err: unknown) => {
-          // Best-effort save; localStorage is used as local fallback.
-          console.warn('Failed to save preferences:', err)
-        })
-      }
-    },
-    [user],
-  )
-
-  // Handles selection from the quick-access dropdown (named cities only).
-  const handleLocationChange = useCallback(
-    (cityName: string) => {
-      userHasSelected.current = true
-      const loc = resolveLocation(cityName, recentLocationsRef.current, knownLocationsRef.current)
-      if (!loc) return
-      setSelectedLocation(loc)
-      const updatedRecents = addRecentLocation(recentLocationsRef.current, loc)
-      setRecentLocations(updatedRecents)
-      saveState(loc, updatedRecents)
-    },
-    [saveState],
-  )
-
-  // Handles selection from the free-text location search (geocoding results).
-  const handleSearchSelect = useCallback(
-    (result: { name: string; country: string; lat: number; lon: number }) => {
-      userHasSelected.current = true
-      const loc: RecentLocation = { name: result.name, lat: result.lat, lon: result.lon }
-      setSelectedLocation(loc)
-      const updatedRecents = addRecentLocation(recentLocationsRef.current, loc)
-      setRecentLocations(updatedRecents)
-      saveState(loc, updatedRecents)
-    },
-    [saveState],
-  )
-
-  // Re-seed displayed data when the active location changes: show the location's
-  // cached forecast instantly, or clear to skeletons when it was never viewed.
-  // useLayoutEffect runs synchronously before paint, preventing a brief flash of
-  // the previous location's forecast under the newly selected location name.
-  useLayoutEffect(() => {
-    if (!selectedLocation) return
-    const cached = readForecastCache<ForecastResponse>(selectedLocation.lat, selectedLocation.lon, user?.id)
-    if (cached) {
-      dispatch({ type: 'seed', data: cached.response, lastUpdated: new Date(cached.lastUpdated) })
-    } else {
-      dispatch({ type: 'reset' })
-    }
-    // Key on coordinates + user so reconciling the location object (same lat/lon,
-    // new reference) does not spuriously clear freshly fetched data, and switching
-    // accounts reads from the correct user-scoped cache.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedLocation?.lat, selectedLocation?.lon, user?.id])
-
-  // Fetch forecast once we know the correct location.
-  useEffect(() => {
-    if (!locationResolved || !selectedLocation) return
-
-    let cancelled = false
-    dispatch({ type: 'start' })
-
-    fetch(forecastUrl(selectedLocation))
-      .then((r) => {
-        if (!r.ok) throw new Error('Failed to fetch forecast')
-        return r.json()
-      })
-      .then((data) => {
-        if (cancelled) return
-        dispatch({ type: 'success', data })
-        // Persist/refresh this location's cache so future revisits render instantly.
-        writeForecastCache(selectedLocation.lat, selectedLocation.lon, data, user?.id)
-      })
-      .catch((err) => {
-        if (!cancelled) dispatch({ type: 'error', message: err.message })
-      })
-
-    return () => {
-      cancelled = true
-    }
-    // user?.id is read only for cache-key scoping, not to trigger a re-fetch.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedLocation, locationResolved, refreshKey])
-
-  // Fetch sunrise/sunset/daylight for the selected location. Computed locally on
-  // the backend and cached per day, so this is cheap and updates when the
-  // location changes.
-  useEffect(() => {
-    if (!locationResolved || !selectedLocation) return
-
-    let cancelled = false
-    const locKey = `${selectedLocation.lat},${selectedLocation.lon}`
-
-    fetch(`/api/weather/sun?lat=${selectedLocation.lat}&lon=${selectedLocation.lon}`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (!cancelled) {
-          setSunEntry(data ? { data: data as SunResponse, locationKey: locKey } : null)
-        }
-      })
-      .catch((err) => {
-        console.warn('Failed to fetch sun data:', err)
-        if (!cancelled) setSunEntry(null)
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [selectedLocation, locationResolved, refreshKey])
-
-  // Auto-refresh every 10 minutes, pausing when the tab is hidden.
-  useEffect(() => {
-    function startInterval() {
-      stopInterval()
-      intervalRef.current = setInterval(triggerRefresh, AUTO_REFRESH_MS)
-    }
-
-    function stopInterval() {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-        intervalRef.current = null
-      }
-    }
-
-    function handleVisibilityChange() {
-      if (document.hidden) {
-        stopInterval()
-      } else {
-        triggerRefresh()
-        startInterval()
-      }
-    }
-
-    // Don't start the interval if the tab is already hidden on mount.
-    if (!document.hidden) {
-      startInterval()
-    }
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-
-    return () => {
-      stopInterval()
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-    }
-  }, [triggerRefresh, intervalResetKey, selectedLocation])
-
-  // Tick every 30 seconds to keep the "Updated X min ago" text current.
-  useEffect(() => {
-    const timer = setInterval(() => setTick(t => t + 1), 30_000)
+    const timer = setInterval(() => setTick((v) => v + 1), TIME_AGO_TICK_MS)
     return () => clearInterval(timer)
   }, [])
   const timeAgo = lastUpdated ? formatTimeAgo(lastUpdated, t) : ''
 
   const timeseries = forecast?.properties?.timeseries ?? []
-  const current = timeseries[0] as TimeseriesEntry | undefined
+  const current = timeseries[0]
   const dailyForecasts = timeseries.length > 0 ? buildDailyForecasts(timeseries, t('page.today')) : []
-
   const currentSymbol =
     current?.data.next_1_hours?.summary.symbol_code ||
     current?.data.next_6_hours?.summary.symbol_code ||
     'cloudy'
-
-  // Build dropdown options: recent locations, then remaining known cities not in recents.
-  // Always include selectedLocation to prevent empty/mismatched dropdown during loading.
-  const displayRecents =
-    selectedLocation && !recentLocations.some((l) => l.name === selectedLocation.name)
-      ? [selectedLocation, ...recentLocations]
-      : recentLocations
-  const recentNames = new Set(displayRecents.map((l) => l.name))
-  const otherCities = knownLocations.filter((l) => !recentNames.has(l.name))
 
   return (
     <main className="max-w-3xl mx-auto px-4 py-8 min-h-screen">
@@ -554,11 +68,11 @@ export default function Weather() {
         <h1 className="text-2xl font-bold">{t('page.title')}</h1>
         <div className="flex items-center gap-2 flex-wrap">
           <MapPin size={16} className="text-gray-400" />
-          <LocationSearch onSelect={handleSearchSelect} />
-          <UseMyLocationButton onSelect={handleSearchSelect} />
+          <LocationSearch onSelect={selectLocation} />
+          <UseMyLocationButton onSelect={selectLocation} />
           <select
-            value={selectedLocation?.name ?? ''}
-            onChange={(e) => handleLocationChange(e.target.value)}
+            value={location?.name ?? ''}
+            onChange={(e) => selectByName(e.target.value)}
             className="bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
             aria-label={t('page.selectLocation')}
           >
@@ -582,7 +96,7 @@ export default function Weather() {
             )}
           </select>
           <button
-            onClick={triggerRefresh}
+            onClick={refresh}
             disabled={loading}
             className="p-2 rounded-lg bg-gray-700 border border-gray-600 text-gray-300 hover:text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
             aria-label={t('page.refreshForecast')}
@@ -600,223 +114,28 @@ export default function Weather() {
         </div>
       )}
 
-      {error && !forecast && (
+      {errorMessage && !forecast && (
         <div className="bg-red-900/30 border border-red-800 rounded-xl p-4 mb-6">
-          <p className="text-red-400 text-sm">{error}</p>
+          <p className="text-red-400 text-sm">{errorMessage}</p>
         </div>
       )}
 
       {current && (
         <>
-          {/* Current Conditions */}
-          <section className="bg-gray-800 rounded-xl p-6 mb-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm text-gray-400 mb-1">{t('page.rightNowIn', { location: selectedLocation?.name })}</p>
-                <div className="flex items-end gap-3">
-                  <span className="text-5xl font-bold">
-                    {Math.round(current.data.instant.details.air_temperature)}°
-                  </span>
-                  {(() => {
-                    const feelsLike = calculateFeelsLike(
-                      current.data.instant.details.air_temperature,
-                      current.data.instant.details.wind_speed,
-                      current.data.instant.details.relative_humidity,
-                    )
-                    return feelsLike !== null ? (
-                      <span className="text-sm text-gray-400 mb-2">
-                        {t('page.feelsLike', { temp: feelsLike })}
-                      </span>
-                    ) : null
-                  })()}
-                  <span className="text-lg text-gray-300 mb-1">
-                    {getWeatherDescription(currentSymbol, t)}
-                  </span>
-                </div>
-                {sun && (
-                  <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-300">
-                    {sun.polarDay ? (
-                      <span className="flex items-center gap-1.5">
-                        <Sunrise size={16} className="text-amber-400 shrink-0" />
-                        {t('sun.polarDay')}
-                      </span>
-                    ) : sun.polarNight ? (
-                      <span className="flex items-center gap-1.5">
-                        <Sunset size={16} className="text-indigo-400 shrink-0" />
-                        {t('sun.polarNight')}
-                      </span>
-                    ) : sun.sunrise && sun.sunset ? (
-                      <>
-                        <span
-                          className="flex items-center gap-1.5"
-                          aria-label={`${t('sun.sunrise')} ${formatTime(sun.sunrise, { hour: '2-digit', minute: '2-digit' })}`}
-                        >
-                          <Sunrise size={16} className="text-amber-400 shrink-0" />
-                          {formatTime(sun.sunrise, { hour: '2-digit', minute: '2-digit' })}
-                        </span>
-                        <span
-                          className="flex items-center gap-1.5"
-                          aria-label={`${t('sun.sunset')} ${formatTime(sun.sunset, { hour: '2-digit', minute: '2-digit' })}`}
-                        >
-                          <Sunset size={16} className="text-orange-400 shrink-0" />
-                          {formatTime(sun.sunset, { hour: '2-digit', minute: '2-digit' })}
-                        </span>
-                        <span className="text-gray-400">
-                          {t('sun.daylight', splitDaylight(sun.daylightSeconds))}
-                        </span>
-                      </>
-                    ) : null}
-                  </div>
-                )}
-              </div>
-              <div className="text-blue-400">
-                {getWeatherIcon(currentSymbol, 56)}
-              </div>
-            </div>
-
-            <div className="grid grid-cols-3 gap-4 mt-6 pt-4 border-t border-gray-700">
-              <div className="flex items-center gap-2">
-                <Wind size={16} className="text-gray-400" />
-                <div>
-                  <p className="text-xs text-gray-400">{t('page.wind')}</p>
-                  <p className="text-sm font-medium flex items-center gap-1">
-                    {current.data.instant.details.wind_speed} m/s
-                    {current.data.instant.details.wind_from_direction !== undefined && (
-                      <ArrowUp
-                        size={14}
-                        className="text-gray-400 shrink-0"
-                        style={{ transform: `rotate(${windArrowRotation(current.data.instant.details.wind_from_direction)}deg)` }}
-                        aria-label={t('page.windFromDirectionAria', { degrees: Math.round(current.data.instant.details.wind_from_direction) })}
-                      />
-                    )}
-                  </p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <Droplets size={16} className="text-gray-400" />
-                <div>
-                  <p className="text-xs text-gray-400">{t('page.humidity')}</p>
-                  <p className="text-sm font-medium">
-                    {Math.round(current.data.instant.details.relative_humidity)}%
-                  </p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <Thermometer size={16} className="text-gray-400" />
-                <div>
-                  <p className="text-xs text-gray-400">{t('page.pressure')}</p>
-                  <p className="text-sm font-medium">
-                    {current.data.instant.details.air_pressure_at_sea_level
-                      ? `${Math.round(current.data.instant.details.air_pressure_at_sea_level)} hPa`
-                      : '—'}
-                  </p>
-                </div>
-              </div>
-            </div>
-            {timeAgo && (
-              <p className="text-xs text-gray-500 mt-4">{timeAgo}</p>
-            )}
-          </section>
+          <CurrentConditionsCard
+            current={current}
+            symbolCode={currentSymbol}
+            locationName={location?.name}
+            sun={sun}
+            timeAgo={timeAgo}
+          />
 
           {/* Hourly trend chart (next 24 hours) */}
           <HourlyChart timeseries={timeseries.slice(0, 24)} />
 
-          {/* Hourly Preview */}
-          <section className="bg-gray-800 rounded-xl p-6 mb-6">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">{t('page.nextHours', { count: hourlyRange })}</h2>
-              <div className="flex rounded-lg overflow-hidden border border-gray-600 text-xs">
-                {([12, 24, 48] as HourlyRange[]).map((range) => (
-                  <button
-                    key={range}
-                    onClick={() => setHourlyRange(range)}
-                    className={`px-3 py-1 transition-colors ${
-                      hourlyRange === range
-                        ? 'bg-blue-600 text-white'
-                        : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
-                    }`}
-                    aria-label={t('page.showNextHours', { count: range })}
-                    aria-pressed={hourlyRange === range}
-                  >
-                    {range}h
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className="flex gap-4 overflow-x-auto pb-2">
-              {timeseries.slice(0, hourlyRange).map((entry, index) => {
-                const dt = new Date(entry.time)
-                const hour = formatTime(dt, {
-                  hour: 'numeric',
-                  hour12: false,
-                })
-                const sym =
-                  entry.data.next_1_hours?.summary.symbol_code ||
-                  entry.data.next_6_hours?.summary.symbol_code ||
-                  'cloudy'
-                // Show date separator when crossing midnight (hour 0) after the first entry
-                const showDateSep = index > 0 && dt.getHours() === 0
-                const dateLabel = formatDate(dt, { weekday: 'short', month: 'short', day: 'numeric' })
-                return (
-                  <div key={entry.time} className="flex items-start gap-4">
-                    {showDateSep && (
-                      <div className="flex flex-col items-center self-stretch">
-                        <div className="w-px bg-gray-600 flex-1" />
-                        <span className="text-xs text-gray-400 whitespace-nowrap rotate-0 py-1 px-1 bg-gray-700 rounded text-center leading-tight">
-                          {dateLabel}
-                        </span>
-                        <div className="w-px bg-gray-600 flex-1" />
-                      </div>
-                    )}
-                    <div className="flex flex-col items-center gap-1 min-w-[3.5rem]">
-                      <span className="text-xs text-gray-400">{hour}</span>
-                      <span className="text-blue-400">{getWeatherIcon(sym, 20)}</span>
-                      <span className="text-sm font-medium">
-                        {Math.round(entry.data.instant.details.air_temperature)}°
-                      </span>
-                      {entry.data.next_1_hours?.details.precipitation_amount ? (
-                        <span className="text-xs text-blue-400">
-                          {entry.data.next_1_hours.details.precipitation_amount} mm
-                        </span>
-                      ) : null}
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          </section>
+          <HourlyStrip timeseries={timeseries} />
 
-          {/* 7-Day Forecast */}
-          <section className="bg-gray-800 rounded-xl p-6">
-            <h2 className="text-lg font-semibold mb-4">{t('page.sevenDayForecast')}</h2>
-            <div className="space-y-3">
-              {dailyForecasts.map((day) => (
-                <div
-                  key={day.date}
-                  className="flex items-center justify-between bg-gray-700/50 rounded-lg px-4 py-3"
-                >
-                  <div className="flex items-center gap-3 w-24">
-                    <span className="text-sm font-medium">{day.dayName}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-blue-400">
-                    {getWeatherIcon(day.symbolCode, 20)}
-                  </div>
-                  <div className="flex items-center gap-1 w-16 justify-end">
-                    <Droplets size={12} className="text-blue-400" />
-                    <span className="text-xs text-gray-400">{day.precipitation} mm</span>
-                  </div>
-                  <div className="flex items-center gap-1 w-16 justify-end">
-                    <Wind size={12} className="text-gray-400" />
-                    <span className="text-xs text-gray-400">{day.windSpeed} m/s</span>
-                  </div>
-                  <div className="flex items-center gap-2 w-20 justify-end">
-                    <span className="text-sm text-gray-400">{day.tempMin}°</span>
-                    <span className="text-sm font-medium">{day.tempMax}°</span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
+          <DailyForecastList days={dailyForecasts} />
 
           {/* Attribution */}
           <p className="text-xs text-gray-500 mt-4 text-center">

--- a/web/src/usePreferredLocation.ts
+++ b/web/src/usePreferredLocation.ts
@@ -7,11 +7,15 @@ import type { RecentLocation } from './recentLocations'
  * Starts with the localStorage/Oslo fallback, then asynchronously fetches the
  * user's saved `weather_location` preference from the server and resolves it to
  * coordinates via `/api/weather/locations`.
+ *
+ * Pass `enabled: false` to skip the server lookup entirely — used by callers that
+ * already have a location but must still call this hook unconditionally.
  */
-export function usePreferredLocation(): RecentLocation {
+export function usePreferredLocation(enabled = true): RecentLocation {
   const [location, setLocation] = useState<RecentLocation>(resolveLocation)
 
   useEffect(() => {
+    if (!enabled) return
     let cancelled = false
 
     async function fetchServerLocation() {
@@ -55,7 +59,7 @@ export function usePreferredLocation(): RecentLocation {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [enabled])
 
   return location
 }


### PR DESCRIPTION
## Changes

- **Weather page split into hooks and components** - The location resolution and persistence state machine, the forecast fetch/auto-refresh loop and the sun-times fetch now live in `useWeatherLocation`, `useForecast` and `useSunTimes`, with the page reduced to layout. Behaviour is unchanged; the auth-timing logic is now unit-tested and reusable by the dashboard widgets. (Hytte-c1x77)

## Original Issue (feature): Extract the location resolution and persistence state machine into hooks

### Scope
Split `web/src/pages/Weather.tsx` (838 lines) into a location hook, a forecast/sun-data hook, and three presentational components, keeping user-visible behaviour identical. Note a collision the executing agent must handle: `web/src/hooks/useForecast.ts` **already exists** with a different contract (zero-arg, sources its location from `usePreferredLocation`, has its own module-level cache) and is consumed by `components/today/AmbientLine.tsx` and `ClockWeatherWidget.tsx`. Extend that hook to accept an optional `location` argument (defaulting to `usePreferredLocation()`) plus `refresh`/`lastUpdated`, rather than adding a second hook with the same name.

### Files to touch
- `web/src/pages/Weather.tsx` — reduce to layout + composition
- `web/src/hooks/useWeatherLocation.ts` (new) — selection, recents, localStorage/preferences split, `pendingPreferenceName` retry, `locationResolved` guard, `userHasSelected`
- `web/src/hooks/useWeatherLocation.test.ts` (new)
- `web/src/hooks/useForecast.ts` — optional location arg, manual refresh, auto-refresh + `visibilitychange` pause, `lastUpdated`
- `web/src/hooks/useForecast.test.ts` — extend for the new arg/refresh paths
- `web/src/hooks/useSunTimes.ts` (new) + test — sunrise/sunset/daylight fetch keyed by location
- `web/src/components/weather/CurrentConditionsCard.tsx`, `HourlyStrip.tsx`, `DailyForecastList.tsx` (new)
- `web/src/pages/Weather.test.tsx` — keep as the behaviour baseline; extend if coverage gaps surface
- Reuse existing `web/src/recentLocations.ts` helpers; do not duplicate them
- `changelog.d/<name>.md` (new)

### Acceptance criteria
- `Weather.tsx` is under ~250 lines and contains no `useRef` state mirrors and no `eslint-disable react-hooks/exhaustive-deps`.
- `useWeatherLocation` has unit tests covering: preference arrives before the locations list (retry path resolves); logged-out user falls back to localStorage; logged-in user persists to preferences and not localStorage; explicit user selection wins over a later-arriving preference; unknown/invalid stored location falls back safely.
- `useForecast()` with no arguments behaves exactly as today; `AmbientLine` and `ClockWeatherWidget` are unchanged or updated only for the new signature, and their existing tests pass untouched.
- Auto-refresh still fires on a 10-minute interval, stops while `document.hidden`, and refreshes immediately on tab re-show; covered by a fake-timer test.
- All existing `Weather.test.tsx` assertions pass without weakening them.
- Manual check at 375px and desktop: location dropdown (recents + other cities), search, "use my location", hourly range toggle, "Updated X min ago", and sun times render and behave as before.
- `npm run lint`, `npm run test`, `npm run build` all pass; changelog fragment present.

### Non-goals
- No changes to `internal/weather/handler.go` or any API contract.
- No visual redesign, new copy, or new i18n keys beyond moving existing ones.
- Not migrating the Dashboard/Today widgets onto `useWeatherLocation` — only making it possible.
- No caching-strategy rework, no new state library, no `SkyWatchPage`/`KioskPage` refactor.

## Source

Created from Suggestions page (suggestion id 354, page slug "weather", source=claude).

## Original suggestion

Weather.tsx is 838 lines, and roughly half of it is a location state machine: six interacting effects, three refs mirroring state (`selectedLocationRef`, `recentLocationsRef`, `knownLocationsRef`), a `pendingPreferenceName` retry path for when preferences arrive before the locations list, a derived `locationResolved` guard, and two `eslint-disable react-hooks/exhaustive-deps` escapes. None of it is covered by tests today because it cannot be exercised without mounting the whole page. Extract a `useWeatherLocation()` hook owning selection, recents, and the localStorage/preferences split, and a `useForecast(location)` hook owning the cache-seeded reducer and auto-refresh, then reduce the remaining JSX to `CurrentConditionsCard`, `HourlyStrip`, and `DailyForecastList` components. The behaviour is unchanged for users, but the tricky auth-timing logic becomes unit-testable and reusable by the Dashboard weather widget, which currently duplicates parts of it.


---
Bead: Hytte-c1x77 | Branch: forge/Hytte-c1x77
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->