### PR TITLE
Encrypt chat message content and conversation titles at rest (Hytte-a8zgt)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ When reviewing PRs, check against the warden rules in `.forge/warden-rules.yaml`
 ### Security & Encryption
 - **All sensitive user data must be encrypted at rest** using `internal/encryption/encryption.go`
 - Use `encryption.EncryptField()` on write, `encryption.DecryptField()` on read
-- Encrypted fields: workout title/notes, note title/content, lactate stage data, push endpoints, VAPID private key, analysis prompt/response, claude_cli_path
+- Encrypted fields: workout title/notes, note title/content, lactate stage data, push endpoints, VAPID private key, analysis prompt/response, claude_cli_path, chat conversation titles and message content
 - Do NOT encrypt fields needed for SQL queries: IDs, timestamps, sport, duration, distance, HR, tags, email
 - Session tokens must be hashed (SHA-256) — never store raw tokens in the DB
 - Public route lists in docs/changelog must match actual code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ Hytte/
   - Push subscriptions: endpoint URLs
   - VAPID: private_key
   - Analysis: prompt, response_json
+  - Chat: conversation title, message content (`chat_conversations.title`, `chat_messages.content`)
   - User preferences: claude_cli_path
   - Sessions: user_agent, ip_address (sign-in metadata; the token column holds a SHA-256 hash, not ciphertext)
 - **Fields that must NOT be encrypted** (needed for queries/filtering): IDs, timestamps, status fields, sport, duration, distance, heart rate, tags, labels, email

--- a/changelog.d/Hytte-a8zgt.md
+++ b/changelog.d/Hytte-a8zgt.md
@@ -1,0 +1,2 @@
+category: Security
+- **Chat transcripts are now encrypted at rest** - Chat message content and conversation titles are encrypted with AES-256-GCM before being written to SQLite, matching the convention already used for notes and workout analyses. Existing plaintext rows keep rendering and are re-encrypted the next time they are written. (Hytte-a8zgt)

--- a/internal/chat/handlers.go
+++ b/internal/chat/handlers.go
@@ -602,15 +602,12 @@ func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, event string, pa
 // and updates the row in place. The caller controls the deadline via ctx.
 func autoTitle(ctx context.Context, db *sql.DB, cfg *training.ClaudeConfig, convoID, userID int64, firstMessage string) {
 	// Re-check the title under the caller's context to avoid overwriting a user-set title.
-	// The stored title is encrypted, so compare against the decrypted value.
-	var currentTitle string
-	if err := db.QueryRowContext(ctx,
-		"SELECT title FROM chat_conversations WHERE id = ? AND user_id = ?",
-		convoID, userID,
-	).Scan(&currentTitle); err != nil {
+	// Read through the store so the stored ciphertext is decrypted before comparison.
+	convo, err := GetConversationContext(ctx, db, convoID, userID)
+	if err != nil {
 		return
 	}
-	if decryptOrRaw(currentTitle) != "" {
+	if convo.Title != "" {
 		return
 	}
 

--- a/internal/chat/handlers.go
+++ b/internal/chat/handlers.go
@@ -602,6 +602,7 @@ func writeSSEEvent(w http.ResponseWriter, flusher http.Flusher, event string, pa
 // and updates the row in place. The caller controls the deadline via ctx.
 func autoTitle(ctx context.Context, db *sql.DB, cfg *training.ClaudeConfig, convoID, userID int64, firstMessage string) {
 	// Re-check the title under the caller's context to avoid overwriting a user-set title.
+	// The stored title is encrypted, so compare against the decrypted value.
 	var currentTitle string
 	if err := db.QueryRowContext(ctx,
 		"SELECT title FROM chat_conversations WHERE id = ? AND user_id = ?",
@@ -609,7 +610,7 @@ func autoTitle(ctx context.Context, db *sql.DB, cfg *training.ClaudeConfig, conv
 	).Scan(&currentTitle); err != nil {
 		return
 	}
-	if currentTitle != "" {
+	if decryptOrRaw(currentTitle) != "" {
 		return
 	}
 

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -2,13 +2,32 @@ package chat
 
 import (
 	"database/sql"
+	"log"
 	"strings"
 	"time"
+
+	"github.com/Robin831/Hytte/internal/encryption"
 )
 
 // timeFormat is a fixed-width UTC timestamp with millisecond precision,
 // ensuring correct lexicographic ordering and consistent string widths.
 const timeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+// decryptOrRaw decrypts a stored conversation title or message body, falling
+// back to the raw column value if decryption fails. Legacy rows written before
+// encryption carry no ciphertext prefix and are returned unchanged by
+// DecryptField; a corrupt ciphertext row would otherwise fail the whole
+// request, so we log and surface the stored value instead. We deliberately do
+// not use encryption.DecryptLenient here — it blanks the value, which would
+// silently drop chat history.
+func decryptOrRaw(value string) string {
+	plain, err := encryption.DecryptField(value)
+	if err != nil {
+		log.Printf("chat: decrypt failed, returning raw stored value: %v", err)
+		return value
+	}
+	return plain
+}
 
 // Conversation represents a chat conversation.
 type Conversation struct {
@@ -50,6 +69,7 @@ func ListConversations(db *sql.DB, userID int64) ([]Conversation, error) {
 		if err := rows.Scan(&c.ID, &c.UserID, &c.Title, &c.Model, &c.SessionID, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
+		c.Title = decryptOrRaw(c.Title)
 		convos = append(convos, c)
 	}
 	return convos, rows.Err()
@@ -58,10 +78,14 @@ func ListConversations(db *sql.DB, userID int64) ([]Conversation, error) {
 // CreateConversation inserts a new conversation and returns it.
 func CreateConversation(db *sql.DB, userID int64, title, model string) (*Conversation, error) {
 	now := time.Now().UTC().Format(timeFormat)
+	encTitle, err := encryption.EncryptField(title)
+	if err != nil {
+		return nil, err
+	}
 	result, err := db.Exec(
 		`INSERT INTO chat_conversations (user_id, title, model, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?)`,
-		userID, title, model, now, now,
+		userID, encTitle, model, now, now,
 	)
 	if err != nil {
 		return nil, err
@@ -92,6 +116,7 @@ func GetConversation(db *sql.DB, id, userID int64) (*Conversation, error) {
 	if err != nil {
 		return nil, err
 	}
+	c.Title = decryptOrRaw(c.Title)
 	return &c, nil
 }
 
@@ -118,9 +143,13 @@ func DeleteConversation(db *sql.DB, id, userID int64) error {
 // RenameConversation updates the title of a conversation owned by the given user.
 func RenameConversation(db *sql.DB, id, userID int64, title string) (*Conversation, error) {
 	now := time.Now().UTC().Format(timeFormat)
+	encTitle, err := encryption.EncryptField(title)
+	if err != nil {
+		return nil, err
+	}
 	result, err := db.Exec(
 		`UPDATE chat_conversations SET title = ?, updated_at = ? WHERE id = ? AND user_id = ?`,
-		title, now, id, userID,
+		encTitle, now, id, userID,
 	)
 	if err != nil {
 		return nil, err
@@ -144,8 +173,12 @@ func UpdateConversation(db *sql.DB, id, userID int64, title, model *string) (*Co
 	sets := []string{"updated_at = ?"}
 	args := []any{now}
 	if title != nil {
+		encTitle, err := encryption.EncryptField(*title)
+		if err != nil {
+			return nil, err
+		}
 		sets = append(sets, "title = ?")
-		args = append(args, *title)
+		args = append(args, encTitle)
 	}
 	if model != nil {
 		sets = append(sets, "model = ?")
@@ -188,6 +221,7 @@ func GetMessages(db *sql.DB, conversationID int64) ([]Message, error) {
 		if err := rows.Scan(&m.ID, &m.ConversationID, &m.Role, &m.Content, &m.CreatedAt); err != nil {
 			return nil, err
 		}
+		m.Content = decryptOrRaw(m.Content)
 		msgs = append(msgs, m)
 	}
 	return msgs, rows.Err()
@@ -222,6 +256,7 @@ func TruncateFrom(db *sql.DB, conversationID, userID, messageID int64) (*Message
 		// conversation, or the conversation isn't owned by this user.
 		return nil, err
 	}
+	m.Content = decryptOrRaw(m.Content)
 
 	// Delete the target and everything after it using the same
 	// (created_at, id) ordering GetMessages reads with, so the surviving
@@ -274,6 +309,11 @@ func UpdateSessionID(db *sql.DB, conversationID, userID int64, sessionID string)
 func InsertMessage(db *sql.DB, conversationID int64, role, content string) (*Message, error) {
 	now := time.Now().UTC().Format(timeFormat)
 
+	encContent, err := encryption.EncryptField(content)
+	if err != nil {
+		return nil, err
+	}
+
 	tx, err := db.Begin()
 	if err != nil {
 		return nil, err
@@ -282,7 +322,7 @@ func InsertMessage(db *sql.DB, conversationID int64, role, content string) (*Mes
 	result, err := tx.Exec(
 		`INSERT INTO chat_messages (conversation_id, role, content, created_at)
 		 VALUES (?, ?, ?, ?)`,
-		conversationID, role, content, now,
+		conversationID, role, encContent, now,
 	)
 	if err != nil {
 		_ = tx.Rollback()

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -1,9 +1,11 @@
 package chat
 
 import (
+	"context"
 	"database/sql"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Robin831/Hytte/internal/encryption"
@@ -12,6 +14,43 @@ import (
 // timeFormat is a fixed-width UTC timestamp with millisecond precision,
 // ensuring correct lexicographic ordering and consistent string widths.
 const timeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+// decryptLogInterval is the minimum spacing between decrypt-failure warnings.
+const decryptLogInterval = time.Minute
+
+// decryptFailures rate-limits the decrypt-failure warning. Decryption runs per
+// row, so a single corrupt conversation would otherwise emit one log line for
+// every row of every list request — enough to drown the journal. We log the
+// first failure immediately and then at most one line per decryptLogInterval,
+// reporting how many failures were suppressed in between so the volume stays
+// visible.
+var decryptFailures struct {
+	mu         sync.Mutex
+	lastLogged time.Time
+	suppressed int
+}
+
+// logDecryptFailure emits a rate-limited warning for a failed decrypt.
+func logDecryptFailure(err error) {
+	decryptFailures.mu.Lock()
+	defer decryptFailures.mu.Unlock()
+
+	now := time.Now()
+	if !decryptFailures.lastLogged.IsZero() && now.Sub(decryptFailures.lastLogged) < decryptLogInterval {
+		decryptFailures.suppressed++
+		return
+	}
+	suppressed := decryptFailures.suppressed
+	decryptFailures.suppressed = 0
+	decryptFailures.lastLogged = now
+
+	if suppressed > 0 {
+		log.Printf("chat: decrypt failed, returning raw stored value: %v (%d further failures suppressed in the last %s)",
+			err, suppressed, decryptLogInterval)
+		return
+	}
+	log.Printf("chat: decrypt failed, returning raw stored value: %v", err)
+}
 
 // decryptOrRaw decrypts a stored conversation title or message body, falling
 // back to the raw column value if decryption fails. Legacy rows written before
@@ -23,7 +62,7 @@ const timeFormat = "2006-01-02T15:04:05.000Z07:00"
 func decryptOrRaw(value string) string {
 	plain, err := encryption.DecryptField(value)
 	if err != nil {
-		log.Printf("chat: decrypt failed, returning raw stored value: %v", err)
+		logDecryptFailure(err)
 		return value
 	}
 	return plain
@@ -106,8 +145,14 @@ func CreateConversation(db *sql.DB, userID int64, title, model string) (*Convers
 
 // GetConversation returns a single conversation owned by the given user.
 func GetConversation(db *sql.DB, id, userID int64) (*Conversation, error) {
+	return GetConversationContext(context.Background(), db, id, userID)
+}
+
+// GetConversationContext is GetConversation with a caller-controlled deadline,
+// for callers running outside a request goroutine (see autoTitle).
+func GetConversationContext(ctx context.Context, db *sql.DB, id, userID int64) (*Conversation, error) {
 	var c Conversation
-	err := db.QueryRow(
+	err := db.QueryRowContext(ctx,
 		`SELECT id, user_id, title, model, session_id, created_at, updated_at
 		 FROM chat_conversations
 		 WHERE id = ? AND user_id = ?`,

--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -3,13 +3,29 @@ package chat
 import (
 	"database/sql"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/Robin831/Hytte/internal/db"
+	"github.com/Robin831/Hytte/internal/encryption"
 )
+
+// rawColumn reads a single string column straight from SQLite, bypassing the
+// store's decrypt path, so tests can assert what is actually stored at rest.
+func rawColumn(t *testing.T, d *sql.DB, query string, args ...any) string {
+	t.Helper()
+	var v string
+	if err := d.QueryRow(query, args...).Scan(&v); err != nil {
+		t.Fatalf("read raw column: %v", err)
+	}
+	return v
+}
 
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
+	t.Setenv("ENCRYPTION_KEY", "test-key-for-chat-tests")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
 	d, err := db.Init(":memory:")
 	if err != nil {
 		t.Fatalf("init test db: %v", err)
@@ -426,5 +442,268 @@ func TestTruncateFrom_MessageFromAnotherConversation(t *testing.T) {
 	}
 	if len(aMsgs) != 1 || len(bMsgs) != 1 {
 		t.Fatalf("expected both conversations untouched, got a=%d b=%d", len(aMsgs), len(bMsgs))
+	}
+}
+
+func TestEncryptionAtRest(t *testing.T) {
+	d := setupTestDB(t)
+
+	const title = "Secret Title"
+	const content = "Secret message body"
+
+	c, err := CreateConversation(d, 1, title, "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	m, err := InsertMessage(d, c.ID, "user", content)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	storedTitle := rawColumn(t, d, `SELECT title FROM chat_conversations WHERE id = ?`, c.ID)
+	if storedTitle == title {
+		t.Fatalf("title stored as plaintext: %q", storedTitle)
+	}
+	if !strings.HasPrefix(storedTitle, "enc:") {
+		t.Fatalf("expected ciphertext prefix on stored title, got %q", storedTitle)
+	}
+
+	storedContent := rawColumn(t, d, `SELECT content FROM chat_messages WHERE id = ?`, m.ID)
+	if storedContent == content {
+		t.Fatalf("content stored as plaintext: %q", storedContent)
+	}
+	if !strings.HasPrefix(storedContent, "enc:") {
+		t.Fatalf("expected ciphertext prefix on stored content, got %q", storedContent)
+	}
+
+	// Model, role, session_id and timestamps stay queryable plaintext.
+	storedModel := rawColumn(t, d, `SELECT model FROM chat_conversations WHERE id = ?`, c.ID)
+	if storedModel != "claude-sonnet-4-6" {
+		t.Fatalf("expected plaintext model, got %q", storedModel)
+	}
+	storedRole := rawColumn(t, d, `SELECT role FROM chat_messages WHERE id = ?`, m.ID)
+	if storedRole != "user" {
+		t.Fatalf("expected plaintext role, got %q", storedRole)
+	}
+}
+
+func TestEncryptionRoundTrip(t *testing.T) {
+	d := setupTestDB(t)
+
+	c, err := CreateConversation(d, 1, "Round Trip", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := InsertMessage(d, c.ID, "user", "Hello there"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := InsertMessage(d, c.ID, "assistant", "General Kenobi"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	got, err := GetConversation(d, c.ID, 1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "Round Trip" {
+		t.Fatalf("expected decrypted title, got %q", got.Title)
+	}
+
+	convos, err := ListConversations(d, 1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(convos) != 1 || convos[0].Title != "Round Trip" {
+		t.Fatalf("expected decrypted title in list, got %+v", convos)
+	}
+
+	msgs, err := GetMessages(d, c.ID)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+	if len(msgs) != 2 || msgs[0].Content != "Hello there" || msgs[1].Content != "General Kenobi" {
+		t.Fatalf("expected decrypted message content, got %+v", msgs)
+	}
+
+	// Rename and UpdateConversation also round-trip.
+	renamed, err := RenameConversation(d, c.ID, 1, "Renamed")
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if renamed.Title != "Renamed" {
+		t.Fatalf("expected 'Renamed', got %q", renamed.Title)
+	}
+	if stored := rawColumn(t, d, `SELECT title FROM chat_conversations WHERE id = ?`, c.ID); stored == "Renamed" {
+		t.Fatalf("rename stored plaintext title")
+	}
+
+	newTitle := "Updated"
+	updated, err := UpdateConversation(d, c.ID, 1, &newTitle, nil)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Title != "Updated" {
+		t.Fatalf("expected 'Updated', got %q", updated.Title)
+	}
+	if stored := rawColumn(t, d, `SELECT title FROM chat_conversations WHERE id = ?`, c.ID); stored == "Updated" {
+		t.Fatalf("update stored plaintext title")
+	}
+}
+
+func TestEmptyTitleStaysEmpty(t *testing.T) {
+	d := setupTestDB(t)
+
+	c, err := CreateConversation(d, 1, "", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if c.Title != "" {
+		t.Fatalf("expected empty title from create, got %q", c.Title)
+	}
+	if stored := rawColumn(t, d, `SELECT title FROM chat_conversations WHERE id = ?`, c.ID); stored != "" {
+		t.Fatalf("expected empty title stored as empty, got %q", stored)
+	}
+	got, err := GetConversation(d, c.ID, 1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "" {
+		t.Fatalf("expected empty title on read, got %q", got.Title)
+	}
+}
+
+func TestLegacyPlaintextRowsStillRead(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Simulate rows written before encryption was introduced: no ciphertext prefix.
+	res, err := d.Exec(
+		`INSERT INTO chat_conversations (user_id, title, model, created_at, updated_at)
+		 VALUES (1, 'Legacy Title', 'claude-sonnet-4-6', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+	)
+	if err != nil {
+		t.Fatalf("insert legacy conversation: %v", err)
+	}
+	convoID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	if _, err := d.Exec(
+		`INSERT INTO chat_messages (conversation_id, role, content, created_at)
+		 VALUES (?, 'user', 'Legacy content', '2026-01-01T00:00:00.000Z')`,
+		convoID,
+	); err != nil {
+		t.Fatalf("insert legacy message: %v", err)
+	}
+
+	got, err := GetConversation(d, convoID, 1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "Legacy Title" {
+		t.Fatalf("expected legacy title unchanged, got %q", got.Title)
+	}
+
+	convos, err := ListConversations(d, 1)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(convos) != 1 || convos[0].Title != "Legacy Title" {
+		t.Fatalf("expected legacy title in list, got %+v", convos)
+	}
+
+	msgs, err := GetMessages(d, convoID)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Content != "Legacy content" {
+		t.Fatalf("expected legacy content unchanged, got %+v", msgs)
+	}
+
+	// A legacy row is re-encrypted the next time it is written.
+	if _, err := RenameConversation(d, convoID, 1, "Now Encrypted"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	stored := rawColumn(t, d, `SELECT title FROM chat_conversations WHERE id = ?`, convoID)
+	if !strings.HasPrefix(stored, "enc:") {
+		t.Fatalf("expected re-encrypted title, got %q", stored)
+	}
+}
+
+func TestCorruptCiphertextFallsBackToRawValue(t *testing.T) {
+	d := setupTestDB(t)
+
+	res, err := d.Exec(
+		`INSERT INTO chat_conversations (user_id, title, model, created_at, updated_at)
+		 VALUES (1, 'enc:not-valid-ciphertext', 'claude-sonnet-4-6', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+	)
+	if err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+	convoID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	if _, err := d.Exec(
+		`INSERT INTO chat_messages (conversation_id, role, content, created_at)
+		 VALUES (?, 'user', 'enc:also-garbage', '2026-01-01T00:00:00.000Z')`,
+		convoID,
+	); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+
+	got, err := GetConversation(d, convoID, 1)
+	if err != nil {
+		t.Fatalf("get should not fail on corrupt ciphertext: %v", err)
+	}
+	if got.Title != "enc:not-valid-ciphertext" {
+		t.Fatalf("expected raw stored title, got %q", got.Title)
+	}
+
+	convos, err := ListConversations(d, 1)
+	if err != nil {
+		t.Fatalf("list should not fail on corrupt ciphertext: %v", err)
+	}
+	if len(convos) != 1 || convos[0].Title != "enc:not-valid-ciphertext" {
+		t.Fatalf("expected raw stored title in list, got %+v", convos)
+	}
+
+	msgs, err := GetMessages(d, convoID)
+	if err != nil {
+		t.Fatalf("get messages should not fail on corrupt ciphertext: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Content != "enc:also-garbage" {
+		t.Fatalf("expected raw stored content, got %+v", msgs)
+	}
+}
+
+func TestTruncateFromReturnsDecryptedContent(t *testing.T) {
+	d := setupTestDB(t)
+
+	c, err := CreateConversation(d, 1, "Truncate", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	target, err := InsertMessage(d, c.ID, "user", "Regenerate me")
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := InsertMessage(d, c.ID, "assistant", "Old reply"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	deleted, err := TruncateFrom(d, c.ID, 1, target.ID)
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if deleted.Content != "Regenerate me" {
+		t.Fatalf("expected decrypted content, got %q", deleted.Content)
+	}
+
+	msgs, err := GetMessages(d, c.ID)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("expected all messages deleted, got %d", len(msgs))
 	}
 }

--- a/internal/chat/store_test.go
+++ b/internal/chat/store_test.go
@@ -1,14 +1,28 @@
 package chat
 
 import (
+	"bytes"
 	"database/sql"
+	"log"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Robin831/Hytte/internal/db"
 	"github.com/Robin831/Hytte/internal/encryption"
 )
+
+// TestMain pins the encryption key for the whole test binary. The key lives in
+// a process-global singleton inside internal/encryption, so deriving it once
+// here keeps individual tests from repeatedly mutating shared state that every
+// other test in this package (and any goroutine they leave running) reads.
+func TestMain(m *testing.M) {
+	os.Setenv("ENCRYPTION_KEY", "test-key-for-chat-tests")
+	encryption.ResetEncryptionKey()
+	os.Exit(m.Run())
+}
 
 // rawColumn reads a single string column straight from SQLite, bypassing the
 // store's decrypt path, so tests can assert what is actually stored at rest.
@@ -23,9 +37,6 @@ func rawColumn(t *testing.T, d *sql.DB, query string, args ...any) string {
 
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	t.Setenv("ENCRYPTION_KEY", "test-key-for-chat-tests")
-	encryption.ResetEncryptionKey()
-	t.Cleanup(func() { encryption.ResetEncryptionKey() })
 	d, err := db.Init(":memory:")
 	if err != nil {
 		t.Fatalf("init test db: %v", err)
@@ -673,6 +684,59 @@ func TestCorruptCiphertextFallsBackToRawValue(t *testing.T) {
 	}
 	if len(msgs) != 1 || msgs[0].Content != "enc:also-garbage" {
 		t.Fatalf("expected raw stored content, got %+v", msgs)
+	}
+}
+
+func TestDecryptFailureLoggingIsRateLimited(t *testing.T) {
+	d := setupTestDB(t)
+
+	// A conversation whose title and every message are undecryptable, so a
+	// single list + read pass decrypts many failing rows.
+	res, err := d.Exec(
+		`INSERT INTO chat_conversations (user_id, title, model, created_at, updated_at)
+		 VALUES (1, 'enc:not-valid-ciphertext', 'claude-sonnet-4-6', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+	)
+	if err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+	convoID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		if _, err := d.Exec(
+			`INSERT INTO chat_messages (conversation_id, role, content, created_at)
+			 VALUES (?, 'user', 'enc:also-garbage', ?)`,
+			convoID, "2026-01-01T00:00:0"+strconv.Itoa(i%10)+".000Z",
+		); err != nil {
+			t.Fatalf("insert message: %v", err)
+		}
+	}
+
+	// Reset the limiter so this test sees a clean window, and restore the
+	// default log destination afterwards.
+	decryptFailures.mu.Lock()
+	decryptFailures.lastLogged = time.Time{}
+	decryptFailures.suppressed = 0
+	decryptFailures.mu.Unlock()
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	for i := 0; i < 5; i++ {
+		if _, err := ListConversations(d, 1); err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if _, err := GetMessages(d, convoID); err != nil {
+			t.Fatalf("get messages: %v", err)
+		}
+	}
+
+	// 5 * (1 title + 20 messages) = 105 decrypt failures, but the limiter
+	// allows only the first one inside a decryptLogInterval window.
+	if n := strings.Count(buf.String(), "chat: decrypt failed"); n != 1 {
+		t.Fatalf("expected 1 rate-limited log line, got %d:\n%s", n, buf.String())
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Chat transcripts are now encrypted at rest** - Chat message content and conversation titles are encrypted with AES-256-GCM before being written to SQLite, matching the convention already used for notes and workout analyses. Existing plaintext rows keep rendering and are re-encrypted the next time they are written. (Hytte-a8zgt)

## Original Issue (feature): Encrypt chat message content and conversation titles at rest

### Scope
Encrypt `chat_messages.content` and `chat_conversations.title` at rest in `internal/chat/store.go`, using the existing `internal/encryption` helpers, so the Chat feature matches the project convention already applied to notes, workout notes and analysis. Encryption is applied at the store boundary only: handlers and the React client keep seeing plaintext, so there is no API or UI change. Reads stay backward compatible — `DecryptField` already returns unprefixed legacy values unchanged, and a decrypt error on a prefixed value falls back to the raw column value plus a log warning rather than failing the request.

### Files to touch
- `internal/chat/store.go` — encrypt on write in `CreateConversation`, `UpdateConversation`, `RenameConversation`, `InsertMessage`; decrypt on read in `ListConversations`, `GetConversation`, `GetMessages`, `TruncateFrom`. Add a small package-local `decryptOrRaw(value string) string` helper (log + return raw on error) since `encryption.DecryptLenient` blanks the value instead of preserving it.
- `internal/chat/handlers.go` — the inline `SELECT title FROM chat_conversations` in `autoTitle` (~line 607) must read through the decrypt path (simplest: call `GetConversation`) so the "title already set?" guard stays correct.
- `internal/chat/store_test.go` — round-trip and legacy-plaintext tests.
- `changelog.d/<bead-id>.md` (new) — `category: Security` fragment.

### Acceptance criteria
- After sending a chat message, `sqlite3 hytte.db "SELECT content FROM chat_messages"` and `SELECT title FROM chat_conversations` show prefixed ciphertext, not readable text.
- The Chat page (`/chat`) shows conversation titles, message history, streaming replies, rename, regenerate and edit exactly as before, for both newly created and pre-existing rows.
- Rows written before this change (plaintext, no ciphertext prefix) still render correctly and are re-encrypted the next time their row is written.
- Auto-title generation still fires only for untitled conversations and never overwrites a user-set title.
- A corrupt/undecryptable ciphertext row logs a warning and returns the raw stored value; the list and message endpoints still return 200.
- `TruncateFrom` returns the decrypted content of the deleted message (Regenerate/Edit prefill the composer with real text).
- Empty titles stay empty end to end (`EncryptField("") == ""`), so `convo.Title == ""` checks keep working.
- `make test` and `go vet ./...` pass; a store test asserts the DB column is not equal to the plaintext.

### Non-goals
- No backfill/migration job to re-encrypt existing rows — they convert lazily on next write.
- `session_id`, `model`, `role`, IDs and timestamps stay plaintext (needed for queries/filtering).
- No change to `internal/stride` chat storage or `family_chat_*` tables.
- No searching/filtering over chat content (encryption makes SQL `LIKE` on content impossible; not currently offered).
- No frontend changes, no API shape changes, no changes to `internal/encryption` itself.

## Source

Created from Suggestions page (suggestion id 335, page slug "chat", source=claude).

## Original suggestion

`chat_messages.content` and `chat_conversations.title` are written and read as plaintext in `internal/chat/store.go`, even though the project convention requires sensitive user text (notes, workout notes, analysis prompts/responses) to go through `encryption.EncryptField`/`DecryptField`. Chat transcripts are at least as sensitive as notes, and auto-generated titles are derived from them. Wrap the insert/select paths in `InsertMessage`, `GetMessages`, `TruncateFrom`, `CreateConversation`, `UpdateConversation` and `ListConversations` with the encryption helpers, tolerating decrypt failures by returning the raw value so existing rows keep rendering. This closes a documented security gap with no user-visible behaviour change beyond the data being unreadable in the SQLite file.


---
Bead: Hytte-a8zgt | Branch: forge/Hytte-a8zgt
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->