### PR TITLE
Show the latest-threshold summary card for users with a single test (Hytte-9oo7h)

### DIFF
--- a/changelog.d/Hytte-9oo7h.md
+++ b/changelog.d/Hytte-9oo7h.md
@@ -1,0 +1,3 @@
+category: Fixed
+- **Show the latest-threshold card after a single lactate test** - The summary card on the lactate list used to require two tests, so the first recorded test showed no threshold speed or heart rate at all. It now appears from the first test, with the "no previous test to compare" note in place of the delta badges. The Insights link still needs two tests. (Hytte-9oo7h)
+- **Render the threshold heart-rate delta neutrally** - A rising threshold heart rate was coloured green like a speed improvement, which it is not. The bpm badge is now gray in every direction while keeping its arrow and signed value. (Hytte-9oo7h)

--- a/web/src/pages/LactateTests.test.tsx
+++ b/web/src/pages/LactateTests.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import LactateTests from './LactateTests'
+import type { LactateTest, PrimaryThreshold } from '../types/lactate'
+
+vi.mock('react-i18next', async () => {
+  const { default: enLactate } = await import('../../public/locales/en/lactate.json')
+
+  function resolveKey(obj: Record<string, unknown>, parts: string[]): unknown {
+    const [head, ...rest] = parts
+    const val = obj[head]
+    if (rest.length === 0) return val
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      return resolveKey(val as Record<string, unknown>, rest)
+    }
+    return undefined
+  }
+
+  // The page and DeltaBadge both call useTranslation, so `t` must be stable —
+  // the load effect depends on it.
+  const t = (key: string, opts?: Record<string, unknown>): string => {
+    const localKey = key.includes(':') ? key.slice(key.indexOf(':') + 1) : key
+    const val = resolveKey(enLactate as Record<string, unknown>, localKey.split('.'))
+    if (typeof val !== 'string') return key
+    if (opts) return val.replace(/\{\{(\w+)\}\}/g, (_, k) => String(opts[k] ?? `{{${k}}}`))
+    return val
+  }
+  const translation = { t, i18n: { language: 'en' } }
+
+  return {
+    useTranslation: () => translation,
+    initReactI18next: { type: '3rdParty', init: () => {} },
+  }
+})
+
+// The real AuthContext keeps `user` in state, so it is referentially stable
+// across renders. Keep the stub stable too, or the load effect refires.
+const authState = { user: { id: 1, email: 'a@b.c' } as object | null, loading: false }
+vi.mock('../auth', () => ({
+  useAuth: () => authState,
+}))
+
+// The real helpers pull in ../i18n; stub them so the tests stay locale-stable.
+vi.mock('../utils/formatDate', () => ({
+  formatDate: () => 'January 1, 2026',
+  formatNumber: (n: number, opts?: Intl.NumberFormatOptions) => n.toFixed(opts?.minimumFractionDigits ?? 0),
+}))
+
+vi.mock('lucide-react', () => {
+  const stub = (name: string) => () => <span data-testid={`icon-${name}`} />
+  return {
+    Activity: stub('activity'),
+    Plus: stub('plus'),
+    Calendar: stub('calendar'),
+    ChevronRight: stub('chevron-right'),
+    TrendingUp: stub('trending-up'),
+    ArrowUp: stub('arrow-up'),
+    ArrowDown: stub('arrow-down'),
+    Minus: stub('minus'),
+    Gauge: stub('gauge'),
+  }
+})
+
+function makeTest(id: number, threshold?: PrimaryThreshold | null): LactateTest {
+  return {
+    id,
+    date: '2026-01-01',
+    comment: `Test ${id}`,
+    protocol_type: 'incremental',
+    warmup_duration_min: 10,
+    stage_duration_min: 4,
+    start_speed_kmh: 8,
+    speed_increment_kmh: 1,
+    stages: [],
+    ...(threshold ? { primary_threshold: threshold } : {}),
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+function threshold(speed: number, hr: number, valid = true): PrimaryThreshold {
+  return { method: 'Dmax', speed_kmh: speed, heart_rate_bpm: hr, valid }
+}
+
+function stubTests(tests: LactateTest[]) {
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ tests }),
+  })))
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <LactateTests />
+    </MemoryRouter>,
+  )
+}
+
+// The badge text node sits inside the coloured wrapper span.
+function badgeWrapper(text: string): HTMLElement {
+  const el = screen.getByText(text)
+  return el.parentElement as HTMLElement
+}
+
+describe('LactateTests summary card', () => {
+  beforeEach(() => {
+    authState.user = { id: 1, email: 'a@b.c' }
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('renders no summary card when the user has no tests', async () => {
+    stubTests([])
+    renderPage()
+
+    expect(await screen.findByText('No lactate tests yet. Record your first test to get started.')).toBeInTheDocument()
+    expect(screen.queryByText('Latest threshold')).not.toBeInTheDocument()
+  })
+
+  it('shows the latest-threshold card for a user with exactly one test', async () => {
+    stubTests([makeTest(1, threshold(12.5, 165))])
+    renderPage()
+
+    expect(await screen.findByText('Latest threshold')).toBeInTheDocument()
+    expect(screen.getByText('12.5 km/h · 165 bpm')).toBeInTheDocument()
+    // The method is shown next to the value, and again in the row chip.
+    expect(screen.getAllByText('Dmax').length).toBeGreaterThan(0)
+  })
+
+  it('shows the no-previous-comparison note and no deltas for a single test', async () => {
+    stubTests([makeTest(1, threshold(12.5, 165))])
+    renderPage()
+
+    expect(await screen.findByText('No previous test to compare.')).toBeInTheDocument()
+    expect(screen.queryByText('vs previous test')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('icon-arrow-up')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('icon-arrow-down')).not.toBeInTheDocument()
+  })
+
+  it('does not show the Insights link with a single test, but does with two', async () => {
+    stubTests([makeTest(1, threshold(12.5, 165))])
+    const { unmount } = renderPage()
+
+    expect(await screen.findByText('Latest threshold')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Insights/ })).not.toBeInTheDocument()
+    unmount()
+
+    stubTests([makeTest(2, threshold(12.5, 165)), makeTest(1, threshold(12.0, 162))])
+    renderPage()
+
+    expect(await screen.findByRole('link', { name: /Insights/ })).toHaveAttribute('href', '/lactate/insights')
+  })
+
+  it('falls back to the no-result copy when the single test has no primary threshold', async () => {
+    stubTests([makeTest(1)])
+    renderPage()
+
+    expect(await screen.findByText('Latest threshold')).toBeInTheDocument()
+    expect(screen.getByText('No result yet')).toBeInTheDocument()
+    expect(screen.queryByText('No previous test to compare.')).not.toBeInTheDocument()
+    expect(document.body.textContent).not.toMatch(/NaN/)
+  })
+
+  it('falls back to the no-result copy when the single test threshold is invalid', async () => {
+    stubTests([makeTest(1, threshold(12.5, 165, false))])
+    renderPage()
+
+    expect(await screen.findByText('Latest threshold')).toBeInTheDocument()
+    expect(screen.getByText('No result yet')).toBeInTheDocument()
+    expect(document.body.textContent).not.toMatch(/NaN/)
+  })
+
+  it('keeps green-up / neutral-HR colouring when the speed improved', async () => {
+    stubTests([makeTest(2, threshold(12.5, 168)), makeTest(1, threshold(12.0, 165))])
+    renderPage()
+
+    expect(await screen.findByText('vs previous test')).toBeInTheDocument()
+
+    const speed = badgeWrapper('+0.5 km/h')
+    expect(speed.className).toContain('text-green-400')
+    expect(speed.querySelector('[data-testid="icon-arrow-up"]')).not.toBeNull()
+
+    const hr = badgeWrapper('+3 bpm')
+    expect(hr.className).toContain('text-gray-400')
+    expect(hr.className).not.toContain('text-green-400')
+    expect(hr.querySelector('[data-testid="icon-arrow-up"]')).not.toBeNull()
+  })
+
+  it('keeps red-down for speed while the HR badge stays neutral when both fall', async () => {
+    stubTests([makeTest(2, threshold(11.5, 160)), makeTest(1, threshold(12.0, 165))])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('vs previous test')).toBeInTheDocument()
+    })
+
+    const speed = badgeWrapper('−0.5 km/h')
+    expect(speed.className).toContain('text-red-400')
+    expect(speed.querySelector('[data-testid="icon-arrow-down"]')).not.toBeNull()
+
+    const hr = badgeWrapper('−5 bpm')
+    expect(hr.className).toContain('text-gray-400')
+    expect(hr.className).not.toContain('text-red-400')
+    expect(hr.querySelector('[data-testid="icon-arrow-down"]')).not.toBeNull()
+  })
+})

--- a/web/src/pages/LactateTests.tsx
+++ b/web/src/pages/LactateTests.tsx
@@ -12,8 +12,10 @@ function validThreshold(test: LactateTest | undefined): PrimaryThreshold | null 
   return pt && pt.valid ? pt : null
 }
 
-// DeltaBadge renders a signed change with up/down/flat styling.
-function DeltaBadge({ value, unit, decimals }: { value: number; unit: string; decimals: number }) {
+// DeltaBadge renders a signed change with up/down/flat styling. `neutral` drops
+// the green/red colouring for metrics where a rise is not inherently better or
+// worse (threshold heart rate), keeping only the arrow and the signed value.
+function DeltaBadge({ value, unit, decimals, neutral = false }: { value: number; unit: string; decimals: number; neutral?: boolean }) {
   const { t } = useTranslation(['lactate'])
   const rounded = Number(value.toFixed(decimals))
   const magnitude = formatNumber(Math.abs(rounded), {
@@ -25,11 +27,11 @@ function DeltaBadge({ value, unit, decimals }: { value: number; unit: string; de
   let sign = ''
   if (rounded > 0) {
     Icon = ArrowUp
-    color = 'text-green-400'
+    if (!neutral) color = 'text-green-400'
     sign = '+'
   } else if (rounded < 0) {
     Icon = ArrowDown
-    color = 'text-red-400'
+    if (!neutral) color = 'text-red-400'
     sign = '−' // minus sign
   }
   return (
@@ -110,9 +112,12 @@ export default function LactateTests() {
         </div>
       )}
 
-      {!isLoading && tests.length >= 2 && (() => {
+      {!isLoading && tests.length >= 1 && (() => {
+        // A single test still has a threshold worth showing — only the deltas
+        // need a second test to compare against.
+        const hasComparison = tests.length >= 2
         const latest = validThreshold(tests[0])
-        const previous = validThreshold(tests[1])
+        const previous = hasComparison ? validThreshold(tests[1]) : null
         return (
           <div className="bg-gray-800 border border-gray-700 rounded-xl p-4 mb-6">
             <div className="flex items-center gap-2 mb-3">
@@ -135,7 +140,7 @@ export default function LactateTests() {
             {latest && previous ? (
               <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-sm">
                 <DeltaBadge value={latest.speed_kmh - previous.speed_kmh} unit={t('units.kmh')} decimals={1} />
-                <DeltaBadge value={latest.heart_rate_bpm - previous.heart_rate_bpm} unit={t('units.bpm')} decimals={0} />
+                <DeltaBadge value={latest.heart_rate_bpm - previous.heart_rate_bpm} unit={t('units.bpm')} decimals={0} neutral />
                 <span className="text-xs text-gray-500">{t('summary.vsPrevious')}</span>
               </div>
             ) : (


### PR DESCRIPTION
## Changes

- **Show the latest-threshold card after a single lactate test** - The summary card on the lactate list used to require two tests, so the first recorded test showed no threshold speed or heart rate at all. It now appears from the first test, with the "no previous test to compare" note in place of the delta badges. The Insights link still needs two tests. (Hytte-9oo7h)
- **Render the threshold heart-rate delta neutrally** - A rising threshold heart rate was coloured green like a speed improvement, which it is not. The bpm badge is now gray in every direction while keeping its arrow and signed value. (Hytte-9oo7h)

## Original Issue (feature): Show the latest-threshold summary card for users with a single test

Here's the plan.

### Scope
Fix the latest-threshold summary card on `/lactate` so it renders for users with exactly one recorded test, and make the heart-rate delta render neutrally instead of green-for-up. Today the card block in `web/src/pages/LactateTests.tsx:113` is gated on `tests.length >= 2`, which makes the existing `summary.noPreviousComparison` branch (line 142) dead code and hides the threshold speed/HR from anyone with a single test — even though `primary_threshold` comes back from `GET /api/lactate/tests` for every test. `DeltaBadge` (line 16) hardcodes green for a positive value, which is semantically wrong for HR. This is a frontend-only change; no backend or schema work.

### Files to touch
- `web/src/pages/LactateTests.tsx` — lower the summary-card gate to `tests.length >= 1`; leave the Insights link at `>= 2`; add a neutral/"no semantic direction" mode to `DeltaBadge` and use it for the bpm badge.
- `web/public/locales/{en,nb,th}/lactate.json` — only if a new key is needed (e.g. an explicit HR-change label under `summary.*`). Add to all three languages if so.
- `web/src/pages/LactateTests.test.tsx` (new) — render tests for the 0/1/2-test cases, following the existing `web/src/pages/*.test.tsx` vitest + Testing Library patterns.
- `changelog.d/<slug>.md` (new) — `category: Fixed` fragment.

### Acceptance criteria
- A user with exactly one lactate test sees the "Latest threshold" card with that test's speed (km/h), HR (bpm) and method.
- That same user sees the `summary.noPreviousComparison` line and no delta badges.
- A user with zero tests sees no summary card at all (unchanged).
- A user with a single test does **not** see the Insights link; at two or more tests it appears (unchanged).
- If the single test's `primary_threshold` is missing or `valid: false`, the card renders the `summary.noResultYet` fallback rather than crashing or showing NaN.
- With two or more tests, the speed DeltaBadge keeps green-up / red-down; the HR DeltaBadge renders gray in all directions, keeping the up/down/flat arrow and the signed value.
- Any new i18n key exists in `en`, `nb` and `th` `lactate.json`; no hardcoded English is added to JSX.
- `npm run lint`, `npm run build` and `npm test` pass in `web/`.

### Non-goals
- No backend changes to `internal/lactate/` — `primary_threshold` is already returned by `List`.
- No change to the Insights page, its `>= 2` requirement, or the empty-state copy on the list page.
- No redesign of the card layout, no new metrics (lactate values, zones, trends) in the card.
- No change to how thresholds are computed, or to the `validThreshold` validity rule.
- Not revisiting delta colouring anywhere outside this card (e.g. `LactateInsights.tsx`, `LactateTestDetail.tsx`).

## Source

Created from Suggestions page (suggestion id 273, page slug "lactate", source=claude).

## Original suggestion

In LactateTests.tsx the summary card is gated behind `tests.length >= 2`, so anyone with exactly one test sees no threshold summary at all — even though `primary_threshold` is already computed and returned by the backend `List` for every test. The card even has a `summary.noPreviousComparison` branch that can never render for a one-test user. Lower the gate to `tests.length >= 1` (keep the Insights link at >= 2) so the first recorded test immediately shows its threshold speed and HR. While in the same card, stop colouring the heart-rate DeltaBadge green for a rise: a higher threshold HR is not an improvement the way a higher threshold speed is, so it should render neutral (gray) with the arrow only, or be relabelled explicitly.


---
Bead: Hytte-9oo7h | Branch: forge/Hytte-9oo7h
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->