### PR TITLE
Drive the dashboard grid from a widget registry instead of inline JSX (Hytte-1gexj)

### DIFF
--- a/changelog.d/Hytte-1gexj.md
+++ b/changelog.d/Hytte-1gexj.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Dashboard loads its heavy widgets on demand** - The Infrastructure, GitHub Actions and Weather Station widgets are code-split into their own chunks so they no longer download and fetch on first paint. Each shows a widget-sized loading placeholder while its chunk arrives, and still degrades to the usual error tile if it fails to load. (Hytte-1gexj)

--- a/web/public/locales/en/dashboard.json
+++ b/web/public/locales/en/dashboard.json
@@ -28,6 +28,10 @@
     "message": "This widget failed to load.",
     "retry": "Retry"
   },
+  "widgetLoading": {
+    "title": "Loading widget…",
+    "titleWithLabel": "Loading {{label}}…"
+  },
   "widgets": {
     "greeting": {
       "title": "Greeting"

--- a/web/public/locales/nb/dashboard.json
+++ b/web/public/locales/nb/dashboard.json
@@ -28,6 +28,10 @@
     "message": "Denne modulen kunne ikke lastes.",
     "retry": "Prøv igjen"
   },
+  "widgetLoading": {
+    "title": "Laster modul…",
+    "titleWithLabel": "Laster {{label}}…"
+  },
   "widgets": {
     "greeting": {
       "title": "Hilsen"

--- a/web/public/locales/th/dashboard.json
+++ b/web/public/locales/th/dashboard.json
@@ -28,6 +28,10 @@
     "message": "ไม่สามารถโหลดวิดเจ็ตนี้ได้",
     "retry": "ลองอีกครั้ง"
   },
+  "widgetLoading": {
+    "title": "กำลังโหลดวิดเจ็ต…",
+    "titleWithLabel": "กำลังโหลด {{label}}…"
+  },
   "widgets": {
     "greeting": {
       "title": "คำทักทาย"

--- a/web/src/components/WidgetSkeleton.tsx
+++ b/web/src/components/WidgetSkeleton.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next'
+import { Skeleton } from './ui/skeleton'
+
+interface WidgetSkeletonProps {
+  /** Human-readable widget name, announced while the chunk loads. */
+  label?: string
+  /** Extra grid classes the widget's cell uses, e.g. `col-span-full`. */
+  className?: string
+}
+
+/**
+ * Placeholder tile for a code-split widget whose chunk has not arrived yet.
+ * It mirrors the `Widget` card shell (background, radius, padding) and reserves
+ * a widget-sized minimum height so the grid does not reflow when the real
+ * widget swaps in.
+ */
+function WidgetSkeleton({ label, className = '' }: WidgetSkeletonProps) {
+  const { t } = useTranslation('dashboard')
+
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className={`bg-gray-800 rounded-xl p-6 min-h-[200px] ${className}`}
+    >
+      <span className="sr-only">
+        {label ? t('widgetLoading.titleWithLabel', { label }) : t('widgetLoading.title')}
+      </span>
+      <Skeleton className="h-3 w-24 mb-4" />
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-3/4" />
+        <Skeleton className="h-5 w-1/2" />
+        <Skeleton className="h-5 w-2/3" />
+      </div>
+    </div>
+  )
+}
+
+export default WidgetSkeleton

--- a/web/src/components/WidgetSkeleton.tsx
+++ b/web/src/components/WidgetSkeleton.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import Widget from './Widget'
 import { Skeleton } from './ui/skeleton'
 
 interface WidgetSkeletonProps {
@@ -10,21 +11,16 @@ interface WidgetSkeletonProps {
 
 /**
  * Placeholder tile for a code-split widget whose chunk has not arrived yet.
- * It mirrors the `Widget` card shell (background, radius, padding) and reserves
- * a widget-sized minimum height so the grid does not reflow when the real
- * widget swaps in.
+ * It reuses the shared `Widget` card shell so the background, radius and
+ * padding cannot drift from the real widget, and reserves a widget-sized
+ * minimum height so the grid does not reflow when the real widget swaps in.
  */
-function WidgetSkeleton({ label, className = '' }: WidgetSkeletonProps) {
+function WidgetSkeleton({ label, className }: WidgetSkeletonProps) {
   const { t } = useTranslation('dashboard')
 
   return (
-    <div
-      role="status"
-      aria-busy="true"
-      aria-live="polite"
-      className={`bg-gray-800 rounded-xl p-6 min-h-[200px] ${className}`}
-    >
-      <span className="sr-only">
+    <Widget className={['min-h-[200px]', className].filter(Boolean).join(' ')}>
+      <span role="status" aria-live="polite" className="sr-only">
         {label ? t('widgetLoading.titleWithLabel', { label }) : t('widgetLoading.title')}
       </span>
       <Skeleton className="h-3 w-24 mb-4" />
@@ -33,7 +29,7 @@ function WidgetSkeleton({ label, className = '' }: WidgetSkeletonProps) {
         <Skeleton className="h-5 w-1/2" />
         <Skeleton className="h-5 w-2/3" />
       </div>
-    </div>
+    </Widget>
   )
 }
 

--- a/web/src/components/widgets/registry.ts
+++ b/web/src/components/widgets/registry.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react'
+import { lazy, type ComponentType } from 'react'
 import type { ParseKeys } from 'i18next'
 import GreetingWidget from './GreetingWidget'
 import WeatherWidget from './WeatherWidget'
@@ -8,10 +8,17 @@ import QuickLinksWidget from './QuickLinksWidget'
 import FitnessWidget from './FitnessWidget'
 import LactateSummaryWidget from './LactateSummaryWidget'
 import ActivityFeedWidget from './ActivityFeedWidget'
-import InfraStatusWidget from './InfraStatusWidget'
-import GitHubStatusWidget from './GitHubStatusWidget'
-import NetatmoWidget from './NetatmoWidget'
 import CalendarWidget from './CalendarWidget'
+
+// Below-the-fold widgets that fetch on mount are code-split so they do not sit
+// in the initial dashboard chunk. Every lazy entry must set `lazy: true` so the
+// dashboard renders it inside a Suspense boundary.
+const InfraStatusWidget = lazy(() => import('./InfraStatusWidget'))
+const GitHubStatusWidget = lazy(() => import('./GitHubStatusWidget'))
+const NetatmoWidget = lazy(() => import('./NetatmoWidget'))
+
+/** Feature key shared by the server-status and GitHub Actions widgets. */
+const INFRA = 'infra'
 
 export interface WidgetDef {
   /** Stable id persisted in the dashboard_widgets preference. */
@@ -25,6 +32,8 @@ export interface WidgetDef {
   colSpanClass?: string
   /** Widgets the user cannot hide (the greeting header). */
   alwaysVisible?: boolean
+  /** True when `component` is a React.lazy wrapper and needs a Suspense boundary. */
+  lazy?: boolean
 }
 
 /**
@@ -43,12 +52,12 @@ export const WIDGET_REGISTRY: WidgetDef[] = [
   { id: 'weather', component: WeatherWidget, titleKey: 'widgets.weather.title' },
   { id: 'daylight', component: DaylightWidget, titleKey: 'widgets.daylight.title' },
   { id: 'calendar', component: CalendarWidget, titleKey: 'widgets.calendar.title', feature: 'calendar' },
-  { id: 'netatmo', component: NetatmoWidget, titleKey: 'widgets.netatmo.title', feature: 'netatmo' },
+  { id: 'netatmo', component: NetatmoWidget, titleKey: 'widgets.netatmo.title', feature: 'netatmo', lazy: true },
   { id: 'training', component: FitnessWidget, titleKey: 'widgets.training.title', feature: 'training' },
   { id: 'lactate', component: LactateSummaryWidget, titleKey: 'widgets.lactate.title', feature: 'lactate' },
   { id: 'activity', component: ActivityFeedWidget, titleKey: 'widgets.activity.title' },
-  { id: 'infra', component: InfraStatusWidget, titleKey: 'widgets.infra.title', feature: 'infra' },
-  { id: 'github', component: GitHubStatusWidget, titleKey: 'widgets.github.title', feature: 'infra' },
+  { id: 'infra', component: InfraStatusWidget, titleKey: 'widgets.infra.title', feature: INFRA, lazy: true },
+  { id: 'github', component: GitHubStatusWidget, titleKey: 'widgets.github.title', feature: INFRA, lazy: true },
   { id: 'norwegian_word', component: NorwegianFunWidget, titleKey: 'widgets.norwegianWord.title' },
   { id: 'quick_links', component: QuickLinksWidget, titleKey: 'widgets.quickLinks.title' },
 ]

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -2,6 +2,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import Dashboard from './Dashboard'
+import { WIDGET_REGISTRY } from '../components/widgets/registry'
+import enDashboard from '../../public/locales/en/dashboard.json'
+import nbDashboard from '../../public/locales/nb/dashboard.json'
+import thDashboard from '../../public/locales/th/dashboard.json'
 
 // ── Translation mock ──────────────────────────────────────────────────────────
 // Widget titles resolve to their registry key segment ("weather", "quickLinks",
@@ -302,5 +306,53 @@ describe('Dashboard – edit mode', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Done' }))
     expect(screen.queryByText('Hidden widgets')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Edit layout' })).toBeInTheDocument()
+  })
+})
+
+describe('Dashboard – code-split widgets', () => {
+  const REACT_LAZY = Symbol.for('react.lazy')
+
+  const isLazyComponent = (component: unknown) =>
+    typeof component === 'object' &&
+    component !== null &&
+    (component as { $$typeof?: symbol }).$$typeof === REACT_LAZY
+
+  it('flags exactly the lazy components with lazy: true', () => {
+    // The dashboard only wraps `lazy` entries in Suspense, so a React.lazy
+    // component without the flag would suspend the whole page.
+    for (const def of WIDGET_REGISTRY) {
+      expect(isLazyComponent(def.component), `${def.id} lazy flag`).toBe(Boolean(def.lazy))
+    }
+  })
+
+  it('code-splits the below-the-fold widgets', () => {
+    const lazyIds = WIDGET_REGISTRY.filter((def) => def.lazy).map((def) => def.id)
+
+    expect(lazyIds).toEqual(['netatmo', 'infra', 'github'])
+  })
+
+  it('renders a code-split widget once its chunk resolves', async () => {
+    authState.features = { infra: true }
+    await renderDashboard()
+
+    await waitFor(() => expect(renderedOrder()).toContain('infra'))
+    expect(renderedOrder()).toContain('github')
+  })
+})
+
+describe('Dashboard – widget titles', () => {
+  const LOCALES: Array<[string, unknown]> = [
+    ['en', enDashboard],
+    ['nb', nbDashboard],
+    ['th', thDashboard],
+  ]
+
+  it.each(LOCALES)('has a %s translation for every widget title key', (locale, messages) => {
+    for (const def of WIDGET_REGISTRY) {
+      const value = def.titleKey.split('.').reduce<unknown>((node, part) => {
+        return node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined
+      }, messages)
+      expect(value, `${locale}: missing ${def.titleKey}`).toBeTypeOf('string')
+    }
   })
 })

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,10 +1,11 @@
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronDown, ChevronUp, Eye, EyeOff, GripVertical } from 'lucide-react'
 import { useAuth } from '../auth'
 import { useToast } from '../hooks/useToast'
 import ToastList from '../components/ToastList'
 import WidgetBoundary from '../components/WidgetBoundary'
+import WidgetSkeleton from '../components/WidgetSkeleton'
 import DashboardEditBar from '../components/widgets/DashboardEditBar'
 import {
   EMPTY_LAYOUT,
@@ -144,9 +145,19 @@ function Dashboard() {
   const renderWidget = (def: WidgetDef, index: number) => {
     const Component = def.component
     const label = t(def.titleKey)
+    // The boundary stays outside Suspense so a lazy chunk that fails to load
+    // degrades to the existing error tile instead of blanking the page. On the
+    // happy path WidgetBoundary renders a bare Fragment, so the skeleton is the
+    // grid cell itself — not a card nested inside another card.
     const boundary = (
       <WidgetBoundary label={label} className={def.colSpanClass}>
-        <Component />
+        {def.lazy ? (
+          <Suspense fallback={<WidgetSkeleton label={label} className={def.colSpanClass} />}>
+            <Component />
+          </Suspense>
+        ) : (
+          <Component />
+        )}
       </WidgetBoundary>
     )
 


### PR DESCRIPTION
## Changes

- **Dashboard loads its heavy widgets on demand** - The dashboard grid is now driven by a widget registry, and the Infrastructure, GitHub Actions and Weather Station widgets are code-split into their own chunks so they no longer download and fetch on first paint. Each shows a widget-sized loading placeholder while its chunk arrives, and still degrades to the usual error tile if it fails to load. (Hytte-1gexj)

## Original Issue (feature): Drive the dashboard grid from a widget registry instead of inline JSX

### Scope
Replace the hand-written `WidgetBoundary` ladder in `Dashboard.tsx` with a single declarative registry array (`{ id, feature?, labelKey, Component, className? }`) that render maps over, so feature gating, boundary wiring and label lookup happen in exactly one place. Then use the now-addressable widget ids to `React.lazy` the three heavy below-the-fold widgets (Infra, GitHub, Netatmo), which today mount and fetch on first paint along with the other nine. Note: the current file is 77 lines, not large — the win is the one-line-per-widget extension point and the deduplicated `hasFeature('infra')` check, not raw line count.

### Files to touch
- `web/src/pages/dashboardWidgets.ts` or `.tsx` (new) — the registry array + its record type, exported for tests
- `web/src/pages/Dashboard.tsx` — collapse to a `.filter(...).map(...)` over the registry
- `web/src/pages/Dashboard.test.tsx` (new) — gating + ordering coverage
- `web/public/locales/{en,nb,th}/dashboard.json` — only if a `widgets.*.title` key is missing for a widget that currently has none (Greeting)
- `changelog.d/` fragment (new)

### Acceptance criteria
- `/dashboard` renders the same twelve widgets, in the same order, with the same grid classes and the same `WidgetBoundary` labels as before; Greeting still spans `col-span-full`.
- Adding a widget requires editing only the registry file — no changes to `Dashboard.tsx` render logic.
- The string `'infra'` appears exactly once in the dashboard source.
- Feature gating is unchanged: a user without `calendar`/`netatmo`/`training`/`lactate`/`infra` sees exactly the widgets they saw before; admin bypass behaviour is untouched (still via `useAuth().hasFeature`).
- `InfraStatusWidget`, `GitHubStatusWidget` and `NetatmoWidget` are code-split: they are absent from the initial dashboard chunk in `npm run build` output and load in separate chunks.
- Each lazy widget renders inside a `Suspense` boundary with a placeholder that occupies the same grid cell (no layout shift or grid reflow while loading), and a lazy chunk that fails to load degrades to the existing `WidgetBoundary` fallback tile rather than blanking the page.
- New `Dashboard.test.tsx` asserts: all ungated widgets render for a featureless user, a gated widget appears only when its feature is on, and registry order matches render order.
- `npm run lint`, `npm run build` and `npm test` pass.

### Non-goals
- No changes to any individual widget's internals, data fetching, or API endpoints.
- No changes to `internal/dashboard/activity.go` or any backend code.
- No user-configurable widget ordering, drag-and-drop, per-user show/hide, or persisted layout — the registry stays a static compile-time array.
- No visual redesign: no new spacing, breakpoints, colours or grid shape.
- Not extending the registry pattern to `HomePage.tsx` or other pages.
- Not adding new feature flags (e.g. splitting `github` out of `infra`) — the dedupe is mechanical only.

## Source

Created from Suggestions page (suggestion id 286, page slug "dashboard", source=claude).

## Original suggestion

Dashboard.tsx repeats the same WidgetBoundary + hasFeature wrapper twelve times, which is why 'infra' is spelled out twice and why adding a widget means touching layout, gating and i18n label in three places. Replace the ladder with a single array of { id, feature?, labelKey, Component, className? } records mapped over in render, so gating and boundary wiring live in one place. Because every widget is then addressable by id, this also unlocks React.lazy for the heavier below-the-fold widgets (Infra, GitHub, Netatmo) — today all twelve mount and fetch simultaneously on page load. No visual change, but the file drops to roughly a third of its size and new widgets become a one-line addition.


---
Bead: Hytte-1gexj | Branch: forge/Hytte-1gexj
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->