### PR TITLE
Make the top-cards deep link actually land on the card in the set view (Hytte-vyvxq)

### DIFF
--- a/changelog.d/Hytte-vyvxq.md
+++ b/changelog.d/Hytte-vyvxq.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Top-card links now land on the card** - Clicking a card in the Pokémon Top view scrolls that card's tile into view on the set page and opens it in the lightbox instead of dropping you at the top of the grid. The `#card-…` fragment is cleared once used, so a reload shows the plain grid, and any `?variant=` filter survives. (Hytte-vyvxq)

--- a/web/src/pages/PokemonSet.test.tsx
+++ b/web/src/pages/PokemonSet.test.tsx
@@ -217,10 +217,18 @@ function renderPage(initialPath = '/pokemon/sets/sv1') {
 
 // LocationProbe exposes the current router location to assertions by writing
 // `?...` into a hidden DOM node. We use it to verify the variant filter
-// round-trips through the URL.
+// round-trips through the URL, and that the `#card-…` deep-link hash is
+// cleared once consumed.
 function LocationProbe() {
   const loc = useLocation()
-  return <div data-testid="location-probe" data-pathname={loc.pathname} data-search={loc.search} />
+  return (
+    <div
+      data-testid="location-probe"
+      data-pathname={loc.pathname}
+      data-search={loc.search}
+      data-hash={loc.hash}
+    />
+  )
 }
 
 function renderPageWithProbe(initialPath = '/pokemon/sets/sv1') {
@@ -950,6 +958,108 @@ describe('PokemonSet – card search', () => {
     // The full grid is back and clicking its first tile opens that card.
     fireEvent.click(screen.getByTestId('card-tile-sv1-6'))
     expect(await screen.findByRole('dialog', { name: 'Charizard ex' })).toBeInTheDocument()
+  })
+})
+
+describe('PokemonSet – #card- deep link', () => {
+  // The Top view navigates to `/pokemon/sets/<id>#card-<collector_no>`; the
+  // set page has to resolve that to a tile, scroll to it and open the lightbox.
+  // happy-dom has no layout engine, so we swap scrollIntoView for a recorder
+  // that also captures the element it was called on.
+  let scrolled: Element[]
+  let originalScrollIntoView: (() => void) | undefined
+
+  beforeEach(() => {
+    scrolled = []
+    const proto = Element.prototype as unknown as { scrollIntoView?: () => void }
+    originalScrollIntoView = proto.scrollIntoView
+    proto.scrollIntoView = function (this: Element) {
+      scrolled.push(this)
+    }
+
+    const set = makeSet({ total_cards: 3 })
+    const cards = [
+      makeCard({ id: 'sv1-1', name: 'Pikachu', collector_no: '001' }),
+      makeCard({
+        id: 'sv1-2',
+        name: 'Eevee',
+        collector_no: '002',
+        variants: [
+          makeVariant({ id: 2, kind: 'normal' }),
+          makeVariant({ id: 3, kind: 'reverse_holofoil' }),
+        ],
+      }),
+      makeCard({ id: 'sv1-3', name: 'Snorlax', collector_no: 'SV1/003' }),
+    ]
+    vi.stubGlobal('fetch', makeFetchMock({ set, cards }))
+  })
+
+  afterEach(() => {
+    const proto = Element.prototype as unknown as { scrollIntoView?: () => void }
+    if (originalScrollIntoView) proto.scrollIntoView = originalScrollIntoView
+    else delete proto.scrollIntoView
+  })
+
+  it('opens the lightbox on the matching card and scrolls its tile into view', async () => {
+    renderPage('/pokemon/sets/sv1#card-002')
+
+    expect(await screen.findByRole('dialog', { name: 'Eevee' })).toBeInTheDocument()
+    expect(scrolled).toEqual([screen.getByTestId('card-tile-sv1-2')])
+  })
+
+  it('decodes a percent-encoded collector number and matches case-insensitively', async () => {
+    renderPage('/pokemon/sets/sv1#card-sv1%2F003')
+
+    expect(await screen.findByRole('dialog', { name: 'Snorlax' })).toBeInTheDocument()
+  })
+
+  it('is a silent no-op when the collector number is not in the set', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    renderPage('/pokemon/sets/sv1#card-999')
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    expect(screen.queryByTestId('card-lightbox')).not.toBeInTheDocument()
+    expect(scrolled).toHaveLength(0)
+    expect(warn).not.toHaveBeenCalled()
+    expect(error).not.toHaveBeenCalled()
+
+    warn.mockRestore()
+    error.mockRestore()
+  })
+
+  it('clears the hash after consuming it while preserving ?variant=', async () => {
+    renderPageWithProbe('/pokemon/sets/sv1?variant=reverse_holofoil#card-002')
+
+    expect(await screen.findByRole('dialog', { name: 'Eevee' })).toBeInTheDocument()
+
+    const probe = screen.getByTestId('location-probe')
+    await waitFor(() => expect(probe).toHaveAttribute('data-hash', ''))
+    expect(probe).toHaveAttribute('data-search', '?variant=reverse_holofoil')
+    expect(probe).toHaveAttribute('data-pathname', '/pokemon/sets/sv1')
+  })
+
+  it('does not reopen the lightbox when the filter changes after consumption', async () => {
+    renderPage('/pokemon/sets/sv1#card-002')
+
+    expect(await screen.findByRole('dialog', { name: 'Eevee' })).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('lightbox-close'))
+    await waitFor(() => expect(screen.queryByTestId('card-lightbox')).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Missing only' }))
+
+    await waitFor(() => expect(screen.getByText('Eevee')).toBeInTheDocument())
+    expect(screen.queryByTestId('card-lightbox')).not.toBeInTheDocument()
+  })
+
+  it('leaves a hash-less URL untouched', async () => {
+    renderPageWithProbe('/pokemon/sets/sv1')
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    expect(screen.queryByTestId('card-lightbox')).not.toBeInTheDocument()
+    expect(scrolled).toHaveLength(0)
+    expect(screen.getByTestId('location-probe')).toHaveAttribute('data-search', '')
   })
 })
 

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { Link, useParams, useSearchParams } from 'react-router'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { ArrowLeft, Check, Minus } from 'lucide-react'
@@ -304,6 +304,9 @@ function CardTile({ card, filter, onClick, t }: TileProps) {
     <button
       type="button"
       onClick={onClick}
+      // The DOM id is the scroll anchor for `#card-<collector_no>` deep links
+      // coming from the Top view; `data-testid` stays for the test suite.
+      id={`card-tile-${card.id}`}
       data-testid={`card-tile-${card.id}`}
       aria-label={t('tile.openCard', { name: card.name, number: card.collector_no })}
       data-ownership={!applicable ? 'na' : owned ? 'owned' : partial ? 'partial' : 'missing'}
@@ -561,12 +564,37 @@ function GridSkeleton() {
   )
 }
 
+const CARD_HASH_PREFIX = '#card-'
+
+// normalizeCollectorNo makes collector numbers comparable across the slightly
+// different spellings the two views use ('001' vs ' 001 ', 'SWSH01' vs
+// 'swsh01').
+function normalizeCollectorNo(value: string | null | undefined): string {
+  return String(value ?? '').trim().toLowerCase()
+}
+
+// parseCardHash turns `#card-<collector_no>` into the collector number the Top
+// view encoded. Returns null for an empty hash, a hash we don't own, or a
+// malformed percent-escape — all of which are silent no-ops.
+function parseCardHash(hash: string): string | null {
+  if (!hash.startsWith(CARD_HASH_PREFIX)) return null
+  const raw = hash.slice(CARD_HASH_PREFIX.length)
+  if (!raw) return null
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return null
+  }
+}
+
 export default function PokemonSetPage() {
   const { t } = useTranslation('pokemon')
   const { id } = useParams<{ id: string }>()
   const setId = id ?? ''
   const { toasts, showToast } = useToast()
   const [searchParams, setSearchParams] = useSearchParams()
+  const location = useLocation()
+  const navigate = useNavigate()
 
   const [set, setSet] = useState<PokemonSet | null>(null)
   const [cards, setCards] = useState<Card[]>([])
@@ -576,6 +604,7 @@ export default function PokemonSetPage() {
   const [lightboxStartIndex, setLightboxStartIndex] = useState<number | null>(null)
   const [savingCardId, setSavingCardId] = useState<string | null>(null)
   const [attempt, setAttempt] = useState(0)
+  const consumedHashRef = useRef<string | null>(null)
   const cardsRef = useRef<Card[]>([])
   useLayoutEffect(() => { cardsRef.current = cards })
   const filterButtonRefs = useRef<Array<HTMLButtonElement | null>>([])
@@ -776,6 +805,37 @@ export default function PokemonSetPage() {
     lightboxStartIndex != null && visibleCards.length > 0
       ? Math.min(lightboxStartIndex, visibleCards.length - 1)
       : null
+
+  // The Top view links here as `/pokemon/sets/<id>#card-<collector_no>`.
+  // Consume that fragment once the cards have loaded: scroll the matching tile
+  // into view, open the lightbox on it, then strip the hash so a reload lands
+  // on the plain grid. A collector number that isn't in the set (or a hash we
+  // don't recognise) is a silent no-op. The ref guard keeps this to one run per
+  // hash value so filtering or searching afterwards doesn't reopen the card.
+  const { hash, pathname, search } = location
+  useEffect(() => {
+    if (loading) return
+    if (!hash || consumedHashRef.current === hash) return
+    const target = parseCardHash(hash)
+    if (target === null) return
+    consumedHashRef.current = hash
+
+    const wanted = normalizeCollectorNo(target)
+    const index = visibleCards.findIndex(c => normalizeCollectorNo(c.collector_no) === wanted)
+    if (index >= 0) {
+      const el = document.getElementById(`card-tile-${visibleCards[index].id}`)
+      if (el && typeof el.scrollIntoView === 'function') {
+        const reduceMotion =
+          typeof window.matchMedia === 'function' &&
+          window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        el.scrollIntoView({ block: 'center', behavior: reduceMotion ? 'auto' : 'smooth' })
+      }
+      setLightboxStartIndex(index)
+    }
+
+    // Drop the fragment while keeping ?variant= / ?q= intact.
+    navigate({ pathname, search }, { replace: true })
+  }, [hash, pathname, search, loading, visibleCards, navigate])
 
   const updateCardVariants = useCallback(
     (cardId: string, mutate: (variants: Variant[]) => Variant[]) => {

--- a/web/src/pages/PokemonSet.tsx
+++ b/web/src/pages/PokemonSet.tsx
@@ -830,6 +830,7 @@ export default function PokemonSetPage() {
           window.matchMedia('(prefers-reduced-motion: reduce)').matches
         el.scrollIntoView({ block: 'center', behavior: reduceMotion ? 'auto' : 'smooth' })
       }
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- opening the lightbox is a one-shot response to the incoming hash, guarded by consumedHashRef so it runs once per hash value
       setLightboxStartIndex(index)
     }
 


### PR DESCRIPTION
## Changes

- **Top-card links now land on the card** - Clicking a card in the Pokémon Top view scrolls that card's tile into view on the set page and opens it in the lightbox instead of dropping you at the top of the grid. The `#card-…` fragment is cleared once used, so a reload shows the plain grid, and any `?variant=` filter survives. (Hytte-vyvxq)

## Original Issue (feature): Make the top-cards deep link actually land on the card in the set view

### Scope
Make the `#card-{collector_no}` hash produced by `PokemonTop.openCard` functional on the set detail page. `PokemonSetPage` (`web/src/pages/PokemonSet.tsx:570`) currently reads only `useParams` and `useSearchParams`, so the hash is ignored. Add hash consumption after the cards fetch resolves: find the matching card in the rendered list, scroll its tile into view, open `CardLightbox` at that index, then strip the hash so a reload doesn't reopen it. Silent no-op when the collector number isn't present.

### Files to touch
- `web/src/pages/PokemonSet.tsx` — read `location.hash`, resolve the card, scroll + open lightbox, clear hash
- `web/src/pages/PokemonSet.test.tsx` — tests for hit, miss, and hash-clearing
- `changelog.d/<slug>.md` (new) — `category: Fixed` fragment
- `web/src/pages/PokemonTop.tsx` — only if the hash format needs adjusting; prefer leaving it as-is

### Implementation notes
- Tiles currently expose `data-testid={card-tile-${card.id}}` but no DOM `id` and no ref. Add a stable anchor (element `id` on the tile, or a ref map keyed by card id) so the target can be scrolled to. Do not remove the existing `data-testid`.
- The lightbox opens by **index into `visibleCards`**, not by card id — resolve the index against `visibleCards` (post-filter), not `cards`.
- `openCard` encodes the collector number, so decode before comparing; compare trimmed/case-insensitively since collector numbers vary in formatting.
- Run the effect when `cards` (or `visibleCards`) changes and `loading` is false, guarded so it fires at most once per hash value — not on every filter change.
- Clear the hash with a `replace` navigation that preserves `?variant=` (don't drop existing search params).
- Respect `prefers-reduced-motion` for the scroll behavior, consistent with the rest of the app.

### Acceptance criteria
- Clicking a card in the Top view lands on `/pokemon/sets/{id}`, scrolls that card's tile into view, and opens `CardLightbox` on it.
- Works on a ~375px viewport (mobile grid), where the problem is most visible.
- A hash whose collector number isn't in the set leaves the page at the top with no lightbox, no error, no console warning.
- After the deep link is consumed, the address bar no longer contains `#card-…`; reloading shows the set grid with no lightbox.
- Any `?variant=` param in the deep-linked URL survives the hash clear.
- Navigating directly to `/pokemon/sets/{id}` with no hash behaves exactly as before.
- New tests in `PokemonSet.test.tsx` cover: match opens lightbox at the right card, unknown collector number is a silent no-op, hash is cleared after consumption.
- `npm run lint`, `npm run build`, and `npm test` pass; changelog fragment present.

### Non-goals
- No change to how `PokemonTop` builds links or to the Top view's UI.
- No new query-param-based card selection scheme (e.g. `?card=`) replacing the hash.
- No deep-linking for `PokemonScanned` or `PokemonSets`.
- No changes to `CardLightbox` internals, filter defaults, or scroll-position restoration on back-navigation.

## Source

Created from Suggestions page (suggestion id 361, page slug "pokemon", source=claude).

## Original suggestion

PokemonTop.openCard navigates to `/pokemon/sets/{set_id}#card-{collector_no}`, but PokemonSet.tsx never reads `location.hash` — it only uses `useParams` and `useSearchParams` — so the hash is dead and the user is dropped at the top of a 200-card grid with no indication of which card they clicked. Fix by reading the hash on load (and after the cards fetch resolves), scrolling the matching tile into view, and opening CardLightbox on that card, falling back silently when the collector number isn't in the set. Also clear the hash after consuming it so a reload doesn't re-open the lightbox. This turns the Top view into a working jump-off point instead of a link that appears to do nothing on mobile.


---
Bead: Hytte-vyvxq | Branch: forge/Hytte-vyvxq
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->