### PR TITLE
Extract MessageList and MessageItem presentational components (Hytte-u5avd)

### DIFF
--- a/changelog.d/Hytte-u5avd.md
+++ b/changelog.d/Hytte-u5avd.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Family chat message list split into presentational components** - The scrollable message log and the individual chat bubble moved out of `ChatView` into `MessageList` and `MessageItem`. Both are purely presentational — every mutation still comes from `useMessageActions` — so the chat behaves exactly as before; bubbles are now memoized, so an arriving message no longer re-renders the whole conversation. (Hytte-u5avd)

--- a/web/src/pages/familychat/ChatView.tsx
+++ b/web/src/pages/familychat/ChatView.tsx
@@ -1,12 +1,9 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type PointerEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   ChevronLeft,
   MessageSquare,
-  Download,
   X,
-  Smile,
-  MoreVertical,
   Phone,
   PhoneOff,
   PhoneIncoming,
@@ -25,8 +22,8 @@ import ConnectionStatus from '../../components/ConnectionStatus'
 import { useAuth } from '../../auth'
 import { useKeyboardInset } from '../../hooks/useKeyboardInset'
 import Composer from './Composer'
-import ReactionChips from './ReactionChips'
-import ReactionPicker from './ReactionPicker'
+import type { Lightbox } from './MessageItem'
+import MessageList, { type ScrollAnchor } from './MessageList'
 import {
   fetchOlderMessages,
   markConversationRead,
@@ -40,9 +37,6 @@ import {
   type ReadReceiptPayload,
 } from './useFamilyChatStream'
 import { useMessageActions } from './useMessageActions'
-import { formatRelative } from './utils'
-import VoiceBubble from './voice/VoiceBubble'
-import { readCachedWaveform, parseWaveformJSON, DEFAULT_BAR_COUNT, type Waveform } from './voice/waveform'
 import * as voicePlayer from './voice/voicePlayer'
 import { useVoiceCall, type CallKind } from './voice/useVoiceCall'
 import { supportedFilters, type FilterKind } from './voice/videoFilters'
@@ -74,15 +68,6 @@ const AT_BOTTOM_THRESHOLD_PX = 80
 // read marker for the newest one, instead of one POST per message.
 const MARK_READ_DEBOUNCE_MS = 300
 
-// parseVoiceMeta extracts a {bars, durationMs} pair from a meta_json blob.
-// Returns null when the field is absent, unparseable, or shaped wrong — the
-// caller falls back to a localStorage cache (and ultimately a flat waveform)
-// so a malformed meta_json never blocks playback.
-function parseVoiceMeta(meta: string | null | undefined): Waveform | null {
-  if (!meta) return null
-  return parseWaveformJSON(meta)
-}
-
 interface MemberInfo {
   label: string
   emoji: string
@@ -111,7 +96,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const { user, familyStatus } = useAuth()
 
   const [memberLookup, setMemberLookup] = useState<Map<number, MemberInfo>>(new Map())
-  const [lightbox, setLightbox] = useState<{ url: string; alt: string } | null>(null)
+  const [lightbox, setLightbox] = useState<Lightbox | null>(null)
   // pickerForMsgId is the id of the bubble whose reaction picker is open, or
   // null when nothing is open. We only show one picker at a time.
   const [pickerForMsgId, setPickerForMsgId] = useState<number | null>(null)
@@ -169,9 +154,9 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   // duplicate pages start before the first render lands.
   const loadingOlderRef = useRef(false)
   // pendingScrollRestoreRef holds the scroll metrics captured immediately
-  // before a prepend. Its presence is also what tells the auto-scroll-to-bottom
-  // effect to stand down for that one commit.
-  const pendingScrollRestoreRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null)
+  // before a prepend. Its presence is also what tells MessageList's
+  // auto-scroll-to-bottom effect to stand down for that one commit.
+  const pendingScrollRestoreRef = useRef<ScrollAnchor | null>(null)
 
   // ── Read markers ───────────────────────────────────────────────────────────
   // refreshConversations makes the sibling ConversationList refetch, which is
@@ -294,7 +279,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     userId: user?.id,
   })
 
-  const messagesEndRef = useRef<HTMLDivElement>(null)
   // conversationIdRef shadows the current conversation so an in-flight
   // "load older" response can tell whether the user has since switched chats.
   const conversationIdRef = useRef(conversationId)
@@ -330,20 +314,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       void groupCallLeaveRef.current()
     }
   }, [conversationId])
-  // lastPointerTypeRef is set by onPointerDown so onContextMenu knows whether
-  // it was triggered by a touch long-press (open picker, suppress native menu)
-  // or a mouse right-click (leave native menu alone; picker is on hover button).
-  const lastPointerTypeRef = useRef<string>('mouse')
-  // pickerAnchorRef: element used by ReactionPicker for placement/positioning.
-  // Set to the hover button or the message bubble (long-press), whichever opened the picker.
-  const pickerAnchorRef = useRef<HTMLElement | null>(null)
-  // pickerGuardRef: the actual toggle button (hover Smile button only). The
-  // picker's outside-click handler ignores clicks on this element so the button
-  // can toggle the picker closed without the picker immediately re-closing on
-  // the same click. NOT set on long-press (no toggle button exists there), so
-  // tapping the bubble correctly closes the picker.
-  const pickerGuardRef = useRef<HTMLElement | null>(null)
-
   // Focus management + Escape handling for the delete confirmation modal,
   // matching the pattern used by ConfirmDialog.
   const confirmDeleteId = deleteTarget.msgId
@@ -429,34 +399,6 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   }, [user, familyStatus, t])
 
   const keyboardInset = useKeyboardInset()
-
-  // Auto-scroll to the bottom whenever the message list updates or the keyboard
-  // opens/closes (keyboardInset changes). useLayoutEffect avoids a visible jump
-  // between initial paint and the scroll snap.
-  useLayoutEffect(() => {
-    // A commit that prepended older history must not jump to the bottom — the
-    // restore effect below re-anchors the view on the message the user was
-    // already reading instead. messages.length changes on a prepend too, which
-    // is why this guard exists rather than a narrower dependency list.
-    if (pendingScrollRestoreRef.current) return
-    if (messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ block: 'end' })
-    }
-  }, [messages.length, conversationId, keyboardInset])
-
-  // Restore the scroll anchor after older messages are prepended: the content
-  // above the viewport grew by (newScrollHeight - savedScrollHeight), so adding
-  // that delta to the saved scrollTop keeps the same message under the user's
-  // eyes. Runs after the auto-scroll effect above (declaration order) and
-  // clears the flag that effect reads.
-  useLayoutEffect(() => {
-    const pending = pendingScrollRestoreRef.current
-    if (!pending) return
-    pendingScrollRestoreRef.current = null
-    const el = messagesScrollRef.current
-    if (!el) return
-    el.scrollTop = el.scrollHeight - pending.scrollHeight + pending.scrollTop
-  }, [prependCounter])
 
   // loadOlderMessages fetches the page immediately preceding the oldest message
   // currently rendered and prepends it. Deduped by id so it can never collide
@@ -732,12 +674,15 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
     }).catch(() => {})
   }, [conversationId])
 
-  const handlePickFromPicker = useCallback((msgId: number, emoji: string) => {
-    setPickerForMsgId(null)
-    const msg = messages.find(m => m.id === msgId)
-    const mine = !!msg?.reactions?.[emoji]?.me
-    void toggleReaction(msgId, emoji, mine)
-  }, [messages, toggleReaction])
+  const closePicker = useCallback(() => setPickerForMsgId(null), [])
+
+  // memberLabel resolves a user id to the friendly name shown on bubbles,
+  // member chips and call banners, falling back to "Member #id" for ids the
+  // current user can't name. Stable so the memoized bubbles only re-render when
+  // the lookup itself changes.
+  const memberLabel = useCallback((id: number) => (
+    memberLookup.get(id)?.label ?? t('chat.memberFallback', { id })
+  ), [memberLookup, t])
 
   const memberChips = useMemo(() => {
     if (!conversation) return []
@@ -760,8 +705,8 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
   const typingLabels = useMemo(() => {
     return Array.from(typingUsers.keys())
       .filter(id => id !== user?.id)
-      .map(id => memberLookup.get(id)?.label ?? t('chat.memberFallback', { id }))
-  }, [typingUsers, memberLookup, user?.id, t])
+      .map(id => memberLabel(id))
+  }, [typingUsers, memberLabel, user?.id])
 
   // seenByLabels names the members whose live read receipt covers our newest
   // message. Receipts are observed in-session only (the conversation API
@@ -782,11 +727,11 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
       if (id === user?.id) continue
       const readAt = Date.parse(at)
       if (Number.isNaN(readAt) || readAt < sentAt) continue
-      labels.push(memberLookup.get(id)?.label ?? t('chat.memberFallback', { id }))
+      labels.push(memberLabel(id))
     }
     // Sorted so the list is stable regardless of receipt arrival order.
     return labels.sort((a, b) => a.localeCompare(b))
-  }, [peerReads, messages, memberLookup, user?.id, t])
+  }, [peerReads, messages, memberLabel, user?.id])
 
   // 1:1 calls use the single-peer voice-call hook (callPeerId is the other
   // member). 3+ member conversations use the group-call mesh instead, gated by
@@ -801,14 +746,13 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
 
   const peerLabel = useCallback((peerId: number | null) => {
     if (peerId === null) return t('chat.memberFallback', { id: 0 })
-    return memberLookup.get(peerId)?.label ?? t('chat.memberFallback', { id: peerId })
-  }, [memberLookup, t])
+    return memberLabel(peerId)
+  }, [memberLabel, t])
 
   // Label/emoji accessors for the group-call overlay tiles.
-  const groupMemberInfo = useCallback((id: number) => {
-    const info = memberLookup.get(id)
-    return { label: info?.label ?? t('chat.memberFallback', { id }), emoji: info?.emoji ?? '👤' }
-  }, [memberLookup, t])
+  const groupMemberInfo = useCallback((id: number) => (
+    { label: memberLabel(id), emoji: memberLookup.get(id)?.emoji ?? '👤' }
+  ), [memberLabel, memberLookup])
   const groupMemberLabel = useCallback((id: number) => groupMemberInfo(id).label, [groupMemberInfo])
   const selfEmoji = (user?.id !== undefined ? memberLookup.get(user.id)?.emoji : undefined) ?? '👤'
 
@@ -1026,356 +970,36 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
         )}
       </header>
 
-      <div
-        ref={messagesScrollRef}
+      <MessageList
+        messages={messages}
+        loading={loading}
+        error={error}
+        loadingOlder={loadingOlder}
+        hasMoreOlder={hasMoreOlder}
+        scrollRef={messagesScrollRef}
         onScroll={handleMessagesScroll}
-        className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 sm:px-4 py-3 space-y-2"
-        role="log"
-        aria-live="polite"
-        aria-relevant="additions"
+        pendingScrollRestoreRef={pendingScrollRestoreRef}
+        prependCounter={prependCounter}
+        conversationId={conversationId}
+        keyboardInset={keyboardInset}
+        currentUserId={user?.id}
+        memberLabel={memberLabel}
+        rtf={rtf}
+        editDraft={editDraft}
+        pickerForMsgId={pickerForMsgId}
+        menuForMsgId={menuForMsgId}
+        onOpenLightbox={setLightbox}
+        onOpenPicker={setPickerForMsgId}
+        onClosePicker={closePicker}
+        onToggleReaction={toggleReaction}
+        onOpenMenu={setMenuForMsgId}
+        onBeginEdit={beginEdit}
+        onConfirmDelete={confirmDelete}
+        onEditTextChange={setEditText}
+        onSaveEdit={saveEdit}
+        onCancelEdit={cancelEdit}
+        onRetry={retryFailedMessage}
       >
-        {loading && (
-          <div className="space-y-3" role="status" aria-busy="true">
-            <span className="sr-only">{t('loading')}</span>
-            <Skeleton className="h-12 w-3/4" />
-            <Skeleton className="h-12 w-2/3 ml-auto" />
-            <Skeleton className="h-12 w-1/2" />
-          </div>
-        )}
-
-        {!loading && error && (
-          <div className="p-3 bg-red-900/40 border border-red-700 rounded-lg text-red-300 text-sm">
-            {error}
-          </div>
-        )}
-
-        {!loading && !error && messages.length === 0 && (
-          <div className="flex flex-col items-center justify-center h-full text-center text-gray-500 py-12">
-            <MessageSquare size={32} className="mb-2 text-gray-600" aria-hidden="true" />
-            <p className="text-sm">{t('chat.emptyMessages')}</p>
-          </div>
-        )}
-
-        {!loading && !error && messages.length > 0 && loadingOlder && (
-          <div
-            className="flex justify-center py-2 text-xs text-gray-500"
-            role="status"
-            aria-busy="true"
-            data-testid="family-chat-loading-older"
-          >
-            {t('chat.loadingOlder')}
-          </div>
-        )}
-
-        {!loading && !error && messages.length > 0 && !hasMoreOlder && !loadingOlder && (
-          <div
-            className="flex justify-center py-2 text-xs text-gray-500"
-            data-testid="family-chat-history-start"
-          >
-            {t('chat.beginningOfConversation')}
-          </div>
-        )}
-
-        {!loading && !error && messages.map(msg => {
-          const isOwn = user?.id === msg.sender_user_id
-          const isDeleted = !!msg.deleted_at
-          const isEditing = editDraft.msgId === msg.id
-          const senderInfo = memberLookup.get(msg.sender_user_id)
-          const senderLabel = senderInfo?.label ?? t('chat.memberFallback', { id: msg.sender_user_id })
-          const relative = formatRelative(msg.created_at, rtf, t('time.justNow'))
-          const attachmentUrl = !isDeleted && msg.attachment_path && msg.attachment_mime
-            ? `/api/familychat/conversations/${msg.conversation_id}/attachments/${msg.id}`
-            : ''
-          const mime = msg.attachment_mime ?? ''
-          const isImage = mime.startsWith('image/')
-          const isAudio = mime.startsWith('audio/')
-          // A voice note is an audio/webm attachment with an empty body —
-          // the recorder always ships these as standalone bubbles. The
-          // bubble renders a precomputed waveform if meta_json carries one;
-          // it falls back to a localStorage cache (written immediately
-          // after upload by the recorder) and finally to a flat waveform.
-          const isVoiceNote = !isDeleted && !!attachmentUrl
-            && (mime.startsWith('audio/webm') || mime.startsWith('audio/ogg'))
-            && !msg.body.trim()
-          const cachedWaveform = isVoiceNote
-            ? (parseVoiceMeta(msg.meta_json) ?? readCachedWaveform(msg.id))
-            : null
-          const voiceBars = cachedWaveform?.bars ?? new Array(DEFAULT_BAR_COUNT).fill(0)
-          const voiceDurationMs = cachedWaveform?.durationMs ?? 0
-          const pickerOpen = pickerForMsgId === msg.id
-          const menuOpen = menuForMsgId === msg.id
-          // Optimistic bubbles (still sending or failed) have no authoritative
-          // id yet, so reactions and edit/delete are suppressed until the row
-          // reconciles to the persisted message.
-          const isPending = msg.status === 'sending' || msg.status === 'failed'
-          const showActions = isOwn && !isDeleted && !isEditing && !isPending
-          const deletedByInfo = msg.deleted_by != null ? memberLookup.get(msg.deleted_by) : undefined
-          const deletedByLabel = msg.deleted_by != null && user?.id === msg.deleted_by
-            ? t('edit.tombstoneSelf')
-            : t('edit.tombstone', { name: deletedByInfo?.label ?? t('chat.memberFallback', { id: msg.deleted_by ?? 0 }) })
-          return (
-            <div
-              key={msg.client_id ?? msg.id}
-              className={`flex flex-col group ${isOwn ? 'items-end' : 'items-start'}`}
-              data-testid={`chat-bubble-${msg.id}`}
-            >
-              {!isOwn && !isDeleted && (
-                <span className="text-xs text-gray-400 mb-0.5 px-1">{senderLabel}</span>
-              )}
-              <div className={`relative max-w-[85%] sm:max-w-[70%]`}>
-                {isDeleted ? (
-                  <div
-                    className="px-3 py-2 rounded-2xl text-sm italic bg-gray-800/60 border border-gray-700 text-gray-400"
-                    data-testid={`chat-tombstone-${msg.id}`}
-                  >
-                    {deletedByLabel}
-                  </div>
-                ) : isEditing ? (
-                  <div className={`px-3 py-2 rounded-2xl text-sm break-words ${
-                    isOwn ? 'bg-blue-600/40 border border-blue-500' : 'bg-gray-800 border border-gray-700'
-                  }`}>
-                    <textarea
-                      value={editDraft.text}
-                      onChange={(e) => setEditText(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Escape') {
-                          e.preventDefault()
-                          cancelEdit()
-                        } else if (e.key === 'Enter' && !e.shiftKey) {
-                          e.preventDefault()
-                          void saveEdit(msg.id)
-                        }
-                      }}
-                      aria-label={t('edit.edit')}
-                      data-testid={`chat-edit-input-${msg.id}`}
-                      className="w-full bg-gray-900 text-gray-100 border border-gray-700 rounded-lg px-2 py-1 text-sm focus:outline-none focus:border-blue-500"
-                      rows={3}
-                      autoFocus
-                    />
-                    {editDraft.error && (
-                      <div className="text-xs text-red-400 mt-1">{editDraft.error}</div>
-                    )}
-                    <div className="flex gap-2 mt-2 justify-end">
-                      <button
-                        type="button"
-                        onClick={cancelEdit}
-                        className="px-2 py-1 text-xs rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600"
-                        data-testid={`chat-edit-cancel-${msg.id}`}
-                      >
-                        {t('edit.cancel')}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => { void saveEdit(msg.id) }}
-                        disabled={editDraft.saving || !editDraft.text.trim()}
-                        className="px-2 py-1 text-xs rounded-md bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                        data-testid={`chat-edit-save-${msg.id}`}
-                      >
-                        {editDraft.saving ? t('edit.saving') : t('edit.save')}
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <div
-                    className={`px-3 py-2 rounded-2xl text-sm break-words ${
-                      isOwn
-                        ? 'bg-blue-600 text-white rounded-br-sm'
-                        : 'bg-gray-800 text-gray-100 rounded-bl-sm'
-                    } ${msg.status === 'sending' ? 'opacity-70' : ''}`}
-                    onPointerDown={(e) => { lastPointerTypeRef.current = e.pointerType }}
-                    onContextMenu={(e) => {
-                      // Only intercept touch long-press (suppress native menu, open
-                      // reaction picker for all messages). Mouse right-clicks keep
-                      // the native menu so users can copy text/images; the reaction
-                      // picker is reachable via the hover button (Smile icon) on
-                      // desktop. Edit/delete actions remain accessible via the
-                      // MoreVertical button for own messages.
-                      if (lastPointerTypeRef.current === 'touch') {
-                        e.preventDefault()
-                        // Use the bubble as the positioning anchor only.
-                        // pickerGuardRef is explicitly cleared here — there is
-                        // no toggle button for long-press, so clicks on the
-                        // bubble should correctly dismiss the picker. Clearing
-                        // prevents a stale guard ref from a prior hover-button
-                        // open from suppressing the outside-click close.
-                        pickerAnchorRef.current = e.currentTarget
-                        pickerGuardRef.current = null
-                        setPickerForMsgId(msg.id)
-                      }
-                    }}
-                  >
-                    {attachmentUrl && isImage && (
-                      <button
-                        type="button"
-                        onClick={() => setLightbox({ url: attachmentUrl, alt: t('chat.attachmentImageAlt') })}
-                        className="block cursor-zoom-in mb-1"
-                        aria-label={t('chat.attachmentImageAlt')}
-                      >
-                        <img
-                          src={attachmentUrl}
-                          alt={t('chat.attachmentImageAlt')}
-                          loading="lazy"
-                          className="rounded-lg max-h-60 max-w-full object-contain"
-                        />
-                      </button>
-                    )}
-                    {attachmentUrl && isVoiceNote && (
-                      <VoiceBubble
-                        messageId={msg.id}
-                        src={attachmentUrl}
-                        bars={voiceBars}
-                        durationMs={voiceDurationMs}
-                        isOwn={isOwn}
-                      />
-                    )}
-                    {attachmentUrl && isAudio && !isVoiceNote && (
-                      <audio
-                        controls
-                        src={attachmentUrl}
-                        className="block max-w-full mb-1"
-                        aria-label={t('chat.attachmentAudioAlt')}
-                      />
-                    )}
-                    {attachmentUrl && !isImage && !isAudio && (
-                      <a
-                        href={attachmentUrl}
-                        download
-                        className={`flex items-center gap-2 rounded-lg px-2 py-1.5 mb-1 text-xs ${
-                          isOwn ? 'bg-blue-700/60 hover:bg-blue-700/80' : 'bg-gray-700/70 hover:bg-gray-700'
-                        }`}
-                      >
-                        <Download size={14} aria-hidden="true" />
-                        <span className="truncate">{t('chat.attachmentFileLabel', { mime })}</span>
-                      </a>
-                    )}
-                    {msg.body && (
-                      <div className="whitespace-pre-wrap">{msg.body}</div>
-                    )}
-                  </div>
-                )}
-                {!isDeleted && !isEditing && !isPending && (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      const willOpen = !pickerOpen
-                      if (willOpen) {
-                        pickerAnchorRef.current = e.currentTarget
-                        pickerGuardRef.current = e.currentTarget
-                      }
-                      setPickerForMsgId(willOpen ? msg.id : null)
-                    }}
-                    aria-label={t('reactions.pickerLabel')}
-                    className={`absolute -top-3 ${isOwn ? '-left-2' : '-right-2'} p-1 rounded-full bg-gray-800 border border-gray-700 text-gray-300 hover:text-white opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity cursor-pointer`}
-                    data-testid={`reaction-trigger-${msg.id}`}
-                  >
-                    <Smile size={14} aria-hidden="true" />
-                  </button>
-                )}
-                {showActions && (
-                  <button
-                    type="button"
-                    onClick={() => setMenuForMsgId(menuOpen ? null : msg.id)}
-                    aria-label={t('edit.menuLabel')}
-                    aria-haspopup="menu"
-                    aria-expanded={menuOpen}
-                    className="absolute -top-3 -right-2 p-1 rounded-full bg-gray-800 border border-gray-700 text-gray-300 hover:text-white opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity cursor-pointer"
-                    data-testid={`chat-actions-trigger-${msg.id}`}
-                  >
-                    <MoreVertical size={14} aria-hidden="true" />
-                  </button>
-                )}
-                {menuOpen && showActions && (
-                  <>
-                    {/* Click outside to dismiss — full-viewport transparent layer
-                        intercepts the next click and closes the menu without
-                        eating any actual UI interaction. */}
-                    <button
-                      type="button"
-                      aria-hidden="true"
-                      tabIndex={-1}
-                      onClick={() => setMenuForMsgId(null)}
-                      className="fixed inset-0 z-40 cursor-default"
-                    />
-                    <div
-                      role="menu"
-                      aria-label={t('edit.menuLabel')}
-                      data-testid={`chat-actions-menu-${msg.id}`}
-                      className="absolute z-50 -top-2 right-0 mt-6 min-w-[8rem] bg-gray-800 border border-gray-700 rounded-lg shadow-lg overflow-hidden"
-                    >
-                      <button
-                        type="button"
-                        role="menuitem"
-                        onClick={() => { setMenuForMsgId(null); beginEdit(msg) }}
-                        className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700"
-                        data-testid={`chat-edit-action-${msg.id}`}
-                      >
-                        {t('edit.edit')}
-                      </button>
-                      <button
-                        type="button"
-                        role="menuitem"
-                        onClick={() => {
-                          setMenuForMsgId(null)
-                          confirmDelete(msg.id)
-                        }}
-                        className="w-full text-left px-3 py-2 text-sm text-red-300 hover:bg-gray-700"
-                        data-testid={`chat-delete-action-${msg.id}`}
-                      >
-                        {t('edit.delete')}
-                      </button>
-                    </div>
-                  </>
-                )}
-                {pickerOpen && (
-                  <ReactionPicker
-                    onPick={(emoji) => handlePickFromPicker(msg.id, emoji)}
-                    onClose={() => setPickerForMsgId(null)}
-                    anchorRef={pickerAnchorRef}
-                    triggerRef={pickerGuardRef}
-                  />
-                )}
-              </div>
-              <ReactionChips
-                reactions={msg.reactions}
-                onToggle={(emoji, mine) => { void toggleReaction(msg.id, emoji, mine) }}
-              />
-              <div className="flex items-center gap-1 mt-0.5 px-1">
-                {msg.status === 'sending' && (
-                  <span
-                    className="text-[10px] text-gray-400 italic"
-                    role="status"
-                    data-testid={`chat-sending-${msg.id}`}
-                  >
-                    {t('composer.sending')}
-                  </span>
-                )}
-                {msg.status === 'failed' && (
-                  <button
-                    type="button"
-                    onClick={() => retryFailedMessage(msg)}
-                    className="text-[10px] text-red-400 hover:text-red-300 italic cursor-pointer"
-                    data-testid={`chat-failed-${msg.id}`}
-                  >
-                    {t('composer.failedRetry')}
-                  </button>
-                )}
-                {!isDeleted && msg.edited_at && (
-                  <span
-                    className="text-[10px] text-gray-500 italic"
-                    title={msg.edited_at}
-                    data-testid={`chat-edited-tag-${msg.id}`}
-                  >
-                    ({t('edit.editedTag')})
-                  </span>
-                )}
-                {relative && (
-                  <span className="text-[10px] text-gray-500">{relative}</span>
-                )}
-              </div>
-            </div>
-          )
-        })}
-
         {!loading && !error && missedCalls.map(entry => (
           <div
             key={`missed-call-${entry.callId}`}
@@ -1430,9 +1054,7 @@ export default function ChatView({ conversationId, onBack }: ChatViewProps) {
               : t('chat.typing.multiple', { count: typingLabels.length })}
           </div>
         )}
-
-        <div ref={messagesEndRef} />
-      </div>
+      </MessageList>
 
       <div className="border-t border-gray-800 bg-gray-950 shrink-0">
         {user && (

--- a/web/src/pages/familychat/MessageItem.test.tsx
+++ b/web/src/pages/familychat/MessageItem.test.tsx
@@ -1,0 +1,297 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import MessageItem, { type MessageItemProps } from './MessageItem'
+import type { ChatMessage } from './useFamilyChatStream'
+
+// Mock voicePlayer so VoiceBubble renders without a real HTMLAudioElement.
+vi.mock('./voice/voicePlayer', () => ({
+  getState: vi.fn(() => ({ currentId: null, playing: false, positionMs: 0, durationMs: 0 })),
+  subscribe: vi.fn((listener: (s: object) => void) => {
+    listener({ currentId: null, playing: false, positionMs: 0, durationMs: 0 })
+    return () => {}
+  }),
+  play: vi.fn().mockResolvedValue(undefined),
+  pause: vi.fn(),
+  seek: vi.fn(),
+  stop: vi.fn(),
+  stopAll: vi.fn(),
+  getCurrentId: vi.fn(() => null),
+  setAudioFactory: vi.fn(),
+}))
+
+// The translation mock echoes the key (plus interpolation options) so the
+// assertions below verify that a t() lookup happened rather than pinning
+// English copy — the real strings live in the locale files.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, string | number>) => (
+      opts ? `${key}:${JSON.stringify(opts)}` : key
+    ),
+  }),
+}))
+
+function makeMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 7,
+    conversation_id: 1,
+    sender_user_id: 2,
+    body: 'Hello there',
+    created_at: '2026-05-01T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+// handlers collects every mutation prop so a test can assert on the one it
+// cares about while the rest stay inert spies.
+function makeHandlers() {
+  return {
+    onOpenLightbox: vi.fn(),
+    onOpenPicker: vi.fn(),
+    onClosePicker: vi.fn(),
+    onToggleReaction: vi.fn(),
+    onOpenMenu: vi.fn(),
+    onBeginEdit: vi.fn(),
+    onConfirmDelete: vi.fn(),
+    onEditTextChange: vi.fn(),
+    onSaveEdit: vi.fn(),
+    onCancelEdit: vi.fn(),
+    onRetry: vi.fn(),
+  }
+}
+
+type Handlers = ReturnType<typeof makeHandlers>
+
+function renderItem(props: Partial<MessageItemProps> = {}): { handlers: Handlers } {
+  const handlers = makeHandlers()
+  render(
+    <MessageItem
+      msg={makeMessage()}
+      isOwn={false}
+      senderLabel="Ada"
+      deletedByLabel="deleted by Ada"
+      relative="just now"
+      editDraft={null}
+      pickerOpen={false}
+      menuOpen={false}
+      {...handlers}
+      {...props}
+    />,
+  )
+  return { handlers }
+}
+
+describe('MessageItem', () => {
+  afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+  it('renders a peer message with its sender label and relative time', () => {
+    renderItem()
+    expect(screen.getByText('Hello there')).toBeInTheDocument()
+    expect(screen.getByText('Ada')).toBeInTheDocument()
+    expect(screen.getByText('just now')).toBeInTheDocument()
+  })
+
+  it('omits the sender label on own messages', () => {
+    renderItem({ isOwn: true })
+    expect(screen.queryByText('Ada')).not.toBeInTheDocument()
+    expect(screen.getByText('Hello there')).toBeInTheDocument()
+  })
+
+  it('renders a tombstone instead of the body for a deleted message', () => {
+    renderItem({ msg: makeMessage({ deleted_at: '2026-05-01T11:00:00.000Z', body: '' }) })
+    expect(screen.getByTestId('chat-tombstone-7').textContent).toBe('deleted by Ada')
+    expect(screen.queryByTestId('reaction-trigger-7')).not.toBeInTheDocument()
+  })
+
+  it('marks an edited message with the edited tag', () => {
+    renderItem({ msg: makeMessage({ edited_at: '2026-05-01T10:05:00.000Z' }) })
+    expect(screen.getByTestId('chat-edited-tag-7')).toBeInTheDocument()
+  })
+
+  it('shows a sending marker and no reaction affordance while optimistic', () => {
+    renderItem({ msg: makeMessage({ status: 'sending', client_id: 'c1' }), isOwn: true })
+    expect(screen.getByTestId('chat-sending-7')).toBeInTheDocument()
+    expect(screen.queryByTestId('reaction-trigger-7')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('chat-actions-trigger-7')).not.toBeInTheDocument()
+  })
+
+  it('retries a failed message with the message itself', () => {
+    const msg = makeMessage({ status: 'failed', client_id: 'c1' })
+    const { handlers } = renderItem({ msg, isOwn: true })
+    fireEvent.click(screen.getByTestId('chat-failed-7'))
+    expect(handlers.onRetry).toHaveBeenCalledWith(msg)
+  })
+
+  describe('attachments', () => {
+    it('opens the lightbox for an image attachment', () => {
+      const { handlers } = renderItem({
+        msg: makeMessage({ attachment_path: 'a.png', attachment_mime: 'image/png', body: '' }),
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'chat.attachmentImageAlt' }))
+      expect(handlers.onOpenLightbox).toHaveBeenCalledWith({
+        url: '/api/familychat/conversations/1/attachments/7',
+        alt: 'chat.attachmentImageAlt',
+      })
+    })
+
+    it('renders a voice bubble for an empty-bodied audio/webm attachment', () => {
+      renderItem({
+        msg: makeMessage({ attachment_path: 'v.webm', attachment_mime: 'audio/webm', body: '' }),
+      })
+      expect(screen.getByTestId('voice-bubble-7')).toBeInTheDocument()
+    })
+
+    it('renders a native audio player for audio that carries a body', () => {
+      renderItem({
+        msg: makeMessage({ attachment_path: 'v.webm', attachment_mime: 'audio/webm', body: 'listen' }),
+      })
+      expect(screen.queryByTestId('voice-bubble-7')).not.toBeInTheDocument()
+      expect(document.querySelector('audio')).toBeInTheDocument()
+    })
+
+    it('renders a download link for a non-image non-audio attachment', () => {
+      renderItem({
+        msg: makeMessage({ attachment_path: 'doc.pdf', attachment_mime: 'application/pdf', body: '' }),
+      })
+      const link = screen.getByRole('link')
+      expect(link).toHaveAttribute('href', '/api/familychat/conversations/1/attachments/7')
+      expect(link.textContent).toContain('chat.attachmentFileLabel')
+    })
+
+    it('suppresses the attachment once the message is deleted', () => {
+      renderItem({
+        msg: makeMessage({
+          attachment_path: 'a.png',
+          attachment_mime: 'image/png',
+          body: '',
+          deleted_at: '2026-05-01T11:00:00.000Z',
+        }),
+      })
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('reactions', () => {
+    it('opens the picker from the hover trigger and closes it on a second press', () => {
+      const { handlers } = renderItem()
+      fireEvent.click(screen.getByTestId('reaction-trigger-7'))
+      expect(handlers.onOpenPicker).toHaveBeenCalledWith(7)
+
+      cleanup()
+      const second = renderItem({ pickerOpen: true })
+      fireEvent.click(screen.getByTestId('reaction-trigger-7'))
+      expect(second.handlers.onClosePicker).toHaveBeenCalled()
+      expect(second.handlers.onOpenPicker).not.toHaveBeenCalled()
+    })
+
+    it('opens the picker on a touch long-press but not on a mouse right-click', () => {
+      const { handlers } = renderItem()
+      const bubble = screen.getByText('Hello there').parentElement!
+
+      fireEvent.pointerDown(bubble, { pointerType: 'mouse' })
+      fireEvent.contextMenu(bubble)
+      expect(handlers.onOpenPicker).not.toHaveBeenCalled()
+
+      fireEvent.pointerDown(bubble, { pointerType: 'touch' })
+      fireEvent.contextMenu(bubble)
+      expect(handlers.onOpenPicker).toHaveBeenCalledWith(7)
+    })
+
+    it('toggles a reaction from a chip with the current me-flag', () => {
+      const { handlers } = renderItem({
+        msg: makeMessage({ reactions: { '👍': { count: 2, users: [1, 2], me: true } } }),
+      })
+      fireEvent.click(screen.getByTestId('reaction-chip-👍'))
+      expect(handlers.onToggleReaction).toHaveBeenCalledWith(7, '👍', true)
+    })
+
+    it('closes the picker and toggles the picked emoji as a new reaction', () => {
+      const { handlers } = renderItem({ pickerOpen: true })
+      fireEvent.click(screen.getByRole('button', { name: '🎉' }))
+      expect(handlers.onClosePicker).toHaveBeenCalled()
+      expect(handlers.onToggleReaction).toHaveBeenCalledWith(7, '🎉', false)
+    })
+  })
+
+  describe('action menu', () => {
+    const ownMsg = makeMessage({ sender_user_id: 1 })
+
+    it('is offered only on own messages', () => {
+      renderItem({ msg: ownMsg, isOwn: false })
+      expect(screen.queryByTestId('chat-actions-trigger-7')).not.toBeInTheDocument()
+      cleanup()
+      renderItem({ msg: ownMsg, isOwn: true })
+      expect(screen.getByTestId('chat-actions-trigger-7')).toBeInTheDocument()
+    })
+
+    it('starts an edit and closes the menu', () => {
+      const { handlers } = renderItem({ msg: ownMsg, isOwn: true, menuOpen: true })
+      fireEvent.click(screen.getByTestId('chat-edit-action-7'))
+      expect(handlers.onOpenMenu).toHaveBeenCalledWith(null)
+      expect(handlers.onBeginEdit).toHaveBeenCalledWith(ownMsg)
+    })
+
+    it('asks for delete confirmation and closes the menu', () => {
+      const { handlers } = renderItem({ msg: ownMsg, isOwn: true, menuOpen: true })
+      fireEvent.click(screen.getByTestId('chat-delete-action-7'))
+      expect(handlers.onOpenMenu).toHaveBeenCalledWith(null)
+      expect(handlers.onConfirmDelete).toHaveBeenCalledWith(7)
+    })
+  })
+
+  describe('inline edit', () => {
+    const draft = { msgId: 7, text: 'Hello there', saving: false, error: '' }
+
+    it('renders the draft text and reports every keystroke', () => {
+      const { handlers } = renderItem({ isOwn: true, editDraft: draft })
+      const input = screen.getByTestId('chat-edit-input-7')
+      expect(input).toHaveValue('Hello there')
+      fireEvent.change(input, { target: { value: 'Hello again' } })
+      expect(handlers.onEditTextChange).toHaveBeenCalledWith('Hello again')
+    })
+
+    it('saves on the save button and on Enter, cancels on Escape', () => {
+      const { handlers } = renderItem({ isOwn: true, editDraft: draft })
+      const input = screen.getByTestId('chat-edit-input-7')
+
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(handlers.onSaveEdit).toHaveBeenCalledWith(7)
+
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(handlers.onCancelEdit).toHaveBeenCalled()
+
+      fireEvent.click(screen.getByTestId('chat-edit-save-7'))
+      expect(handlers.onSaveEdit).toHaveBeenCalledTimes(2)
+    })
+
+    it('leaves Shift+Enter to the textarea for a newline', () => {
+      const { handlers } = renderItem({ isOwn: true, editDraft: draft })
+      fireEvent.keyDown(screen.getByTestId('chat-edit-input-7'), { key: 'Enter', shiftKey: true })
+      expect(handlers.onSaveEdit).not.toHaveBeenCalled()
+    })
+
+    it('disables saving while a save is in flight and shows the saving label', () => {
+      renderItem({ isOwn: true, editDraft: { ...draft, saving: true } })
+      expect(screen.getByTestId('chat-edit-save-7')).toBeDisabled()
+      expect(screen.getByTestId('chat-edit-save-7').textContent).toBe('edit.saving')
+    })
+
+    it('disables saving for a blank draft and surfaces a save error', () => {
+      renderItem({ isOwn: true, editDraft: { msgId: 7, text: '   ', saving: false, error: 'boom' } })
+      expect(screen.getByTestId('chat-edit-save-7')).toBeDisabled()
+      expect(screen.getByText('boom')).toBeInTheDocument()
+    })
+
+    it('hides the reaction and action affordances while editing', () => {
+      renderItem({ isOwn: true, editDraft: draft })
+      expect(screen.queryByTestId('reaction-trigger-7')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('chat-actions-trigger-7')).not.toBeInTheDocument()
+    })
+
+    it('cancels from the cancel button', () => {
+      const { handlers } = renderItem({ isOwn: true, editDraft: draft })
+      fireEvent.click(screen.getByTestId('chat-edit-cancel-7'))
+      expect(handlers.onCancelEdit).toHaveBeenCalled()
+    })
+  })
+})

--- a/web/src/pages/familychat/MessageItem.tsx
+++ b/web/src/pages/familychat/MessageItem.tsx
@@ -1,0 +1,403 @@
+import { memo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Download, MoreVertical, Smile } from 'lucide-react'
+import ReactionChips from './ReactionChips'
+import ReactionPicker from './ReactionPicker'
+import VoiceBubble from './voice/VoiceBubble'
+import { readCachedWaveform, parseWaveformJSON, DEFAULT_BAR_COUNT, type Waveform } from './voice/waveform'
+import type { ChatMessage } from './useFamilyChatStream'
+import type { EditDraft } from './useMessageActions'
+
+// MessageItem renders exactly one bubble: attachments (image / voice note /
+// audio / generic download), the message body, the inline edit form, the
+// tombstone for a soft-deleted message, reaction chips plus the picker anchor,
+// the own-message action menu, and the sending/failed/edited/time footer.
+//
+// It is purely presentational — every mutation arrives as a prop from
+// useMessageActions via ChatView. The only state it owns is view-local
+// bookkeeping that belongs to this bubble alone: which pointer type opened the
+// context menu, and the two elements ReactionPicker positions itself against.
+
+// Lightbox is the image preview request emitted when an image attachment is
+// tapped. The overlay itself lives in ChatView.
+export interface Lightbox {
+  url: string
+  alt: string
+}
+
+export interface MessageItemProps {
+  msg: ChatMessage
+  // isOwn drives the whole own/peer split: bubble colour and side, whether the
+  // sender label renders, and whether edit/delete are offered at all.
+  isOwn: boolean
+  senderLabel: string
+  // deletedByLabel is the pre-resolved tombstone text ("You deleted this" vs
+  // "<name> deleted this"); only rendered when the message is soft-deleted.
+  deletedByLabel: string
+  // relative is the already-formatted relative timestamp, or '' to hide it.
+  relative: string
+  // editDraft is non-null only while this bubble is the one being edited, so
+  // keystrokes in one bubble don't re-render every other bubble.
+  editDraft: EditDraft | null
+  pickerOpen: boolean
+  menuOpen: boolean
+  onOpenLightbox: (lightbox: Lightbox) => void
+  onOpenPicker: (msgId: number) => void
+  onClosePicker: () => void
+  onToggleReaction: (msgId: number, emoji: string, currentlyMine: boolean) => void
+  // onOpenMenu takes null to close the currently open action menu.
+  onOpenMenu: (msgId: number | null) => void
+  onBeginEdit: (msg: ChatMessage) => void
+  onConfirmDelete: (msgId: number) => void
+  onEditTextChange: (text: string) => void
+  onSaveEdit: (msgId: number) => void
+  onCancelEdit: () => void
+  onRetry: (msg: ChatMessage) => void
+}
+
+// parseVoiceMeta extracts a {bars, durationMs} pair from a meta_json blob.
+// Returns null when the field is absent, unparseable, or shaped wrong — the
+// caller falls back to a localStorage cache (and ultimately a flat waveform)
+// so a malformed meta_json never blocks playback.
+function parseVoiceMeta(meta: string | null | undefined): Waveform | null {
+  if (!meta) return null
+  return parseWaveformJSON(meta)
+}
+
+function MessageItem({
+  msg,
+  isOwn,
+  senderLabel,
+  deletedByLabel,
+  relative,
+  editDraft,
+  pickerOpen,
+  menuOpen,
+  onOpenLightbox,
+  onOpenPicker,
+  onClosePicker,
+  onToggleReaction,
+  onOpenMenu,
+  onBeginEdit,
+  onConfirmDelete,
+  onEditTextChange,
+  onSaveEdit,
+  onCancelEdit,
+  onRetry,
+}: MessageItemProps) {
+  const { t } = useTranslation('familyChat')
+
+  // lastPointerTypeRef is set by onPointerDown so onContextMenu knows whether
+  // it was triggered by a touch long-press (open picker, suppress native menu)
+  // or a mouse right-click (leave native menu alone; picker is on hover button).
+  const lastPointerTypeRef = useRef<string>('mouse')
+  // pickerAnchorRef: element used by ReactionPicker for placement/positioning.
+  // Set to the hover button or the message bubble (long-press), whichever opened the picker.
+  const pickerAnchorRef = useRef<HTMLElement | null>(null)
+  // pickerGuardRef: the actual toggle button (hover Smile button only). The
+  // picker's outside-click handler ignores clicks on this element so the button
+  // can toggle the picker closed without the picker immediately re-closing on
+  // the same click. NOT set on long-press (no toggle button exists there), so
+  // tapping the bubble correctly closes the picker.
+  const pickerGuardRef = useRef<HTMLElement | null>(null)
+
+  const isDeleted = !!msg.deleted_at
+  const isEditing = editDraft !== null
+  const attachmentUrl = !isDeleted && msg.attachment_path && msg.attachment_mime
+    ? `/api/familychat/conversations/${msg.conversation_id}/attachments/${msg.id}`
+    : ''
+  const mime = msg.attachment_mime ?? ''
+  const isImage = mime.startsWith('image/')
+  const isAudio = mime.startsWith('audio/')
+  // A voice note is an audio/webm attachment with an empty body — the recorder
+  // always ships these as standalone bubbles. The bubble renders a precomputed
+  // waveform if meta_json carries one; it falls back to a localStorage cache
+  // (written immediately after upload by the recorder) and finally to a flat
+  // waveform.
+  const isVoiceNote = !isDeleted && !!attachmentUrl
+    && (mime.startsWith('audio/webm') || mime.startsWith('audio/ogg'))
+    && !msg.body.trim()
+  const cachedWaveform = isVoiceNote
+    ? (parseVoiceMeta(msg.meta_json) ?? readCachedWaveform(msg.id))
+    : null
+  const voiceBars = cachedWaveform?.bars ?? new Array(DEFAULT_BAR_COUNT).fill(0)
+  const voiceDurationMs = cachedWaveform?.durationMs ?? 0
+  // Optimistic bubbles (still sending or failed) have no authoritative id yet,
+  // so reactions and edit/delete are suppressed until the row reconciles to the
+  // persisted message.
+  const isPending = msg.status === 'sending' || msg.status === 'failed'
+  const showActions = isOwn && !isDeleted && !isEditing && !isPending
+
+  return (
+    <div
+      className={`flex flex-col group ${isOwn ? 'items-end' : 'items-start'}`}
+      data-testid={`chat-bubble-${msg.id}`}
+    >
+      {!isOwn && !isDeleted && (
+        <span className="text-xs text-gray-400 mb-0.5 px-1">{senderLabel}</span>
+      )}
+      <div className="relative max-w-[85%] sm:max-w-[70%]">
+        {isDeleted ? (
+          <div
+            className="px-3 py-2 rounded-2xl text-sm italic bg-gray-800/60 border border-gray-700 text-gray-400"
+            data-testid={`chat-tombstone-${msg.id}`}
+          >
+            {deletedByLabel}
+          </div>
+        ) : editDraft ? (
+          <div className={`px-3 py-2 rounded-2xl text-sm break-words ${
+            isOwn ? 'bg-blue-600/40 border border-blue-500' : 'bg-gray-800 border border-gray-700'
+          }`}>
+            <textarea
+              value={editDraft.text}
+              onChange={(e) => onEditTextChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.preventDefault()
+                  onCancelEdit()
+                } else if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault()
+                  onSaveEdit(msg.id)
+                }
+              }}
+              aria-label={t('edit.edit')}
+              data-testid={`chat-edit-input-${msg.id}`}
+              className="w-full bg-gray-900 text-gray-100 border border-gray-700 rounded-lg px-2 py-1 text-sm focus:outline-none focus:border-blue-500"
+              rows={3}
+              autoFocus
+            />
+            {editDraft.error && (
+              <div className="text-xs text-red-400 mt-1">{editDraft.error}</div>
+            )}
+            <div className="flex gap-2 mt-2 justify-end">
+              <button
+                type="button"
+                onClick={onCancelEdit}
+                className="px-2 py-1 text-xs rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600"
+                data-testid={`chat-edit-cancel-${msg.id}`}
+              >
+                {t('edit.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={() => onSaveEdit(msg.id)}
+                disabled={editDraft.saving || !editDraft.text.trim()}
+                className="px-2 py-1 text-xs rounded-md bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                data-testid={`chat-edit-save-${msg.id}`}
+              >
+                {editDraft.saving ? t('edit.saving') : t('edit.save')}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div
+            className={`px-3 py-2 rounded-2xl text-sm break-words ${
+              isOwn
+                ? 'bg-blue-600 text-white rounded-br-sm'
+                : 'bg-gray-800 text-gray-100 rounded-bl-sm'
+            } ${msg.status === 'sending' ? 'opacity-70' : ''}`}
+            onPointerDown={(e) => { lastPointerTypeRef.current = e.pointerType }}
+            onContextMenu={(e) => {
+              // Only intercept touch long-press (suppress native menu, open
+              // reaction picker for all messages). Mouse right-clicks keep
+              // the native menu so users can copy text/images; the reaction
+              // picker is reachable via the hover button (Smile icon) on
+              // desktop. Edit/delete actions remain accessible via the
+              // MoreVertical button for own messages.
+              if (lastPointerTypeRef.current === 'touch') {
+                e.preventDefault()
+                // Use the bubble as the positioning anchor only.
+                // pickerGuardRef is explicitly cleared here — there is
+                // no toggle button for long-press, so clicks on the
+                // bubble should correctly dismiss the picker. Clearing
+                // prevents a stale guard ref from a prior hover-button
+                // open from suppressing the outside-click close.
+                pickerAnchorRef.current = e.currentTarget
+                pickerGuardRef.current = null
+                onOpenPicker(msg.id)
+              }
+            }}
+          >
+            {attachmentUrl && isImage && (
+              <button
+                type="button"
+                onClick={() => onOpenLightbox({ url: attachmentUrl, alt: t('chat.attachmentImageAlt') })}
+                className="block cursor-zoom-in mb-1"
+                aria-label={t('chat.attachmentImageAlt')}
+              >
+                <img
+                  src={attachmentUrl}
+                  alt={t('chat.attachmentImageAlt')}
+                  loading="lazy"
+                  className="rounded-lg max-h-60 max-w-full object-contain"
+                />
+              </button>
+            )}
+            {attachmentUrl && isVoiceNote && (
+              <VoiceBubble
+                messageId={msg.id}
+                src={attachmentUrl}
+                bars={voiceBars}
+                durationMs={voiceDurationMs}
+                isOwn={isOwn}
+              />
+            )}
+            {attachmentUrl && isAudio && !isVoiceNote && (
+              <audio
+                controls
+                src={attachmentUrl}
+                className="block max-w-full mb-1"
+                aria-label={t('chat.attachmentAudioAlt')}
+              />
+            )}
+            {attachmentUrl && !isImage && !isAudio && (
+              <a
+                href={attachmentUrl}
+                download
+                className={`flex items-center gap-2 rounded-lg px-2 py-1.5 mb-1 text-xs ${
+                  isOwn ? 'bg-blue-700/60 hover:bg-blue-700/80' : 'bg-gray-700/70 hover:bg-gray-700'
+                }`}
+              >
+                <Download size={14} aria-hidden="true" />
+                <span className="truncate">{t('chat.attachmentFileLabel', { mime })}</span>
+              </a>
+            )}
+            {msg.body && (
+              <div className="whitespace-pre-wrap">{msg.body}</div>
+            )}
+          </div>
+        )}
+        {!isDeleted && !isEditing && !isPending && (
+          <button
+            type="button"
+            onClick={(e) => {
+              const willOpen = !pickerOpen
+              if (willOpen) {
+                pickerAnchorRef.current = e.currentTarget
+                pickerGuardRef.current = e.currentTarget
+                onOpenPicker(msg.id)
+              } else {
+                onClosePicker()
+              }
+            }}
+            aria-label={t('reactions.pickerLabel')}
+            className={`absolute -top-3 ${isOwn ? '-left-2' : '-right-2'} p-1 rounded-full bg-gray-800 border border-gray-700 text-gray-300 hover:text-white opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity cursor-pointer`}
+            data-testid={`reaction-trigger-${msg.id}`}
+          >
+            <Smile size={14} aria-hidden="true" />
+          </button>
+        )}
+        {showActions && (
+          <button
+            type="button"
+            onClick={() => onOpenMenu(menuOpen ? null : msg.id)}
+            aria-label={t('edit.menuLabel')}
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            className="absolute -top-3 -right-2 p-1 rounded-full bg-gray-800 border border-gray-700 text-gray-300 hover:text-white opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity cursor-pointer"
+            data-testid={`chat-actions-trigger-${msg.id}`}
+          >
+            <MoreVertical size={14} aria-hidden="true" />
+          </button>
+        )}
+        {menuOpen && showActions && (
+          <>
+            {/* Click outside to dismiss — full-viewport transparent layer
+                intercepts the next click and closes the menu without
+                eating any actual UI interaction. */}
+            <button
+              type="button"
+              aria-hidden="true"
+              tabIndex={-1}
+              onClick={() => onOpenMenu(null)}
+              className="fixed inset-0 z-40 cursor-default"
+            />
+            <div
+              role="menu"
+              aria-label={t('edit.menuLabel')}
+              data-testid={`chat-actions-menu-${msg.id}`}
+              className="absolute z-50 -top-2 right-0 mt-6 min-w-[8rem] bg-gray-800 border border-gray-700 rounded-lg shadow-lg overflow-hidden"
+            >
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => { onOpenMenu(null); onBeginEdit(msg) }}
+                className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700"
+                data-testid={`chat-edit-action-${msg.id}`}
+              >
+                {t('edit.edit')}
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  onOpenMenu(null)
+                  onConfirmDelete(msg.id)
+                }}
+                className="w-full text-left px-3 py-2 text-sm text-red-300 hover:bg-gray-700"
+                data-testid={`chat-delete-action-${msg.id}`}
+              >
+                {t('edit.delete')}
+              </button>
+            </div>
+          </>
+        )}
+        {pickerOpen && (
+          <ReactionPicker
+            onPick={(emoji) => {
+              onClosePicker()
+              onToggleReaction(msg.id, emoji, !!msg.reactions?.[emoji]?.me)
+            }}
+            onClose={onClosePicker}
+            anchorRef={pickerAnchorRef}
+            triggerRef={pickerGuardRef}
+          />
+        )}
+      </div>
+      <ReactionChips
+        reactions={msg.reactions}
+        onToggle={(emoji, mine) => onToggleReaction(msg.id, emoji, mine)}
+      />
+      <div className="flex items-center gap-1 mt-0.5 px-1">
+        {msg.status === 'sending' && (
+          <span
+            className="text-[10px] text-gray-400 italic"
+            role="status"
+            data-testid={`chat-sending-${msg.id}`}
+          >
+            {t('composer.sending')}
+          </span>
+        )}
+        {msg.status === 'failed' && (
+          <button
+            type="button"
+            onClick={() => onRetry(msg)}
+            className="text-[10px] text-red-400 hover:text-red-300 italic cursor-pointer"
+            data-testid={`chat-failed-${msg.id}`}
+          >
+            {t('composer.failedRetry')}
+          </button>
+        )}
+        {!isDeleted && msg.edited_at && (
+          <span
+            className="text-[10px] text-gray-500 italic"
+            title={msg.edited_at}
+            data-testid={`chat-edited-tag-${msg.id}`}
+          >
+            ({t('edit.editedTag')})
+          </span>
+        )}
+        {relative && (
+          <span className="text-[10px] text-gray-500">{relative}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// Memoized: a chat can hold hundreds of bubbles, and every arriving message,
+// keystroke in the composer or reaction toggle re-renders the list. Every
+// handler prop is stable (useCallback / useMessageActions), and editDraft is
+// null for all but the bubble actually being edited, so this cuts the re-render
+// down to the messages that genuinely changed.
+export default memo(MessageItem)

--- a/web/src/pages/familychat/MessageList.tsx
+++ b/web/src/pages/familychat/MessageList.tsx
@@ -1,0 +1,226 @@
+import { useLayoutEffect, useRef, type MutableRefObject, type ReactNode, type RefObject } from 'react'
+import { useTranslation } from 'react-i18next'
+import { MessageSquare } from 'lucide-react'
+import { Skeleton } from '../../components/ui/skeleton'
+import MessageItem, { type Lightbox } from './MessageItem'
+import { formatRelative } from './utils'
+import type { ChatMessage } from './useFamilyChatStream'
+import type { EditDraft } from './useMessageActions'
+
+// MessageList owns the scrollable message log: the initial loading skeleton,
+// the load error, the empty state, the older-history chips, the bubbles
+// themselves, and the bottom scroll anchor with its stick-to-bottom behaviour.
+//
+// It is purely presentational. Paging (which page to fetch, when history has
+// run out) and every message mutation stay with ChatView and useMessageActions;
+// this component only reports scroll events upward and renders what it is told.
+//
+// Anything that belongs below the bubbles but above the bottom anchor —
+// missed-call rows, the seen-by line, the typing indicator — is passed as
+// children so the anchor stays the very last node in the scroll container.
+
+// ScrollAnchor is the pair of scroll metrics captured immediately before older
+// history is prepended, used to re-anchor the view on the message the user was
+// already reading.
+export interface ScrollAnchor {
+  scrollHeight: number
+  scrollTop: number
+}
+
+export interface MessageListProps {
+  messages: ChatMessage[]
+  loading: boolean
+  error: string
+  loadingOlder: boolean
+  hasMoreOlder: boolean
+  // scrollRef is owned by ChatView, which reads the element's scroll metrics to
+  // decide when to page backward and when the newest message counts as read.
+  scrollRef: RefObject<HTMLDivElement | null>
+  onScroll: () => void
+  // pendingScrollRestoreRef is set by ChatView just before a prepend; its
+  // presence tells the stick-to-bottom effect below to stand down for that one
+  // commit so the restore can re-anchor instead.
+  pendingScrollRestoreRef: MutableRefObject<ScrollAnchor | null>
+  // prependCounter ticks once per prepended page so the restore runs exactly
+  // when older messages land, and never on a normal append.
+  prependCounter: number
+  // conversationId and keyboardInset are stick-to-bottom triggers only: opening
+  // a chat and opening/closing the on-screen keyboard both have to re-snap the
+  // view to the newest message.
+  conversationId: number | null
+  keyboardInset: number
+  currentUserId: number | undefined
+  // memberLabel resolves a user id to a friendly display name, falling back to
+  // "Member #id" for ids the current user cannot name.
+  memberLabel: (id: number) => string
+  rtf: Intl.RelativeTimeFormat
+  editDraft: EditDraft
+  pickerForMsgId: number | null
+  menuForMsgId: number | null
+  onOpenLightbox: (lightbox: Lightbox) => void
+  onOpenPicker: (msgId: number) => void
+  onClosePicker: () => void
+  onToggleReaction: (msgId: number, emoji: string, currentlyMine: boolean) => void
+  onOpenMenu: (msgId: number | null) => void
+  onBeginEdit: (msg: ChatMessage) => void
+  onConfirmDelete: (msgId: number) => void
+  onEditTextChange: (text: string) => void
+  onSaveEdit: (msgId: number) => void
+  onCancelEdit: () => void
+  onRetry: (msg: ChatMessage) => void
+  children?: ReactNode
+}
+
+export default function MessageList({
+  messages,
+  loading,
+  error,
+  loadingOlder,
+  hasMoreOlder,
+  scrollRef,
+  onScroll,
+  pendingScrollRestoreRef,
+  prependCounter,
+  conversationId,
+  keyboardInset,
+  currentUserId,
+  memberLabel,
+  rtf,
+  editDraft,
+  pickerForMsgId,
+  menuForMsgId,
+  onOpenLightbox,
+  onOpenPicker,
+  onClosePicker,
+  onToggleReaction,
+  onOpenMenu,
+  onBeginEdit,
+  onConfirmDelete,
+  onEditTextChange,
+  onSaveEdit,
+  onCancelEdit,
+  onRetry,
+  children,
+}: MessageListProps) {
+  const { t } = useTranslation('familyChat')
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  // Auto-scroll to the bottom whenever the message list updates or the keyboard
+  // opens/closes (keyboardInset changes). useLayoutEffect avoids a visible jump
+  // between initial paint and the scroll snap.
+  useLayoutEffect(() => {
+    // A commit that prepended older history must not jump to the bottom — the
+    // restore effect below re-anchors the view on the message the user was
+    // already reading instead. messages.length changes on a prepend too, which
+    // is why this guard exists rather than a narrower dependency list.
+    if (pendingScrollRestoreRef.current) return
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ block: 'end' })
+    }
+  }, [messages.length, conversationId, keyboardInset, pendingScrollRestoreRef])
+
+  // Restore the scroll anchor after older messages are prepended: the content
+  // above the viewport grew by (newScrollHeight - savedScrollHeight), so adding
+  // that delta to the saved scrollTop keeps the same message under the user's
+  // eyes. Runs after the auto-scroll effect above (declaration order) and
+  // clears the flag that effect reads.
+  useLayoutEffect(() => {
+    const pending = pendingScrollRestoreRef.current
+    if (!pending) return
+    pendingScrollRestoreRef.current = null
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight - pending.scrollHeight + pending.scrollTop
+  }, [prependCounter, pendingScrollRestoreRef, scrollRef])
+
+  const showMessages = !loading && !error
+
+  return (
+    <div
+      ref={scrollRef}
+      onScroll={onScroll}
+      className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 sm:px-4 py-3 space-y-2"
+      role="log"
+      aria-live="polite"
+      aria-relevant="additions"
+    >
+      {loading && (
+        <div className="space-y-3" role="status" aria-busy="true">
+          <span className="sr-only">{t('loading')}</span>
+          <Skeleton className="h-12 w-3/4" />
+          <Skeleton className="h-12 w-2/3 ml-auto" />
+          <Skeleton className="h-12 w-1/2" />
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="p-3 bg-red-900/40 border border-red-700 rounded-lg text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+
+      {showMessages && messages.length === 0 && (
+        <div className="flex flex-col items-center justify-center h-full text-center text-gray-500 py-12">
+          <MessageSquare size={32} className="mb-2 text-gray-600" aria-hidden="true" />
+          <p className="text-sm">{t('chat.emptyMessages')}</p>
+        </div>
+      )}
+
+      {showMessages && messages.length > 0 && loadingOlder && (
+        <div
+          className="flex justify-center py-2 text-xs text-gray-500"
+          role="status"
+          aria-busy="true"
+          data-testid="family-chat-loading-older"
+        >
+          {t('chat.loadingOlder')}
+        </div>
+      )}
+
+      {showMessages && messages.length > 0 && !hasMoreOlder && !loadingOlder && (
+        <div
+          className="flex justify-center py-2 text-xs text-gray-500"
+          data-testid="family-chat-history-start"
+        >
+          {t('chat.beginningOfConversation')}
+        </div>
+      )}
+
+      {showMessages && messages.map(msg => {
+        const deletedById = msg.deleted_by
+        return (
+          <MessageItem
+            key={msg.client_id ?? msg.id}
+            msg={msg}
+            isOwn={currentUserId === msg.sender_user_id}
+            senderLabel={memberLabel(msg.sender_user_id)}
+            deletedByLabel={
+              deletedById != null && currentUserId === deletedById
+                ? t('edit.tombstoneSelf')
+                : t('edit.tombstone', { name: memberLabel(deletedById ?? 0) })
+            }
+            relative={formatRelative(msg.created_at, rtf, t('time.justNow'))}
+            editDraft={editDraft.msgId === msg.id ? editDraft : null}
+            pickerOpen={pickerForMsgId === msg.id}
+            menuOpen={menuForMsgId === msg.id}
+            onOpenLightbox={onOpenLightbox}
+            onOpenPicker={onOpenPicker}
+            onClosePicker={onClosePicker}
+            onToggleReaction={onToggleReaction}
+            onOpenMenu={onOpenMenu}
+            onBeginEdit={onBeginEdit}
+            onConfirmDelete={onConfirmDelete}
+            onEditTextChange={onEditTextChange}
+            onSaveEdit={onSaveEdit}
+            onCancelEdit={onCancelEdit}
+            onRetry={onRetry}
+          />
+        )
+      })}
+
+      {children}
+
+      <div ref={messagesEndRef} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Changes

- **Family chat message list split into presentational components** - The scrollable message log and the individual chat bubble moved out of `ChatView` into `MessageList` and `MessageItem`. Both are purely presentational — every mutation still comes from `useMessageActions` — so the chat behaves exactly as before; bubbles are now memoized, so an arriving message no longer re-renders the whole conversation. (Hytte-u5avd)

## Original Issue (task): Extract MessageList and MessageItem presentational components

Create `web/src/pages/familychat/MessageItem.tsx` (one bubble: text/attachments, voice bubble, reaction chips + picker anchor, inline edit form, action menu, deleted/pending/failed states) and `web/src/pages/familychat/MessageList.tsx` (loading skeleton, empty state, the `messages.map` from ChatView lines ~1525–1950, scroll-anchor ref and stick-to-bottom behaviour). Both purely presentational: all mutation handlers arrive as props from sub-task 2's hook. Reuse existing `ReactionChips`/`ReactionPicker` — no re-extraction. Preserve every `t()` call; no hardcoded English. Add `MessageItem.test.tsx`. Keep each file under ~450 lines.

---
Bead: Hytte-u5avd | Branch: forge/Hytte-u5avd
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->