### PR TITLE
Mark conversations read from the client so unread badges clear (Hytte-e3b89)

### DIFF
--- a/changelog.d/Hytte-e3b89.md
+++ b/changelog.d/Hytte-e3b89.md
@@ -1,0 +1,4 @@
+category: Fixed
+- **Family chat unread badges now clear** - Opening a conversation marks it read, and new messages are acknowledged while the tab is visible and the list is scrolled to the bottom, so the unread badge no longer stays lit in the chat you are reading. Peers' read receipts arriving on the live stream are shown as a "Seen by" line under your newest message. (Hytte-e3b89)
+</content>
+</invoke>

--- a/web/public/locales/en/familyChat.json
+++ b/web/public/locales/en/familyChat.json
@@ -26,6 +26,7 @@
     "emptyMessages": "No messages yet. Say hello!",
     "loadingOlder": "Loading older messages…",
     "beginningOfConversation": "This is the beginning of the conversation",
+    "seenBy": "Seen by {{names}}",
     "noSelectionTitle": "Pick a conversation",
     "noSelectionHint": "Choose a chat from the list to start reading.",
     "attachmentImageAlt": "Attached image",

--- a/web/public/locales/nb/familyChat.json
+++ b/web/public/locales/nb/familyChat.json
@@ -26,6 +26,7 @@
     "emptyMessages": "Ingen meldinger ennå. Si hei!",
     "loadingOlder": "Laster eldre meldinger…",
     "beginningOfConversation": "Dette er starten på samtalen",
+    "seenBy": "Sett av {{names}}",
     "noSelectionTitle": "Velg en samtale",
     "noSelectionHint": "Velg en chat fra listen for å begynne å lese.",
     "attachmentImageAlt": "Vedlagt bilde",

--- a/web/public/locales/th/familyChat.json
+++ b/web/public/locales/th/familyChat.json
@@ -26,6 +26,7 @@
     "emptyMessages": "ยังไม่มีข้อความ ลองทักทายกันสิ!",
     "loadingOlder": "กำลังโหลดข้อความเก่า…",
     "beginningOfConversation": "นี่คือจุดเริ่มต้นของการสนทนา",
+    "seenBy": "{{names}} อ่านแล้ว",
     "noSelectionTitle": "เลือกการสนทนา",
     "noSelectionHint": "เลือกแชตจากรายการเพื่อเริ่มอ่าน",
     "attachmentImageAlt": "รูปภาพแนบ",

--- a/web/src/pages/familychat/ChatView.test.tsx
+++ b/web/src/pages/familychat/ChatView.test.tsx
@@ -35,6 +35,7 @@ const TRANSLATIONS: Record<string, string> = {
   'chat.emptyMessages': 'No messages yet. Say hello!',
   'chat.loadingOlder': 'Loading older messages…',
   'chat.beginningOfConversation': 'This is the beginning of the conversation',
+  'chat.seenBy': 'Seen by {{names}}',
   'chat.noSelectionTitle': 'Pick a conversation',
   'chat.noSelectionHint': 'Choose a chat from the list to start reading.',
   'composer.placeholder': 'Write a message…',
@@ -121,6 +122,16 @@ vi.mock('../../auth', () => ({
   useAuth: () => authState,
 }))
 
+// ── Family chat context mock ──────────────────────────────────────────────────
+// ChatView is rendered bare here (the real app wraps it in FamilyChatProvider),
+// so the context is mocked; refreshConversations doubles as the spy that proves
+// the conversation list was told to refetch after a read marker.
+const refreshConversations = vi.fn()
+
+vi.mock('./FamilyChatContext', () => ({
+  useFamilyChat: () => ({ refreshConversations, refreshSignal: 0 }),
+}))
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeConversation(overrides: Record<string, unknown> = {}) {
@@ -188,6 +199,19 @@ function streamWithController() {
       streamController?.close()
     },
   }
+}
+
+// withReadMarker answers the read-marker POST that ChatView fires shortly after
+// a conversation with messages loads. Tests built on an ordered
+// mockResolvedValueOnce queue need it: without it the marker would consume the
+// next queued response and shift every later call by one.
+function withReadMarker(queued: (url: string, init?: RequestInit) => unknown) {
+  return vi.fn((url: string, init?: RequestInit) => {
+    if ((init?.method ?? 'GET').toUpperCase() === 'POST' && String(url).endsWith('/read')) {
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) })
+    }
+    return queued(url, init)
+  })
 }
 
 function renderChatView(conversationId: number | null = 1, onBack = vi.fn()) {
@@ -745,7 +769,7 @@ describe('ChatView – reconnect gap-fill', () => {
       .mockResolvedValueOnce({ ok: true, body: firstStream })
       .mockResolvedValueOnce(msgsOk([gapMsg2, gapMsg1]))  // API newest-first
       .mockResolvedValueOnce(streamOk())
-    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('fetch', withReadMarker(fetchMock))
 
     renderChatView()
     await waitFor(() => expect(screen.getByText('Before disconnect')).toBeInTheDocument())
@@ -833,7 +857,7 @@ describe('ChatView – reconnect gap-fill', () => {
       .mockResolvedValueOnce({ ok: true, body: firstStream })
       .mockResolvedValueOnce(msgsOk([gapMsg]))   // gap-fill on reconnect
       .mockResolvedValueOnce(streamOk())          // reconnect stream opens cleanly
-    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('fetch', withReadMarker(fetchMock))
 
     renderChatView()
     await waitFor(() => expect(screen.getByText('Before disconnect')).toBeInTheDocument())
@@ -1657,5 +1681,254 @@ describe('ChatView – call UI', () => {
       expect(screen.getByTestId('family-chat-incoming-overlay')).toBeInTheDocument()
     }, { timeout: 5000 })
     expect(screen.getByTestId('family-chat-incoming-kind-label').textContent).toBe('Incoming video call')
+  })
+})
+
+describe('ChatView – read markers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    setVisibility('visible')
+  })
+
+  // routedFetch dispatches on URL + method instead of a positional
+  // mockResolvedValueOnce queue: the read marker fires on its own schedule
+  // (debounced, and again on scroll / tab focus), so an ordered queue would be
+  // decided by timing rather than by what the test is asserting.
+  function routedFetch(opts: {
+    messages?: ReturnType<typeof makeMessage>[]
+    stream?: () => unknown
+    read?: () => Promise<unknown>
+  } = {}) {
+    return vi.fn((url: string, init?: RequestInit) => {
+      const u = String(url)
+      const method = (init?.method ?? 'GET').toUpperCase()
+      const convId = Number(u.match(/conversations\/(\d+)/)?.[1] ?? 1)
+      if (method === 'POST' && u.endsWith('/read')) {
+        return opts.read
+          ? opts.read()
+          : Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: 'ok' }) })
+      }
+      if (u.includes('/stream')) return Promise.resolve(opts.stream ? opts.stream() : streamOk())
+      if (u.includes('/messages')) {
+        return Promise.resolve(msgsOk(convId === 1 ? (opts.messages ?? []) : []))
+      }
+      return Promise.resolve(convOk(makeConversation({ id: convId, member_ids: [1, 2] })))
+    })
+  }
+
+  function readCalls(fetchMock: ReturnType<typeof vi.fn>) {
+    return fetchMock.mock.calls.filter(c => String(c[0]).endsWith('/read'))
+  }
+
+  function readBodies(fetchMock: ReturnType<typeof vi.fn>) {
+    return readCalls(fetchMock).map(c => JSON.parse(String((c[1] as RequestInit).body)))
+  }
+
+  function setVisibility(state: 'visible' | 'hidden') {
+    Object.defineProperty(document, 'visibilityState', { value: state, configurable: true })
+  }
+
+  // Fake the scroll metrics of the message list: happy-dom reports 0 for all
+  // three, which reads as "at the bottom" (the sensible default for a list that
+  // fits the viewport).
+  function setScrollMetrics(scrollTop: number, scrollHeight: number, clientHeight: number) {
+    const el = screen.getByRole('log')
+    Object.defineProperty(el, 'scrollTop', { value: scrollTop, writable: true, configurable: true })
+    Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true })
+    return el
+  }
+
+  // settle waits out the mark-read debounce (plus slack) so "nothing was
+  // posted" assertions test the absence of a request rather than its latency.
+  async function settle(ms = 500) {
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, ms)) })
+  }
+
+  const incoming = makeMessage({
+    id: 5,
+    sender_user_id: 2,
+    body: 'Hi there',
+    created_at: '2026-05-01T10:00:00.000Z',
+  })
+
+  it('marks the conversation read on open and refreshes the conversation list', async () => {
+    const fetchMock = routedFetch({ messages: [incoming] })
+    vi.stubGlobal('fetch', fetchMock)
+    renderChatView()
+    await waitFor(() => screen.getByText('Hi there'))
+
+    await waitFor(() => expect(readCalls(fetchMock)).toHaveLength(1), { timeout: 3000 })
+    const [url, init] = readCalls(fetchMock)[0]
+    expect(url).toBe('/api/familychat/conversations/1/read')
+    expect((init as RequestInit).method).toBe('POST')
+    expect((init as RequestInit).credentials).toBe('include')
+    expect(readBodies(fetchMock)[0]).toEqual({ at: '2026-05-01T10:00:00.000Z' })
+    await waitFor(() => expect(refreshConversations).toHaveBeenCalled())
+  })
+
+  it('does not mark read while the tab is hidden, and catches up when it becomes visible', async () => {
+    setVisibility('hidden')
+    const fetchMock = routedFetch({ messages: [incoming] })
+    vi.stubGlobal('fetch', fetchMock)
+    renderChatView()
+    await waitFor(() => screen.getByText('Hi there'))
+
+    await settle()
+    expect(readCalls(fetchMock)).toHaveLength(0)
+    expect(refreshConversations).not.toHaveBeenCalled()
+
+    setVisibility('visible')
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(readCalls(fetchMock)).toHaveLength(1), { timeout: 3000 })
+  })
+
+  it('does not mark read while scrolled up in history, and marks read on scrolling back down', async () => {
+    const sse = streamWithController()
+    const fetchMock = routedFetch({ messages: [incoming], stream: () => sse.response })
+    vi.stubGlobal('fetch', fetchMock)
+    renderChatView()
+    await waitFor(() => screen.getByText('Hi there'))
+    await waitFor(() => expect(readCalls(fetchMock)).toHaveLength(1), { timeout: 3000 })
+
+    // Scroll up into history — well clear of the bottom, and clear of the
+    // load-older threshold at the top.
+    setScrollMetrics(200, 1000, 300)
+    await act(async () => {
+      sse.push('message_new', {
+        message: makeMessage({
+          id: 6,
+          sender_user_id: 2,
+          body: 'Newer message',
+          created_at: '2026-05-01T11:00:00.000Z',
+        }),
+      })
+      await Promise.resolve()
+    })
+    await waitFor(() => screen.getByText('Newer message'))
+
+    await settle()
+    expect(readCalls(fetchMock)).toHaveLength(1)
+
+    // Back at the bottom: the deferred marker goes out for the newest message.
+    const log = setScrollMetrics(700, 1000, 300)
+    fireEvent.scroll(log)
+    await waitFor(() => expect(readCalls(fetchMock)).toHaveLength(2), { timeout: 3000 })
+    expect(readBodies(fetchMock)[1]).toEqual({ at: '2026-05-01T11:00:00.000Z' })
+  })
+
+  it('deduplicates: a burst of messages produces a single marker for the newest id', async () => {
+    const sse = streamWithController()
+    const fetchMock = routedFetch({ messages: [incoming], stream: () => sse.response })
+    vi.stubGlobal('fetch', fetchMock)
+    const { rerender } = renderChatView()
+    await waitFor(() => screen.getByText('Hi there'))
+    await waitFor(() => expect(readCalls(fetchMock)).toHaveLength(1), { timeout: 3000 })
+
+    await act(async () => {
+      for (const [id, hour] of [[6, '11'], [7, '12'], [8, '13']] as const) {
+        sse.push('message_new', {
+          message: makeMessage({
+            id,
+            sender_user_id: 2,
+            body: `Burst ${id}`,
+            created_at: `2026-05-01T${hour}:00:00.000Z`,
+          }),
+        })
+      }
+      await Promise.resolve()
+    })
+    await waitFor(() => screen.getByText('Burst 8'))
+
+    await settle()
+    expect(readCalls(fetchMock)).toHaveLength(2)
+    expect(readBodies(fetchMock)[1]).toEqual({ at: '2026-05-01T13:00:00.000Z' })
+
+    // A re-render with no new messages must not re-post the same marker.
+    rerender(<ChatView conversationId={1} onBack={vi.fn()} />)
+    await settle()
+    expect(readCalls(fetchMock)).toHaveLength(2)
+  })
+
+  it('shows a peer read receipt as "Seen by" without posting a marker of its own', async () => {
+    const own = makeMessage({
+      id: 5,
+      sender_user_id: 1,
+      body: 'My message',
+      created_at: '2026-05-01T10:00:00.000Z',
+    })
+    const sse = streamWithController()
+    const fetchMock = routedFetch({ messages: [own], stream: () => sse.response })
+    vi.stubGlobal('fetch', fetchMock)
+    renderChatView()
+    await waitFor(() => screen.getByText('My message'))
+    await waitFor(() => expect(readCalls(fetchMock)).toHaveLength(1), { timeout: 3000 })
+
+    await act(async () => {
+      sse.push('read_receipt', {
+        conversation_id: 1,
+        user_id: 2,
+        at: '2026-05-01T10:05:00.000Z',
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('family-chat-seen-by').textContent).toBe('Seen by Member #2')
+    })
+    await settle()
+    expect(readCalls(fetchMock)).toHaveLength(1)
+  })
+
+  it('ignores our own read_receipt echo', async () => {
+    const own = makeMessage({
+      id: 5,
+      sender_user_id: 1,
+      body: 'My message',
+      created_at: '2026-05-01T10:00:00.000Z',
+    })
+    const sse = streamWithController()
+    const fetchMock = routedFetch({ messages: [own], stream: () => sse.response })
+    vi.stubGlobal('fetch', fetchMock)
+    renderChatView()
+    await waitFor(() => screen.getByText('My message'))
+    await waitFor(() => expect(readCalls(fetchMock)).toHaveLength(1), { timeout: 3000 })
+
+    await act(async () => {
+      sse.push('read_receipt', {
+        conversation_id: 1,
+        user_id: 1,
+        at: '2026-05-01T10:05:00.000Z',
+      })
+      await Promise.resolve()
+    })
+
+    await settle()
+    expect(screen.queryByTestId('family-chat-seen-by')).not.toBeInTheDocument()
+    expect(readCalls(fetchMock)).toHaveLength(1)
+  })
+
+  it('aborts an in-flight read marker when the conversation changes, without surfacing an error', async () => {
+    const fetchMock = routedFetch({
+      messages: [incoming],
+      // Never settles, so the request is still in flight at the switch.
+      read: () => new Promise(() => {}),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { rerender } = renderChatView()
+    await waitFor(() => screen.getByText('Hi there'))
+    await waitFor(() => expect(readCalls(fetchMock)).toHaveLength(1), { timeout: 3000 })
+
+    rerender(<ChatView conversationId={2} onBack={vi.fn()} />)
+    await waitFor(() => {
+      const signal = (readCalls(fetchMock)[0][1] as RequestInit).signal
+      expect(signal?.aborted).toBe(true)
+    })
+    expect(refreshConversations).not.toHaveBeenCalled()
+    expect(screen.queryByText('Failed to load messages')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -34,13 +34,16 @@ import {
   editMessage,
   deleteMessage,
   fetchOlderMessages,
+  markConversationRead,
   OLDER_PAGE_SIZE,
 } from './api'
+import { useFamilyChat } from './FamilyChatContext'
 import {
   useFamilyChatStream,
   reconcileMessage,
   type ChatMessage,
   type MissedCallEntry,
+  type ReadReceiptPayload,
 } from './useFamilyChatStream'
 import { formatRelative } from './utils'
 import VoiceBubble from './voice/VoiceBubble'
@@ -65,6 +68,16 @@ export type { ChatMessage }
 // the page usually lands before the user hits the very top, small enough that
 // it doesn't fire on an idle list that merely isn't scrolled to the bottom.
 const OLDER_SCROLL_THRESHOLD_PX = 150
+
+// AT_BOTTOM_THRESHOLD_PX is how far from the very bottom of the message list
+// still counts as "the user is looking at the newest message". A few dozen
+// pixels of slack keeps a half-scrolled-by-a-hair list from being treated as
+// reading history.
+const AT_BOTTOM_THRESHOLD_PX = 80
+
+// MARK_READ_DEBOUNCE_MS collapses a burst of arriving messages into a single
+// read marker for the newest one, instead of one POST per message.
+const MARK_READ_DEBOUNCE_MS = 300
 
 // parseVoiceMeta extracts a {bars, durationMs} pair from a meta_json blob.
 // Returns null when the field is absent, unparseable, or shaped wrong — the
@@ -173,6 +186,33 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // effect to stand down for that one commit.
   const pendingScrollRestoreRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null)
 
+  // ── Read markers ───────────────────────────────────────────────────────────
+  // refreshConversations makes the sibling ConversationList refetch, which is
+  // what actually clears the unread badge after the server accepts our marker.
+  const { refreshConversations } = useFamilyChat()
+  // peerReads maps a member's user id to the timestamp of their most recent
+  // read receipt. Live-only: the conversation API exposes no per-member
+  // last_read_at, so this starts empty on every load and fills in as peers read.
+  const [peerReads, setPeerReads] = useState<Map<number, string>>(new Map())
+  // lastAckedIdRef is the newest message id we have already told the server we
+  // read, so re-renders and repeat effect runs don't re-POST. Reset per
+  // conversation (see onConversationOpen and the cleanup effect below).
+  const lastAckedIdRef = useRef(0)
+  // readAbortRef / readTimerRef own the in-flight read request and the pending
+  // debounce for the current conversation; both are torn down on a switch.
+  const readAbortRef = useRef<AbortController | null>(null)
+  const readTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // handleReadReceipt records a peer's read marker. The stream already drops
+  // our own echo, so anything arriving here belongs to another member.
+  const handleReadReceipt = useCallback((payload: ReadReceiptPayload) => {
+    setPeerReads(prev => {
+      const next = new Map(prev)
+      next.set(payload.user_id, payload.at)
+      return next
+    })
+  }, [])
+
   // Voice-call state machine. skipSignalSubscription is set so the hook
   // doesn't open its own SSE stream — useFamilyChatStream below already owns
   // one for messages and reactions, and forwards call_* frames into
@@ -212,9 +252,20 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     callKind: voiceCall.callKind,
     onSignal: voiceCall.handleSignalEvent,
     onGroupSignal: groupCall.handleSignalEvent,
+    onReadReceipt: handleReadReceipt,
     onConversationOpen: () => {
       setEndedCallSummary(null)
       lastTypingSentRef.current = 0
+      // Read state is per-conversation: drop the acknowledged watermark, any
+      // pending/in-flight marker, and the peers' live receipts.
+      lastAckedIdRef.current = 0
+      if (readTimerRef.current !== null) {
+        clearTimeout(readTimerRef.current)
+        readTimerRef.current = null
+      }
+      readAbortRef.current?.abort()
+      readAbortRef.current = null
+      setPeerReads(new Map())
       // Older-history paging is per-conversation: nothing is cached across a
       // switch, so every conversation starts out assuming there is more to
       // load and discovers otherwise on the first upward scroll.
@@ -441,14 +492,116 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     }
   }, [conversationId, hasMoreOlder, messages, setMessages])
 
-  // Near-top scroll is the only trigger for backward paging: no observer, no
-  // timer, and nothing fires while a page is already in flight or once the
-  // start of the conversation has been reached.
+  // newestServerMessage is the last message carrying an authoritative id. An
+  // optimistic bubble has no server id yet, so it can never anchor a read
+  // marker; it reconciles a moment later and this picks it up then.
+  const newestServerMessage = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (!messages[i].status) return messages[i]
+    }
+    return null
+  }, [messages])
+
+  // isAtBottom reports whether the message list is scrolled at (or within a
+  // hair of) the newest message. A list that has never been scrolled — or one
+  // shorter than the viewport — counts as at the bottom.
+  const isAtBottom = useCallback(() => {
+    const el = messagesScrollRef.current
+    if (!el) return true
+    return el.scrollHeight - el.scrollTop - el.clientHeight <= AT_BOTTOM_THRESHOLD_PX
+  }, [])
+
+  // postReadMarker sends the marker for `newestId` and refreshes the sibling
+  // conversation list so the unread badge drops. Deduplicated against the last
+  // acknowledged id, and best-effort: a failed or aborted request never shows an
+  // error and never disturbs the stream.
+  const postReadMarker = useCallback((newestId: number, at: string) => {
+    if (conversationId === null) return
+    if (newestId <= 0 || newestId <= lastAckedIdRef.current) return
+    // Claim the watermark before the request so a burst of renders can't queue
+    // several POSTs for the same id while the first is still in flight.
+    lastAckedIdRef.current = newestId
+    readAbortRef.current?.abort()
+    const controller = new AbortController()
+    readAbortRef.current = controller
+    markConversationRead(conversationId, { at, signal: controller.signal })
+      .then(() => {
+        if (controller.signal.aborted) return
+        refreshConversations()
+      })
+      .catch((err: unknown) => {
+        // An abort means we switched conversations (or superseded this marker
+        // with a newer one) — the watermark is reset by whoever aborted, so
+        // leave it alone. A genuine failure rolls it back so the next arriving
+        // message, scroll or tab focus retries.
+        if (err instanceof Error && err.name === 'AbortError') return
+        if (lastAckedIdRef.current === newestId) lastAckedIdRef.current = 0
+      })
+      .finally(() => {
+        if (readAbortRef.current === controller) readAbortRef.current = null
+      })
+  }, [conversationId, refreshConversations])
+
+  // maybeMarkRead marks the conversation read only when the user can actually
+  // see the newest message: the tab is visible and the list is at the bottom.
+  // Hidden tabs and scrolled-up history readers keep their unread badge until
+  // they come back, which is what the visibility/scroll listeners below are for.
+  const maybeMarkRead = useCallback(() => {
+    if (conversationId === null || !newestServerMessage) return
+    if (newestServerMessage.id <= lastAckedIdRef.current) return
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return
+    if (!isAtBottom()) return
+    const { id, created_at } = newestServerMessage
+    if (readTimerRef.current !== null) clearTimeout(readTimerRef.current)
+    readTimerRef.current = setTimeout(() => {
+      readTimerRef.current = null
+      postReadMarker(id, created_at)
+    }, MARK_READ_DEBOUNCE_MS)
+  }, [conversationId, newestServerMessage, isAtBottom, postReadMarker])
+
+  // Mark read on open and whenever a newer message lands (the callback's
+  // identity changes with newestServerMessage, so this is exactly once per new
+  // newest message).
+  useEffect(() => {
+    maybeMarkRead()
+  }, [maybeMarkRead])
+
+  // Returning to the tab is the other moment a deferred marker can be sent.
+  // The ref keeps the listener registration independent of message arrivals.
+  const maybeMarkReadRef = useRef(maybeMarkRead)
+  useEffect(() => { maybeMarkReadRef.current = maybeMarkRead })
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const onVisibility = () => { maybeMarkReadRef.current() }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => document.removeEventListener('visibilitychange', onVisibility)
+  }, [])
+
+  // Drop any pending/in-flight marker when the conversation changes or the view
+  // unmounts, so a late response can't refresh the list for a chat the user has
+  // already left.
+  useEffect(() => {
+    return () => {
+      if (readTimerRef.current !== null) {
+        clearTimeout(readTimerRef.current)
+        readTimerRef.current = null
+      }
+      readAbortRef.current?.abort()
+      readAbortRef.current = null
+      lastAckedIdRef.current = 0
+    }
+  }, [conversationId])
+
+  // Scroll drives both directions of paging state: near the top loads the
+  // previous page, back at the bottom acknowledges the newest message. Nothing
+  // fires while a page is already in flight or once the start of the
+  // conversation has been reached.
   const handleMessagesScroll = useCallback(() => {
+    maybeMarkRead()
     const el = messagesScrollRef.current
     if (!el || el.scrollTop > OLDER_SCROLL_THRESHOLD_PX) return
     void loadOlderMessages()
-  }, [loadOlderMessages])
+  }, [loadOlderMessages, maybeMarkRead])
 
   // Lightbox: ESC closes; scroll on body locked while open.
   useEffect(() => {
@@ -774,6 +927,31 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       .filter(id => id !== user?.id)
       .map(id => memberLookup.get(id)?.label ?? t('chat.memberFallback', { id }))
   }, [typingUsers, memberLookup, user?.id, t])
+
+  // seenByLabels names the members whose live read receipt covers our newest
+  // message. Receipts are observed in-session only (the conversation API
+  // carries no per-member last_read_at), so this stays empty after a reload
+  // until a peer reads something new.
+  const seenByLabels = useMemo(() => {
+    if (peerReads.size === 0) return []
+    let lastOwn: ChatMessage | null = null
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i]
+      if (m.sender_user_id === user?.id && !m.status) { lastOwn = m; break }
+    }
+    if (!lastOwn) return []
+    const sentAt = Date.parse(lastOwn.created_at)
+    if (Number.isNaN(sentAt)) return []
+    const labels: string[] = []
+    for (const [id, at] of peerReads) {
+      if (id === user?.id) continue
+      const readAt = Date.parse(at)
+      if (Number.isNaN(readAt) || readAt < sentAt) continue
+      labels.push(memberLookup.get(id)?.label ?? t('chat.memberFallback', { id }))
+    }
+    // Sorted so the list is stable regardless of receipt arrival order.
+    return labels.sort((a, b) => a.localeCompare(b))
+  }, [peerReads, messages, memberLookup, user?.id, t])
 
   // 1:1 calls use the single-peer voice-call hook (callPeerId is the other
   // member). 3+ member conversations use the group-call mesh instead, gated by
@@ -1396,6 +1574,15 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
             </div>
           </div>
         ))}
+
+        {seenByLabels.length > 0 && (
+          <div
+            className="flex justify-end px-1 text-[11px] text-gray-500"
+            data-testid="family-chat-seen-by"
+          >
+            {t('chat.seenBy', { names: seenByLabels.join(', ') })}
+          </div>
+        )}
 
         {typingLabels.length > 0 && (
           <div

--- a/web/src/pages/familychat/api.test.ts
+++ b/web/src/pages/familychat/api.test.ts
@@ -8,6 +8,7 @@ import {
   deleteMessage,
   uploadAttachment,
   fetchOlderMessages,
+  markConversationRead,
   OLDER_PAGE_SIZE,
   UploadError,
   type ReactionMap,
@@ -174,6 +175,43 @@ describe('fetchOlderMessages', () => {
   it('throws when the response is not ok', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 400 }))
     await expect(fetchOlderMessages(1, 2)).rejects.toThrow()
+  })
+})
+
+describe('markConversationRead', () => {
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('POSTs the read endpoint with the at timestamp', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+    await markConversationRead(7, { at: '2026-05-01T10:00:00Z' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/familychat/conversations/7/read')
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('include')
+    expect(JSON.parse(init.body)).toEqual({ at: '2026-05-01T10:00:00Z' })
+  })
+
+  it('omits at when no timestamp is given so the server stamps its own clock', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+    await markConversationRead(3)
+    const [, init] = fetchMock.mock.calls[0]
+    expect(JSON.parse(init.body)).toEqual({})
+  })
+
+  it('forwards an abort signal', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+    const controller = new AbortController()
+    await markConversationRead(1, { signal: controller.signal })
+    expect(fetchMock.mock.calls[0][1].signal).toBe(controller.signal)
+  })
+
+  it('throws when the response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }))
+    await expect(markConversationRead(1)).rejects.toThrow()
   })
 })
 

--- a/web/src/pages/familychat/api.ts
+++ b/web/src/pages/familychat/api.ts
@@ -144,6 +144,29 @@ export async function deleteMessage(convID: number, msgID: number): Promise<void
   if (!res.ok) throw new Error(`delete message failed: ${res.status}`)
 }
 
+// markConversationRead POSTs the read marker for a conversation, moving the
+// caller's own last_read_at forward so the unread badge drops to zero. `at` is
+// the timestamp of the newest message the user has actually seen; omitting it
+// lets the server stamp its own clock. Throws on any non-success response —
+// the chat view swallows the failure, since a missed read marker only means the
+// badge lingers until the next attempt.
+export async function markConversationRead(
+  convID: number,
+  opts: { at?: string; signal?: AbortSignal } = {},
+): Promise<void> {
+  const res = await fetch(
+    `/api/familychat/conversations/${convID}/read`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(opts.at ? { at: opts.at } : {}),
+      signal: opts.signal,
+    },
+  )
+  if (!res.ok) throw new Error(`mark read failed: ${res.status}`)
+}
+
 // OLDER_PAGE_SIZE is how many messages one "load older" page requests. It
 // matches the server's default page size, so a shorter response is an
 // unambiguous signal that the caller has reached the start of the history.

--- a/web/src/pages/familychat/useFamilyChatStream.ts
+++ b/web/src/pages/familychat/useFamilyChatStream.ts
@@ -92,6 +92,14 @@ interface MessageDeletedPayload {
   conversation_id?: number
 }
 
+// ReadReceiptPayload is the frame the server publishes after a member POSTs to
+// /read. `at` is the member's new last_read_at (RFC3339, UTC).
+export interface ReadReceiptPayload {
+  user_id: number
+  at: string
+  conversation_id?: number
+}
+
 // reconcileMessage merges an authoritative message into the list. When the
 // incoming message carries a client_id that matches a local optimistic bubble,
 // it replaces that bubble in place — preserving the client_id (so the React key
@@ -142,6 +150,10 @@ export interface UseFamilyChatStreamOptions {
   onSignal: (event: CallSignalEventName, payload: CallSignalPayload) => void | Promise<void>
   // onGroupSignal receives mesh call signalling frames (3+ member conversations).
   onGroupSignal: (event: GroupSignalEventName, payload: CallSignalPayload) => void | Promise<void>
+  // onReadReceipt fires for a *peer's* read marker. Our own echo (the hub fans
+  // the frame back to every subscriber, sender included) is filtered out here,
+  // so the caller can never feed its own POST back into another POST.
+  onReadReceipt?: (payload: ReadReceiptPayload) => void
   // onConversationOpen fires when a conversation's stream starts, so the caller
   // can clear per-conversation UI state it still owns.
   onConversationOpen?: () => void
@@ -206,6 +218,7 @@ export function useFamilyChatStream(options: UseFamilyChatStreamOptions): UseFam
   const conversationRef = useRef<Conversation | null>(null)
   const signalRef = useRef(options.onSignal)
   const groupSignalRef = useRef(options.onGroupSignal)
+  const readReceiptRef = useRef(options.onReadReceipt)
   const conversationOpenRef = useRef(options.onConversationOpen)
   const conversationCloseRef = useRef(options.onConversationClose)
   // callKindRef shadows the 1:1 hook's callKind — the hook resets it
@@ -218,6 +231,7 @@ export function useFamilyChatStream(options: UseFamilyChatStreamOptions): UseFam
   useEffect(() => {
     signalRef.current = options.onSignal
     groupSignalRef.current = options.onGroupSignal
+    readReceiptRef.current = options.onReadReceipt
     conversationOpenRef.current = options.onConversationOpen
     conversationCloseRef.current = options.onConversationClose
     callKindRef.current = callKind
@@ -427,6 +441,17 @@ export function useFamilyChatStream(options: UseFamilyChatStreamOptions): UseFam
         payload?.user_id !== undefined
       ) {
         recordTyping(payload.user_id as number)
+      } else if (
+        eventName === 'read_receipt' &&
+        payload?.user_id !== undefined &&
+        payload?.at !== undefined
+      ) {
+        const receipt = payload as unknown as ReadReceiptPayload
+        if (receipt.conversation_id !== undefined && receipt.conversation_id !== conversationId) return
+        // Our own marker echoes back to us; forwarding it would let the caller
+        // treat its own POST as new peer activity.
+        if (receipt.user_id === currentUserIdRef.current) return
+        readReceiptRef.current?.(receipt)
       } else if (
         eventName === 'call_join'
         || eventName === 'call_leave'


### PR DESCRIPTION
## Changes

- **Family chat unread badges now clear** - Opening a conversation marks it read, and new messages are acknowledged while the tab is visible and the list is scrolled to the bottom, so the unread badge no longer stays lit in the chat you are reading. Peers' read receipts arriving on the live stream are shown as a "Seen by" line under your newest message. (Hytte-e3b89)
</content>
</invoke>

## Original Issue (feature): Mark conversations read from the client so unread badges clear

### Scope
Wire the existing, already-tested `POST /api/familychat/conversations/{id}/read` endpoint into the frontend so unread badges clear. `ChatView` posts a read marker when a conversation is opened, and again when new messages arrive while the tab is visible and the message list is scrolled to the bottom; after a successful post it calls `refreshConversations()` from `FamilyChatContext` so `ConversationList` refetches and the badge drops to zero. `ChatView`'s SSE parser also gains a `read_receipt` branch so peers' reads are observed live.

### Files to touch
- `web/src/pages/familychat/ChatView.tsx` — mark-read effects (on open, on new message when visible + at bottom), `read_receipt` branch in the SSE event dispatch, wire `useFamilyChat()`.
- `web/src/pages/familychat/api.ts` — a `markConversationRead(convID, at?)` helper alongside the existing reaction/message helpers.
- `web/src/pages/familychat/ChatView.test.tsx` — tests for the new behaviour.
- `web/src/pages/familychat/api.test.ts` — test for the new helper.
- `changelog.d/<bead-id>.md` (new) — `category: Fixed` fragment.
- `web/public/locales/{en,nb,th}/*.json` — only if a user-visible "Seen" string is added.

### Acceptance criteria
- Opening a conversation with `unread_count > 0` posts once to `/read`, and the badge in `ConversationList` disappears without a manual page reload.
- Receiving a new message while the conversation is open, the tab is visible (`document.visibilityState === 'visible'`) and the list is scrolled at/near the bottom posts a new read marker; the badge stays at zero.
- Receiving a new message while the tab is hidden or the user is scrolled up in history does **not** post; the unread badge appears and only clears once the user returns/scrolls to the bottom.
- Marking read is deduplicated: no repeat POST for a conversation whose newest message id/timestamp was already acknowledged, and rapid message bursts do not produce one request per message.
- Switching conversations aborts any in-flight read request (reusing ChatView's existing per-conversation `AbortController` pattern); a failed/aborted `/read` never surfaces an error to the user and never breaks the stream.
- A `read_receipt` SSE event for another member updates in-session peer read state; the client's own `read_receipt` echo is ignored and does not re-trigger a POST (no feedback loop).
- New Vitest cases cover: mark-read on open, no mark-read when hidden/scrolled-up, dedup on repeat renders, and `read_receipt` parsing.
- `npm run lint`, `npm run build`, `npm test`, and `go test ./...` all pass.

### Non-goals
- No backend changes — `MarkReadHandler`, `MarkRead`, and the `read_receipt` publish already exist and are tested.
- No new API field for per-member `last_read_at`; `Conversation` does not expose it today, so any "Seen by X" indicator is limited to receipts observed live in the current session and is not restored on reload. A persisted seen-state UI is separate follow-up work.
- No push-notification, per-message read state, or typing-indicator changes.
- No rework of `ConversationList` fetching beyond the existing `refreshSignal` mechanism.
- No changes to unread-count SQL or badge styling.

## Source

Created from Suggestions page (suggestion id 365, page slug "family-chat", source=claude).

## Original suggestion

The backend exposes POST /api/familychat/conversations/{id}/read and publishes read_receipt events, and ConversationList renders an unread_count badge, but nothing in web/src ever calls that endpoint — a grep across the frontend finds no mark-read request and no read_receipt consumer. The result is that unread counts grow forever once a conversation has any traffic, the badge stays lit even in the conversation you are actively reading, and no one ever sees a 'seen' signal. Fix by posting the read marker from ChatView when a conversation is opened and when new messages arrive while the tab is visible and the list is scrolled to the bottom, then refreshing the conversation list (via FamilyChatContext) and handling the read_receipt SSE event to update peers' seen state.


---
Bead: Hytte-e3b89 | Branch: forge/Hytte-e3b89
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->