### PR TITLE
Surface award-stars failures inside the modal instead of behind it (Hytte-8bo4i)

### DIFF
--- a/changelog.d/Hytte-8bo4i.md
+++ b/changelog.d/Hytte-8bo4i.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Award-stars failures now show inside the modal** - A failed star award reported its error in the page-level banner behind the full-screen overlay, so the dialog looked like it did nothing. The message now renders inside the dialog as a live alert, clears when the modal is reopened and on each resubmit, and focus lands on the amount field when the modal opens so Escape closes it right away. (Hytte-8bo4i)

--- a/web/src/pages/Family.tsx
+++ b/web/src/pages/Family.tsx
@@ -88,6 +88,8 @@ export default function Family() {
   const [awardDescription, setAwardDescription] = useState('')
   const [awarding, setAwarding] = useState(false)
   const [awardSuccess, setAwardSuccess] = useState(false)
+  const [awardError, setAwardError] = useState('')
+  const awardAmountRef = useRef<HTMLInputElement>(null)
   const [myFamily, setMyFamily] = useState<MyFamilyData | null>(null)
   const [myFamilyLoading, setMyFamilyLoading] = useState(false)
 
@@ -124,6 +126,12 @@ export default function Family() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     loadData().catch(err => console.error('Family: loadData failed', err))
   }, [loadData])
+
+  // Move focus into the award dialog when it opens, so the Escape handler on
+  // the dialog container receives key events without the admin tabbing first.
+  useEffect(() => {
+    if (awardingForChild) awardAmountRef.current?.focus()
+  }, [awardingForChild])
 
   async function loadMyFamily() {
     try {
@@ -305,6 +313,7 @@ export default function Family() {
     setAwardReason('')
     setAwardDescription('')
     setAwardSuccess(false)
+    setAwardError('')
   }
 
   function closeAwardModal() {
@@ -317,6 +326,7 @@ export default function Family() {
     const amount = Number(awardAmount)
     if (!Number.isInteger(amount) || amount === 0) return
     if (!awardReason.trim()) return
+    setAwardError('')
     try {
       setAwarding(true)
       const res = await fetch('/api/admin/stars/award', {
@@ -335,7 +345,9 @@ export default function Family() {
       // Refresh stats to show updated balance.
       loadStats(children).catch(err => console.error('Family: loadStats failed', err))
     } catch {
-      setError(t('family.errors.failedToAward'))
+      // Report inside the dialog: the page-level banner renders behind the
+      // fixed overlay, so a failed award would look like a no-op.
+      setAwardError(t('family.errors.failedToAward'))
     } finally {
       setAwarding(false)
     }
@@ -775,6 +787,7 @@ export default function Family() {
                   </label>
                   <input
                     id="award-amount"
+                    ref={awardAmountRef}
                     type="number"
                     value={awardAmount}
                     onChange={e => setAwardAmount(e.target.value)}
@@ -809,6 +822,9 @@ export default function Family() {
                     className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white text-sm"
                   />
                 </div>
+                {awardError && (
+                  <p role="alert" className="text-red-400 text-sm">{awardError}</p>
+                )}
                 <div className="flex gap-2 pt-2">
                   <button
                     onClick={submitAward}

--- a/web/src/pages/__tests__/FamilyAwardModal.test.tsx
+++ b/web/src/pages/__tests__/FamilyAwardModal.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import Family from '../Family'
+
+// ── Translation mock ──────────────────────────────────────────────────────────
+// stableT must be a stable reference: Family keeps `t` in the loadData
+// dependency list, so a fresh function per render would re-run the effect.
+
+const TRANSLATIONS: Record<string, string> = {
+  'family.title': 'Family',
+  'family.overview': 'Overview',
+  'family.children': 'Children',
+  'family.addChild': 'Add child',
+  'family.editChild': 'Edit child',
+  'family.removeChild': 'Remove child',
+  'family.viewDetails': 'View details',
+  'family.manageRewards': 'Manage rewards',
+  'family.awardStars.button': 'Award stars',
+  'family.awardStars.title': 'Award stars',
+  'family.awardStars.amount': 'Amount',
+  'family.awardStars.amountPlaceholder': 'e.g. 10',
+  'family.awardStars.reason': 'Reason',
+  'family.awardStars.reasonPlaceholder': 'e.g. Helped out',
+  'family.awardStars.description': 'Description',
+  'family.awardStars.descriptionPlaceholder': 'Optional detail',
+  'family.awardStars.submit': 'Award',
+  'family.awardStars.success': 'Stars awarded',
+  'family.errors.failedToAward': 'Failed to award stars',
+  'family.errors.failedToLoad': 'Failed to load family',
+  'actions.close': 'Close',
+  'actions.cancel': 'Cancel',
+  'skeleton.loading': 'Loading...',
+}
+
+function stableT(key: string, opts?: Record<string, unknown>): string {
+  const template = TRANSLATIONS[key] ?? key
+  if (!opts) return template
+  return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) =>
+    opts[name] === undefined ? '' : String(opts[name]),
+  )
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: stableT, i18n: { language: 'en' } }),
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}))
+
+// Keep the HttpBackend out of the test run — formatDate only needs a language.
+vi.mock('../../i18n', () => ({
+  default: { language: 'en' },
+}))
+
+// ── Auth mock ─────────────────────────────────────────────────────────────────
+// The award button only renders for admins.
+
+const authState = {
+  user: { id: 1, name: 'Alice', email: 'alice@example.com', is_admin: true },
+  refreshFamilyStatus: vi.fn(),
+}
+
+vi.mock('../../auth', () => ({
+  useAuth: () => authState,
+}))
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CHILDREN = [
+  { id: 1, parent_id: 1, child_id: 2, nickname: 'Ada', avatar_emoji: '⭐', created_at: '2026-01-01T00:00:00Z' },
+  { id: 2, parent_id: 1, child_id: 3, nickname: 'Bo', avatar_emoji: '🚀', created_at: '2026-01-01T00:00:00Z' },
+]
+
+const STATS = {
+  current_balance: 40,
+  total_earned: 60,
+  total_spent: 20,
+  level: 2,
+  xp: 120,
+  title: 'Explorer',
+  current_streak: 3,
+  longest_streak: 5,
+  this_week_stars: 10,
+  this_week_starred_workouts: 2,
+  last_week_stars: 8,
+  last_week_starred_workouts: 1,
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as unknown as Response
+}
+
+const fetchMock = vi.fn()
+
+/** Award responses are per-test; everything else uses the same happy path. */
+function routeFetch(award: () => Promise<Response>) {
+  fetchMock.mockImplementation((url: string) => {
+    if (url === '/api/family/status') {
+      return Promise.resolve(jsonResponse({ is_parent: true, is_child: false }))
+    }
+    if (url === '/api/family/children') {
+      return Promise.resolve(jsonResponse({ children: CHILDREN }))
+    }
+    if (/^\/api\/family\/children\/\d+\/stats$/.test(url)) {
+      return Promise.resolve(jsonResponse(STATS))
+    }
+    if (url === '/api/admin/stars/award') {
+      return award()
+    }
+    return Promise.reject(new Error(`unexpected url: ${url}`))
+  })
+}
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  routeFetch(() => Promise.resolve(jsonResponse({ ok: true })))
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+async function renderFamily() {
+  render(
+    <MemoryRouter>
+      <Family />
+    </MemoryRouter>,
+  )
+  await screen.findByText('Ada')
+}
+
+/** Opens the award modal for the nth child card (0-indexed). */
+function openAwardModal(index = 0) {
+  fireEvent.click(screen.getAllByRole('button', { name: 'Award stars' })[index])
+}
+
+function fillAndSubmit() {
+  fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '5' } })
+  fireEvent.change(screen.getByLabelText('Reason'), { target: { value: 'Tidied up' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Award' }))
+}
+
+describe('Family award stars modal', () => {
+  it('shows the failure inside the dialog and keeps it open', async () => {
+    routeFetch(() => Promise.resolve(jsonResponse({ error: 'nope' }, false)))
+    await renderFamily()
+    openAwardModal()
+    fillAndSubmit()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Failed to award stars')
+    // The dialog stays open with the entered values, so the award can be retried.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByLabelText('Reason')).toHaveValue('Tidied up')
+    // The message renders inside the dialog, not in the page-level banner
+    // that sits behind the overlay.
+    expect(within(screen.getByRole('dialog')).getByRole('alert')).toBe(alert)
+  })
+
+  it('reports network failures the same way', async () => {
+    routeFetch(() => Promise.reject(new Error('offline')))
+    await renderFamily()
+    openAwardModal()
+    fillAndSubmit()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Failed to award stars')
+  })
+
+  it('clears a stale error when the modal is reopened for another child', async () => {
+    routeFetch(() => Promise.resolve(jsonResponse({ error: 'nope' }, false)))
+    await renderFamily()
+    openAwardModal()
+    fillAndSubmit()
+    await screen.findByRole('alert')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    openAwardModal(1)
+
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.queryByText('Failed to award stars')).toBeNull()
+  })
+
+  it('clears the previous error before the next submit', async () => {
+    let fail = true
+    routeFetch(() =>
+      Promise.resolve(fail ? jsonResponse({ error: 'nope' }, false) : jsonResponse({ ok: true })),
+    )
+    await renderFamily()
+    openAwardModal()
+    fillAndSubmit()
+    await screen.findByRole('alert')
+
+    fail = false
+    fireEvent.click(screen.getByRole('button', { name: 'Award' }))
+
+    await screen.findByText('Stars awarded')
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('shows the success state with no error text', async () => {
+    await renderFamily()
+    openAwardModal()
+    fillAndSubmit()
+
+    await screen.findByText('Stars awarded')
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.queryByText('Failed to award stars')).toBeNull()
+  })
+
+  it('focuses the amount input on open so Escape closes the dialog immediately', async () => {
+    await renderFamily()
+    openAwardModal()
+
+    const amount = screen.getByLabelText('Amount')
+    await waitFor(() => expect(document.activeElement).toBe(amount))
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Changes

- **Award-stars failures now show inside the modal** - A failed star award reported its error in the page-level banner behind the full-screen overlay, so the dialog looked like it did nothing. The message now renders inside the dialog as a live alert, clears when the modal is reopened and on each resubmit, and focus lands on the amount field when the modal opens so Escape closes it right away. (Hytte-8bo4i)

## Original Issue (feature): Surface award-stars failures inside the modal instead of behind it

### Scope
Fix the award-stars modal in `web/src/pages/Family.tsx` so failures are visible where the admin is looking. Today `submitAward()` calls `setError(...)`, which renders in the page-level banner *behind* the fixed `z-50` overlay, so a failed award looks like a no-op. Add a modal-local error state rendered inside the dialog body, clear it when the modal opens and on each resubmit, and move focus into the dialog on open so the existing Escape handler works immediately. Reuse the existing `family.errors.failedToAward` string (already present in `en`/`nb`/`th` `common.json`) — no new translation keys required.

### Files to touch
- `web/src/pages/Family.tsx` — add `awardError` state; set it in the `catch` of `submitAward()` (replacing the page-level `setError` for this path); clear it in `openAwardModal()` and at the start of `submitAward()`; render it inside the dialog above the buttons; add a ref + `useEffect` to focus the amount input (or the dialog itself) when `awardingForChild` becomes non-null.
- `web/src/pages/__tests__/FamilyAwardModal.test.tsx` (new) — vitest/RTL coverage, following `AllowancePageBulkApproval.test.tsx` as the pattern.
- `changelog.d/<Hytte-id>.md` (new) — `category: Fixed` fragment.

### Acceptance criteria
- With the award POST failing (non-2xx or network error), the modal stays open and shows the `family.errors.failedToAward` message inside the dialog body, visible above the overlay.
- The error message is styled as an in-dialog error (red text, consistent with existing error styling on the page) and is announced to assistive tech (`role="alert"`).
- Reopening the modal for any child shows no stale error; clicking Submit again clears the previous error before the request fires.
- A successful award still shows the existing success state, with no error text present.
- On open, focus lands inside the dialog (amount input preferred), and pressing Escape immediately closes the modal without first tabbing into a field.
- The page-level `error` banner no longer receives the award failure (other handlers keep using it unchanged).
- Vitest coverage exists for: failure → in-dialog message, reopen → cleared, success → no error, Escape-on-open → closed.
- `npm run lint`, `npm run build`, and `npm run test` pass in `web/`.
- A `changelog.d/` fragment under `Fixed` is included with the bead ID.

### Non-goals
- No changes to `internal/family/handlers.go` or any backend behaviour; the client keeps treating any non-OK response as a generic failure rather than surfacing server-supplied error text.
- No focus trap, focus restoration on close, or a shared `<Modal>` component extraction — that is a broader accessibility refactor.
- No changes to the other modals or pages (`FamilyChildDetail.tsx`, `FamilyRewards.tsx`, `family/FamilyChallenges.tsx`), even if they share the same pattern.
- No new i18n keys, no retry/backoff logic, and no redesign of the award form fields or validation rules.

## Source

Created from Suggestions page (suggestion id 307, page slug "family", source=claude).

## Original suggestion

In `Family.tsx`, `submitAward()` reports failures with `setError(t('family.errors.failedToAward'))`, but that error banner renders at the top of the page underneath the fixed full-screen modal overlay, so an admin who hits a failed award sees the form simply do nothing and is likely to submit again. The same modal is also never focused despite carrying `tabIndex={-1}` and an `onKeyDown` Escape handler, so Escape does nothing until the user tabs into a field. Add a local `awardError` state rendered inside the dialog body, clear it on open and on resubmit, and focus the dialog (or the amount input) when it opens. Parents get real feedback on failed awards and can dismiss the modal with the keyboard.


---
Bead: Hytte-8bo4i | Branch: forge/Hytte-8bo4i
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->