### PR TITLE
Stop rendering hours-old cached data as current conditions (Hytte-cv7bo)

### DIFF
--- a/changelog.d/Hytte-cv7bo.md
+++ b/changelog.d/Hytte-cv7bo.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Weather page no longer passes hours-old cache off as current conditions** - The "right now" card now shows the forecast hour nearest the clock instead of the first cached entry, the hourly strip and 24-hour chart start at the current hour with elapsed hours dropped, "Updated X ago" counts in hours and days rather than reporting a day-old cache as "1440 min ago", and a dismissible "showing cached data" chip appears whenever a refresh fails while a cached forecast is still on screen. (Hytte-cv7bo)

--- a/web/public/locales/en/weather.json
+++ b/web/public/locales/en/weather.json
@@ -11,6 +11,7 @@
     "pressure": "Pressure",
     "nextHours": "Next {{count}} hours",
     "showNextHours": "Show next {{count}} hours",
+    "noUpcomingHours": "No upcoming hours in this forecast.",
     "sevenDayForecast": "7-day forecast",
     "today": "Today",
     "recentLocations": "Recent",
@@ -56,8 +57,16 @@
   },
   "updated": {
     "justNow": "Updated just now",
-    "minuteAgo": "Updated 1 min ago",
-    "minutesAgo": "Updated {{count}} min ago"
+    "minutes_one": "Updated {{count}} min ago",
+    "minutes_other": "Updated {{count}} min ago",
+    "hours_one": "Updated {{count}} hour ago",
+    "hours_other": "Updated {{count}} hours ago",
+    "days_one": "Updated {{count}} day ago",
+    "days_other": "Updated {{count}} days ago"
+  },
+  "stale": {
+    "chip": "Showing cached data — the forecast could not be refreshed",
+    "dismiss": "Dismiss the cached data notice"
   },
   "sun": {
     "sunrise": "Sunrise",

--- a/web/public/locales/nb/weather.json
+++ b/web/public/locales/nb/weather.json
@@ -11,6 +11,7 @@
     "pressure": "Lufttrykk",
     "nextHours": "Neste {{count}} timer",
     "showNextHours": "Vis neste {{count}} timer",
+    "noUpcomingHours": "Ingen kommende timer i dette varselet.",
     "sevenDayForecast": "7-dagers varsel",
     "today": "I dag",
     "recentLocations": "Siste",
@@ -56,8 +57,16 @@
   },
   "updated": {
     "justNow": "Oppdatert akkurat nå",
-    "minuteAgo": "Oppdatert for 1 min siden",
-    "minutesAgo": "Oppdatert for {{count}} min siden"
+    "minutes_one": "Oppdatert for {{count}} min siden",
+    "minutes_other": "Oppdatert for {{count}} min siden",
+    "hours_one": "Oppdatert for {{count}} time siden",
+    "hours_other": "Oppdatert for {{count}} timer siden",
+    "days_one": "Oppdatert for {{count}} dag siden",
+    "days_other": "Oppdatert for {{count}} dager siden"
+  },
+  "stale": {
+    "chip": "Viser bufrede data – varselet kunne ikke oppdateres",
+    "dismiss": "Lukk varselet om bufrede data"
   },
   "sun": {
     "sunrise": "Soloppgang",

--- a/web/public/locales/th/weather.json
+++ b/web/public/locales/th/weather.json
@@ -11,6 +11,7 @@
     "pressure": "ความกดอากาศ",
     "nextHours": "{{count}} ชั่วโมงถัดไป",
     "showNextHours": "แสดง {{count}} ชั่วโมงถัดไป",
+    "noUpcomingHours": "ไม่มีชั่วโมงถัดไปในพยากรณ์นี้",
     "sevenDayForecast": "พยากรณ์ 7 วัน",
     "today": "วันนี้",
     "recentLocations": "ล่าสุด",
@@ -56,8 +57,16 @@
   },
   "updated": {
     "justNow": "อัปเดตเมื่อกี้",
-    "minuteAgo": "อัปเดต 1 นาทีที่แล้ว",
-    "minutesAgo": "อัปเดต {{count}} นาทีที่แล้ว"
+    "minutes_one": "อัปเดต {{count}} นาทีที่แล้ว",
+    "minutes_other": "อัปเดต {{count}} นาทีที่แล้ว",
+    "hours_one": "อัปเดต {{count}} ชั่วโมงที่แล้ว",
+    "hours_other": "อัปเดต {{count}} ชั่วโมงที่แล้ว",
+    "days_one": "อัปเดต {{count}} วันที่แล้ว",
+    "days_other": "อัปเดต {{count}} วันที่แล้ว"
+  },
+  "stale": {
+    "chip": "กำลังแสดงข้อมูลที่แคชไว้ — ไม่สามารถรีเฟรชพยากรณ์ได้",
+    "dismiss": "ปิดการแจ้งเตือนข้อมูลที่แคชไว้"
   },
   "sun": {
     "sunrise": "พระอาทิตย์ขึ้น",

--- a/web/src/components/weather/HourlyStrip.tsx
+++ b/web/src/components/weather/HourlyStrip.tsx
@@ -35,6 +35,9 @@ export default function HourlyStrip({ timeseries }: { timeseries: TimeseriesEntr
           ))}
         </div>
       </div>
+      {timeseries.length === 0 && (
+        <p className="text-sm text-gray-400">{t('page.noUpcomingHours')}</p>
+      )}
       <div className="flex gap-4 overflow-x-auto pb-2">
         {timeseries.slice(0, hourlyRange).map((entry, index) => {
           const dt = new Date(entry.time)

--- a/web/src/lib/weatherForecast.ts
+++ b/web/src/lib/weatherForecast.ts
@@ -1,3 +1,4 @@
+import type { TFunction } from 'i18next'
 import { formatDate } from '../utils/formatDate'
 
 export interface TimeseriesEntry {
@@ -24,6 +25,77 @@ export interface TimeseriesEntry {
       summary: { symbol_code: string }
     }
   }
+}
+
+/**
+ * Coarsest unit that still describes how old a forecast is. A cache left overnight
+ * must not read as "1440 min ago", so minutes give way to hours and then to days.
+ */
+export type TimeAgoTier =
+  | { unit: 'justNow' }
+  | { unit: 'minutes' | 'hours' | 'days'; count: number }
+
+export function timeAgoTier(elapsedMs: number): TimeAgoTier {
+  const seconds = Math.floor(elapsedMs / 1000)
+  if (seconds < 60) return { unit: 'justNow' }
+
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return { unit: 'minutes', count: minutes }
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return { unit: 'hours', count: hours }
+
+  return { unit: 'days', count: Math.floor(hours / 24) }
+}
+
+/** Render "Updated X ago" for a forecast fetched at `date`, in the `weather` namespace. */
+export function formatTimeAgo(date: Date, t: TFunction<'weather'>, now: number = Date.now()): string {
+  const tier = timeAgoTier(now - date.getTime())
+  switch (tier.unit) {
+    case 'minutes':
+      return t('updated.minutes', { count: tier.count })
+    case 'hours':
+      return t('updated.hours', { count: tier.count })
+    case 'days':
+      return t('updated.days', { count: tier.count })
+    default:
+      return t('updated.justNow')
+  }
+}
+
+/**
+ * Index of the entry whose timestamp sits closest to `now`, or -1 for an empty
+ * series. Distance is absolute, so 20 minutes into the current hour still resolves
+ * to that hour rather than jumping ahead to the next one. Entries with an
+ * unparseable timestamp are skipped.
+ */
+export function selectCurrentIndex(timeseries: TimeseriesEntry[], now: number): number {
+  let best = -1
+  let bestDistance = Infinity
+
+  for (let i = 0; i < timeseries.length; i++) {
+    const distance = Math.abs(new Date(timeseries[i].time).getTime() - now)
+    if (distance < bestDistance) {
+      best = i
+      bestDistance = distance
+    }
+  }
+
+  return best
+}
+
+/**
+ * Entries that have not fully elapsed: everything timestamped at or after the start
+ * of the current local hour. A cache old enough that every hour is already in the
+ * past yields an empty list, which callers render as "nothing upcoming" rather than
+ * passing off history as a forecast.
+ */
+export function selectUpcoming(timeseries: TimeseriesEntry[], now: number): TimeseriesEntry[] {
+  const startOfHour = new Date(now)
+  startOfHour.setMinutes(0, 0, 0)
+  const cutoff = startOfHour.getTime()
+
+  return timeseries.filter((entry) => new Date(entry.time).getTime() >= cutoff)
 }
 
 export interface DayForecast {

--- a/web/src/pages/Weather.test.tsx
+++ b/web/src/pages/Weather.test.tsx
@@ -1,6 +1,99 @@
 // @vitest-environment happy-dom
-import { describe, it, expect } from 'vitest'
-import { buildDailyForecasts, type TimeseriesEntry } from '../lib/weatherForecast'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import type { TFunction } from 'i18next'
+import {
+  buildDailyForecasts,
+  formatTimeAgo,
+  selectCurrentIndex,
+  selectUpcoming,
+  type TimeseriesEntry,
+} from '../lib/weatherForecast'
+import { formatDate } from '../utils/formatDate'
+import weatherEn from '../../public/locales/en/weather.json'
+import weatherNb from '../../public/locales/nb/weather.json'
+import weatherTh from '../../public/locales/th/weather.json'
+import Weather from './Weather'
+
+// ── Translation ───────────────────────────────────────────────────────────────
+// Translate against the real locale bundles rather than a hand-written map, so a
+// missing or renamed key fails the test instead of silently falling through.
+
+type Bundle = Record<string, unknown>
+
+function lookup(bundle: Bundle, key: string): unknown {
+  return key
+    .split('.')
+    .reduce<unknown>((acc, part) => (acc as Bundle | undefined)?.[part], bundle)
+}
+
+/** Minimal stand-in for i18next: `_one`/`_other` plurals plus `{{var}}` interpolation. */
+function makeT(bundle: Bundle) {
+  return (key: string, opts?: Record<string, unknown>): string => {
+    const count = opts?.count
+    const plural =
+      typeof count === 'number' ? lookup(bundle, `${key}_${count === 1 ? 'one' : 'other'}`) : undefined
+    const value = plural ?? lookup(bundle, key)
+    if (typeof value !== 'string') return (opts?.defaultValue as string | undefined) ?? key
+
+    return Object.entries(opts ?? {}).reduce<string>(
+      (acc, [name, replacement]) => acc.replaceAll(`{{${name}}}`, String(replacement)),
+      value,
+    )
+  }
+}
+
+const tEn = makeT(weatherEn as Bundle)
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: tEn, i18n: { language: 'en' } }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// ── Page dependencies ─────────────────────────────────────────────────────────
+
+vi.mock('../auth', () => ({ useAuth: () => ({ user: { id: 1 }, loading: false }) }))
+
+vi.mock('../components/LocationSearch', () => ({ default: () => null }))
+vi.mock('../components/UseMyLocationButton', () => ({ default: () => null }))
+
+const OSLO = { name: 'Oslo', lat: 59.9139, lon: 10.7522 }
+
+vi.mock('../hooks/useWeatherLocation', () => ({
+  useWeatherLocation: () => ({
+    location: OSLO,
+    recents: [OSLO],
+    knownLocations: [OSLO],
+    displayRecents: [OSLO],
+    otherCities: [],
+    locationResolved: true,
+    userHasSelected: false,
+    selectByName: () => {},
+    selectLocation: () => {},
+  }),
+}))
+
+vi.mock('../hooks/useSunTimes', () => ({ useSunTimes: () => null }))
+
+interface ForecastMock {
+  data: { properties: { timeseries: TimeseriesEntry[] } } | null
+  loading: boolean
+  error: boolean
+  errorMessage: string | null
+  lastUpdated: Date | null
+}
+
+const forecastMock: ForecastMock = {
+  data: null,
+  loading: false,
+  error: false,
+  errorMessage: null,
+  lastUpdated: null,
+}
+
+vi.mock('../hooks/useForecast', () => ({
+  useForecast: () => ({ ...forecastMock, refresh: () => {} }),
+}))
 
 /**
  * Build a minimal timeseries entry. `time` is parsed with `new Date(time)`; using
@@ -142,5 +235,299 @@ describe('buildDailyForecasts', () => {
       '2026-06-16',
       '2026-06-17',
     ])
+  })
+})
+
+describe('selectCurrentIndex', () => {
+  const series = [
+    entry('2026-06-10T12:00:00'),
+    entry('2026-06-10T13:00:00'),
+    entry('2026-06-10T14:00:00'),
+    entry('2026-06-10T15:00:00'),
+  ]
+
+  it('returns -1 for an empty series', () => {
+    expect(selectCurrentIndex([], new Date('2026-06-10T14:20:00').getTime())).toBe(-1)
+  })
+
+  it('picks the entry 20 minutes in the past over the nearer-in-index next hour', () => {
+    const now = new Date('2026-06-10T14:20:00').getTime()
+    expect(selectCurrentIndex(series, now)).toBe(2)
+  })
+
+  it('rolls over to the next hour past the half-hour mark', () => {
+    const now = new Date('2026-06-10T14:40:00').getTime()
+    expect(selectCurrentIndex(series, now)).toBe(3)
+  })
+
+  it('never picks index 0 just because the cache is old', () => {
+    // Every entry is hours in the past: the last one is still the closest.
+    const now = new Date('2026-06-11T09:00:00').getTime()
+    expect(selectCurrentIndex(series, now)).toBe(series.length - 1)
+  })
+
+  it('picks the first entry when the cache is somehow ahead of the clock', () => {
+    const now = new Date('2026-06-10T06:00:00').getTime()
+    expect(selectCurrentIndex(series, now)).toBe(0)
+  })
+})
+
+describe('selectUpcoming', () => {
+  const series = [
+    entry('2026-06-10T12:00:00'),
+    entry('2026-06-10T13:00:00'),
+    entry('2026-06-10T14:00:00'),
+    entry('2026-06-10T15:00:00'),
+  ]
+
+  it('keeps the current hour and drops the ones that fully elapsed', () => {
+    const now = new Date('2026-06-10T14:20:00').getTime()
+    expect(selectUpcoming(series, now).map((e) => e.time)).toEqual([
+      '2026-06-10T14:00:00',
+      '2026-06-10T15:00:00',
+    ])
+  })
+
+  it('returns everything when the forecast starts in the future', () => {
+    const now = new Date('2026-06-10T06:00:00').getTime()
+    expect(selectUpcoming(series, now)).toHaveLength(4)
+  })
+
+  it('returns nothing when the whole series is in the past', () => {
+    const now = new Date('2026-06-11T09:00:00').getTime()
+    expect(selectUpcoming(series, now)).toEqual([])
+  })
+
+  it('handles an empty series', () => {
+    expect(selectUpcoming([], Date.now())).toEqual([])
+  })
+})
+
+describe('formatTimeAgo', () => {
+  const now = new Date('2026-06-10T14:00:00').getTime()
+  const ago = (ms: number) => new Date(now - ms)
+
+  const MINUTE = 60_000
+  const HOUR = 60 * MINUTE
+  const DAY = 24 * HOUR
+
+  it('reads "just now" under a minute', () => {
+    expect(formatTimeAgo(ago(30_000), tEn as unknown as TFunction<'weather'>, now)).toBe(
+      'Updated just now',
+    )
+  })
+
+  it('reads minutes under an hour', () => {
+    const t = tEn as unknown as TFunction<'weather'>
+    expect(formatTimeAgo(ago(MINUTE), t, now)).toBe('Updated 1 min ago')
+    expect(formatTimeAgo(ago(45 * MINUTE), t, now)).toBe('Updated 45 min ago')
+    expect(formatTimeAgo(ago(59 * MINUTE), t, now)).toBe('Updated 59 min ago')
+  })
+
+  it('reads hours under a day, singular and plural', () => {
+    const t = tEn as unknown as TFunction<'weather'>
+    expect(formatTimeAgo(ago(HOUR), t, now)).toBe('Updated 1 hour ago')
+    expect(formatTimeAgo(ago(5 * HOUR), t, now)).toBe('Updated 5 hours ago')
+    expect(formatTimeAgo(ago(23 * HOUR), t, now)).toBe('Updated 23 hours ago')
+  })
+
+  it('reads days beyond 24 hours instead of 1440 minutes', () => {
+    const t = tEn as unknown as TFunction<'weather'>
+    expect(formatTimeAgo(ago(DAY), t, now)).toBe('Updated 1 day ago')
+    expect(formatTimeAgo(ago(3 * DAY), t, now)).toBe('Updated 3 days ago')
+  })
+
+  it('resolves every tier in all three locales', () => {
+    for (const bundle of [weatherEn, weatherNb, weatherTh] as Bundle[]) {
+      const t = makeT(bundle) as unknown as TFunction<'weather'>
+      for (const elapsed of [30_000, MINUTE, 45 * MINUTE, HOUR, 5 * HOUR, DAY, 3 * DAY]) {
+        const text = formatTimeAgo(ago(elapsed), t, now)
+        // A missing key would fall through to the raw key path.
+        expect(text.startsWith('updated.')).toBe(false)
+        expect(text).not.toContain('{{')
+      }
+    }
+  })
+})
+
+// ── Page rendering ────────────────────────────────────────────────────────────
+
+function setForecast(timeseries: TimeseriesEntry[], overrides: Partial<ForecastMock> = {}) {
+  Object.assign(forecastMock, {
+    data: { properties: { timeseries } },
+    loading: false,
+    error: false,
+    errorMessage: null,
+    lastUpdated: null,
+    ...overrides,
+  })
+}
+
+function sectionFor(headingText: string, label: string): HTMLElement {
+  const section = screen.getByText(headingText).closest('section')
+  if (!section) throw new Error(`${label} not found`)
+  return section
+}
+
+function currentCard(): HTMLElement {
+  return sectionFor(tEn('page.rightNowIn', { location: 'Oslo' }), 'current conditions card')
+}
+
+/**
+ * The hour-by-hour strip. The 7-day cards below it summarise the *whole* cached
+ * series by design, so past temperatures legitimately survive there — staleness
+ * assertions have to be scoped to the strip.
+ */
+function hourlyStrip(): HTMLElement {
+  return sectionFor(tEn('page.nextHours', { count: 12 }), 'hourly strip')
+}
+
+/** Same formatting HourlyStrip uses for its midnight separator. */
+function dateSeparatorLabel(iso: string): string {
+  return formatDate(new Date(iso), { weekday: 'short', month: 'short', day: 'numeric' })
+}
+
+describe('Weather page', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.assign(forecastMock, {
+      data: null,
+      loading: false,
+      error: false,
+      errorMessage: null,
+      lastUpdated: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows the entry nearest to now, not the first cached one', () => {
+    vi.setSystemTime(new Date('2026-06-10T14:20:00'))
+    setForecast([
+      entry('2026-06-10T12:00:00', 'rain', { temp: -8 }),
+      entry('2026-06-10T13:00:00', 'rain', { temp: -7 }),
+      entry('2026-06-10T14:00:00', 'cloudy', { temp: 14 }),
+      entry('2026-06-10T15:00:00', 'cloudy', { temp: 15 }),
+    ])
+
+    render(<Weather />)
+
+    expect(within(currentCard()).getByText('14°')).toBeTruthy()
+    // The elapsed hours are gone from the strip.
+    const strip = within(hourlyStrip())
+    expect(strip.queryByText('-8°')).toBeNull()
+    expect(strip.queryByText('-7°')).toBeNull()
+    expect(strip.getByText('14°')).toBeTruthy()
+    expect(strip.getByText('15°')).toBeTruthy()
+  })
+
+  it('starts the hourly strip at the current hour and keeps date separators correct', () => {
+    // 00:00 is the first upcoming entry, so it must not draw a "new day" separator.
+    vi.setSystemTime(new Date('2026-06-11T00:30:00'))
+    setForecast([
+      entry('2026-06-10T22:00:00', 'cloudy', { temp: -21 }),
+      entry('2026-06-10T23:00:00', 'cloudy', { temp: -22 }),
+      entry('2026-06-11T00:00:00', 'cloudy', { temp: 1 }),
+      entry('2026-06-11T01:00:00', 'cloudy', { temp: 2 }),
+    ])
+
+    render(<Weather />)
+
+    const strip = within(hourlyStrip())
+    expect(strip.queryByText('-21°')).toBeNull()
+    expect(strip.queryByText('-22°')).toBeNull()
+    expect(strip.getByText('1°')).toBeTruthy()
+    expect(strip.getByText('2°')).toBeTruthy()
+    expect(strip.queryByText(dateSeparatorLabel('2026-06-11T00:00:00'))).toBeNull()
+  })
+
+  it('still draws the separator when the retained hours cross midnight', () => {
+    vi.setSystemTime(new Date('2026-06-10T22:20:00'))
+    setForecast([
+      entry('2026-06-10T20:00:00', 'cloudy', { temp: -21 }),
+      entry('2026-06-10T22:00:00', 'cloudy', { temp: 22 }),
+      entry('2026-06-10T23:00:00', 'cloudy', { temp: 23 }),
+      entry('2026-06-11T00:00:00', 'cloudy', { temp: 1 }),
+    ])
+
+    render(<Weather />)
+
+    const strip = within(hourlyStrip())
+    expect(strip.queryByText('-21°')).toBeNull()
+    expect(strip.getAllByText(dateSeparatorLabel('2026-06-11T00:00:00'))).toHaveLength(1)
+  })
+
+  it('falls back to the last entry and reports no upcoming hours for a fully elapsed cache', () => {
+    vi.setSystemTime(new Date('2026-06-13T09:00:00'))
+    setForecast(
+      [
+        entry('2026-06-10T12:00:00', 'cloudy', { temp: 12 }),
+        entry('2026-06-10T13:00:00', 'cloudy', { temp: 13 }),
+      ],
+      { error: true, errorMessage: 'Failed to fetch forecast', lastUpdated: new Date('2026-06-10T13:00:00') },
+    )
+
+    render(<Weather />)
+
+    expect(within(currentCard()).getByText('13°')).toBeTruthy()
+    expect(screen.getByText(tEn('page.noUpcomingHours'))).toBeTruthy()
+    expect(screen.getByText(tEn('stale.chip'))).toBeTruthy()
+    expect(within(currentCard()).getByText('Updated 2 days ago')).toBeTruthy()
+  })
+
+  it('shows a dismissible cached-data chip while a forecast is on screen', () => {
+    vi.setSystemTime(new Date('2026-06-10T14:20:00'))
+    setForecast([entry('2026-06-10T14:00:00', 'cloudy', { temp: 14 })], {
+      error: true,
+      errorMessage: 'Failed to fetch forecast',
+    })
+
+    const { rerender } = render(<Weather />)
+
+    expect(screen.getByText(tEn('stale.chip'))).toBeTruthy()
+    // The red banner is for the no-data case only.
+    expect(screen.queryByText('Failed to fetch forecast')).toBeNull()
+
+    fireEvent.click(screen.getByLabelText(tEn('stale.dismiss')))
+    expect(screen.queryByText(tEn('stale.chip'))).toBeNull()
+
+    // A recovered refresh followed by a new failure brings the chip back.
+    Object.assign(forecastMock, { error: false, errorMessage: null })
+    rerender(<Weather />)
+    expect(screen.queryByText(tEn('stale.chip'))).toBeNull()
+
+    Object.assign(forecastMock, { error: true, errorMessage: 'Failed to fetch forecast' })
+    rerender(<Weather />)
+    expect(screen.getByText(tEn('stale.chip'))).toBeTruthy()
+  })
+
+  it('keeps the red banner and hides the chip when there is nothing cached to show', () => {
+    vi.setSystemTime(new Date('2026-06-10T14:20:00'))
+    Object.assign(forecastMock, {
+      data: null,
+      loading: false,
+      error: true,
+      errorMessage: 'Failed to fetch forecast',
+      lastUpdated: null,
+    })
+
+    render(<Weather />)
+
+    expect(screen.getByText('Failed to fetch forecast')).toBeTruthy()
+    expect(screen.queryByText(tEn('stale.chip'))).toBeNull()
+  })
+
+  it('shows no chip when a fresh forecast loaded successfully', () => {
+    vi.setSystemTime(new Date('2026-06-10T14:20:00'))
+    setForecast([entry('2026-06-10T14:00:00', 'cloudy', { temp: 14 })], {
+      lastUpdated: new Date('2026-06-10T14:19:00'),
+    })
+
+    render(<Weather />)
+
+    expect(screen.queryByText(tEn('stale.chip'))).toBeNull()
+    expect(within(currentCard()).getByText('Updated 1 min ago')).toBeTruthy()
   })
 })

--- a/web/src/pages/Weather.tsx
+++ b/web/src/pages/Weather.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react'
-import type { TFunction } from 'i18next'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { MapPin, RefreshCw } from 'lucide-react'
+import { CloudOff, MapPin, RefreshCw, X } from 'lucide-react'
 import { useAuth } from '../auth'
 import { Skeleton } from '../components/ui/skeleton'
 import LocationSearch from '../components/LocationSearch'
@@ -13,18 +12,13 @@ import DailyForecastList from '../components/weather/DailyForecastList'
 import { useWeatherLocation } from '../hooks/useWeatherLocation'
 import { useForecast } from '../hooks/useForecast'
 import { useSunTimes } from '../hooks/useSunTimes'
-import { buildDailyForecasts } from '../lib/weatherForecast'
-
-/** How often the "Updated X min ago" label is recomputed. */
-const TIME_AGO_TICK_MS = 30_000
-
-function formatTimeAgo(date: Date, t: TFunction<'weather'>): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
-  if (seconds < 60) return t('updated.justNow')
-  const minutes = Math.floor(seconds / 60)
-  if (minutes === 1) return t('updated.minuteAgo')
-  return t('updated.minutesAgo', { count: minutes })
-}
+import { useCurrentTime } from '../hooks/useCurrentTime'
+import {
+  buildDailyForecasts,
+  formatTimeAgo,
+  selectCurrentIndex,
+  selectUpcoming,
+} from '../lib/weatherForecast'
 
 export default function Weather() {
   const { t } = useTranslation('weather')
@@ -38,7 +32,7 @@ export default function Weather() {
     selectLocation,
   } = useWeatherLocation()
 
-  const { data: forecast, loading, errorMessage, lastUpdated, refresh } = useForecast(location, {
+  const { data: forecast, loading, error, errorMessage, lastUpdated, refresh } = useForecast(location, {
     persist: true,
     userId: user?.id,
     autoRefresh: true,
@@ -46,16 +40,32 @@ export default function Weather() {
   })
   const sun = useSunTimes(location, locationResolved)
 
-  // Tick periodically to keep the "Updated X min ago" text current.
-  const [, setTick] = useState(0)
-  useEffect(() => {
-    const timer = setInterval(() => setTick((v) => v + 1), TIME_AGO_TICK_MS)
-    return () => clearInterval(timer)
-  }, [])
-  const timeAgo = lastUpdated ? formatTimeAgo(lastUpdated, t) : ''
+  // A live clock keeps the "Updated X ago" text and the now-relative entry
+  // selection below current, so the page rolls over to the next hour on its own
+  // instead of waiting for a fetch to re-render it.
+  const now = useCurrentTime().getTime()
+
+  // Re-armed on every new failure so the chip returns after the user dismissed an
+  // earlier one, but stays hidden for the rest of the current failure. Compared
+  // against the previous render rather than reset from an effect, which would
+  // paint the dismissed chip once before removing it.
+  const [staleDismissed, setStaleDismissed] = useState(false)
+  const [dismissedForError, setDismissedForError] = useState(error)
+  if (dismissedForError !== error) {
+    setDismissedForError(error)
+    setStaleDismissed(false)
+  }
+
+  const timeAgo = lastUpdated ? formatTimeAgo(lastUpdated, t, now) : ''
 
   const timeseries = forecast?.properties?.timeseries ?? []
-  const current = timeseries[0]
+  // Index 0 is only "right now" for a freshly fetched forecast. A cached one can
+  // start hours or days back, so pick the entry nearest the clock instead. When
+  // the whole series has elapsed this still resolves to the last entry, keeping
+  // the card populated while the stale chip explains what it is showing.
+  const currentIndex = selectCurrentIndex(timeseries, now)
+  const current = currentIndex >= 0 ? timeseries[currentIndex] : undefined
+  const upcoming = selectUpcoming(timeseries, now)
   const dailyForecasts = timeseries.length > 0 ? buildDailyForecasts(timeseries, t('page.today')) : []
   const currentSymbol =
     current?.data.next_1_hours?.summary.symbol_code ||
@@ -125,6 +135,29 @@ export default function Weather() {
         </div>
       )}
 
+      {/*
+        A failed refresh with a forecast still on screen is exactly the case the
+        banner above skips. Say plainly that the numbers come from the cache
+        rather than letting an hours-old reading pass for the current conditions.
+      */}
+      {error && forecast && !staleDismissed && (
+        <div
+          role="status"
+          className="flex items-center gap-2 bg-amber-900/30 border border-amber-800 rounded-xl px-4 py-2 mb-4 text-sm text-amber-300"
+        >
+          <CloudOff size={16} className="shrink-0" />
+          <span className="flex-1">{t('stale.chip')}</span>
+          <button
+            type="button"
+            onClick={() => setStaleDismissed(true)}
+            aria-label={t('stale.dismiss')}
+            className="p-1 -mr-1 rounded text-amber-400 hover:text-amber-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      )}
+
       {current && (
         <>
           <CurrentConditionsCard
@@ -136,9 +169,9 @@ export default function Weather() {
           />
 
           {/* Hourly trend chart (next 24 hours) */}
-          <HourlyChart timeseries={timeseries.slice(0, 24)} />
+          <HourlyChart timeseries={upcoming.slice(0, 24)} />
 
-          <HourlyStrip timeseries={timeseries} />
+          <HourlyStrip timeseries={upcoming} />
 
           <DailyForecastList days={dailyForecasts} />
 


### PR DESCRIPTION
## Changes

- **Weather page no longer passes hours-old cache off as current conditions** - The "right now" card now shows the forecast hour nearest the clock instead of the first cached entry, the hourly strip and 24-hour chart start at the current hour with elapsed hours dropped, "Updated X ago" counts in hours and days rather than reporting a day-old cache as "1440 min ago", and a dismissible "showing cached data" chip appears whenever a refresh fails while a cached forecast is still on screen. (Hytte-cv7bo)

## Original Issue (feature): Stop rendering hours-old cached data as current conditions

### Scope
Make the Weather page honest about staleness. Derive the "right now" card and hourly views from the timeseries entry nearest `Date.now()` rather than index 0, extend the "Updated X ago" text past minutes, and surface a dismissible "showing cached data" chip whenever a fetch error coexists with a rendered (cached) forecast. No cache-format or backend changes.

### Files to touch
- `web/src/pages/Weather.tsx` — nearest/future entry selection, `formatTimeAgo` hours+days, stale chip, error banner condition
- `web/src/components/HourlyChart.tsx` — only if a prop/empty-state tweak is needed once past hours are dropped
- `web/src/pages/Weather.test.tsx` — tests for selection, staleness chip, relative-time formatting
- `web/public/locales/en/weather.json`, `nb/weather.json`, `th/weather.json` — new `updated.*` and stale-chip keys
- `changelog.d/<name>.md` (new) — `category: Fixed` fragment with the bead id

### Acceptance criteria
- With a cached forecast whose leading entries are in the past, the current-conditions card shows the entry closest to now (past entry only if it is the nearest one, e.g. 20 min into the current hour), not `timeseries[0]`.
- The hourly strip (12/24/48) and `HourlyChart` start at the current/next hour; entries wholly in the past are never rendered, and the strip's date separators and counts stay correct after the drop.
- `formatTimeAgo` renders minutes under an hour, hours under a day, and days beyond that (singular/plural handled), in all three locales — a 24h-old cache reads "1 day ago", never "1440 min ago".
- When `error` is set **and** a forecast is displayed, a dismissible "showing cached data" chip appears near the current card; dismissing hides it until the next error. The existing red banner still shows when `error` is set with no forecast.
- If every timeseries entry is in the past (very stale cache), the page does not crash or render an empty current card — it falls back to the last entry with the stale chip visible, or shows the error/empty state.
- All user-facing strings go through `t('weather:...')`; keys exist in `en`, `nb`, and `th`.
- `npm run lint`, `npm run build`, and `npm test` pass; new tests cover nearest-entry selection, past-entry filtering, hour/day formatting, and chip visibility.

### Non-goals
- Adding a TTL, expiry, or eviction-on-age to `web/src/lib/weatherCache.ts` — the cache keeps storing the last successful response indefinitely; only rendering changes.
- Changing `internal/weather/handler.go`, the yr.no request/response shape, or server-side caching.
- Altering the auto-refresh interval, retry/backoff behavior, or adding a manual "refresh now" control beyond what already exists.
- Reworking the multi-day forecast cards, sunrise/sunset section, or location picker.
- Redesigning the current-conditions card layout or the chart's visual style.

## Source

Created from Suggestions page (suggestion id 352, page slug "weather", source=claude).

## Original suggestion

The localStorage forecast cache in web/src/lib/weatherCache.ts has no TTL, and Weather.tsx seeds the reducer from it and then reads `current = timeseries[0]` plus `timeseries.slice(0, hourlyRange)` — so after a few days away, or whenever the background refresh fails, the card labelled "Right now in Oslo" shows a timestamp that is already in the past and the hourly strip starts with hours that have already happened. The error banner is also hidden in exactly this case (`{error && !forecast && ...}`), and `formatTimeAgo` only formats minutes, so a day-old cache reads "1440 minutes ago". Fix by selecting the timeseries entry nearest to `Date.now()` for the current card, dropping past entries from the hourly strip and HourlyChart, extending `formatTimeAgo` to hours and days, and rendering a dismissible "showing cached data" chip whenever `error` is set while a forecast is displayed. Users then either see live numbers or are told plainly that what they are looking at is stale.


---
Bead: Hytte-cv7bo | Branch: forge/Hytte-cv7bo
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->