### PR TITLE
Weather prefs sync pushes stale recents when a selection races the preferences load (Hytte-lexeh)

### DIFF
--- a/changelog.d/Hytte-lexeh.md
+++ b/changelog.d/Hytte-lexeh.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Weather recents no longer diverge from the server when a selection races the preferences load** - Picking a location before saved preferences arrived made the dropdown show the server's recent locations while pushing the local list (containing the new pick) back to the server. The local list now wins for both the displayed recents and the saved preference. (Hytte-lexeh)

--- a/web/src/hooks/useWeatherLocation.test.ts
+++ b/web/src/hooks/useWeatherLocation.test.ts
@@ -159,7 +159,14 @@ describe('useWeatherLocation', () => {
     const gate = deferred()
     const fetchSpy = routeFetch({
       locations: LOCATIONS,
-      prefs: { preferences: { weather_location: 'Bergen' } },
+      prefs: {
+        preferences: {
+          weather_location: 'Bergen',
+          // Server recents that predate the selection — they must not replace the
+          // local list, which is what gets pushed back.
+          recent_locations: JSON.stringify([BERGEN, OSLO]),
+        },
+      },
       prefsGate: gate.promise,
     })
 
@@ -177,6 +184,34 @@ describe('useWeatherLocation', () => {
     // The late-arriving sync pushes the user's choice back to the server.
     const put = fetchSpy.mock.calls.find(([, init]) => init?.method === 'PUT')
     expect(put).toBeDefined()
+    const body = JSON.parse(String(put![1]!.body)) as {
+      preferences: { weather_location: string; recent_locations: string }
+    }
+    expect(body.preferences.weather_location).toBe('Trondheim')
+    // Display and the PUT body must agree, and both must contain the selection.
+    const pushedRecents = JSON.parse(body.preferences.recent_locations) as typeof LOCATIONS
+    expect(pushedRecents).toEqual(result.current.recents)
+    expect(pushedRecents[0]).toEqual(TRONDHEIM)
+    expect(result.current.recents).toContainEqual(TRONDHEIM)
+  })
+
+  it('adopts the server recents when no selection races the preferences load', async () => {
+    mockAuth = { user: { id: 7 }, loading: false }
+    routeFetch({
+      locations: LOCATIONS,
+      prefs: {
+        preferences: {
+          weather_location: 'Bergen',
+          recent_locations: JSON.stringify([BERGEN, TRONDHEIM]),
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useWeatherLocation())
+    await waitFor(() => expect(result.current.locationResolved).toBe(true))
+
+    expect(result.current.location).toEqual(BERGEN)
+    expect(result.current.recents).toEqual([BERGEN, TRONDHEIM])
   })
 
   it('falls back safely when the stored location is invalid', async () => {

--- a/web/src/hooks/useWeatherLocation.ts
+++ b/web/src/hooks/useWeatherLocation.ts
@@ -130,12 +130,18 @@ function locationReducer(state: LocationState, action: LocationAction): Location
       // Recents captured before the server sync — they carry a selection the user
       // may have made while the preferences request was still in flight.
       const priorRecents = state.recents
-      const recents = serverRecents && serverRecents.length > 0 ? serverRecents : priorRecents
+      // A selection that raced the load makes the local list authoritative: it is
+      // the one pushed back to the server below, so displaying anything else would
+      // leave the dropdown and the server disagreeing for a round trip.
+      const selectionRaced = state.userHasSelected && state.selected !== null
+      const recents =
+        !selectionRaced && serverRecents && serverRecents.length > 0 ? serverRecents : priorRecents
 
       if (state.userHasSelected) {
-        // User interacted before prefs loaded; push their choice server-side.
+        // User interacted before prefs loaded; push their choice server-side using
+        // the same list that is now on display.
         return state.selected
-          ? { ...state, recents, pendingSave: { location: state.selected, recents: priorRecents } }
+          ? { ...state, recents, pendingSave: { location: state.selected, recents } }
           : { ...state, recents }
       }
       if (!savedName) return { ...state, recents }


### PR DESCRIPTION
## Changes

- **Weather recents no longer diverge from the server when a selection races the preferences load** - Picking a location before saved preferences arrived made the dropdown show the server's recent locations while pushing the local list (containing the new pick) back to the server. The local list now wins for both the displayed recents and the saved preference. (Hytte-lexeh)

## Original Issue (bug): Weather prefs sync pushes stale recents when a selection races the preferences load

In web/src/hooks/useWeatherLocation.ts, the 'preferencesResolved' reducer branch preserves a pre-existing inconsistency carried over verbatim from the old Weather.tsx effect: when the user picks a location before GET /api/settings/preferences resolves, the hook adopts the server's recent_locations for display but PUTs back the locally-captured recents (the ones containing the user's just-made selection). Display and server state therefore diverge for one round trip - the dropdown can show a recents list that does not include the location the user just selected, while the server stores the opposite. Decide which list should win and make both the state and the PUT body use it. Covered today by the 'keeps an explicit selection when a stored preference arrives later' test in useWeatherLocation.test.ts, which asserts only that the PUT happens.

---
Bead: Hytte-lexeh | Branch: forge/Hytte-lexeh
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->