### PR TITLE
Extract message mutations into useMessageActions (Hytte-nsaxs)

### DIFF
--- a/changelog.d/Hytte-nsaxs.md
+++ b/changelog.d/Hytte-nsaxs.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Family chat drops a half-typed edit when you switch conversations** - Message mutations (optimistic send/retry, inline edit, soft delete, reactions) moved into a dedicated `useMessageActions` hook; as part of that, an open inline editor or delete confirmation is now cleared on a conversation switch instead of carrying over into the new chat. (Hytte-nsaxs)

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -28,11 +28,6 @@ import Composer from './Composer'
 import ReactionChips from './ReactionChips'
 import ReactionPicker from './ReactionPicker'
 import {
-  addReaction,
-  removeReaction,
-  applyReactionEvent,
-  editMessage,
-  deleteMessage,
   fetchOlderMessages,
   markConversationRead,
   OLDER_PAGE_SIZE,
@@ -40,11 +35,11 @@ import {
 import { useFamilyChat } from './FamilyChatContext'
 import {
   useFamilyChatStream,
-  reconcileMessage,
   type ChatMessage,
   type MissedCallEntry,
   type ReadReceiptPayload,
 } from './useFamilyChatStream'
+import { useMessageActions } from './useMessageActions'
 import { formatRelative } from './utils'
 import VoiceBubble from './voice/VoiceBubble'
 import { readCachedWaveform, parseWaveformJSON, DEFAULT_BAR_COUNT, type Waveform } from './voice/waveform'
@@ -123,17 +118,9 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // menuForMsgId is the id of the own-message bubble whose actions menu (edit /
   // delete) is open. Only one menu is open at a time.
   const [menuForMsgId, setMenuForMsgId] = useState<number | null>(null)
-  // editingMsgId is the id of the message currently being edited inline, with
-  // editingDraft holding the in-progress text and editingError the most recent
-  // save failure (so the user can retry without losing their draft).
-  const [editingMsgId, setEditingMsgId] = useState<number | null>(null)
-  const [editingDraft, setEditingDraft] = useState('')
-  const [editingSaving, setEditingSaving] = useState(false)
-  const [editingError, setEditingError] = useState('')
-  // confirmDeleteId holds the id of the message whose delete-confirm modal is
-  // open, or null when the modal is closed.
-  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
-  const [deleteError, setDeleteError] = useState('')
+  // Inline-edit and delete-confirm state live in useMessageActions below; only
+  // the focus bookkeeping for the confirmation modal stays here, since it is a
+  // pure view concern.
   const deleteConfirmBtnRef = useRef<HTMLButtonElement>(null)
   const deletePrevFocusRef = useRef<Element | null>(null)
   // lastTypingSentRef throttles outbound typing POSTs to at most one per ~3s
@@ -283,6 +270,30 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     },
   })
 
+  // Every mutation a message can undergo — optimistic send + reconcile, retry,
+  // inline edit, soft delete and reaction toggles — lives in this hook. It
+  // shares the stream's messages/setMessages pair so optimistic bubbles and
+  // SSE-delivered rows reconcile through a single list.
+  const {
+    send,
+    retry: retryFailedMessage,
+    editDraft,
+    setEditText,
+    beginEdit,
+    saveEdit,
+    cancelEdit,
+    deleteTarget,
+    confirmDelete,
+    cancelDelete,
+    doDelete,
+    toggleReaction,
+  } = useMessageActions({
+    conversationId,
+    messages,
+    setMessages,
+    userId: user?.id,
+  })
+
   const messagesEndRef = useRef<HTMLDivElement>(null)
   // conversationIdRef shadows the current conversation so an in-flight
   // "load older" response can tell whether the user has since switched chats.
@@ -335,6 +346,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
 
   // Focus management + Escape handling for the delete confirmation modal,
   // matching the pattern used by ConfirmDialog.
+  const confirmDeleteId = deleteTarget.msgId
   useEffect(() => {
     if (confirmDeleteId !== null) {
       deletePrevFocusRef.current = document.activeElement
@@ -347,11 +359,11 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   useEffect(() => {
     if (confirmDeleteId === null) return
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') { setConfirmDeleteId(null); setDeleteError('') }
+      if (e.key === 'Escape') cancelDelete()
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [confirmDeleteId])
+  }, [confirmDeleteId, cancelDelete])
 
   const rtf = useMemo(
     () => new Intl.RelativeTimeFormat(i18n.language, { numeric: 'auto' }),
@@ -720,189 +732,12 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     }).catch(() => {})
   }, [conversationId])
 
-  const handleMessageCreated = useCallback((msg: ChatMessage) => {
-    // Defensive: if the user switched conversations while a send was in
-    // flight, drop the message rather than leaking it into the wrong chat.
-    if (msg.conversation_id !== conversationId) return
-    // Reconcile against an optimistic bubble when the message carries a
-    // client_id (the POST-response path for text sends); otherwise dedupe by
-    // id (voice notes and attachments, which are not rendered optimistically).
-    setMessages(prev => reconcileMessage(prev, msg.client_id, msg))
-  }, [conversationId, setMessages])
-
-  // handleOptimisticMessage renders a just-typed text message immediately in a
-  // 'sending' state, before any network round-trip. Scoped to the active
-  // conversation so a stray emit can't leak into the wrong chat.
-  const handleOptimisticMessage = useCallback((msg: ChatMessage) => {
-    if (msg.conversation_id !== conversationId) return
-    setMessages(prev => [...prev, msg])
-  }, [conversationId, setMessages])
-
-  // handleMessageFailed flips an optimistic bubble to the 'failed' state when
-  // its POST errors, preserving the typed text so the user can tap to retry.
-  // No conversation guard is needed: after a switch the bubble is gone, so the
-  // client_id no longer matches and this is a no-op.
-  const handleMessageFailed = useCallback((clientId: string) => {
-    setMessages(prev => prev.map(m =>
-      m.client_id === clientId ? { ...m, status: 'failed' as const } : m,
-    ))
-  }, [setMessages])
-
-  // composerRetryRef holds the Composer's retry entry point. The failed bubble's
-  // tap target calls it to re-POST the preserved text under the same client_id
-  // so a successful retry reconciles normally.
-  const composerRetryRef = useRef<
-    ((clientId: string, text: string, targetConversationId: number) => void) | null
-  >(null)
-
-  const retryFailedMessage = useCallback((msg: ChatMessage) => {
-    if (!msg.client_id) return
-    const clientId = msg.client_id
-    // Flip back to 'sending' immediately so the affordance reflects the retry.
-    setMessages(prev => prev.map(m =>
-      m.client_id === clientId ? { ...m, status: 'sending' as const } : m,
-    ))
-    composerRetryRef.current?.(clientId, msg.body, msg.conversation_id)
-  }, [setMessages])
-
-  // toggleReaction applies the change optimistically (chips update before the
-  // network round-trip) and rolls back on failure. The eventual SSE
-  // confirmation overwrites the optimistic state with the server-authoritative
-  // count, which keeps two clients in sync even if either one races.
-  const userId = user?.id
-  const toggleReaction = useCallback(async (msgId: number, emoji: string, currentlyMine: boolean) => {
-    if (conversationId === null || userId === undefined) return
-    const meID = userId
-    const snapshot = messages.find(m => m.id === msgId) ?? null
-    setMessages(prev => prev.map(m => {
-      if (m.id !== msgId) return m
-      const synthetic = currentlyMine
-        ? { user_id: meID, emoji, count: Math.max((m.reactions?.[emoji]?.count ?? 1) - 1, 0) }
-        : { user_id: meID, emoji, count: (m.reactions?.[emoji]?.count ?? 0) + 1 }
-      return {
-        ...m,
-        reactions: applyReactionEvent(m.reactions, synthetic, meID, currentlyMine),
-      }
-    }))
-    try {
-      if (currentlyMine) {
-        await removeReaction(conversationId, msgId, emoji)
-      } else {
-        await addReaction(conversationId, msgId, emoji)
-      }
-    } catch {
-      // Roll back only the reactions field to the pre-toggle snapshot. Rolling
-      // back the whole message would clobber any concurrent SSE updates (edits,
-      // other reactions) that arrived between the optimistic update and the
-      // network failure.
-      if (snapshot) {
-        setMessages(prev => prev.map(m =>
-          m.id === msgId ? { ...m, reactions: snapshot.reactions } : m,
-        ))
-      }
-    }
-  }, [conversationId, userId, messages, setMessages])
-
   const handlePickFromPicker = useCallback((msgId: number, emoji: string) => {
     setPickerForMsgId(null)
     const msg = messages.find(m => m.id === msgId)
     const mine = !!msg?.reactions?.[emoji]?.me
     void toggleReaction(msgId, emoji, mine)
   }, [messages, toggleReaction])
-
-  // openEditor opens the inline editor for a message bubble. Seeds the draft
-  // from the current body so the user starts from what's on screen.
-  const openEditor = useCallback((msg: ChatMessage) => {
-    setMenuForMsgId(null)
-    setEditingMsgId(msg.id)
-    setEditingDraft(msg.body)
-    setEditingError('')
-    setEditingSaving(false)
-  }, [])
-
-  const cancelEditor = useCallback(() => {
-    setEditingMsgId(null)
-    setEditingDraft('')
-    setEditingError('')
-    setEditingSaving(false)
-  }, [])
-
-  const saveEditor = useCallback(async (msgId: number) => {
-    if (conversationId === null) return
-    const trimmed = editingDraft.trim()
-    if (!trimmed) {
-      setEditingError(t('edit.saveError'))
-      return
-    }
-    setEditingSaving(true)
-    setEditingError('')
-    // Capture the pre-edit body/edited_at so a failed save can revert the
-    // optimistic update — otherwise the bubble would keep showing the
-    // unsaved draft as if it had been persisted.
-    const snapshot = messages.find(m => m.id === msgId) ?? null
-    // Optimistic update first: the SSE confirmation will overwrite shortly
-    // with the server's authoritative edited_at, which matches the pattern
-    // used by reactions / message sends in this view.
-    const optimisticTime = new Date().toISOString()
-    setMessages(prev => prev.map(m =>
-      m.id === msgId ? { ...m, body: trimmed, edited_at: optimisticTime } : m,
-    ))
-    try {
-      const updated = await editMessage(conversationId, msgId, trimmed)
-      setMessages(prev => prev.map(m =>
-        m.id === msgId
-          ? { ...m, body: updated.body, edited_at: updated.edited_at }
-          : m,
-      ))
-      setEditingMsgId(null)
-      setEditingDraft('')
-      setEditingSaving(false)
-    } catch {
-      if (snapshot) {
-        setMessages(prev => prev.map(m =>
-          m.id === msgId
-            ? { ...m, body: snapshot.body, edited_at: snapshot.edited_at ?? null }
-            : m,
-        ))
-      }
-      setEditingError(t('edit.saveError'))
-      setEditingSaving(false)
-    }
-  }, [conversationId, editingDraft, messages, t, setMessages])
-
-  const confirmDelete = useCallback(async (msgId: number) => {
-    if (conversationId === null) return
-    setDeleteError('')
-    const meID = user?.id ?? null
-    const now = new Date().toISOString()
-    // Capture the pre-delete snapshot from the current render's state so the
-    // rollback in catch{} doesn't depend on the setState updater having run.
-    const snapshot = messages.find(m => m.id === msgId) ?? null
-    setMessages(prev => prev.map(m => {
-      if (m.id !== msgId) return m
-      return {
-        ...m,
-        body: '',
-        attachment_path: '',
-        attachment_mime: '',
-        edited_at: null,
-        deleted_at: now,
-        deleted_by: meID,
-      }
-    }))
-    try {
-      await deleteMessage(conversationId, msgId)
-      // Only dismiss the confirm modal after the server has accepted the
-      // delete — closing it earlier would hide the error message rendered
-      // inside the same modal if the request fails.
-      setConfirmDeleteId(null)
-    } catch {
-      if (snapshot) {
-        setMessages(prev => prev.map(m => (m.id === msgId ? snapshot : m)))
-      }
-      setDeleteError(t('edit.deleteError'))
-    }
-  }, [conversationId, user?.id, t, messages, setMessages])
 
   const memberChips = useMemo(() => {
     if (!conversation) return []
@@ -1244,7 +1079,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         {!loading && !error && messages.map(msg => {
           const isOwn = user?.id === msg.sender_user_id
           const isDeleted = !!msg.deleted_at
-          const isEditing = editingMsgId === msg.id
+          const isEditing = editDraft.msgId === msg.id
           const senderInfo = memberLookup.get(msg.sender_user_id)
           const senderLabel = senderInfo?.label ?? t('chat.memberFallback', { id: msg.sender_user_id })
           const relative = formatRelative(msg.created_at, rtf, t('time.justNow'))
@@ -1300,15 +1135,15 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                     isOwn ? 'bg-blue-600/40 border border-blue-500' : 'bg-gray-800 border border-gray-700'
                   }`}>
                     <textarea
-                      value={editingDraft}
-                      onChange={(e) => setEditingDraft(e.target.value)}
+                      value={editDraft.text}
+                      onChange={(e) => setEditText(e.target.value)}
                       onKeyDown={(e) => {
                         if (e.key === 'Escape') {
                           e.preventDefault()
-                          cancelEditor()
+                          cancelEdit()
                         } else if (e.key === 'Enter' && !e.shiftKey) {
                           e.preventDefault()
-                          void saveEditor(msg.id)
+                          void saveEdit(msg.id)
                         }
                       }}
                       aria-label={t('edit.edit')}
@@ -1317,13 +1152,13 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                       rows={3}
                       autoFocus
                     />
-                    {editingError && (
-                      <div className="text-xs text-red-400 mt-1">{editingError}</div>
+                    {editDraft.error && (
+                      <div className="text-xs text-red-400 mt-1">{editDraft.error}</div>
                     )}
                     <div className="flex gap-2 mt-2 justify-end">
                       <button
                         type="button"
-                        onClick={cancelEditor}
+                        onClick={cancelEdit}
                         className="px-2 py-1 text-xs rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600"
                         data-testid={`chat-edit-cancel-${msg.id}`}
                       >
@@ -1331,12 +1166,12 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                       </button>
                       <button
                         type="button"
-                        onClick={() => { void saveEditor(msg.id) }}
-                        disabled={editingSaving || !editingDraft.trim()}
+                        onClick={() => { void saveEdit(msg.id) }}
+                        disabled={editDraft.saving || !editDraft.text.trim()}
                         className="px-2 py-1 text-xs rounded-md bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
                         data-testid={`chat-edit-save-${msg.id}`}
                       >
-                        {editingSaving ? t('edit.saving') : t('edit.save')}
+                        {editDraft.saving ? t('edit.saving') : t('edit.save')}
                       </button>
                     </div>
                   </div>
@@ -1470,7 +1305,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                       <button
                         type="button"
                         role="menuitem"
-                        onClick={() => openEditor(msg)}
+                        onClick={() => { setMenuForMsgId(null); beginEdit(msg) }}
                         className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700"
                         data-testid={`chat-edit-action-${msg.id}`}
                       >
@@ -1481,8 +1316,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
                         role="menuitem"
                         onClick={() => {
                           setMenuForMsgId(null)
-                          setDeleteError('')
-                          setConfirmDeleteId(msg.id)
+                          confirmDelete(msg.id)
                         }}
                         className="w-full text-left px-3 py-2 text-sm text-red-300 hover:bg-gray-700"
                         data-testid={`chat-delete-action-${msg.id}`}
@@ -1605,10 +1439,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
           <Composer
             conversationId={conversationId}
             currentUserId={user.id}
-            onMessageCreated={handleMessageCreated}
-            onOptimisticMessage={handleOptimisticMessage}
-            onMessageFailed={handleMessageFailed}
-            retryRef={composerRetryRef}
+            {...send}
             onTyping={notifyTyping}
           />
         )}
@@ -1644,20 +1475,20 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
           aria-modal="true"
           aria-labelledby="family-chat-confirm-delete-title"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-          onClick={(e) => { if (e.target === e.currentTarget) setConfirmDeleteId(null) }}
+          onClick={(e) => { if (e.target === e.currentTarget) cancelDelete() }}
           data-testid="chat-delete-confirm"
         >
           <div className="bg-gray-900 border border-gray-700 rounded-lg max-w-md w-full p-4 shadow-xl">
             <p id="family-chat-confirm-delete-title" className="text-sm text-gray-100">
               {t('edit.confirmDelete')}
             </p>
-            {deleteError && (
-              <p className="mt-2 text-xs text-red-400">{deleteError}</p>
+            {deleteTarget.error && (
+              <p className="mt-2 text-xs text-red-400">{deleteTarget.error}</p>
             )}
             <div className="mt-4 flex justify-end gap-2">
               <button
                 type="button"
-                onClick={() => setConfirmDeleteId(null)}
+                onClick={cancelDelete}
                 className="px-3 py-1.5 text-sm rounded-md bg-gray-800 text-gray-200 hover:bg-gray-700"
                 data-testid="chat-delete-cancel"
               >
@@ -1666,7 +1497,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
               <button
                 ref={deleteConfirmBtnRef}
                 type="button"
-                onClick={() => { void confirmDelete(confirmDeleteId) }}
+                onClick={() => { void doDelete(confirmDeleteId) }}
                 className="px-3 py-1.5 text-sm rounded-md bg-red-600 text-white hover:bg-red-500"
                 data-testid="chat-delete-confirm-button"
               >

--- a/web/src/pages/familychat/useMessageActions.test.ts
+++ b/web/src/pages/familychat/useMessageActions.test.ts
@@ -1,0 +1,477 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { useMessageActions } from './useMessageActions'
+import type { ChatMessage } from './useFamilyChatStream'
+
+// ── i18n mock ─────────────────────────────────────────────────────────────────
+// `t` echoes the key back, so assertions read as the key the UI would render.
+// Kept stable across renders so the hook's callbacks don't churn identity.
+const stableT = (key: string) => key
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: stableT, i18n: { language: 'en' } }),
+}))
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ME = 1
+
+function makeMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 1,
+    conversation_id: 1,
+    sender_user_id: ME,
+    body: 'Hello!',
+    created_at: '2026-05-01T10:00:00Z',
+    ...overrides,
+  }
+}
+
+function optimistic(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return makeMessage({
+    id: -1,
+    body: 'typed text',
+    client_id: 'c-1',
+    status: 'sending',
+    created_at: '2026-05-01T10:05:00Z',
+    ...overrides,
+  })
+}
+
+interface HarnessOptions {
+  conversationId?: number | null
+  initial?: ChatMessage[]
+  userId?: number | undefined
+}
+
+// useHarness owns the messages/setMessages pair the way useFamilyChatStream
+// does in production, so the hook reads a genuinely up-to-date list when it
+// snapshots for rollback.
+function useHarness(opts: HarnessOptions = {}) {
+  const [messages, setMessages] = useState<ChatMessage[]>(opts.initial ?? [])
+  const actions = useMessageActions({
+    conversationId: opts.conversationId === undefined ? 1 : opts.conversationId,
+    messages,
+    setMessages,
+    userId: 'userId' in opts ? opts.userId : ME,
+  })
+  return { messages, actions }
+}
+
+function renderActions(opts: HarnessOptions = {}) {
+  return renderHook((props: HarnessOptions) => useHarness(props), {
+    initialProps: opts,
+  })
+}
+
+// ── fetch mock ────────────────────────────────────────────────────────────────
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+function okResponse(body: unknown = {}) {
+  return { ok: true, status: 200, json: () => Promise.resolve(body) }
+}
+
+function errResponse(status = 500) {
+  return { ok: false, status, json: () => Promise.resolve({ error: 'nope' }) }
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue(okResponse())
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+// lastCall returns the [url, init] pair of the most recent fetch.
+function lastCall(): [string, RequestInit] {
+  const call = fetchMock.mock.calls.at(-1)
+  return [String(call?.[0]), (call?.[1] ?? {}) as RequestInit]
+}
+
+// ── Optimistic send lifecycle ─────────────────────────────────────────────────
+
+describe('useMessageActions — optimistic send', () => {
+  it('inserts an optimistic bubble and reconciles it with the server row', () => {
+    const { result } = renderActions()
+
+    act(() => { result.current.actions.send.onOptimisticMessage(optimistic()) })
+    expect(result.current.messages).toHaveLength(1)
+    expect(result.current.messages[0]).toMatchObject({
+      id: -1,
+      client_id: 'c-1',
+      status: 'sending',
+      body: 'typed text',
+    })
+
+    act(() => {
+      result.current.actions.send.onMessageCreated(makeMessage({
+        id: 42,
+        body: 'typed text',
+        client_id: 'c-1',
+      }))
+    })
+    // The optimistic bubble is replaced in place — same list slot, real id, no
+    // status, client_id kept so the React key stays stable.
+    expect(result.current.messages).toHaveLength(1)
+    expect(result.current.messages[0]).toMatchObject({ id: 42, client_id: 'c-1' })
+    expect(result.current.messages[0].status).toBeUndefined()
+  })
+
+  it('appends a server message that has no optimistic counterpart', () => {
+    const { result } = renderActions()
+
+    act(() => {
+      result.current.actions.send.onMessageCreated(makeMessage({ id: 7, sender_user_id: 2 }))
+    })
+    expect(result.current.messages).toHaveLength(1)
+
+    // A duplicate frame for the same id must not add a second bubble.
+    act(() => {
+      result.current.actions.send.onMessageCreated(makeMessage({ id: 7, sender_user_id: 2 }))
+    })
+    expect(result.current.messages).toHaveLength(1)
+  })
+
+  it('drops messages that belong to a different conversation', () => {
+    const { result } = renderActions({ conversationId: 1 })
+
+    act(() => {
+      result.current.actions.send.onOptimisticMessage(optimistic({ conversation_id: 99 }))
+      result.current.actions.send.onMessageCreated(makeMessage({ id: 5, conversation_id: 99 }))
+    })
+    expect(result.current.messages).toEqual([])
+  })
+
+  it('flips a failed send to "failed" and back to "sending" on retry', () => {
+    const { result } = renderActions()
+
+    act(() => { result.current.actions.send.onOptimisticMessage(optimistic()) })
+    act(() => { result.current.actions.send.onMessageFailed('c-1') })
+    expect(result.current.messages[0].status).toBe('failed')
+
+    const composerRetry = vi.fn()
+    result.current.actions.send.retryRef.current = composerRetry
+
+    act(() => { result.current.actions.retry(result.current.messages[0]) })
+    expect(result.current.messages[0].status).toBe('sending')
+    expect(composerRetry).toHaveBeenCalledWith('c-1', 'typed text', 1)
+
+    // ...and a successful retry reconciles the same bubble.
+    act(() => {
+      result.current.actions.send.onMessageCreated(makeMessage({
+        id: 43,
+        body: 'typed text',
+        client_id: 'c-1',
+      }))
+    })
+    expect(result.current.messages).toHaveLength(1)
+    expect(result.current.messages[0].id).toBe(43)
+    expect(result.current.messages[0].status).toBeUndefined()
+  })
+
+  it('ignores a retry for a bubble with no client_id', () => {
+    const { result } = renderActions({ initial: [makeMessage({ status: 'failed' })] })
+    const composerRetry = vi.fn()
+    result.current.actions.send.retryRef.current = composerRetry
+
+    act(() => { result.current.actions.retry(result.current.messages[0]) })
+    expect(composerRetry).not.toHaveBeenCalled()
+  })
+})
+
+// ── Inline edit ───────────────────────────────────────────────────────────────
+
+describe('useMessageActions — edit', () => {
+  it('seeds the draft from the bubble body and clears it on cancel', () => {
+    const { result } = renderActions({ initial: [makeMessage({ body: 'first' })] })
+
+    act(() => { result.current.actions.beginEdit(result.current.messages[0]) })
+    expect(result.current.actions.editDraft).toMatchObject({ msgId: 1, text: 'first', error: '' })
+
+    act(() => { result.current.actions.setEditText('second') })
+    expect(result.current.actions.editDraft.text).toBe('second')
+
+    act(() => { result.current.actions.cancelEdit() })
+    expect(result.current.actions.editDraft.msgId).toBeNull()
+    expect(result.current.actions.editDraft.text).toBe('')
+  })
+
+  it('applies the edit optimistically then adopts the server row', async () => {
+    fetchMock.mockResolvedValue(okResponse({
+      message: {
+        id: 1,
+        conversation_id: 1,
+        sender_user_id: ME,
+        body: 'edited',
+        created_at: '2026-05-01T10:00:00Z',
+        edited_at: '2026-05-01T11:00:00Z',
+        deleted_at: null,
+        deleted_by: null,
+      },
+    }))
+    const { result } = renderActions({ initial: [makeMessage({ body: 'first' })] })
+
+    act(() => { result.current.actions.beginEdit(result.current.messages[0]) })
+    act(() => { result.current.actions.setEditText('  edited  ') })
+    await act(async () => { await result.current.actions.saveEdit(1) })
+
+    const [url, init] = lastCall()
+    expect(url).toBe('/api/familychat/conversations/1/messages/1')
+    expect(init.method).toBe('PATCH')
+    expect(JSON.parse(String(init.body))).toEqual({ body: 'edited' })
+
+    expect(result.current.messages[0].body).toBe('edited')
+    expect(result.current.messages[0].edited_at).toBe('2026-05-01T11:00:00Z')
+    // Editor closes only after the server accepts.
+    expect(result.current.actions.editDraft.msgId).toBeNull()
+  })
+
+  it('rolls the body back and surfaces an error when the save fails', async () => {
+    fetchMock.mockResolvedValue(errResponse(500))
+    const { result } = renderActions({
+      initial: [makeMessage({ body: 'first', edited_at: null })],
+    })
+
+    act(() => { result.current.actions.beginEdit(result.current.messages[0]) })
+    act(() => { result.current.actions.setEditText('edited') })
+    await act(async () => { await result.current.actions.saveEdit(1) })
+
+    expect(result.current.messages[0].body).toBe('first')
+    expect(result.current.messages[0].edited_at).toBeNull()
+    // The draft survives so the user can retry without retyping.
+    expect(result.current.actions.editDraft).toMatchObject({
+      msgId: 1,
+      text: 'edited',
+      saving: false,
+      error: 'edit.saveError',
+    })
+  })
+
+  it('refuses to save a blank draft without hitting the network', async () => {
+    const { result } = renderActions({ initial: [makeMessage({ body: 'first' })] })
+
+    act(() => { result.current.actions.beginEdit(result.current.messages[0]) })
+    act(() => { result.current.actions.setEditText('   ') })
+    await act(async () => { await result.current.actions.saveEdit(1) })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.actions.editDraft.error).toBe('edit.saveError')
+    expect(result.current.messages[0].body).toBe('first')
+  })
+
+  it('is a no-op when no conversation is open', async () => {
+    const { result } = renderActions({
+      conversationId: null,
+      initial: [makeMessage({ body: 'first' })],
+    })
+
+    act(() => { result.current.actions.beginEdit(result.current.messages[0]) })
+    act(() => { result.current.actions.setEditText('edited') })
+    await act(async () => { await result.current.actions.saveEdit(1) })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.messages[0].body).toBe('first')
+  })
+})
+
+// ── Soft delete ───────────────────────────────────────────────────────────────
+
+describe('useMessageActions — delete', () => {
+  it('tombstones the message and closes the modal once the server accepts', async () => {
+    const { result } = renderActions({
+      initial: [makeMessage({ body: 'bye', attachment_path: '/a.png', attachment_mime: 'image/png' })],
+    })
+
+    act(() => { result.current.actions.confirmDelete(1) })
+    expect(result.current.actions.deleteTarget).toEqual({ msgId: 1, error: '' })
+
+    await act(async () => { await result.current.actions.doDelete() })
+
+    const [url, init] = lastCall()
+    expect(url).toBe('/api/familychat/conversations/1/messages/1')
+    expect(init.method).toBe('DELETE')
+
+    expect(result.current.messages[0]).toMatchObject({
+      body: '',
+      attachment_path: '',
+      attachment_mime: '',
+      deleted_by: ME,
+    })
+    expect(result.current.messages[0].deleted_at).toBeTruthy()
+    expect(result.current.actions.deleteTarget.msgId).toBeNull()
+  })
+
+  it('restores the message and keeps the modal open when the delete fails', async () => {
+    fetchMock.mockResolvedValue(errResponse(403))
+    const before = makeMessage({ body: 'bye' })
+    const { result } = renderActions({ initial: [before] })
+
+    act(() => { result.current.actions.confirmDelete(1) })
+    await act(async () => { await result.current.actions.doDelete() })
+
+    expect(result.current.messages[0]).toEqual(before)
+    expect(result.current.actions.deleteTarget).toEqual({
+      msgId: 1,
+      error: 'edit.deleteError',
+    })
+  })
+
+  it('does nothing when no message is targeted', async () => {
+    const { result } = renderActions({ initial: [makeMessage()] })
+
+    await act(async () => { await result.current.actions.doDelete() })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('drops the target on cancel', () => {
+    const { result } = renderActions({ initial: [makeMessage()] })
+
+    act(() => { result.current.actions.confirmDelete(1) })
+    act(() => { result.current.actions.cancelDelete() })
+    expect(result.current.actions.deleteTarget.msgId).toBeNull()
+  })
+})
+
+// ── Reactions ─────────────────────────────────────────────────────────────────
+
+describe('useMessageActions — reactions', () => {
+  it('adds a reaction optimistically and POSTs it', async () => {
+    const { result } = renderActions({ initial: [makeMessage()] })
+
+    await act(async () => { await result.current.actions.toggleReaction(1, '👍', false) })
+
+    const [url, init] = lastCall()
+    expect(url).toBe('/api/familychat/conversations/1/messages/1/reactions')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(String(init.body))).toEqual({ emoji: '👍' })
+
+    expect(result.current.messages[0].reactions?.['👍']).toMatchObject({
+      count: 1,
+      users: [ME],
+      me: true,
+    })
+  })
+
+  it('removes an existing reaction with a DELETE', async () => {
+    const { result } = renderActions({
+      initial: [makeMessage({ reactions: { '👍': { count: 1, users: [ME], me: true } } })],
+    })
+
+    await act(async () => { await result.current.actions.toggleReaction(1, '👍', true) })
+
+    const [url, init] = lastCall()
+    expect(url).toContain('/messages/1/reactions?emoji=')
+    expect(init.method).toBe('DELETE')
+    // Count hit zero, so the bucket is dropped entirely.
+    expect(result.current.messages[0].reactions?.['👍']).toBeUndefined()
+  })
+
+  it('rolls the reaction back when the add fails', async () => {
+    fetchMock.mockResolvedValue(errResponse(500))
+    const { result } = renderActions({
+      initial: [makeMessage({ reactions: { '🎉': { count: 2, users: [2, 3], me: false } } })],
+    })
+
+    await act(async () => { await result.current.actions.toggleReaction(1, '👍', false) })
+
+    // Only the reactions field is reverted, and it reverts to the exact
+    // pre-toggle snapshot — the optimistic 👍 is gone, 🎉 is untouched.
+    expect(result.current.messages[0].reactions).toEqual({
+      '🎉': { count: 2, users: [2, 3], me: false },
+    })
+  })
+
+  it('rolls the reaction back when the remove fails', async () => {
+    fetchMock.mockResolvedValue(errResponse(500))
+    const { result } = renderActions({
+      initial: [makeMessage({ reactions: { '👍': { count: 2, users: [ME, 2], me: true } } })],
+    })
+
+    await act(async () => { await result.current.actions.toggleReaction(1, '👍', true) })
+
+    expect(result.current.messages[0].reactions?.['👍']).toEqual({
+      count: 2,
+      users: [ME, 2],
+      me: true,
+    })
+  })
+
+  it('does nothing without a signed-in user', async () => {
+    const { result } = renderActions({ initial: [makeMessage()], userId: undefined })
+
+    await act(async () => { await result.current.actions.toggleReaction(1, '👍', false) })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.messages[0].reactions).toBeUndefined()
+  })
+})
+
+// ── Pending markers & conversation switches ───────────────────────────────────
+
+describe('useMessageActions — pendingIds', () => {
+  it('marks a message pending while its mutation is in flight', async () => {
+    let release: (v: unknown) => void = () => {}
+    fetchMock.mockImplementationOnce(() => new Promise(resolve => { release = resolve }))
+    const { result } = renderActions({ initial: [makeMessage()] })
+
+    let inFlight: Promise<void> = Promise.resolve()
+    act(() => { inFlight = result.current.actions.doDelete(1) })
+    expect(result.current.actions.pendingIds.has(1)).toBe(true)
+
+    await act(async () => {
+      release(okResponse())
+      await inFlight
+    })
+    expect(result.current.actions.pendingIds.has(1)).toBe(false)
+  })
+
+  it('keeps the marker until the last concurrent mutation settles', async () => {
+    const releases: Array<(v: unknown) => void> = []
+    fetchMock.mockImplementation(() => new Promise(resolve => { releases.push(resolve) }))
+    const { result } = renderActions({ initial: [makeMessage()] })
+
+    let first: Promise<void> = Promise.resolve()
+    let second: Promise<void> = Promise.resolve()
+    act(() => { first = result.current.actions.toggleReaction(1, '👍', false) })
+    act(() => { second = result.current.actions.toggleReaction(1, '🎉', false) })
+    expect(result.current.actions.pendingIds.has(1)).toBe(true)
+
+    await act(async () => {
+      releases[0](okResponse())
+      await first
+    })
+    expect(result.current.actions.pendingIds.has(1)).toBe(true)
+
+    await act(async () => {
+      releases[1](okResponse())
+      await second
+    })
+    expect(result.current.actions.pendingIds.has(1)).toBe(false)
+  })
+})
+
+describe('useMessageActions — conversation switches', () => {
+  it('drops the edit draft, delete target and pending markers', () => {
+    const { result, rerender } = renderActions({
+      conversationId: 1,
+      initial: [makeMessage()],
+    })
+
+    act(() => { result.current.actions.beginEdit(result.current.messages[0]) })
+    act(() => { result.current.actions.confirmDelete(1) })
+    expect(result.current.actions.editDraft.msgId).toBe(1)
+    expect(result.current.actions.deleteTarget.msgId).toBe(1)
+
+    rerender({ conversationId: 2, initial: [] })
+
+    expect(result.current.actions.editDraft.msgId).toBeNull()
+    expect(result.current.actions.editDraft.text).toBe('')
+    expect(result.current.actions.deleteTarget.msgId).toBeNull()
+    expect(result.current.actions.pendingIds.size).toBe(0)
+  })
+})

--- a/web/src/pages/familychat/useMessageActions.ts
+++ b/web/src/pages/familychat/useMessageActions.ts
@@ -1,0 +1,396 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  addReaction,
+  removeReaction,
+  applyReactionEvent,
+  editMessage,
+  deleteMessage,
+} from './api'
+import { reconcileMessage, type ChatMessage } from './useFamilyChatStream'
+// Type-only import: erased at compile time, so this does not create a runtime
+// import cycle with Composer (which imports ChatMessage back out of ChatView).
+import type { RetryHandle } from './Composer'
+
+// useMessageActions owns every mutation a message can undergo inside one
+// conversation: the optimistic-send lifecycle (insert → reconcile → fail →
+// retry), the inline edit draft, the soft-delete confirm flow, and reaction
+// toggles.
+//
+// It deliberately does not own the message list. It operates on the
+// `messages` / `setMessages` pair produced by useFamilyChatStream so optimistic
+// entries and SSE-delivered entries reconcile through a single list — two lists
+// would need a merge step, and the reconcile-by-client_id trick only works when
+// the optimistic bubble and the authoritative row live in the same array.
+//
+// The POST for a text send still lives in Composer, which also owns the
+// attachment and voice-note upload wiring. This hook supplies the callbacks
+// Composer reports progress through (`send`) plus the retry entry point the
+// failed bubble taps.
+
+export interface UseMessageActionsOptions {
+  // conversationId is the open conversation, or null when none is selected.
+  // Every mutation is a no-op while it is null.
+  conversationId: number | null
+  messages: ChatMessage[]
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>
+  // userId is the signed-in user's id, used to stamp optimistic reaction
+  // updates with the correct `me` flag.
+  userId: number | undefined
+}
+
+// EditDraft is the inline editor's whole state: which bubble is open, the
+// in-progress text, whether a save is in flight, and the last save failure
+// (kept so the user can retry without losing what they typed).
+export interface EditDraft {
+  msgId: number | null
+  text: string
+  saving: boolean
+  error: string
+}
+
+// DeleteTarget is the soft-delete confirmation modal's state: which message it
+// is asking about, and the last failure to show inside the modal.
+export interface DeleteTarget {
+  msgId: number | null
+  error: string
+}
+
+// ComposerSendHandlers is shaped to spread straight into <Composer {...send} />.
+export interface ComposerSendHandlers {
+  onMessageCreated: (msg: ChatMessage) => void
+  onOptimisticMessage: (msg: ChatMessage) => void
+  onMessageFailed: (clientId: string) => void
+  retryRef: MutableRefObject<RetryHandle | null>
+}
+
+export interface UseMessageActions {
+  send: ComposerSendHandlers
+  // retry re-POSTs a failed optimistic bubble under its original client_id.
+  retry: (msg: ChatMessage) => void
+  editDraft: EditDraft
+  setEditText: (text: string) => void
+  beginEdit: (msg: ChatMessage) => void
+  saveEdit: (msgId: number) => Promise<void>
+  cancelEdit: () => void
+  deleteTarget: DeleteTarget
+  // confirmDelete opens the confirmation modal; doDelete performs the delete.
+  confirmDelete: (msgId: number) => void
+  cancelDelete: () => void
+  doDelete: (msgId?: number) => Promise<void>
+  toggleReaction: (msgId: number, emoji: string, currentlyMine: boolean) => Promise<void>
+  // pendingIds holds the ids of messages with a server mutation in flight
+  // (edit save, delete, or reaction toggle), so bubbles can disable their own
+  // action affordances while one is outstanding.
+  pendingIds: Set<number>
+}
+
+const EMPTY_EDIT_DRAFT: EditDraft = { msgId: null, text: '', saving: false, error: '' }
+const EMPTY_DELETE_TARGET: DeleteTarget = { msgId: null, error: '' }
+
+export function useMessageActions({
+  conversationId,
+  messages,
+  setMessages,
+  userId,
+}: UseMessageActionsOptions): UseMessageActions {
+  const { t } = useTranslation('familyChat')
+
+  const [editDraft, setEditDraft] = useState<EditDraft>(EMPTY_EDIT_DRAFT)
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget>(EMPTY_DELETE_TARGET)
+  const [pendingIds, setPendingIds] = useState<Set<number>>(() => new Set())
+
+  // messagesRef mirrors the list so the mutation callbacks can read a
+  // pre-change snapshot (for rollback) without taking `messages` as a
+  // dependency — otherwise every callback would change identity on each
+  // arriving message and defeat memoization in the bubble components.
+  const messagesRef = useRef(messages)
+  useEffect(() => { messagesRef.current = messages })
+
+  // editDraftRef does the same for the in-progress edit text, keeping saveEdit
+  // stable across keystrokes.
+  const editDraftRef = useRef(editDraft)
+  useEffect(() => { editDraftRef.current = editDraft })
+
+  // pendingCountsRef ref-counts in-flight mutations per message id: a bubble
+  // can have two reaction toggles outstanding at once, and the first one to
+  // finish must not clear the pending flag for the second.
+  const pendingCountsRef = useRef<Map<number, number>>(new Map())
+
+  const beginPending = useCallback((msgId: number) => {
+    const counts = pendingCountsRef.current
+    counts.set(msgId, (counts.get(msgId) ?? 0) + 1)
+    setPendingIds(new Set(counts.keys()))
+  }, [])
+
+  const endPending = useCallback((msgId: number) => {
+    const counts = pendingCountsRef.current
+    const remaining = (counts.get(msgId) ?? 0) - 1
+    if (remaining > 0) counts.set(msgId, remaining)
+    else counts.delete(msgId)
+    setPendingIds(new Set(counts.keys()))
+  }, [])
+
+  // Editing, deleting and pending markers are all per-conversation: a switch
+  // must not carry a half-typed edit or an open delete confirmation into a
+  // different chat. Guarded on the previous id so this does nothing on mount.
+  const prevConversationRef = useRef(conversationId)
+  useEffect(() => {
+    if (prevConversationRef.current === conversationId) return
+    prevConversationRef.current = conversationId
+    pendingCountsRef.current.clear()
+    /* eslint-disable react-hooks/set-state-in-effect -- per-conversation state must be dropped on a switch; it cannot be derived from the new id */
+    setEditDraft(EMPTY_EDIT_DRAFT)
+    setDeleteTarget(EMPTY_DELETE_TARGET)
+    setPendingIds(new Set())
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [conversationId])
+
+  // ── Send lifecycle ─────────────────────────────────────────────────────────
+
+  // onMessageCreated folds the authoritative row (from the POST response or an
+  // SSE frame) into the list. Reconciles against an optimistic bubble when the
+  // message carries a client_id (the text-send path); otherwise dedupes by id
+  // (voice notes and attachments, which are not rendered optimistically).
+  const onMessageCreated = useCallback((msg: ChatMessage) => {
+    // Defensive: if the user switched conversations while a send was in
+    // flight, drop the message rather than leaking it into the wrong chat.
+    if (msg.conversation_id !== conversationId) return
+    setMessages(prev => reconcileMessage(prev, msg.client_id, msg))
+  }, [conversationId, setMessages])
+
+  // onOptimisticMessage renders a just-typed text message immediately in a
+  // 'sending' state, before any network round-trip. Scoped to the active
+  // conversation so a stray emit can't leak into the wrong chat.
+  const onOptimisticMessage = useCallback((msg: ChatMessage) => {
+    if (msg.conversation_id !== conversationId) return
+    setMessages(prev => [...prev, msg])
+  }, [conversationId, setMessages])
+
+  // onMessageFailed flips an optimistic bubble to the 'failed' state when its
+  // POST errors, preserving the typed text so the user can tap to retry. No
+  // conversation guard is needed: after a switch the bubble is gone, so the
+  // client_id no longer matches and this is a no-op.
+  const onMessageFailed = useCallback((clientId: string) => {
+    setMessages(prev => prev.map(m =>
+      m.client_id === clientId ? { ...m, status: 'failed' as const } : m,
+    ))
+  }, [setMessages])
+
+  // retryRef holds Composer's retry entry point. The failed bubble's tap target
+  // calls it to re-POST the preserved text under the same client_id so a
+  // successful retry reconciles the existing bubble in place.
+  const retryRef = useRef<RetryHandle | null>(null)
+
+  const retry = useCallback((msg: ChatMessage) => {
+    if (!msg.client_id) return
+    const clientId = msg.client_id
+    // Flip back to 'sending' immediately so the affordance reflects the retry.
+    setMessages(prev => prev.map(m =>
+      m.client_id === clientId ? { ...m, status: 'sending' as const } : m,
+    ))
+    retryRef.current?.(clientId, msg.body, msg.conversation_id)
+  }, [setMessages])
+
+  // send bundles the Composer wiring so callers can spread it in one place.
+  const send = useMemo<ComposerSendHandlers>(() => ({
+    onMessageCreated,
+    onOptimisticMessage,
+    onMessageFailed,
+    retryRef,
+  }), [onMessageCreated, onOptimisticMessage, onMessageFailed])
+
+  // ── Reactions ──────────────────────────────────────────────────────────────
+
+  // toggleReaction applies the change optimistically (chips update before the
+  // network round-trip) and rolls back on failure. The eventual SSE
+  // confirmation overwrites the optimistic state with the server-authoritative
+  // count, which keeps two clients in sync even if either one races.
+  const toggleReaction = useCallback(async (
+    msgId: number,
+    emoji: string,
+    currentlyMine: boolean,
+  ) => {
+    if (conversationId === null || userId === undefined) return
+    const meID = userId
+    const snapshot = messagesRef.current.find(m => m.id === msgId) ?? null
+    setMessages(prev => prev.map(m => {
+      if (m.id !== msgId) return m
+      const synthetic = currentlyMine
+        ? { user_id: meID, emoji, count: Math.max((m.reactions?.[emoji]?.count ?? 1) - 1, 0) }
+        : { user_id: meID, emoji, count: (m.reactions?.[emoji]?.count ?? 0) + 1 }
+      return {
+        ...m,
+        reactions: applyReactionEvent(m.reactions, synthetic, meID, currentlyMine),
+      }
+    }))
+    beginPending(msgId)
+    try {
+      if (currentlyMine) {
+        await removeReaction(conversationId, msgId, emoji)
+      } else {
+        await addReaction(conversationId, msgId, emoji)
+      }
+    } catch {
+      // Roll back only the reactions field to the pre-toggle snapshot. Rolling
+      // back the whole message would clobber any concurrent SSE updates (edits,
+      // other reactions) that arrived between the optimistic update and the
+      // network failure.
+      if (snapshot) {
+        setMessages(prev => prev.map(m =>
+          m.id === msgId ? { ...m, reactions: snapshot.reactions } : m,
+        ))
+      }
+    } finally {
+      endPending(msgId)
+    }
+  }, [conversationId, userId, setMessages, beginPending, endPending])
+
+  // ── Inline edit ────────────────────────────────────────────────────────────
+
+  // beginEdit opens the inline editor for a bubble, seeding the draft from the
+  // current body so the user starts from what is on screen.
+  const beginEdit = useCallback((msg: ChatMessage) => {
+    setEditDraft({ msgId: msg.id, text: msg.body, saving: false, error: '' })
+  }, [])
+
+  const setEditText = useCallback((text: string) => {
+    setEditDraft(prev => ({ ...prev, text }))
+  }, [])
+
+  const cancelEdit = useCallback(() => {
+    setEditDraft(EMPTY_EDIT_DRAFT)
+  }, [])
+
+  const saveEdit = useCallback(async (msgId: number) => {
+    if (conversationId === null) return
+    const trimmed = editDraftRef.current.text.trim()
+    if (!trimmed) {
+      setEditDraft(prev => ({ ...prev, error: t('edit.saveError') }))
+      return
+    }
+    setEditDraft(prev => ({ ...prev, saving: true, error: '' }))
+    // Capture the pre-edit body/edited_at so a failed save can revert the
+    // optimistic update — otherwise the bubble would keep showing the unsaved
+    // draft as if it had been persisted.
+    const snapshot = messagesRef.current.find(m => m.id === msgId) ?? null
+    // Optimistic update first: the SSE confirmation will overwrite shortly with
+    // the server's authoritative edited_at, which matches the pattern used by
+    // reactions and message sends.
+    const optimisticTime = new Date().toISOString()
+    setMessages(prev => prev.map(m =>
+      m.id === msgId ? { ...m, body: trimmed, edited_at: optimisticTime } : m,
+    ))
+    beginPending(msgId)
+    try {
+      const updated = await editMessage(conversationId, msgId, trimmed)
+      setMessages(prev => prev.map(m =>
+        m.id === msgId
+          ? { ...m, body: updated.body, edited_at: updated.edited_at }
+          : m,
+      ))
+      // Only close the editor if it is still the one we saved: the user may
+      // have cancelled or opened another bubble while the PATCH was in flight,
+      // and clobbering that would discard a draft they are actively typing.
+      setEditDraft(prev => (prev.msgId === msgId ? EMPTY_EDIT_DRAFT : prev))
+    } catch {
+      if (snapshot) {
+        setMessages(prev => prev.map(m =>
+          m.id === msgId
+            ? { ...m, body: snapshot.body, edited_at: snapshot.edited_at ?? null }
+            : m,
+        ))
+      }
+      setEditDraft(prev => (
+        prev.msgId === msgId
+          ? { ...prev, saving: false, error: t('edit.saveError') }
+          : prev
+      ))
+    } finally {
+      endPending(msgId)
+    }
+  }, [conversationId, t, setMessages, beginPending, endPending])
+
+  // ── Soft delete ────────────────────────────────────────────────────────────
+
+  const confirmDelete = useCallback((msgId: number) => {
+    setDeleteTarget({ msgId, error: '' })
+  }, [])
+
+  const cancelDelete = useCallback(() => {
+    setDeleteTarget(EMPTY_DELETE_TARGET)
+  }, [])
+
+  // deleteTargetRef keeps doDelete stable while still letting it default to
+  // whatever message the confirmation modal is currently asking about.
+  const deleteTargetRef = useRef(deleteTarget)
+  useEffect(() => { deleteTargetRef.current = deleteTarget })
+
+  const doDelete = useCallback(async (msgId?: number) => {
+    if (conversationId === null) return
+    const targetId = msgId ?? deleteTargetRef.current.msgId
+    if (targetId === null) return
+    setDeleteTarget(prev => ({ ...prev, error: '' }))
+    const meID = userId ?? null
+    const now = new Date().toISOString()
+    // Capture the pre-delete snapshot from the current list so the rollback in
+    // catch{} doesn't depend on the setState updater having run.
+    const snapshot = messagesRef.current.find(m => m.id === targetId) ?? null
+    setMessages(prev => prev.map(m => {
+      if (m.id !== targetId) return m
+      return {
+        ...m,
+        body: '',
+        attachment_path: '',
+        attachment_mime: '',
+        edited_at: null,
+        deleted_at: now,
+        deleted_by: meID,
+      }
+    }))
+    beginPending(targetId)
+    try {
+      await deleteMessage(conversationId, targetId)
+      // Only dismiss the confirm modal after the server has accepted the
+      // delete — closing it earlier would hide the error message rendered
+      // inside the same modal if the request fails. Guarded on the target so a
+      // late response cannot close a modal that has since moved to another
+      // message.
+      setDeleteTarget(prev => (prev.msgId === targetId ? EMPTY_DELETE_TARGET : prev))
+    } catch {
+      if (snapshot) {
+        setMessages(prev => prev.map(m => (m.id === targetId ? snapshot : m)))
+      }
+      setDeleteTarget(prev => (
+        prev.msgId === targetId ? { ...prev, error: t('edit.deleteError') } : prev
+      ))
+    } finally {
+      endPending(targetId)
+    }
+  }, [conversationId, userId, t, setMessages, beginPending, endPending])
+
+  return {
+    send,
+    retry,
+    editDraft,
+    setEditText,
+    beginEdit,
+    saveEdit,
+    cancelEdit,
+    deleteTarget,
+    confirmDelete,
+    cancelDelete,
+    doDelete,
+    toggleReaction,
+    pendingIds,
+  }
+}


### PR DESCRIPTION
## Changes

- **Family chat drops a half-typed edit when you switch conversations** - Message mutations (optimistic send/retry, inline edit, soft delete, reactions) moved into a dedicated `useMessageActions` hook; as part of that, an open inline editor or delete confirmation is now cleared on a conversation switch instead of carrying over into the new chat. (Hytte-nsaxs)

## Original Issue (task): Extract message mutations into useMessageActions

Create `web/src/pages/familychat/useMessageActions.ts` holding optimistic insert + server reconcile, failed-send retry state, edit draft state, soft-delete confirm flow, and `toggleReaction`. Signature roughly `useMessageActions({ chatId, messages, setMessages, me }): { send, retry, editDraft, beginEdit, saveEdit, cancelEdit, confirmDelete, doDelete, toggleReaction, pendingIds }`. It operates on the `messages`/`setMessages` pair produced by sub-task 1 so optimistic entries and SSE-delivered entries reconcile through one list. Keep attachment and voice-note upload wiring intact (Composer stays as-is). Add `useMessageActions.test.ts` covering optimistic-then-confirm, optimistic-then-fail-then-retry, edit, delete, and reaction-toggle error paths. The returned callbacks are what sub-task 3 threads down into MessageItem as props.

---
Bead: Hytte-nsaxs | Branch: forge/Hytte-nsaxs
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->