### PR TITLE
Normalise unit prices to kg/l so offers are actually comparable (Hytte-848vs)

### DIFF
--- a/changelog.d/Hytte-848vs.md
+++ b/changelog.d/Hytte-848vs.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Comparable unit prices on offers** - Derived unit prices are now normalised to one of three scales (kr/kg, kr/l or kr/stk) instead of using the raw unit symbol from the source data, so a 500 g item at 45 kr shows as 90,00/kg next to a 1 kg item at 89,00/kg. Grams, millilitres, centilitres and decilitres are converted to their base unit, and unrecognised symbols no longer produce a misleading number. Corrected values land on the next daily sync. (Hytte-848vs)

--- a/internal/offers/client.go
+++ b/internal/offers/client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -165,9 +166,37 @@ func fetchPage(ctx context.Context, fullURL string) ([]tjekOffer, error) {
 	return nil, lastErr
 }
 
+// unitConversions maps a lowercased, trimmed Tjek unit symbol to the base unit
+// we express prices in and the factor that converts a raw size into that base
+// unit. Sub-units are scaled up so a 500 g item and a 1 kg item are both priced
+// per kg and stay comparable side by side in the same list. Symbols outside
+// this table (including "pcs"/"stk") deliberately yield no unit price.
+var unitConversions = map[string]struct {
+	label  string
+	factor float64
+}{
+	"g":  {"kg", 1.0 / 1000},
+	"kg": {"kg", 1},
+	"ml": {"l", 1.0 / 1000},
+	"cl": {"l", 1.0 / 100},
+	"dl": {"l", 1.0 / 10},
+	"l":  {"l", 1},
+}
+
+// normaliseUnit resolves a raw Tjek unit symbol to a base unit label and the
+// multiplier converting the raw size into that base unit. ok is false for empty
+// or unrecognised symbols, which must not produce a misleading unit price.
+func normaliseUnit(symbol string) (label string, factor float64, ok bool) {
+	c, ok := unitConversions[strings.ToLower(strings.TrimSpace(symbol))]
+	if !ok {
+		return "", 0, false
+	}
+	return c.label, c.factor, true
+}
+
 // convertOffer maps a Tjek offer onto our storage model, deriving the unit
-// price (price per liter/kg when the quantity is known, else per piece for
-// multi-packs) and normalizing validity timestamps to dates.
+// price (price per kg or per liter when the quantity is known, else per piece
+// for multi-packs) and normalizing validity timestamps to dates.
 func convertOffer(t tjekOffer) Offer {
 	o := Offer{
 		ID:          t.ID,
@@ -195,11 +224,17 @@ func convertOffer(t tjekOffer) Offer {
 	if t.Quantity.Pieces.From != nil {
 		pieces = *t.Quantity.Pieces.From
 	}
-	switch {
-	case t.Quantity.Unit != nil && t.Quantity.Unit.Symbol != "" && size > 0 && (size != 1 || t.Quantity.Unit.Symbol != "pcs"):
-		o.UnitPrice = round2(o.Price / size)
-		o.UnitLabel = t.Quantity.Unit.Symbol
-	case pieces > 1:
+	if t.Quantity.Unit != nil && size > 0 && (size != 1 || t.Quantity.Unit.Symbol != "pcs") {
+		if label, factor, ok := normaliseUnit(t.Quantity.Unit.Symbol); ok {
+			if base := size * factor; base > 0 {
+				o.UnitPrice = round2(o.Price / base)
+				o.UnitLabel = label
+			}
+		}
+	}
+	// Unknown or missing units fall through to the per-piece price so
+	// multi-packs still get something comparable.
+	if o.UnitLabel == "" && pieces > 1 {
 		o.UnitPrice = round2(o.Price / pieces)
 		o.UnitLabel = "stk"
 	}

--- a/internal/offers/offers_test.go
+++ b/internal/offers/offers_test.go
@@ -278,3 +278,98 @@ func TestWatchlistCRUD(t *testing.T) {
 		t.Errorf("watchlist has %d entries after delete, want 0", len(list))
 	}
 }
+
+// quantityOffer builds a tjekOffer with just the pricing and quantity fields
+// convertOffer derives the unit price from. A nil symbol means the payload had
+// no unit object at all.
+func quantityOffer(price float64, symbol *string, size, pieces float64) tjekOffer {
+	var t tjekOffer
+	t.Pricing.Price = price
+	if symbol != nil {
+		t.Quantity.Unit = &struct {
+			Symbol string `json:"symbol"`
+		}{Symbol: *symbol}
+	}
+	if size > 0 {
+		t.Quantity.Size.From = &size
+	}
+	if pieces > 0 {
+		t.Quantity.Pieces.From = &pieces
+	}
+	return t
+}
+
+func TestConvertOfferUnitPriceNormalisation(t *testing.T) {
+	sym := func(s string) *string { return &s }
+
+	tests := []struct {
+		name      string
+		price     float64
+		symbol    *string
+		size      float64
+		pieces    float64
+		wantPrice float64
+		wantLabel string
+	}{
+		{"grams scale to kg", 45, sym("g"), 500, 0, 90, "kg"},
+		{"kg passes through", 89, sym("kg"), 1, 0, 89, "kg"},
+		{"multi-kg divides", 60, sym("kg"), 2.5, 0, 24, "kg"},
+		{"millilitres scale to litre", 20, sym("ml"), 500, 0, 40, "l"},
+		{"centilitres scale to litre", 15, sym("cl"), 33, 0, 45.45, "l"},
+		{"decilitres scale to litre", 30, sym("dl"), 5, 0, 60, "l"},
+		{"litres pass through", 36.4, sym("l"), 1.75, 0, 20.8, "l"},
+		{"symbol matching ignores case and whitespace", 45, sym(" G "), 500, 0, 90, "kg"},
+		{"upper-case kg", 89, sym(" KG "), 1, 0, 89, "kg"},
+		{"unknown symbol falls back to pieces", 79.9, sym("bundt"), 3, 24, 3.33, "stk"},
+		{"empty symbol falls back to pieces", 79.9, sym(""), 3, 24, 3.33, "stk"},
+		{"missing unit falls back to pieces", 79.9, nil, 0, 24, 3.33, "stk"},
+		{"unknown symbol without pieces yields nothing", 79.9, sym("bundt"), 3, 0, 0, ""},
+		{"stk symbol without pieces yields nothing", 79.9, sym("stk"), 3, 0, 0, ""},
+		{"single piece yields nothing", 12, sym("pcs"), 1, 1, 0, ""},
+		{"pcs multipack uses pieces", 79.9, sym("pcs"), 24, 24, 3.33, "stk"},
+		{"zero size with single piece yields nothing", 12, sym("kg"), 0, 1, 0, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertOffer(quantityOffer(tc.price, tc.symbol, tc.size, tc.pieces))
+			if diff := got.UnitPrice - tc.wantPrice; diff > 0.001 || diff < -0.001 {
+				t.Errorf("UnitPrice = %v, want %v", got.UnitPrice, tc.wantPrice)
+			}
+			if got.UnitLabel != tc.wantLabel {
+				t.Errorf("UnitLabel = %q, want %q", got.UnitLabel, tc.wantLabel)
+			}
+		})
+	}
+}
+
+func TestNormaliseUnit(t *testing.T) {
+	for _, tc := range []struct {
+		symbol     string
+		wantLabel  string
+		wantFactor float64
+		wantOK     bool
+	}{
+		{"g", "kg", 0.001, true},
+		{"kg", "kg", 1, true},
+		{"ml", "l", 0.001, true},
+		{"cl", "l", 0.01, true},
+		{"dl", "l", 0.1, true},
+		{"l", "l", 1, true},
+		{"  Dl\t", "l", 0.1, true},
+		{"stk", "", 0, false},
+		{"pcs", "", 0, false},
+		{"", "", 0, false},
+		{"bundt", "", 0, false},
+	} {
+		label, factor, ok := normaliseUnit(tc.symbol)
+		if ok != tc.wantOK || label != tc.wantLabel {
+			t.Errorf("normaliseUnit(%q) = %q, %v, %v; want %q, %v, %v",
+				tc.symbol, label, factor, ok, tc.wantLabel, tc.wantFactor, tc.wantOK)
+			continue
+		}
+		if diff := factor - tc.wantFactor; diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("normaliseUnit(%q) factor = %v, want %v", tc.symbol, factor, tc.wantFactor)
+		}
+	}
+}


### PR DESCRIPTION
## Changes

- **Comparable unit prices on offers** - Derived unit prices are now normalised to one of three scales (kr/kg, kr/l or kr/stk) instead of using the raw unit symbol from the source data, so a 500 g item at 45 kr shows as 90,00/kg next to a 1 kg item at 89,00/kg. Grams, millilitres, centilitres and decilitres are converted to their base unit, and unrecognised symbols no longer produce a misleading number. Corrected values land on the next daily sync. (Hytte-848vs)

## Original Issue (feature): Normalise unit prices to kg/l so offers are actually comparable

### Scope
Normalise the derived unit price in `convertOffer` (`internal/offers/client.go`) so every offer is expressed on one of three scales — kr/kg, kr/l, or kr/stk — instead of copying Tjek's raw unit symbol. Sub-units (g, ml, cl, dl) are converted to their base unit with the matching factor before dividing price by size; kg/l pass through unchanged; the existing pieces fallback keeps `stk`. Unknown or unrecognised symbols must not produce a misleading number. Sync upserts every offer daily, so corrected values land on the next scheduled run without a backfill.

### Files to touch
- `internal/offers/client.go` — normalisation helper (symbol → base unit + multiplier) applied in `convertOffer` before computing `UnitPrice`/`UnitLabel`
- `internal/offers/offers_test.go` — table-driven tests per symbol
- `changelog.d/<bead-id>-unit-price-normalisation.md` (new) — `category: Fixed` fragment
- `web/src/pages/OffersPage.tsx` — only if the page hardcodes or special-cases unit labels; otherwise leave untouched

### Acceptance criteria
- A 500 g item at 45 kr renders as `90,00/kg`; a 1 kg item at 89 kr still renders as `89,00/kg` — both comparable in the same list.
- Volume symbols convert to litres with the correct factor: ml ÷1000, cl ÷100, dl ÷10; e.g. 500 ml at 20 kr → `40,00/l`.
- `kg` and `l` inputs are unchanged in both value and label.
- Symbol matching is case-insensitive and tolerant of surrounding whitespace.
- The pieces branch is unaffected: multi-packs with no usable size still yield `UnitPrice = price/pieces` and `UnitLabel = "stk"`.
- An unrecognised or empty unit symbol leaves `UnitPrice`/`UnitLabel` at zero value rather than emitting a raw-symbol price, falling through to the pieces branch when pieces > 1.
- The existing guard for `size == 1 && symbol == "pcs"` still holds.
- Table-driven tests in `internal/offers` cover every supported symbol (g, kg, ml, cl, dl, l, stk/pcs) plus the unknown-symbol and pieces-fallback cases, and `go test ./internal/offers/...` passes.
- `gofmt -l`, `go vet`, and `npm run build` are clean.
- No DB migration or backfill script is added; the next scheduled `Sync` overwrites stored rows.

### Non-goals
- Backfilling or migrating existing rows in the offers table.
- Changing the `Offer` model's schema, JSON field names, or the store's read/write paths.
- Reworking how the frontend formats or sorts by unit price beyond whatever is needed for the new labels to render.
- Ranking, matching (`match.go`), or watchlist-priority behaviour.
- Handling pack-size arithmetic ("3 × 400 g"), `Size.To`/`Pieces.To` ranges, or per-dealer quirks in Tjek quantity data.
- Adding new i18n keys or a user-facing unit-preference setting.

## Source

Created from Suggestions page (suggestion id 252, page slug "offers", source=claude).

## Original suggestion

convertOffer in internal/offers/client.go divides price by Quantity.Size.From and copies the raw Tjek unit symbol, so a 500 g cheese at 45 kr renders as "0,09/g" while a 1 kg cheese at 89 kr renders as "89,00/kg" — the two numbers sit side by side in the same list and cannot be compared, which defeats the main reason the unit price is shown. Convert g→kg (×1000), ml/cl/dl→l with the matching factor, and keep kg/l/stk as-is before computing UnitPrice, with table-driven tests covering each symbol. Because Sync upserts every offer daily, the corrected values land on the next scheduled run without a backfill. Users get one consistent kr/kg and kr/l scale across all 16 chains.


---
Bead: Hytte-848vs | Branch: forge/Hytte-848vs
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->