### PR TITLE
Stop blanking the whole page on month navigation and surface silent fetch errors (Hytte-s0lhf)

### DIFF
--- a/changelog.d/Hytte-s0lhf.md
+++ b/changelog.d/Hytte-s0lhf.md
@@ -1,0 +1,3 @@
+category: Changed
+- **Salary month navigation no longer blanks the page** - Stepping between months keeps the heading, tabs, config panel and cards on screen; the previous month's numbers stay visible (dimmed, with a spinner and an accessible label) until the new estimate arrives. The full-page loader and error are now reserved for the very first load, so a failed refetch keeps the last good estimate and reports the error inline. (Hytte-s0lhf)
+- **Failing vacation and trekktabell fetches are visible** - Both areas now show a localized error with a Retry button instead of silently rendering an empty box. (Hytte-s0lhf)

--- a/web/public/locales/en/salary.json
+++ b/web/public/locales/en/salary.json
@@ -208,6 +208,14 @@
     "failedToImport": "Import failed",
     "failedToLoadAssignments": "Failed to load assignments",
     "failedToSaveAssignment": "Save failed",
-    "failedToFetchDefaults": "Failed to fetch defaults"
+    "failedToFetchDefaults": "Failed to fetch defaults",
+    "failedToLoadVacation": "Failed to load vacation data",
+    "failedToLoadTrekktabell": "Failed to load trekktabell parameters"
+  },
+  "actions": {
+    "retry": "Retry"
+  },
+  "a11y": {
+    "refreshing": "Updating month estimate…"
   }
 }

--- a/web/public/locales/nb/salary.json
+++ b/web/public/locales/nb/salary.json
@@ -208,6 +208,14 @@
     "failedToImport": "Importering mislyktes",
     "failedToLoadAssignments": "Klarte ikke å laste tilknytninger",
     "failedToSaveAssignment": "Lagring mislyktes",
-    "failedToFetchDefaults": "Klarte ikke å hente standardverdier"
+    "failedToFetchDefaults": "Klarte ikke å hente standardverdier",
+    "failedToLoadVacation": "Klarte ikke å laste feriedata",
+    "failedToLoadTrekktabell": "Klarte ikke å laste trekktabellparametere"
+  },
+  "actions": {
+    "retry": "Prøv igjen"
+  },
+  "a11y": {
+    "refreshing": "Oppdaterer månedsestimatet…"
   }
 }

--- a/web/public/locales/th/salary.json
+++ b/web/public/locales/th/salary.json
@@ -208,6 +208,14 @@
     "failedToImport": "การนำเข้าล้มเหลว",
     "failedToLoadAssignments": "โหลดการกำหนดไม่สำเร็จ",
     "failedToSaveAssignment": "การบันทึกล้มเหลว",
-    "failedToFetchDefaults": "ดึงค่าเริ่มต้นไม่สำเร็จ"
+    "failedToFetchDefaults": "ดึงค่าเริ่มต้นไม่สำเร็จ",
+    "failedToLoadVacation": "โหลดข้อมูลวันลาพักร้อนไม่สำเร็จ",
+    "failedToLoadTrekktabell": "โหลดพารามิเตอร์ trekktabell ไม่สำเร็จ"
+  },
+  "actions": {
+    "retry": "ลองอีกครั้ง"
+  },
+  "a11y": {
+    "refreshing": "กำลังอัปเดตค่าประมาณของเดือน…"
   }
 }

--- a/web/src/pages/SalaryPage.test.tsx
+++ b/web/src/pages/SalaryPage.test.tsx
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import { parseDecimal } from '../utils/parseDecimal'
+import SalaryPage from './SalaryPage'
+import { addMonth, formatMonthLabel } from './salary/types'
+import type { EstimateResponse, TrekktabellParams, VacationResponse } from './salary/types'
 
 describe('parseDecimal', () => {
   it('parses Norwegian comma decimals', () => {
@@ -28,5 +32,292 @@ describe('parseDecimal', () => {
   it('preserves explicit zero', () => {
     expect(parseDecimal('0')).toBe(0)
     expect(parseDecimal('0,0')).toBe(0)
+  })
+})
+
+// ── Translation mock ──────────────────────────────────────────────────────────
+// mockT is a stable reference so effects that depend on `t` do not re-run.
+
+const TRANSLATIONS: Record<string, string> = {
+  'title': 'Salary Estimator',
+  'config.edit': 'Edit Config',
+  'year.tabs.month': 'This Month',
+  'year.tabs.year': 'Year View',
+  'month.prev': 'Previous month',
+  'month.next': 'Next month',
+  'hero.estimate': 'Estimate',
+  'hero.actual': 'Actual',
+  'hero.gross': 'Gross',
+  'hero.tax': 'Tax',
+  'hero.net': 'Net',
+  'hours.title': 'Hours',
+  'hours.worked': '{{worked}} / {{total}} h',
+  'workingDays.title': 'Working Days',
+  'vacation.title': 'Vacation',
+  'vacation.used': '{{used}} of {{allowance}} days used',
+  'trekktabell.title': 'Trekktabell',
+  'trekktabell.year': 'Year {{year}}',
+  'trekktabell.edit': 'Edit',
+  'trekktabellAssignments.title': 'Tabelltrekk assignments',
+  'actions.retry': 'Retry',
+  'a11y.refreshing': 'Updating month estimate…',
+  'errors.failedToLoad': 'Failed to load salary data',
+  'errors.failedToLoadVacation': 'Failed to load vacation data',
+  'errors.failedToLoadTrekktabell': 'Failed to load trekktabell parameters',
+}
+
+function mockT(key: string, opts?: Record<string, string | number>): string {
+  const template = TRANSLATIONS[key]
+  if (template === undefined) return key
+  if (!opts) return template
+  return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(opts[name] ?? ''))
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockT,
+    i18n: { language: 'en' },
+  }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// ── Auth mock ─────────────────────────────────────────────────────────────────
+
+vi.mock('../auth', () => ({
+  useAuth: () => ({ user: { id: 1, is_admin: false } }),
+}))
+
+// ── Fixtures & fetch routing ──────────────────────────────────────────────────
+
+function makeEstimate(month: string, hoursWorked = 120): EstimateResponse {
+  return {
+    month,
+    config: {
+      id: 1, user_id: 1, base_salary: 50000, hourly_rate: 1200,
+      internal_hourly_rate: 600, standard_hours: 7.5, currency: 'NOK',
+      taxable_benefits: 0, effective_from: '2026-01-01',
+    },
+    commission_tiers: [],
+    adjusted_commission_tiers: [],
+    estimate: {
+      id: 1, user_id: 1, month, working_days: 20, hours_worked: hoursWorked,
+      billable_hours: hoursWorked, internal_hours: 0, base_amount: 50000,
+      commission: 0, gross: 50000, tax: 15000, net: 35000,
+      vacation_days: 0, sick_days: 0, is_estimate: true,
+    },
+    working_days: 20,
+    working_days_done: 10,
+    working_days_remaining: 10,
+    hours_worked: hoursWorked,
+    internal_hours_worked: 0,
+    standard_hours_total: 150,
+    billable_revenue: 144000,
+    internal_revenue: 0,
+    absence_cost_per_day: 0,
+    sick_day_cost: 0,
+    vacation_day_cost: 0,
+    extra_hour_net: 0,
+  }
+}
+
+const VACATION: VacationResponse = {
+  year: 2026, days_allowance: 25, days_used: 5, days_remaining: 20,
+  gross_ytd: 400000, feriepenger_pct: 12, feriepenger_accrued: 48000,
+}
+
+const TREKKTABELL: TrekktabellParams = {
+  id: 1, user_id: 1, year: 2026,
+  minstefradrag_rate: 0.46, minstefradrag_min: 4000, minstefradrag_max: 92000,
+  personfradrag: 88250, alminnelig_skatt_rate: 0.22, trygdeavgift: 0.078,
+  trinnskatt_tiers: [],
+}
+
+type FakeResponse = { ok: boolean; status: number; json: () => Promise<unknown>; text: () => Promise<string> }
+
+function jsonOk(data: unknown): Promise<FakeResponse> {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data), text: () => Promise.resolve('') })
+}
+
+function httpError(status: number, body: string): Promise<FakeResponse> {
+  return Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: body }),
+    text: () => Promise.resolve(body),
+  })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+// Mutable routing table — individual tests swap a single route to fail or hang.
+const routes = {
+  estimate: (month: string): Promise<FakeResponse> => jsonOk(makeEstimate(month)),
+  vacation: (): Promise<FakeResponse> => jsonOk(VACATION),
+  trekktabell: (): Promise<FakeResponse> => jsonOk(TREKKTABELL),
+  assignments: (): Promise<FakeResponse> => jsonOk({ assignments: [] }),
+}
+
+function installFetch() {
+  const fetchMock = vi.fn((input: string) => {
+    const url = String(input)
+    if (url.startsWith('/api/salary/estimate/month')) {
+      const month = new URLSearchParams(url.split('?')[1] ?? '').get('month') ?? ''
+      return routes.estimate(month)
+    }
+    if (url.startsWith('/api/salary/trekktabell-assignments')) return routes.assignments()
+    if (url.startsWith('/api/salary/trekktabell')) return routes.trekktabell()
+    if (url.startsWith('/api/salary/vacation')) return routes.vacation()
+    return jsonOk({})
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+const currentMonthStr = (() => {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+})()
+const nextMonthStr = addMonth(currentMonthStr, 1)
+const currentMonthLabel = formatMonthLabel(currentMonthStr, 'en')
+const nextMonthLabel = formatMonthLabel(nextMonthStr, 'en')
+
+async function renderLoaded() {
+  render(<SalaryPage />)
+  await waitFor(() => expect(screen.getByText(currentMonthLabel)).toBeInTheDocument())
+}
+
+// The tab switcher and config toggle only exist in the full page render — their
+// presence proves the page shell was never torn down.
+function expectShellVisible() {
+  expect(screen.getByRole('heading', { name: 'Salary Estimator' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'This Month' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Year View' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /Edit Config/ })).toBeInTheDocument()
+}
+
+describe('SalaryPage – month navigation continuity', () => {
+  beforeEach(() => {
+    routes.estimate = (month: string) => jsonOk(makeEstimate(month))
+    routes.vacation = () => jsonOk(VACATION)
+    routes.trekktabell = () => jsonOk(TREKKTABELL)
+    routes.assignments = () => jsonOk({ assignments: [] })
+    installFetch()
+  })
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('keeps the shell and the previous month on screen while the next month loads', async () => {
+    await renderLoaded()
+
+    const pending = deferred<FakeResponse>()
+    routes.estimate = () => pending.promise
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }))
+
+    // Still the old month's card, no full-page loader.
+    expectShellVisible()
+    expect(screen.getByText(currentMonthLabel)).toBeInTheDocument()
+    expect(screen.queryByText(nextMonthLabel)).not.toBeInTheDocument()
+
+    await act(async () => {
+      pending.resolve(await jsonOk(makeEstimate(nextMonthStr)))
+    })
+
+    await waitFor(() => expect(screen.getByText(nextMonthLabel)).toBeInTheDocument())
+    expectShellVisible()
+  })
+
+  it('dims the hero card and announces the refresh while a month refetch is in flight', async () => {
+    await renderLoaded()
+    const heroCard = screen.getByText(currentMonthLabel).closest('div.bg-gray-800') as HTMLElement
+    expect(heroCard).toHaveAttribute('aria-busy', 'false')
+
+    const pending = deferred<FakeResponse>()
+    routes.estimate = () => pending.promise
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }))
+
+    const busyCard = screen.getByText(currentMonthLabel).closest('div.bg-gray-800') as HTMLElement
+    expect(busyCard).toHaveAttribute('aria-busy', 'true')
+    expect(busyCard.className).toContain('opacity-60')
+    expect(screen.getByText('Updating month estimate…')).toBeInTheDocument()
+
+    await act(async () => {
+      pending.resolve(await jsonOk(makeEstimate(nextMonthStr)))
+    })
+
+    await waitFor(() => expect(screen.queryByText('Updating month estimate…')).not.toBeInTheDocument())
+    const settledCard = screen.getByText(nextMonthLabel).closest('div.bg-gray-800') as HTMLElement
+    expect(settledCard).toHaveAttribute('aria-busy', 'false')
+  })
+
+  it('keeps the last good estimate and reports inline when a refetch fails', async () => {
+    await renderLoaded()
+
+    routes.estimate = () => httpError(500, 'boom')
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to load salary data')
+    })
+    // The previous month's card and the page shell survived the failure.
+    expect(screen.getByText(currentMonthLabel)).toBeInTheDocument()
+    expectShellVisible()
+  })
+
+  it('shows the full-page error when the very first load fails', async () => {
+    routes.estimate = () => httpError(500, 'boom')
+    render(<SalaryPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to load salary data')
+    })
+    expect(screen.queryByRole('button', { name: 'This Month' })).not.toBeInTheDocument()
+  })
+})
+
+describe('SalaryPage – sub-fetch errors', () => {
+  beforeEach(() => {
+    routes.estimate = (month: string) => jsonOk(makeEstimate(month))
+    routes.vacation = () => jsonOk(VACATION)
+    routes.trekktabell = () => jsonOk(TREKKTABELL)
+    routes.assignments = () => jsonOk({ assignments: [] })
+    installFetch()
+  })
+  afterEach(() => { vi.unstubAllGlobals(); vi.clearAllMocks() })
+
+  it('offers a retry when the vacation fetch fails and renders the card on success', async () => {
+    routes.vacation = () => httpError(500, 'vacation down')
+    await renderLoaded()
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load vacation data')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Vacation')).not.toBeInTheDocument()
+
+    routes.vacation = () => jsonOk(VACATION)
+    fireEvent.click(screen.getByRole('button', { name: /Retry/ }))
+
+    await waitFor(() => expect(screen.getByText('Vacation')).toBeInTheDocument())
+    expect(screen.queryByText('Failed to load vacation data')).not.toBeInTheDocument()
+  })
+
+  it('offers a retry when the trekktabell fetch fails instead of rendering nothing', async () => {
+    routes.trekktabell = () => httpError(500, 'trekktabell down')
+    await renderLoaded()
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load trekktabell parameters')).toBeInTheDocument()
+    })
+
+    routes.trekktabell = () => jsonOk(TREKKTABELL)
+    fireEvent.click(screen.getByRole('button', { name: /Retry/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /Trekktabell/ })).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Failed to load trekktabell parameters')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/SalaryPage.tsx
+++ b/web/src/pages/SalaryPage.tsx
@@ -38,17 +38,20 @@ export default function SalaryPage() {
   }
 
   const salary = useSalaryData(selectedMonth, selectedYear, activeTab)
-  const { estimate, loading, error } = salary
+  const { estimate, initialLoading, loadedOnce, error } = salary
 
-  if (loading) {
+  // The full-page loader and error are reserved for the very first load, when
+  // there is nothing on screen yet. Once a month estimate has arrived, a failed
+  // month change keeps the last good numbers and reports the error inline.
+  if (initialLoading) {
     return (
-      <div className="p-6 text-gray-400">{t('title')}…</div>
+      <div className="p-6 text-gray-400" role="status" aria-busy="true">{t('title')}…</div>
     )
   }
 
-  if (error) {
+  if (error && !loadedOnce) {
     return (
-      <div className="p-6 text-red-400">{t('errors.failedToLoad')}: {error}</div>
+      <div className="p-6 text-red-400" role="alert">{t('errors.failedToLoad')}: {error}</div>
     )
   }
 
@@ -70,6 +73,13 @@ export default function SalaryPage() {
           </button>
         )}
       </div>
+
+      {/* A refetch that failed after a successful first load — the page stays put */}
+      {error && loadedOnce && (
+        <div className="text-sm text-red-400" role="alert">
+          {t('errors.failedToLoad')}: {error}
+        </div>
+      )}
 
       {/* Config panel */}
       {(showConfig || noConfig || noConfigPastMonth) && (

--- a/web/src/pages/salary/InlineRetry.tsx
+++ b/web/src/pages/salary/InlineRetry.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next'
+import { RefreshCw } from 'lucide-react'
+
+interface InlineRetryProps {
+  message: string
+  onRetry: () => void
+}
+
+/**
+ * Card-sized inline error with a retry button. Used where a sub-fetch of the
+ * Salary page fails so the affected card explains itself instead of silently
+ * rendering nothing.
+ */
+export default function InlineRetry({ message, onRetry }: InlineRetryProps) {
+  const { t } = useTranslation('salary')
+
+  return (
+    <div
+      role="alert"
+      className="bg-gray-800 rounded-xl p-5 flex flex-wrap items-center justify-between gap-3"
+    >
+      <p className="text-sm text-red-400">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm rounded-lg transition-colors"
+      >
+        <RefreshCw size={14} />
+        {t('actions.retry')}
+      </button>
+    </div>
+  )
+}

--- a/web/src/pages/salary/MonthView.tsx
+++ b/web/src/pages/salary/MonthView.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Loader2 } from 'lucide-react'
 import { formatMonthLabel, formatHours, formatCompact } from './types'
 import { getTierProgress, getTierEarnings, isTierActive } from './tierMath'
 import type { SalaryData } from './useSalaryData'
 import VacationCard from './VacationCard'
+import InlineRetry from './InlineRetry'
 import TrekktabellEditor from './TrekktabellEditor'
 import AssignmentsList from './AssignmentsList'
 import WhatIfTierSlider from './WhatIfTierSlider'
@@ -24,7 +25,7 @@ interface MonthViewProps {
  */
 export default function MonthView({ salary, selectedMonth, currentMonthStr, locale, onChangeMonth }: MonthViewProps) {
   const { t } = useTranslation('salary')
-  const { estimate, vacation, formatCurrency, saveOverride } = salary
+  const { estimate, refreshing, vacation, vacationError, retryVacation, formatCurrency, saveOverride } = salary
 
   // Manual override form state (for past estimate months).
   const [showOverride, setShowOverride] = useState(false)
@@ -119,8 +120,13 @@ export default function MonthView({ salary, selectedMonth, currentMonthStr, loca
 
   return (
     <>
-      {/* Hero card — month estimate with prev/next navigation */}
-      <div className="bg-gray-800 rounded-xl p-5 space-y-4">
+      {/* Hero card — month estimate with prev/next navigation. While a new month
+          is loading the card dims so the previous month's numbers are visibly
+          stale rather than passing for fresh ones. */}
+      <div
+        className={`bg-gray-800 rounded-xl p-5 space-y-4 transition-opacity ${refreshing ? 'opacity-60' : ''}`}
+        aria-busy={refreshing}
+      >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1">
             <button
@@ -142,6 +148,12 @@ export default function MonthView({ salary, selectedMonth, currentMonthStr, loca
             >
               <ChevronRight size={16} />
             </button>
+            {refreshing && (
+              <span role="status" className="ml-1 flex items-center text-gray-400">
+                <Loader2 size={14} className="animate-spin" aria-hidden="true" />
+                <span className="sr-only">{t('a11y.refreshing')}</span>
+              </span>
+            )}
           </div>
           <span className={`text-xs px-2 py-0.5 rounded-full ${estimate.estimate.is_estimate ? 'bg-yellow-900/60 text-yellow-300' : 'bg-green-900/60 text-green-300'}`}>
             {estimate.estimate.is_estimate ? t('hero.estimate') : t('hero.actual')}
@@ -482,7 +494,9 @@ export default function MonthView({ salary, selectedMonth, currentMonthStr, loca
       )}
 
       {/* Vacation tracker */}
-      {vacation && <VacationCard vacation={vacation} formatCurrency={formatCurrency} />}
+      {vacationError
+        ? <InlineRetry message={t('errors.failedToLoadVacation')} onRetry={retryVacation} />
+        : vacation && <VacationCard vacation={vacation} formatCurrency={formatCurrency} />}
 
       {/* Trekktabell parameters */}
       <TrekktabellEditor salary={salary} />

--- a/web/src/pages/salary/TrekktabellEditor.tsx
+++ b/web/src/pages/salary/TrekktabellEditor.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TrekktabellParams } from './types'
 import type { SalaryData } from './useSalaryData'
+import InlineRetry from './InlineRetry'
 
 interface TrekktabellEditorProps {
   salary: SalaryData
@@ -13,12 +14,18 @@ interface TrekktabellEditorProps {
  */
 export default function TrekktabellEditor({ salary }: TrekktabellEditorProps) {
   const { t } = useTranslation('salary')
-  const { trekktabell, saveTrekktabell, resetTrekktabellDefaults } = salary
+  const { trekktabell, trekktabellError, retryTrekktabell, saveTrekktabell, resetTrekktabellDefaults } = salary
 
   const [showEditor, setShowEditor] = useState(false)
   const [editorTrekktabell, setEditorTrekktabell] = useState<TrekktabellParams | null>(null)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+
+  // A failed fetch is explained inline; only a genuinely absent (not yet loaded)
+  // trekktabell renders nothing.
+  if (trekktabellError) {
+    return <InlineRetry message={t('errors.failedToLoadTrekktabell')} onRetry={retryTrekktabell} />
+  }
 
   if (!trekktabell) return null
 

--- a/web/src/pages/salary/useSalaryData.ts
+++ b/web/src/pages/salary/useSalaryData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type {
   EstimateResponse,
@@ -42,10 +42,20 @@ export function useSalaryData(selectedMonth: string, selectedYear: number, activ
 
   const monthYear = Number.parseInt(selectedMonth.split('-')[0] ?? '', 10) || selectedYear
 
-  // Month estimate
+  // Month estimate. `initialLoading` covers only the very first fetch (the page
+  // has nothing to show yet); every later fetch — month navigation or a manual
+  // refresh — reports through `refreshing` so the previous estimate stays on
+  // screen instead of the page blanking out.
   const [estimate, setEstimate] = useState<EstimateResponse | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [initialLoading, setInitialLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  // True once a month estimate has been fetched successfully at least once, so
+  // a failed refetch can be surfaced inline rather than as a full-page error.
+  const [loadedOnce, setLoadedOnce] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Tracks whether any estimate fetch has settled, so a StrictMode double-invoke
+  // or rapid month clicks can never flip `initialLoading` back on.
+  const estimateSettledRef = useRef(false)
   // Force a refetch of the current month's estimate after assignment / import changes.
   const [estimateRefreshToken, setEstimateRefreshToken] = useState(0)
 
@@ -56,9 +66,13 @@ export function useSalaryData(selectedMonth: string, selectedYear: number, activ
 
   // Vacation
   const [vacation, setVacation] = useState<VacationResponse | null>(null)
+  const [vacationError, setVacationError] = useState<string | null>(null)
+  const [vacationRefreshToken, setVacationRefreshToken] = useState(0)
 
   // Trekktabell params
   const [trekktabell, setTrekktabell] = useState<TrekktabellParams | null>(null)
+  const [trekktabellError, setTrekktabellError] = useState<string | null>(null)
+  const [trekktabellRefreshToken, setTrekktabellRefreshToken] = useState(0)
 
   // Trekktabell assignments (per-month table number selection). Shared because
   // both the initial fetch and the mutations write the same error state.
@@ -81,10 +95,11 @@ export function useSalaryData(selectedMonth: string, selectedYear: number, activ
 
   useEffect(() => {
     let cancelled = false
+    // Deliberately keep the previous estimate: month navigation swaps the numbers
+    // in place instead of unmounting the whole page while the request is out.
     /* eslint-disable react-hooks/set-state-in-effect -- reset before fetch */
-    setLoading(true)
     setError(null)
-    setEstimate(null)
+    if (estimateSettledRef.current) setRefreshing(true)
     /* eslint-enable react-hooks/set-state-in-effect */
 
     fetch(`/api/salary/estimate/month?month=${selectedMonth}`, { credentials: 'include' })
@@ -94,25 +109,41 @@ export function useSalaryData(selectedMonth: string, selectedYear: number, activ
         return res.json() as Promise<EstimateResponse>
       })
       .then(data => {
+        // A cancelled request belongs to a month the user has already navigated
+        // away from — dropping it here keeps out-of-order responses off screen.
         if (cancelled) return
         setEstimate(data)
+        setLoadedOnce(true)
       })
       .catch(err => {
         if (!cancelled) setError(err.message)
       })
       .finally(() => {
-        if (!cancelled) setLoading(false)
+        if (cancelled) return
+        estimateSettledRef.current = true
+        setInitialLoading(false)
+        setRefreshing(false)
       })
 
     return () => { cancelled = true }
   }, [selectedMonth, estimateRefreshToken])
 
-  // Load vacation data when estimate is available (has config).
+  // Both the vacation and trekktabell payloads are per-year, so they are keyed on
+  // the year plus "do we have a config at all" — not on the `estimate` object
+  // identity, which changes on every month fetch and would refetch needlessly.
+  const hasConfig = estimate !== null
+
+  const retryVacation = useCallback(() => setVacationRefreshToken(tok => tok + 1), [])
+  const retryTrekktabell = useCallback(() => setTrekktabellRefreshToken(tok => tok + 1), [])
+
+  // Load vacation data when a config is available.
   // Use monthYear so vacation data always matches the selected month's year,
   // not the independently-selectable year tab year.
   useEffect(() => {
-    if (!estimate) return
+    if (!hasConfig) return
     let cancelled = false
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- clear stale error before fetch
+    setVacationError(null)
 
     fetch(`/api/salary/vacation?year=${monthYear}`, { credentials: 'include' })
       .then(async res => {
@@ -120,15 +151,20 @@ export function useSalaryData(selectedMonth: string, selectedYear: number, activ
         return res.json() as Promise<VacationResponse>
       })
       .then(data => { if (!cancelled) setVacation(data) })
-      .catch(err => { if (!cancelled) console.error('Failed to load vacation data:', err) })
+      .catch(err => {
+        if (cancelled) return
+        setVacationError(err instanceof Error ? err.message : String(err))
+      })
 
     return () => { cancelled = true }
-  }, [estimate, monthYear])
+  }, [hasConfig, monthYear, vacationRefreshToken])
 
-  // Load trekktabell params when estimate is available.
+  // Load trekktabell params when a config is available.
   useEffect(() => {
-    if (!estimate) return
+    if (!hasConfig) return
     let cancelled = false
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- clear stale error before fetch
+    setTrekktabellError(null)
 
     fetch(`/api/salary/trekktabell?year=${monthYear}`, { credentials: 'include' })
       .then(async res => {
@@ -136,10 +172,13 @@ export function useSalaryData(selectedMonth: string, selectedYear: number, activ
         return res.json() as Promise<TrekktabellParams>
       })
       .then(data => { if (!cancelled) setTrekktabell(data) })
-      .catch(err => { if (!cancelled) console.error('Failed to load trekktabell:', err) })
+      .catch(err => {
+        if (cancelled) return
+        setTrekktabellError(err instanceof Error ? err.message : String(err))
+      })
 
     return () => { cancelled = true }
-  }, [estimate, monthYear])
+  }, [hasConfig, monthYear, trekktabellRefreshToken])
 
   useEffect(() => {
     if (activeTab !== 'year') return
@@ -396,13 +435,19 @@ export function useSalaryData(selectedMonth: string, selectedYear: number, activ
 
   return {
     estimate,
-    loading,
+    initialLoading,
+    refreshing,
+    loadedOnce,
     error,
     yearData,
     yearLoading,
     yearError,
     vacation,
+    vacationError,
+    retryVacation,
     trekktabell,
+    trekktabellError,
+    retryTrekktabell,
     assignments,
     assignmentsLoading,
     assignmentsError,


### PR DESCRIPTION
## Changes

- **Salary month navigation no longer blanks the page** - Stepping between months keeps the heading, tabs, config panel and cards on screen; the previous month's numbers stay visible (dimmed, with a spinner and an accessible label) until the new estimate arrives. The full-page loader and error are now reserved for the very first load, so a failed refetch keeps the last good estimate and reports the error inline. (Hytte-s0lhf)
- **Failing vacation and trekktabell fetches are visible** - Both areas now show a localized error with a Retry button instead of silently rendering an empty box. (Hytte-s0lhf)

## Original Issue (feature): Stop blanking the whole page on month navigation and surface silent fetch errors

### Scope
Frontend-only change to the Salary page's loading and error handling. Split `useSalaryData`'s month-estimate `loading` into a first-load flag and a background `refreshing` flag so prev/next month navigation keeps the previous estimate on screen (dimmed, with a small spinner) instead of unmounting the heading, tabs, config panel and all cards. Add real error state + retry for the vacation and trekktabell fetches, which today only `console.error` and leave `VacationCard` / `TrekktabellEditor` rendering nothing.

### Files to touch
- `web/src/pages/salary/useSalaryData.ts` — stop `setEstimate(null)` on month change; expose `initialLoading` (true only until the first month estimate settles) and `refreshing`; add `vacationError` / `trekktabellError` plus `retryVacation()` / `retryTrekktabell()` (refresh-token pattern already used by `estimateRefreshToken`)
- `web/src/pages/SalaryPage.tsx` — gate the full-page `Salary…` loader on `initialLoading`; same for the full-page error branch (a failed *refetch* must not blank the page)
- `web/src/pages/salary/MonthView.tsx` — dim/spinner treatment on the hero card while `refreshing`; render an inline retry chip when `vacationError` is set instead of skipping `VacationCard`
- `web/src/pages/salary/TrekktabellEditor.tsx` — render an inline retry chip when `trekktabellError` is set instead of `return null`
- `web/src/pages/salary/VacationCard.tsx` — only if the chip is placed inside the card
- `web/public/locales/{en,nb,th}/salary.json` — new keys (e.g. `errors.failedToLoadVacation`, `errors.failedToLoadTrekktabell`, `actions.retry`, `a11y.refreshing`)
- `web/src/pages/SalaryPage.test.tsx` — tests for continuity + retry chips
- `changelog.d/<name>.md` (new)

Watch out: the vacation/trekktabell effects currently depend on the `estimate` object identity. Once `estimate` survives a month change they will still refire on every new object — key them on `monthYear` plus a "has config" boolean so they fetch once per year, not once per month.

### Acceptance criteria
- Clicking prev/next month never unmounts the `Salary` heading, config toggle, tab switcher, or month/year cards; the previous month's numbers stay visible until the new ones arrive.
- While a month refetch is in flight the hero card is visibly dimmed and shows a spinner with an accessible label; stale numbers are never presented as fresh.
- The full-page `Salary…` loader appears only on the very first load of the page (or a hard tab/route re-entry), not on subsequent month changes.
- A failed month refetch keeps the last good estimate on screen and surfaces the error inline; only a first-load failure shows the full-page error.
- If `/api/salary/vacation` fails, the vacation area shows a localized error message with a Retry button; clicking it refetches and renders the card on success.
- If `/api/salary/trekktabell` fails, the trekktabell area shows the same treatment rather than rendering nothing.
- New strings exist in `en`, `nb` and `th`; no hardcoded English in JSX.
- `npm run lint`, `npm run build` and `npm test` pass; a changelog fragment is present.

### Non-goals
- No backend changes in `internal/salary/`.
- No caching/prefetching of adjacent months, no react-query or other data-layer library.
- No change to the year tab's existing `yearLoading` / `yearError` handling, to assignments loading, or to mutation (save/confirm/sync) error UX.
- No visual redesign of the salary cards beyond the dim/spinner and retry chip.

## Source

Created from Suggestions page (suggestion id 359, page slug "salary", source=claude).

## Original suggestion

`useSalaryData` clears `estimate` and sets `loading` on every month change, and `SalaryPage` returns a bare "Salary…" line while loading, so each click on the prev/next chevrons wipes the heading, tabs, config panel and all cards before redrawing them — a full-page flash for what is a single-card update. Meanwhile the vacation and trekktabell fetches only `console.error` on failure, leaving `VacationCard` and `TrekktabellEditor` blank with no explanation. Keep the previous estimate visible during a refetch (dim it or show a small spinner in the hero card), reserve the full-page loader for the very first load, and add error state for the vacation/trekktabell fetches rendered as an inline retry chip on the affected card. Month-to-month browsing then feels continuous, and a failing sub-fetch is visible rather than an empty box.


---
Bead: Hytte-s0lhf | Branch: forge/Hytte-s0lhf
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->