### PR TITLE
Add older-message pagination so chat history is reachable (Hytte-cl1sg)

### DIFF
--- a/changelog.d/Hytte-cl1sg.md
+++ b/changelog.d/Hytte-cl1sg.md
@@ -1,0 +1,2 @@
+category: Added
+- **Scroll back through family chat history** - Scrolling a conversation near the top now loads the previous page of messages and keeps the message you were reading in place, so older history is reachable instead of being capped at the most recent 50 messages. A "beginning of the conversation" marker appears once the oldest message has been loaded. Backed by a new `before=<id>` cursor on `GET /api/familychat/conversations/{id}/messages`. (Hytte-cl1sg)

--- a/internal/familychat/handlers.go
+++ b/internal/familychat/handlers.go
@@ -175,8 +175,16 @@ func GetConversationHandler(db *sql.DB) http.HandlerFunc {
 
 // ListMessagesHandler returns messages, newest first. Optional query params:
 //
-//	since=<id>  - return only messages with id > since
+//	since=<id>  - return only messages with id > since (forward catch-up)
+//	before=<id> - return only messages with id < before (older-history paging)
 //	limit=<n>   - cap the response size (default 50, max 500)
+//
+// since and before are mutually exclusive: a request carrying both is rejected
+// with 400 rather than silently picking one, because the two cursors describe
+// opposite directions of travel and a client combining them is confused about
+// which page it wants. A short page (fewer than limit messages) means the
+// caller has reached the end of history in that direction; there is no separate
+// has_more flag.
 func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		user := auth.UserFromContext(r.Context())
@@ -195,6 +203,19 @@ func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
 			}
 			since = n
 		}
+		var before int64
+		if v := strings.TrimSpace(r.URL.Query().Get("before")); v != "" {
+			n, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || n < 0 {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid before parameter"})
+				return
+			}
+			before = n
+		}
+		if since > 0 && before > 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "since and before cannot be combined"})
+			return
+		}
 		limit := defaultMsgLimit
 		if v := strings.TrimSpace(r.URL.Query().Get("limit")); v != "" {
 			n, err := strconv.Atoi(v)
@@ -205,7 +226,7 @@ func ListMessagesHandler(db *sql.DB) http.HandlerFunc {
 			limit = n
 		}
 
-		msgs, err := ListMessages(db, convID, user.ID, since, limit)
+		msgs, err := ListMessages(db, convID, user.ID, ListMessagesOpts{Since: since, Before: before, Limit: limit})
 		if err != nil {
 			if errors.Is(err, ErrForbidden) {
 				notFound(w)

--- a/internal/familychat/handlers_test.go
+++ b/internal/familychat/handlers_test.go
@@ -781,6 +781,120 @@ func TestListMessagesHandler_PaginationWithSince(t *testing.T) {
 	}
 }
 
+func TestListMessagesHandler_PaginationWithBefore(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+
+	const total = 7
+	for i := 1; i <= total; i++ {
+		if _, err := CreateMessage(db, convID, 1, fmt.Sprintf("msg %d", i), "", ""); err != nil {
+			t.Fatalf("seed message %d: %v", i, err)
+		}
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+	listBefore := func(before int64, limit int) []Message {
+		t.Helper()
+		url := fmt.Sprintf("/api/familychat/conversations/%s/messages?before=%d&limit=%d", idStr, before, limit)
+		req := withUser(httptest.NewRequest("GET", url, nil), 1)
+		req = withChiParam(req, "id", idStr)
+		rec := httptest.NewRecorder()
+		ListMessagesHandler(db).ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("before=%d: expected 200, got %d: %s", before, rec.Code, rec.Body.String())
+		}
+		var body struct {
+			Messages []Message `json:"messages"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode before=%d: %v", before, err)
+		}
+		return body.Messages
+	}
+
+	// Page back from the newest message: ids 4, 3, 2 (5 itself is excluded).
+	page := listBefore(5, 3)
+	if len(page) != 3 {
+		t.Fatalf("before=5 len = %d, want 3", len(page))
+	}
+	for i, want := range []int64{4, 3, 2} {
+		if page[i].ID != want {
+			t.Errorf("before=5[%d] = %d, want %d", i, page[i].ID, want)
+		}
+	}
+	if page[0].Body != "msg 4" {
+		t.Errorf("before=5[0] body = %q, want %q", page[0].Body, "msg 4")
+	}
+
+	// A short page means the caller has reached the start of history.
+	page = listBefore(2, 10)
+	if len(page) != 1 || page[0].ID != 1 {
+		t.Fatalf("before=2 = %+v, want just id 1", page)
+	}
+
+	// Nothing precedes the oldest message.
+	page = listBefore(1, 10)
+	if len(page) != 0 {
+		t.Errorf("before=1 len = %d, want 0", len(page))
+	}
+}
+
+func TestListMessagesHandler_InvalidBefore(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	convID := seedConversation(t, db, 1, "Family")
+	idStr := strconv.FormatInt(convID, 10)
+
+	for _, q := range []string{"before=abc", "before=-1", "before=3&since=1"} {
+		url := "/api/familychat/conversations/" + idStr + "/messages?" + q
+		req := withUser(httptest.NewRequest("GET", url, nil), 1)
+		req = withChiParam(req, "id", idStr)
+		rec := httptest.NewRecorder()
+		ListMessagesHandler(db).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d", q, rec.Code)
+			continue
+		}
+		var body struct {
+			Error string `json:"error"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Errorf("%s: decode: %v", q, err)
+			continue
+		}
+		if body.Error == "" {
+			t.Errorf("%s: expected an error message in the body", q)
+		}
+	}
+}
+
+// TestListMessagesHandler_BeforeNonMember pins that the membership check still
+// runs for a backward page — a non-member gets the same "conversation does not
+// exist" 404 the rest of the endpoints return (existence is never leaked).
+func TestListMessagesHandler_BeforeNonMember(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+	makeUser(t, db, 3, "carol@example.com")
+	convID := seedConversation(t, db, 1, "Family", 2)
+	if _, err := CreateMessage(db, convID, 1, "hi", "", ""); err != nil {
+		t.Fatalf("seed message: %v", err)
+	}
+
+	idStr := strconv.FormatInt(convID, 10)
+	req := withUser(httptest.NewRequest("GET", "/api/familychat/conversations/"+idStr+"/messages?before=99", nil), 3)
+	req = withChiParam(req, "id", idStr)
+	rec := httptest.NewRecorder()
+	ListMessagesHandler(db).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
 func TestMarkReadHandler(t *testing.T) {
 	db := setupTestDB(t)
 	makeUser(t, db, 1, "alice@example.com")
@@ -1344,7 +1458,7 @@ func TestEditMessageHandler_NonAuthor404(t *testing.T) {
 	}
 
 	// The body must be unchanged.
-	msgs, err := ListMessages(db, convID, 1, 0, 10)
+	msgs, err := ListMessages(db, convID, 1, ListMessagesOpts{Limit: 10})
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -1439,7 +1553,7 @@ func TestDeleteMessageHandler_AuthorSoftDeletePreservesRow(t *testing.T) {
 	}
 
 	// ListMessages still returns the tombstone with cleared body.
-	msgs, err := ListMessages(db, convID, 1, 0, 10)
+	msgs, err := ListMessages(db, convID, 1, ListMessagesOpts{Limit: 10})
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/internal/familychat/store.go
+++ b/internal/familychat/store.go
@@ -299,10 +299,26 @@ func DeleteConversation(db *sql.DB, convID, userID int64) error {
 	return nil
 }
 
-// ListMessages returns up to limit messages from convID, newest-first.
-// If since > 0, only messages with id > since are returned (still newest-first)
-// — this lets the client poll for new messages incrementally.
-func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message, error) {
+// ListMessagesOpts bounds a ListMessages query. Both cursors are exclusive and
+// may be combined (an id range), though the handler currently rejects that
+// combination so each client request walks history in exactly one direction.
+type ListMessagesOpts struct {
+	// Since, when > 0, restricts the result to messages with id > Since —
+	// the forward (catch-up) cursor used by delta polling and gap-fill.
+	Since int64
+	// Before, when > 0, restricts the result to messages with id < Before —
+	// the backward cursor used by "load older messages" pagination.
+	Before int64
+	// Limit caps the page size. Values <= 0 fall back to 50; anything above
+	// 500 is clamped to 500.
+	Limit int
+}
+
+// ListMessages returns up to opts.Limit messages from convID, newest-first,
+// bounded by the optional Since / Before cursors. Newest-first ordering holds
+// for every combination, so a backward page (Before) arrives in the same shape
+// as the initial load and the client only has to reverse it for display.
+func ListMessages(db *sql.DB, convID, userID int64, opts ListMessagesOpts) ([]Message, error) {
 	ok, err := IsMember(db, convID, userID)
 	if err != nil {
 		return nil, err
@@ -311,36 +327,34 @@ func ListMessages(db *sql.DB, convID, userID, since int64, limit int) ([]Message
 		return nil, ErrForbidden
 	}
 
+	limit := opts.Limit
 	if limit <= 0 {
-		limit = 50
+		limit = defaultMsgLimit
 	}
-	if limit > 500 {
-		limit = 500
+	if limit > maxMsgLimit {
+		limit = maxMsgLimit
 	}
 
-	var (
-		rows     *sql.Rows
-		queryErr error
-	)
-	if since > 0 {
-		rows, queryErr = db.Query(
-			messageSelectColumns+`
-			 FROM family_chat_messages
-			 WHERE conversation_id = ? AND id > ?
-			 ORDER BY id DESC
-			 LIMIT ?`,
-			convID, since, limit,
-		)
-	} else {
-		rows, queryErr = db.Query(
-			messageSelectColumns+`
-			 FROM family_chat_messages
-			 WHERE conversation_id = ?
-			 ORDER BY id DESC
-			 LIMIT ?`,
-			convID, limit,
-		)
+	conds := []string{"conversation_id = ?"}
+	args := []any{convID}
+	if opts.Since > 0 {
+		conds = append(conds, "id > ?")
+		args = append(args, opts.Since)
 	}
+	if opts.Before > 0 {
+		conds = append(conds, "id < ?")
+		args = append(args, opts.Before)
+	}
+	args = append(args, limit)
+
+	rows, queryErr := db.Query(
+		messageSelectColumns+`
+		 FROM family_chat_messages
+		 WHERE `+strings.Join(conds, " AND ")+`
+		 ORDER BY id DESC
+		 LIMIT ?`,
+		args...,
+	)
 	if queryErr != nil {
 		return nil, queryErr
 	}

--- a/internal/familychat/store_test.go
+++ b/internal/familychat/store_test.go
@@ -3,6 +3,7 @@ package familychat
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -176,7 +177,7 @@ func TestStoreListMessages_SinceAndLimit(t *testing.T) {
 	}
 
 	// Default order is newest-first. limit=2 returns the 2 most recently inserted.
-	msgs, err := ListMessages(db, c.ID, 1, 0, 2)
+	msgs, err := ListMessages(db, c.ID, 1, ListMessagesOpts{Limit: 2})
 	if err != nil {
 		t.Fatalf("list limit=2: %v", err)
 	}
@@ -188,12 +189,116 @@ func TestStoreListMessages_SinceAndLimit(t *testing.T) {
 	}
 
 	// since=ids[1] returns ids > ids[1], newest-first: ids[4], ids[3], ids[2].
-	msgs, err = ListMessages(db, c.ID, 1, ids[1], 10)
+	msgs, err = ListMessages(db, c.ID, 1, ListMessagesOpts{Since: ids[1], Limit: 10})
 	if err != nil {
 		t.Fatalf("list since: %v", err)
 	}
 	if len(msgs) != 3 {
 		t.Fatalf("since returned %d messages, want 3", len(msgs))
+	}
+}
+
+func TestStoreListMessages_BeforePaging(t *testing.T) {
+	db := setupTestDB(t)
+	makeUser(t, db, 1, "alice@example.com")
+	makeUser(t, db, 2, "bob@example.com")
+
+	c, err := CreateConversation(db, 1, "", []int64{2})
+	if err != nil {
+		t.Fatalf("create conv: %v", err)
+	}
+
+	// Seed enough messages that the default page size is exceeded, so the
+	// clamping assertions below are meaningful.
+	const total = 120
+	ids := make([]int64, 0, total)
+	for i := 0; i < total; i++ {
+		msg, err := CreateMessage(db, c.ID, 1, fmt.Sprintf("msg %d", i), "", "")
+		if err != nil {
+			t.Fatalf("create msg %d: %v", i, err)
+		}
+		ids = append(ids, msg.ID)
+	}
+
+	// before is strictly exclusive: the cursor message itself is never echoed
+	// back, and the page walks backward newest-first.
+	msgs, err := ListMessages(db, c.ID, 1, ListMessagesOpts{Before: ids[10], Limit: 3})
+	if err != nil {
+		t.Fatalf("list before: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("before returned %d messages, want 3", len(msgs))
+	}
+	for i, want := range []int64{ids[9], ids[8], ids[7]} {
+		if msgs[i].ID != want {
+			t.Errorf("before[%d] = %d, want %d", i, msgs[i].ID, want)
+		}
+	}
+
+	// Walking backward from the newest message covers the whole history
+	// without gaps or repeats.
+	seen := map[int64]bool{}
+	cursor := ids[total-1] + 1
+	for {
+		page, err := ListMessages(db, c.ID, 1, ListMessagesOpts{Before: cursor, Limit: 25})
+		if err != nil {
+			t.Fatalf("walk before=%d: %v", cursor, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, m := range page {
+			if seen[m.ID] {
+				t.Fatalf("message %d returned twice while walking backward", m.ID)
+			}
+			seen[m.ID] = true
+		}
+		cursor = page[len(page)-1].ID
+	}
+	if len(seen) != total {
+		t.Errorf("backward walk covered %d messages, want %d", len(seen), total)
+	}
+
+	// Limit <= 0 falls back to the 50-message default.
+	msgs, err = ListMessages(db, c.ID, 1, ListMessagesOpts{Before: ids[total-1], Limit: 0})
+	if err != nil {
+		t.Fatalf("list before default limit: %v", err)
+	}
+	if len(msgs) != defaultMsgLimit {
+		t.Errorf("default limit returned %d messages, want %d", len(msgs), defaultMsgLimit)
+	}
+
+	// A limit above the cap is clamped rather than rejected at this layer.
+	msgs, err = ListMessages(db, c.ID, 1, ListMessagesOpts{Before: ids[total-1], Limit: maxMsgLimit + 1000})
+	if err != nil {
+		t.Fatalf("list before clamped limit: %v", err)
+	}
+	if len(msgs) != total-1 {
+		t.Errorf("clamped limit returned %d messages, want %d", len(msgs), total-1)
+	}
+
+	// The oldest message has nothing before it.
+	msgs, err = ListMessages(db, c.ID, 1, ListMessagesOpts{Before: ids[0], Limit: 10})
+	if err != nil {
+		t.Fatalf("list before oldest: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("before oldest returned %d messages, want 0", len(msgs))
+	}
+
+	// Since + before together bound an open id range (the handler rejects the
+	// combination, but the store contract stays predictable).
+	msgs, err = ListMessages(db, c.ID, 1, ListMessagesOpts{Since: ids[0], Before: ids[4], Limit: 10})
+	if err != nil {
+		t.Fatalf("list since+before: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("since+before returned %d messages, want 3", len(msgs))
+	}
+	for i, want := range []int64{ids[3], ids[2], ids[1]} {
+		if msgs[i].ID != want {
+			t.Errorf("since+before[%d] = %d, want %d", i, msgs[i].ID, want)
+		}
 	}
 }
 
@@ -208,7 +313,7 @@ func TestStoreListMessages_NonMember(t *testing.T) {
 		t.Fatalf("create conv: %v", err)
 	}
 
-	_, err = ListMessages(db, c.ID, 3, 0, 100)
+	_, err = ListMessages(db, c.ID, 3, ListMessagesOpts{Limit: 100})
 	if !errors.Is(err, ErrForbidden) {
 		t.Errorf("expected ErrForbidden, got %v", err)
 	}

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -24,6 +24,8 @@
     "memberFallback": "Member #{{id}}",
     "you": "You",
     "emptyMessages": "No messages yet. Say hello!",
+    "loadingOlder": "Loading older messages…",
+    "beginningOfConversation": "This is the beginning of the conversation",
     "noSelectionTitle": "Pick a conversation",
     "noSelectionHint": "Choose a chat from the list to start reading.",
     "attachmentImageAlt": "Attached image",

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -24,6 +24,8 @@
     "memberFallback": "Medlem #{{id}}",
     "you": "Deg",
     "emptyMessages": "Ingen meldinger ennå. Si hei!",
+    "loadingOlder": "Laster eldre meldinger…",
+    "beginningOfConversation": "Dette er starten på samtalen",
     "noSelectionTitle": "Velg en samtale",
     "noSelectionHint": "Velg en chat fra listen for å begynne å lese.",
     "attachmentImageAlt": "Vedlagt bilde",

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -24,6 +24,8 @@
     "memberFallback": "สมาชิก #{{id}}",
     "you": "คุณ",
     "emptyMessages": "ยังไม่มีข้อความ ลองทักทายกันสิ!",
+    "loadingOlder": "กำลังโหลดข้อความเก่า…",
+    "beginningOfConversation": "นี่คือจุดเริ่มต้นของการสนทนา",
     "noSelectionTitle": "เลือกการสนทนา",
     "noSelectionHint": "เลือกแชตจากรายการเพื่อเริ่มอ่าน",
     "attachmentImageAlt": "รูปภาพแนบ",

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -33,6 +33,8 @@ const TRANSLATIONS: Record<string, string> = {
   'chat.memberFallback': 'Member #{{id}}',
   'chat.you': 'You',
   'chat.emptyMessages': 'No messages yet. Say hello!',
+  'chat.loadingOlder': 'Loading older messages…',
+  'chat.beginningOfConversation': 'This is the beginning of the conversation',
   'chat.noSelectionTitle': 'Pick a conversation',
   'chat.noSelectionHint': 'Choose a chat from the list to start reading.',
   'composer.placeholder': 'Write a message…',
@@ -280,6 +282,113 @@ describe('ChatView – message rendering order', () => {
     expect(bubbles[0].textContent).toBe('First message')
     expect(bubbles[1].textContent).toBe('Second message')
     expect(bubbles[2].textContent).toBe('Third message')
+  })
+})
+
+describe('ChatView – older-message pagination', () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  // olderPage builds a newest-first server page of `count` messages whose
+  // newest id is `newestId` — the shape GET /messages?before= returns.
+  function olderPage(newestId: number, count: number) {
+    return Array.from({ length: count }, (_, i) => makeMessage({
+      id: newestId - i,
+      body: `Old ${newestId - i}`,
+      created_at: '2026-04-01T10:00:00Z',
+    }))
+  }
+
+  function beforeCalls(fetchMock: ReturnType<typeof vi.fn>): string[] {
+    return fetchMock.mock.calls
+      .map(c => String(c[0]))
+      .filter(u => u.includes('before='))
+  }
+
+  function bubbleTexts(): (string | null)[] {
+    return Array.from(screen.getByRole('log').querySelectorAll('[class*="rounded-2xl"]'))
+      .map(el => el.textContent)
+  }
+
+  it('fetches the page before the oldest rendered message and prepends it oldest-first', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([makeMessage({ id: 51, body: 'Newest message' })]))
+      .mockResolvedValueOnce(streamOk())
+      // A full page (50) leaves hasMore true, so no terminator yet.
+      .mockResolvedValueOnce(msgsOk(olderPage(50, 50)))
+    vi.stubGlobal('fetch', fetchMock)
+    renderChatView()
+    await waitFor(() => expect(screen.getByText('Newest message')).toBeInTheDocument())
+
+    fireEvent.scroll(screen.getByRole('log'))
+    await waitFor(() => expect(screen.getByText('Old 1')).toBeInTheDocument())
+
+    expect(beforeCalls(fetchMock)).toEqual([
+      '/api/familychat/conversations/1/messages?before=51&limit=50',
+    ])
+    const texts = bubbleTexts()
+    expect(texts[0]).toBe('Old 1')
+    expect(texts[49]).toBe('Old 50')
+    expect(texts[50]).toBe('Newest message')
+    expect(screen.queryByTestId('family-chat-history-start')).not.toBeInTheDocument()
+  })
+
+  it('does not duplicate a message the older page overlaps with the live list', async () => {
+    const initial = [
+      makeMessage({ id: 3, body: 'Third message' }),
+      makeMessage({ id: 2, body: 'Second message' }),
+    ]
+    // The page overlaps on id 2, which is already rendered.
+    const older = [
+      makeMessage({ id: 2, body: 'Second message' }),
+      makeMessage({ id: 1, body: 'First message' }),
+    ]
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk(initial))
+      .mockResolvedValueOnce(streamOk())
+      .mockResolvedValueOnce(msgsOk(older))
+    vi.stubGlobal('fetch', fetchMock)
+    renderChatView()
+    await waitFor(() => expect(screen.getByText('Second message')).toBeInTheDocument())
+
+    fireEvent.scroll(screen.getByRole('log'))
+    await waitFor(() => expect(screen.getByText('First message')).toBeInTheDocument())
+
+    expect(screen.getAllByText('Second message')).toHaveLength(1)
+    expect(bubbleTexts()).toEqual(['First message', 'Second message', 'Third message'])
+  })
+
+  it('renders the beginning-of-conversation terminator and stops requesting once history runs out', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(convOk())
+      .mockResolvedValueOnce(msgsOk([makeMessage({ id: 5, body: 'Only message' })]))
+      .mockResolvedValueOnce(streamOk())
+      .mockResolvedValueOnce(msgsOk([]))
+    vi.stubGlobal('fetch', fetchMock)
+    renderChatView()
+    await waitFor(() => expect(screen.getByText('Only message')).toBeInTheDocument())
+
+    fireEvent.scroll(screen.getByRole('log'))
+    await waitFor(() => {
+      expect(screen.getByText('This is the beginning of the conversation')).toBeInTheDocument()
+    })
+    expect(beforeCalls(fetchMock)).toHaveLength(1)
+
+    // Further upward scrolling must not re-request a history we know is empty.
+    fireEvent.scroll(screen.getByRole('log'))
+    fireEvent.scroll(screen.getByRole('log'))
+    await waitFor(() => expect(beforeCalls(fetchMock)).toHaveLength(1))
+  })
+
+  it('does not page backward while the initial load is still in flight', async () => {
+    const fetchMock = vi.fn(() => new Promise(() => {}))
+    vi.stubGlobal('fetch', fetchMock)
+    const { container } = renderChatView()
+    const log = container.querySelector('[role="log"]')!
+    fireEvent.scroll(log)
+    // Only the conversation + messages requests from the initial load.
+    expect(beforeCalls(fetchMock as unknown as ReturnType<typeof vi.fn>)).toHaveLength(0)
   })
 })
 

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -33,6 +33,8 @@ import {
   applyReactionEvent,
   editMessage,
   deleteMessage,
+  fetchOlderMessages,
+  OLDER_PAGE_SIZE,
 } from './api'
 import {
   useFamilyChatStream,
@@ -57,6 +59,12 @@ interface ChatViewProps {
 // ChatMessage is defined alongside the stream that produces it; re-exported
 // here because the composer and bubble components import it from this module.
 export type { ChatMessage }
+
+// OLDER_SCROLL_THRESHOLD_PX is how close to the top of the message list the
+// user has to scroll before the previous page starts loading. Wide enough that
+// the page usually lands before the user hits the very top, small enough that
+// it doesn't fire on an idle list that merely isn't scrolled to the bottom.
+const OLDER_SCROLL_THRESHOLD_PX = 150
 
 // parseVoiceMeta extracts a {bars, durationMs} pair from a meta_json blob.
 // Returns null when the field is absent, unparseable, or shaped wrong — the
@@ -145,6 +153,26 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const [pipPosition, setPipPosition] = useState<{ x: number; y: number } | null>(null)
   const pipDragRef = useRef<{ offsetX: number; offsetY: number; pointerId: number } | null>(null)
 
+  // ── Older-history pagination ───────────────────────────────────────────────
+  // loadingOlder is true while a backward page is in flight; hasMoreOlder stays
+  // true until a page comes back short (or empty), which is the server's way of
+  // saying "that was the start of the conversation". Neither is cached across
+  // conversation switches — both reset in onConversationOpen below.
+  const [loadingOlder, setLoadingOlder] = useState(false)
+  const [hasMoreOlder, setHasMoreOlder] = useState(true)
+  // prependCounter ticks once per prepended page so the scroll-anchor restore
+  // below runs exactly when older messages land, and never on a normal append.
+  const [prependCounter, setPrependCounter] = useState(0)
+  const messagesScrollRef = useRef<HTMLDivElement>(null)
+  // loadingOlderRef mirrors loadingOlder synchronously: scroll events fire far
+  // faster than React commits, so the state flag alone would let several
+  // duplicate pages start before the first render lands.
+  const loadingOlderRef = useRef(false)
+  // pendingScrollRestoreRef holds the scroll metrics captured immediately
+  // before a prepend. Its presence is also what tells the auto-scroll-to-bottom
+  // effect to stand down for that one commit.
+  const pendingScrollRestoreRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null)
+
   // Voice-call state machine. skipSignalSubscription is set so the hook
   // doesn't open its own SSE stream — useFamilyChatStream below already owns
   // one for messages and reactions, and forwards call_* frames into
@@ -187,6 +215,13 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     onConversationOpen: () => {
       setEndedCallSummary(null)
       lastTypingSentRef.current = 0
+      // Older-history paging is per-conversation: nothing is cached across a
+      // switch, so every conversation starts out assuming there is more to
+      // load and discovers otherwise on the first upward scroll.
+      setLoadingOlder(false)
+      setHasMoreOlder(true)
+      loadingOlderRef.current = false
+      pendingScrollRestoreRef.current = null
     },
     onConversationClose: () => {
       // Stop any voice-note playback owned by this conversation. Switching
@@ -198,6 +233,12 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   })
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  // conversationIdRef shadows the current conversation so an in-flight
+  // "load older" response can tell whether the user has since switched chats.
+  const conversationIdRef = useRef(conversationId)
+  useEffect(() => {
+    conversationIdRef.current = conversationId
+  })
   // voiceCallEndRef lets the conversationId-change cleanup end any active call
   // on the old conversation without re-subscribing on every voice-call state change.
   const voiceCallEndRef = useRef(voiceCall.endCall)
@@ -330,10 +371,84 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // opens/closes (keyboardInset changes). useLayoutEffect avoids a visible jump
   // between initial paint and the scroll snap.
   useLayoutEffect(() => {
+    // A commit that prepended older history must not jump to the bottom — the
+    // restore effect below re-anchors the view on the message the user was
+    // already reading instead. messages.length changes on a prepend too, which
+    // is why this guard exists rather than a narrower dependency list.
+    if (pendingScrollRestoreRef.current) return
     if (messagesEndRef.current) {
       messagesEndRef.current.scrollIntoView({ block: 'end' })
     }
   }, [messages.length, conversationId, keyboardInset])
+
+  // Restore the scroll anchor after older messages are prepended: the content
+  // above the viewport grew by (newScrollHeight - savedScrollHeight), so adding
+  // that delta to the saved scrollTop keeps the same message under the user's
+  // eyes. Runs after the auto-scroll effect above (declaration order) and
+  // clears the flag that effect reads.
+  useLayoutEffect(() => {
+    const pending = pendingScrollRestoreRef.current
+    if (!pending) return
+    pendingScrollRestoreRef.current = null
+    const el = messagesScrollRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight - pending.scrollHeight + pending.scrollTop
+  }, [prependCounter])
+
+  // loadOlderMessages fetches the page immediately preceding the oldest message
+  // currently rendered and prepends it. Deduped by id so it can never collide
+  // with a message the live stream (or a gap-fill) already delivered, and a
+  // short page flips hasMoreOlder off so the terminator renders and no further
+  // requests are made.
+  const loadOlderMessages = useCallback(async () => {
+    if (conversationId === null) return
+    if (loadingOlderRef.current || !hasMoreOlder) return
+    const oldest = messages[0]
+    // An optimistic bubble carries no server id yet, so it can't anchor a
+    // backward page. It is always appended at the end, so this only skips the
+    // degenerate case where the list holds nothing else.
+    if (!oldest || oldest.status) return
+
+    loadingOlderRef.current = true
+    setLoadingOlder(true)
+    try {
+      const page = await fetchOlderMessages(conversationId, oldest.id, OLDER_PAGE_SIZE)
+      // The user may have switched conversations while this was in flight;
+      // the reset in onConversationOpen already ran, so applying now would
+      // leak the previous chat's history into the new one.
+      if (conversationIdRef.current !== conversationId) return
+      // A short page means the server had nothing more to give.
+      if (page.length < OLDER_PAGE_SIZE) setHasMoreOlder(false)
+      if (page.length === 0) return
+      // The API returns newest-first; the list renders oldest-first.
+      const older = page.slice().reverse()
+      const el = messagesScrollRef.current
+      if (el) {
+        pendingScrollRestoreRef.current = { scrollHeight: el.scrollHeight, scrollTop: el.scrollTop }
+      }
+      setMessages(prev => {
+        const known = new Set(prev.map(m => m.id))
+        const fresh = older.filter(m => !known.has(m.id))
+        if (fresh.length === 0) return prev
+        return [...fresh, ...prev]
+      })
+      setPrependCounter(c => c + 1)
+    } catch {
+      // Non-fatal: hasMoreOlder is left alone so scrolling up again retries.
+    } finally {
+      loadingOlderRef.current = false
+      setLoadingOlder(false)
+    }
+  }, [conversationId, hasMoreOlder, messages, setMessages])
+
+  // Near-top scroll is the only trigger for backward paging: no observer, no
+  // timer, and nothing fires while a page is already in flight or once the
+  // start of the conversation has been reached.
+  const handleMessagesScroll = useCallback(() => {
+    const el = messagesScrollRef.current
+    if (!el || el.scrollTop > OLDER_SCROLL_THRESHOLD_PX) return
+    void loadOlderMessages()
+  }, [loadOlderMessages])
 
   // Lightbox: ESC closes; scroll on body locked while open.
   useEffect(() => {
@@ -899,6 +1014,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       </header>
 
       <div
+        ref={messagesScrollRef}
+        onScroll={handleMessagesScroll}
         className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 sm:px-4 py-3 space-y-2"
         role="log"
         aria-live="polite"
@@ -923,6 +1040,26 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
           <div className="flex flex-col items-center justify-center h-full text-center text-gray-500 py-12">
             <MessageSquare size={32} className="mb-2 text-gray-600" aria-hidden="true" />
             <p className="text-sm">{t('chat.emptyMessages')}</p>
+          </div>
+        )}
+
+        {!loading && !error && messages.length > 0 && loadingOlder && (
+          <div
+            className="flex justify-center py-2 text-xs text-gray-500"
+            role="status"
+            aria-busy="true"
+            data-testid="family-chat-loading-older"
+          >
+            {t('chat.loadingOlder')}
+          </div>
+        )}
+
+        {!loading && !error && messages.length > 0 && !hasMoreOlder && !loadingOlder && (
+          <div
+            className="flex justify-center py-2 text-xs text-gray-500"
+            data-testid="family-chat-history-start"
+          >
+            {t('chat.beginningOfConversation')}
           </div>
         )}
 

--- a/web/src/pages/familychat/api.test.ts
+++ b/web/src/pages/familychat/api.test.ts
@@ -7,6 +7,8 @@ import {
   editMessage,
   deleteMessage,
   uploadAttachment,
+  fetchOlderMessages,
+  OLDER_PAGE_SIZE,
   UploadError,
   type ReactionMap,
 } from './api'
@@ -129,6 +131,49 @@ describe('deleteMessage', () => {
   it('throws when the response is not ok', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }))
     await expect(deleteMessage(1, 1)).rejects.toThrow()
+  })
+})
+
+describe('fetchOlderMessages', () => {
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('GETs the messages endpoint with the before cursor and limit', async () => {
+    const messages = [{ id: 4 }, { id: 3 }]
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ messages }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const out = await fetchOlderMessages(7, 5)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`/api/familychat/conversations/7/messages?before=5&limit=${OLDER_PAGE_SIZE}`)
+    expect(init.credentials).toBe('include')
+    expect(out).toEqual(messages)
+  })
+
+  it('honors an explicit limit', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ messages: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    await fetchOlderMessages(1, 99, 10)
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      '/api/familychat/conversations/1/messages?before=99&limit=10',
+    )
+  })
+
+  it('returns an empty array when the response omits messages', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    }))
+    await expect(fetchOlderMessages(1, 2)).resolves.toEqual([])
+  })
+
+  it('throws when the response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 400 }))
+    await expect(fetchOlderMessages(1, 2)).rejects.toThrow()
   })
 })
 

--- a/web/src/pages/familychat/api.ts
+++ b/web/src/pages/familychat/api.ts
@@ -2,6 +2,10 @@
 // the reactions feature for now; if other pages start hitting the API
 // directly we can grow this into a fuller wrapper.
 
+// Type-only import: erased at compile time, so this does not create a runtime
+// import cycle with useFamilyChatStream (which imports helpers from here).
+import type { ChatMessage } from './useFamilyChatStream'
+
 export interface ReactionBucket {
   count: number
   users: number[]
@@ -138,6 +142,29 @@ export async function deleteMessage(convID: number, msgID: number): Promise<void
     },
   )
   if (!res.ok) throw new Error(`delete message failed: ${res.status}`)
+}
+
+// OLDER_PAGE_SIZE is how many messages one "load older" page requests. It
+// matches the server's default page size, so a shorter response is an
+// unambiguous signal that the caller has reached the start of the history.
+export const OLDER_PAGE_SIZE = 50
+
+// fetchOlderMessages loads the page of messages immediately preceding beforeId
+// (strictly older, newest-first — the same shape as the initial load). Throws
+// on any non-success response so the caller can leave its "more history"
+// assumption untouched and retry on the next upward scroll.
+export async function fetchOlderMessages(
+  convID: number,
+  beforeId: number,
+  limit: number = OLDER_PAGE_SIZE,
+): Promise<ChatMessage[]> {
+  const res = await fetch(
+    `/api/familychat/conversations/${convID}/messages?before=${beforeId}&limit=${limit}`,
+    { credentials: 'include' },
+  )
+  if (!res.ok) throw new Error(`load older messages failed: ${res.status}`)
+  const data = await res.json()
+  return data.messages ?? []
 }
 
 // applyReactionEvent returns a new reaction map reflecting an add/remove SSE


### PR DESCRIPTION
## Changes

- **Scroll back through family chat history** - Scrolling a conversation near the top now loads the previous page of messages and keeps the message you were reading in place, so older history is reachable instead of being capped at the most recent 50 messages. A "beginning of the conversation" marker appears once the oldest message has been loaded. Backed by a new `before=<id>` cursor on `GET /api/familychat/conversations/{id}/messages`. (Hytte-cl1sg)

## Original Issue (feature): Add older-message pagination so chat history is reachable

I have what I need. Here's the plan:

### Scope
Add backward pagination to the family chat message API and wire an infinite-scroll "load older" loader into `ChatView`. Backend: a `before=<id>` query parameter on `GET /api/familychat/conversations/{id}/messages`, plumbed through `ListMessages` with the same membership check and limit clamping (default 50, max 500) as `since`. Frontend: when the message list is scrolled near the top, fetch the previous page, prepend it while preserving the scroll anchor, and render a translated "beginning of conversation" terminator once the oldest message has been reached.

### Files to touch
- `internal/familychat/store.go` — extend `ListMessages` with a `before` bound (`id < before`, still `ORDER BY id DESC LIMIT ?`); keep the existing signature callers working (add a param or an options struct — update all call sites).
- `internal/familychat/handlers.go` — parse/validate `before` in `ListMessagesHandler` (400 on non-numeric, same as `since`), reject `since` + `before` combined or define one precedence and document it in the handler comment.
- `internal/familychat/store_test.go` — coverage for `before` paging, boundary (exclusive), limit clamp, and empty result at the start of history.
- `internal/familychat/handlers_test.go` — coverage for `?before=`, invalid `before`, non-member 403.
- `web/src/pages/familychat/api.ts` — a `fetchOlderMessages(convID, beforeId, limit)` helper alongside the existing message calls.
- `web/src/pages/familychat/ChatView.tsx` — scroll container at line 1498: `onScroll` near-top trigger, `loadingOlder` / `hasMore` state, prepend + scroll-anchor restore in `useLayoutEffect`, and a guard so the existing auto-scroll-to-bottom effect (line ~903, keyed on `messages.length`) does **not** fire on a prepend.
- `web/src/pages/familychat/ChatView.test.tsx` — tests for the load-older fetch URL, prepend order, no-duplicate-ids, terminator rendering.
- `web/public/locales/{en,nb,th}/familyChat.json` — keys for the loading spinner label and the "beginning of conversation" terminator.
- `changelog.d/<name>.md` (new) — `category: Added` fragment.

### Acceptance criteria
- `GET /api/familychat/conversations/{id}/messages?before=<id>&limit=<n>` returns up to `n` messages strictly older than `<id>`, newest first, same shape as the existing response; `limit` defaults to 50 and clamps at 500.
- Invalid or non-numeric `before` returns 400 with `{"error": ...}`; a non-member still gets 403.
- Scrolling the chat message list to near the top in the UI fetches and prepends the previous page, and the message the user was looking at stays visually in place (no jump to bottom, no jump to top).
- Repeated upward scrolling walks back through the entire history; once the oldest message is loaded, a translated "beginning of conversation" marker renders and no further requests are made.
- Loading older messages never duplicates a message already in the list, and does not interfere with live `?since=` delta polling / hub updates or with new-message auto-scroll to bottom.
- All new strings exist in `en`, `nb`, and `th`; `go test ./...`, `npm run lint`, and `npm run build` pass.

### Non-goals
- No server-side cursor tokens, total counts, or `has_more` metadata beyond what a short page already implies.
- No jump-to-date, search-within-conversation, or deep-link-to-old-message navigation.
- No virtualized/windowed list or message-list rendering performance rework.
- No changes to attachments, reactions, calls, turn prompts, or the hub/streaming protocol.
- No caching of loaded pages across conversation switches or unmount.

## Source

Created from Suggestions page (suggestion id 366, page slug "family-chat", source=claude).

## Original suggestion

ListMessages only supports a `since` cursor (messages newer than an id) plus a 50-message default, and ChatView only ever fetches the initial page and `?since=<lastId>` deltas — there is no way to scroll back past the most recent 50 messages, so older family history is effectively unreachable in the UI. Add a `before=<id>` query parameter to GET /familychat/conversations/{id}/messages with the same limit clamping, and wire an infinite-scroll loader in ChatView that fetches the previous page when the message list is scrolled near the top, prepending while preserving scroll anchor. Include a 'beginning of conversation' terminator so users know when they have reached the start.


---
Bead: Hytte-cl1sg | Branch: forge/Hytte-cl1sg
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->