### PR TITLE
Surface the API's real error message instead of a generic banner (Hytte-aut7n)

### DIFF
--- a/changelog.d/Hytte-aut7n.md
+++ b/changelog.d/Hytte-aut7n.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Wardrobe forms show the real reason a save failed** - Validation errors from the API (measurement out of range, name is required, birthdate format, quantity limits, category in use) are now translated and shown inside the form that caused them instead of a generic "failed to save" banner, and the dialog stays open with the entered values. (Hytte-aut7n)

--- a/web/public/locales/en/wardrobe.json
+++ b/web/public/locales/en/wardrobe.json
@@ -115,6 +115,23 @@
   "errors": {
     "failedToLoad": "Failed to load wardrobe data",
     "failedToSave": "Failed to save",
-    "failedToDelete": "Failed to delete"
+    "failedToDelete": "Failed to delete",
+    "server": {
+      "nameRequired": "Name is required",
+      "birthdateFormat": "Birthdate must be a valid date (YYYY-MM-DD)",
+      "measuredAtFormat": "The measurement date must be a valid date (YYYY-MM-DD)",
+      "measurementOutOfRange": "The measurement is out of range — check height, foot length and weight",
+      "measurementRequired": "Enter at least one measurement",
+      "quantityMax": "Quantity can be at most 99",
+      "invalidCondition": "Choose a valid condition",
+      "invalidStatus": "Choose a valid status",
+      "invalidLocation": "Choose a valid location",
+      "invalidSeason": "Choose a valid season",
+      "kidRequired": "Choose a child",
+      "kidNotFound": "That child no longer exists",
+      "categoryNotFound": "That category no longer exists",
+      "targetQtyRange": "Target must be between 0 and 99",
+      "invalidSizeSystem": "Choose a valid sizing system"
+    }
   }
 }

--- a/web/public/locales/nb/wardrobe.json
+++ b/web/public/locales/nb/wardrobe.json
@@ -115,6 +115,23 @@
   "errors": {
     "failedToLoad": "Kunne ikke laste garderobedata",
     "failedToSave": "Kunne ikke lagre",
-    "failedToDelete": "Kunne ikke slette"
+    "failedToDelete": "Kunne ikke slette",
+    "server": {
+      "nameRequired": "Navn er påkrevd",
+      "birthdateFormat": "Fødselsdato må være en gyldig dato (ÅÅÅÅ-MM-DD)",
+      "measuredAtFormat": "Måledatoen må være en gyldig dato (ÅÅÅÅ-MM-DD)",
+      "measurementOutOfRange": "Målingen er utenfor gyldig område – sjekk høyde, fotlengde og vekt",
+      "measurementRequired": "Fyll inn minst én måling",
+      "quantityMax": "Antall kan være høyst 99",
+      "invalidCondition": "Velg en gyldig tilstand",
+      "invalidStatus": "Velg en gyldig status",
+      "invalidLocation": "Velg et gyldig sted",
+      "invalidSeason": "Velg en gyldig sesong",
+      "kidRequired": "Velg et barn",
+      "kidNotFound": "Barnet finnes ikke lenger",
+      "categoryNotFound": "Kategorien finnes ikke lenger",
+      "targetQtyRange": "Målet må være mellom 0 og 99",
+      "invalidSizeSystem": "Velg et gyldig størrelsessystem"
+    }
   }
 }

--- a/web/public/locales/th/wardrobe.json
+++ b/web/public/locales/th/wardrobe.json
@@ -115,6 +115,23 @@
   "errors": {
     "failedToLoad": "โหลดข้อมูลตู้เสื้อผ้าไม่สำเร็จ",
     "failedToSave": "บันทึกไม่สำเร็จ",
-    "failedToDelete": "ลบไม่สำเร็จ"
+    "failedToDelete": "ลบไม่สำเร็จ",
+    "server": {
+      "nameRequired": "ต้องระบุชื่อ",
+      "birthdateFormat": "วันเกิดต้องเป็นวันที่ที่ถูกต้อง (ปปปป-ดด-วว)",
+      "measuredAtFormat": "วันที่วัดต้องเป็นวันที่ที่ถูกต้อง (ปปปป-ดด-วว)",
+      "measurementOutOfRange": "ค่าที่วัดอยู่นอกช่วงที่กำหนด — ตรวจสอบส่วนสูง ความยาวเท้า และน้ำหนัก",
+      "measurementRequired": "กรอกค่าที่วัดอย่างน้อยหนึ่งรายการ",
+      "quantityMax": "จำนวนต้องไม่เกิน 99",
+      "invalidCondition": "เลือกสภาพที่ถูกต้อง",
+      "invalidStatus": "เลือกสถานะที่ถูกต้อง",
+      "invalidLocation": "เลือกสถานที่ที่ถูกต้อง",
+      "invalidSeason": "เลือกฤดูกาลที่ถูกต้อง",
+      "kidRequired": "เลือกเด็ก",
+      "kidNotFound": "ไม่พบเด็กคนนี้แล้ว",
+      "categoryNotFound": "ไม่พบหมวดหมู่นี้แล้ว",
+      "targetQtyRange": "เป้าต้องอยู่ระหว่าง 0 ถึง 99",
+      "invalidSizeSystem": "เลือกระบบไซซ์ที่ถูกต้อง"
+    }
   }
 }

--- a/web/src/pages/WardrobePage.test.tsx
+++ b/web/src/pages/WardrobePage.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import WardrobePage from './WardrobePage'
+import WardrobePage, { ApiError, api, messageFor } from './WardrobePage'
 
 // ── Translation mock ──────────────────────────────────────────────────────────
 // mockT must be a stable reference — WardrobePage's load effects have `t` as a
@@ -23,7 +23,17 @@ const TRANSLATIONS: Record<string, string> = {
   'needs.missingTitle': 'Missing',
   'needs.empty': 'All covered',
   'inventory.empty': 'No items here yet',
+  'kidForm.name': 'Name',
+  'measurements.add': 'New measurement',
+  'measurements.height': 'Height (cm)',
+  'common:actions.save': 'Save',
   'errors.failedToLoad': 'Failed to load wardrobe data',
+  'errors.failedToSave': 'Failed to save',
+  'errors.failedToDelete': 'Failed to delete',
+  'errors.server.measurementOutOfRange': 'The measurement is out of range',
+  'errors.server.nameRequired': 'Name is required',
+  'errors.server.birthdateFormat': 'Birthdate must be a valid date',
+  'categories.inUse': 'This category still has items',
 }
 
 function mockT(key: string, opts?: Record<string, unknown>): string {
@@ -80,8 +90,12 @@ const needsPayload = {
   too_small: [],
 }
 
-// stubFetch dispatches on URL so the page's parallel loads all resolve.
-function stubFetch(overrides: Partial<Record<string, unknown>> = {}) {
+// stubFetch dispatches on URL so the page's parallel loads all resolve. `onWrite`
+// lets a test answer a specific mutation (POST/PATCH/DELETE) with an error body.
+function stubFetch(
+  overrides: Partial<Record<string, unknown>> = {},
+  onWrite?: (path: string, init?: RequestInit) => unknown,
+) {
   const routes: Record<string, unknown> = {
     '/kids': { kids: [kid] },
     '/categories': { categories },
@@ -90,8 +104,12 @@ function stubFetch(overrides: Partial<Record<string, unknown>> = {}) {
     '/needs': needsPayload,
     ...overrides,
   }
-  const fetchMock = vi.fn((url: string) => {
+  const fetchMock = vi.fn((url: string, init?: RequestInit) => {
     const path = url.replace('/api/wardrobe', '').split('?')[0]
+    if (init?.method && onWrite) {
+      const custom = onWrite(path, init)
+      if (custom) return Promise.resolve(custom)
+    }
     const match = Object.keys(routes).find(k => path === k || path.endsWith(k))
     if (!match) return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
     return Promise.resolve({ ok: true, json: () => Promise.resolve(routes[match]) })
@@ -99,6 +117,14 @@ function stubFetch(overrides: Partial<Record<string, unknown>> = {}) {
   vi.stubGlobal('fetch', fetchMock)
   return fetchMock
 }
+
+// errorResponse mimics the backend's `{"error": "..."}` failure body.
+function errorResponse(status: number, message: string) {
+  return { ok: false, status, json: () => Promise.resolve({ error: message }) }
+}
+
+// messageFor takes the page's TFunction; the mock stands in for it in tests.
+const t = mockT as unknown as Parameters<typeof messageFor>[1]
 
 function renderPage() {
   return render(
@@ -168,5 +194,132 @@ describe('WardrobePage', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent('Failed to load wardrobe data')
     })
+  })
+
+  it('shows the backend validation message inside the measurements form', async () => {
+    stubFetch({}, (path, init) =>
+      init?.method === 'POST' && path === '/kids/1/measurements'
+        ? errorResponse(400, 'measurement out of range')
+        : undefined,
+    )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Ola').length).toBeGreaterThan(0)
+    })
+    fireEvent.click(screen.getByRole('tab', { name: /Measurements/ }))
+
+    const panel = screen.getByRole('tabpanel', { name: /Measurements/ })
+    fireEvent.change(within(panel).getByLabelText('Height (cm)'), { target: { value: '400' } })
+    fireEvent.click(within(panel).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(within(panel).getByRole('alert')).toHaveTextContent('The measurement is out of range')
+    })
+    // The page-level banner stays empty — the only alert is the one in the form.
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    expect(screen.queryByText('Failed to save')).not.toBeInTheDocument()
+  })
+
+  it('keeps the kid dialog open with its values when the backend rejects the save', async () => {
+    stubFetch({}, (path, init) =>
+      init?.method === 'POST' && path === '/kids'
+        ? errorResponse(400, 'birthdate must be YYYY-MM-DD')
+        : undefined,
+    )
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Ola').length).toBeGreaterThan(0)
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add child' }))
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'Kari' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(within(dialog).getByRole('alert')).toHaveTextContent('Birthdate must be a valid date')
+    })
+    // The dialog stays open with the entered name so it can be corrected.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(within(dialog).getByLabelText('Name')).toHaveValue('Kari')
+    expect(screen.queryByText('Failed to save')).not.toBeInTheDocument()
+  })
+})
+
+describe('api', () => {
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('throws an ApiError carrying the status and the backend message', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(errorResponse(400, 'measurement out of range'))))
+    const err = await api('/kids/1/measurements', { method: 'POST', body: '{}' }).catch(e => e)
+    expect(err).toBeInstanceOf(ApiError)
+    expect(err.status).toBe(400)
+    expect(err.serverMessage).toBe('measurement out of range')
+  })
+
+  it('leaves serverMessage null for a non-JSON body', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      ok: false,
+      status: 502,
+      json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON')),
+    })))
+    const err = await api('/items', { method: 'POST', body: '{}' }).catch(e => e)
+    expect(err).toBeInstanceOf(ApiError)
+    expect(err.status).toBe(502)
+    expect(err.serverMessage).toBeNull()
+  })
+
+  it('leaves serverMessage null when the body has no error field', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) })))
+    const err = await api('/items').catch(e => e)
+    expect(err.serverMessage).toBeNull()
+  })
+
+  it('returns the response untouched when the request succeeds', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ kids: [] }) })))
+    const res = await api('/kids')
+    expect(await res.json()).toEqual({ kids: [] })
+  })
+})
+
+describe('messageFor', () => {
+  it.each([
+    ['measurement out of range', 'The measurement is out of range'],
+    ['name is required', 'Name is required'],
+    ['category has items', 'This category still has items'],
+    ['birthdate must be YYYY-MM-DD', 'Birthdate must be a valid date'],
+    // Unmapped in the test translation table, so mockT echoes the key back —
+    // enough to prove the message resolved to a translation key, not raw English.
+    ['measured_at must be YYYY-MM-DD', 'errors.server.measuredAtFormat'],
+    ['at least one measurement is required', 'errors.server.measurementRequired'],
+    ['quantity must be at most 99', 'errors.server.quantityMax'],
+    ['invalid condition', 'errors.server.invalidCondition'],
+    ['invalid status', 'errors.server.invalidStatus'],
+    ['invalid location', 'errors.server.invalidLocation'],
+    ['invalid season', 'errors.server.invalidSeason'],
+    ['kid_id is required', 'errors.server.kidRequired'],
+    ['kid not found', 'errors.server.kidNotFound'],
+    ['category not found', 'errors.server.categoryNotFound'],
+    ['target_qty must be between 0 and 99', 'errors.server.targetQtyRange'],
+    ['invalid size_system', 'errors.server.invalidSizeSystem'],
+  ])('translates %s', (serverMessage, expected) => {
+    const err = new ApiError(400, serverMessage, 'POST /x failed')
+    expect(messageFor(err, t, 'errors.failedToSave')).toBe(expected)
+  })
+
+  it('falls back to the generic message for unmapped backend messages', () => {
+    const err = new ApiError(500, 'failed to add item', 'POST /items failed')
+    expect(messageFor(err, t, 'errors.failedToSave')).toBe('Failed to save')
+  })
+
+  it('falls back when there is no server message', () => {
+    expect(messageFor(new ApiError(502, null, 'boom'), t, 'errors.failedToDelete')).toBe('Failed to delete')
+  })
+
+  it('falls back for errors that are not ApiError', () => {
+    expect(messageFor(new Error('network down'), t, 'errors.failedToSave')).toBe('Failed to save')
+    expect(messageFor(undefined, t, 'errors.failedToDelete')).toBe('Failed to delete')
   })
 })

--- a/web/src/pages/WardrobePage.test.tsx
+++ b/web/src/pages/WardrobePage.test.tsx
@@ -2,7 +2,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import WardrobePage, { ApiError, api, messageFor } from './WardrobePage'
+import WardrobePage from './WardrobePage'
+import { ApiError, api, messageFor } from './wardrobeApi'
 
 // ── Translation mock ──────────────────────────────────────────────────────────
 // mockT must be a stable reference — WardrobePage's load effects have `t` as a

--- a/web/src/pages/WardrobePage.tsx
+++ b/web/src/pages/WardrobePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
 import { Plus, Pencil, Trash2, Ruler, Settings2, X, Baby, ShoppingBag } from 'lucide-react'
 import { useAuth } from '../auth'
 import { Dialog, DialogHeader, DialogBody, DialogFooter } from '../components/ui/dialog'
@@ -97,14 +98,78 @@ function today(): string {
   return new Date().toISOString().slice(0, 10)
 }
 
-async function api(path: string, init?: RequestInit): Promise<Response> {
+// ApiError carries the HTTP status and the backend's `{"error": "..."}` message
+// so callers can show something more useful than a generic failure notice.
+export class ApiError extends Error {
+  readonly status: number
+  readonly serverMessage: string | null
+
+  constructor(status: number, serverMessage: string | null, message: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.serverMessage = serverMessage
+  }
+}
+
+export async function api(path: string, init?: RequestInit): Promise<Response> {
   const res = await fetch(`/api/wardrobe${path}`, {
     credentials: 'include',
     headers: init?.body ? { 'Content-Type': 'application/json' } : undefined,
     ...init,
   })
-  if (!res.ok) throw new Error(`${init?.method ?? 'GET'} ${path} failed`)
+  if (!res.ok) {
+    let serverMessage: string | null = null
+    try {
+      const body = await res.json()
+      if (body && typeof body.error === 'string') serverMessage = body.error
+    } catch {
+      // Non-JSON body (an HTML error page, an empty 502) — fall back to the generic text.
+    }
+    throw new ApiError(res.status, serverMessage, `${init?.method ?? 'GET'} ${path} failed`)
+  }
   return res
+}
+
+// Backend messages (internal/wardrobe/handlers.go) mapped to translation keys.
+// Anything not listed here — 5xx internals, "invalid JSON" — falls back to the
+// caller's generic key so no raw English reaches the UI.
+const SERVER_MESSAGE_KEYS = {
+  'name is required': 'errors.server.nameRequired',
+  'birthdate must be YYYY-MM-DD': 'errors.server.birthdateFormat',
+  'measured_at must be YYYY-MM-DD': 'errors.server.measuredAtFormat',
+  'measurement out of range': 'errors.server.measurementOutOfRange',
+  'at least one measurement is required': 'errors.server.measurementRequired',
+  'quantity must be at most 99': 'errors.server.quantityMax',
+  'invalid condition': 'errors.server.invalidCondition',
+  'invalid status': 'errors.server.invalidStatus',
+  'invalid location': 'errors.server.invalidLocation',
+  'invalid season': 'errors.server.invalidSeason',
+  'kid_id is required': 'errors.server.kidRequired',
+  'kid not found': 'errors.server.kidNotFound',
+  'category not found': 'errors.server.categoryNotFound',
+  'target_qty must be between 0 and 99': 'errors.server.targetQtyRange',
+  'invalid size_system': 'errors.server.invalidSizeSystem',
+  'category has items': 'categories.inUse',
+} as const
+
+type ServerMessageKey = (typeof SERVER_MESSAGE_KEYS)[keyof typeof SERVER_MESSAGE_KEYS]
+type FallbackKey = 'errors.failedToSave' | 'errors.failedToDelete' | 'errors.failedToLoad'
+type WardrobeT = TFunction<['wardrobe', 'common']>
+
+// messageFor translates a known backend message, or the generic fallback.
+export function messageFor(err: unknown, t: WardrobeT, fallbackKey: FallbackKey): string {
+  if (err instanceof ApiError && err.serverMessage) {
+    const key: ServerMessageKey | undefined = SERVER_MESSAGE_KEYS[err.serverMessage as keyof typeof SERVER_MESSAGE_KEYS]
+    if (key) return t(key)
+  }
+  return t(fallbackKey)
+}
+
+// FormError renders a validation message inside the form that produced it.
+function FormError({ message, className }: { message: string; className?: string }) {
+  if (!message) return null
+  return <p role="alert" className={`text-sm text-red-400${className ? ` ${className}` : ''}`}>{message}</p>
 }
 
 export default function WardrobePage() {
@@ -123,10 +188,23 @@ export default function WardrobePage() {
   const [error, setError] = useState('')
 
   const [kidDialog, setKidDialog] = useState<{ id?: number; name: string; birthdate: string; emoji: string } | null>(null)
+  const [kidError, setKidError] = useState('')
   const [itemDialog, setItemDialog] = useState<ItemForm | null>(null)
+  const [itemError, setItemError] = useState('')
   const [categoriesOpen, setCategoriesOpen] = useState(false)
   const [confirm, setConfirm] = useState<{ message: string; action: () => void } | null>(null)
   const [saving, setSaving] = useState(false)
+
+  // Opening or closing a dialog clears whatever error the last attempt left behind.
+  const openKidDialog = (form: { id?: number; name: string; birthdate: string; emoji: string } | null) => {
+    setKidError('')
+    setKidDialog(form)
+  }
+
+  const openItemDialog = (form: ItemForm | null) => {
+    setItemError('')
+    setItemDialog(form)
+  }
 
   const selectedKid = kids.find(k => k.id === selectedKidId) ?? null
 
@@ -212,7 +290,7 @@ export default function WardrobePage() {
   const saveKid = async () => {
     if (!kidDialog || saving) return
     setSaving(true)
-    setError('')
+    setKidError('')
     try {
       const body = JSON.stringify({
         name: kidDialog.name.trim(),
@@ -226,10 +304,11 @@ export default function WardrobePage() {
         const data = await res.json()
         setSelectedKidId(data.kid.id as number)
       }
-      setKidDialog(null)
+      openKidDialog(null)
       await refreshAll()
-    } catch {
-      setError(t('errors.failedToSave'))
+    } catch (e) {
+      // Keep the dialog open with the entered values so they can be corrected.
+      setKidError(messageFor(e, t, 'errors.failedToSave'))
     } finally {
       setSaving(false)
     }
@@ -244,8 +323,8 @@ export default function WardrobePage() {
           await api(`/kids/${kid.id}`, { method: 'DELETE' })
           setSelectedKidId(null)
           await refreshAll()
-        } catch {
-          setError(t('errors.failedToDelete'))
+        } catch (e) {
+          setError(messageFor(e, t, 'errors.failedToDelete'))
         }
       },
     })
@@ -256,7 +335,7 @@ export default function WardrobePage() {
   const saveItem = async () => {
     if (!itemDialog || saving) return
     setSaving(true)
-    setError('')
+    setItemError('')
     try {
       const body = JSON.stringify({
         kid_id: itemDialog.kid_id,
@@ -275,10 +354,11 @@ export default function WardrobePage() {
       } else {
         await api('/items', { method: 'POST', body })
       }
-      setItemDialog(null)
+      openItemDialog(null)
       if (selectedKidId !== null) await refreshKidData(selectedKidId)
-    } catch {
-      setError(t('errors.failedToSave'))
+    } catch (e) {
+      // Keep the dialog open with the entered values so they can be corrected.
+      setItemError(messageFor(e, t, 'errors.failedToSave'))
     } finally {
       setSaving(false)
     }
@@ -292,8 +372,8 @@ export default function WardrobePage() {
         body: JSON.stringify({ ...item, status }),
       })
       if (selectedKidId !== null) await refreshKidData(selectedKidId)
-    } catch {
-      setError(t('errors.failedToSave'))
+    } catch (e) {
+      setError(messageFor(e, t, 'errors.failedToSave'))
     }
   }
 
@@ -305,8 +385,8 @@ export default function WardrobePage() {
         try {
           await api(`/items/${item.id}`, { method: 'DELETE' })
           if (selectedKidId !== null) await refreshKidData(selectedKidId)
-        } catch {
-          setError(t('errors.failedToDelete'))
+        } catch (e) {
+          setError(messageFor(e, t, 'errors.failedToDelete'))
         }
       },
     })
@@ -340,7 +420,7 @@ export default function WardrobePage() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">{t('title')}</h1>
         <button
-          onClick={() => setKidDialog({ name: '', birthdate: '', emoji: '🧒' })}
+          onClick={() => openKidDialog({ name: '', birthdate: '', emoji: '🧒' })}
           className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg px-3 py-2 text-sm cursor-pointer transition-colors"
         >
           <Plus size={16} />
@@ -390,7 +470,7 @@ export default function WardrobePage() {
               <KidStatsCard
                 kid={selectedKid}
                 dateFmt={dateFmt}
-                onEdit={() => setKidDialog({
+                onEdit={() => openKidDialog({
                   id: selectedKid.id,
                   name: selectedKid.name,
                   birthdate: selectedKid.birthdate,
@@ -417,8 +497,8 @@ export default function WardrobePage() {
                   <InventoryTab
                     items={items}
                     categories={categories}
-                    onAdd={() => selectedKidId !== null && setItemDialog(emptyItemForm(selectedKidId))}
-                    onEdit={item => setItemDialog({
+                    onAdd={() => selectedKidId !== null && openItemDialog(emptyItemForm(selectedKidId))}
+                    onEdit={item => openItemDialog({
                       id: item.id,
                       kid_id: item.kid_id,
                       category_id: String(item.category_id),
@@ -443,7 +523,6 @@ export default function WardrobePage() {
                     measurements={measurements}
                     dateFmt={dateFmt}
                     onChanged={refreshAll}
-                    onError={() => setError(t('errors.failedToSave'))}
                   />
                 </TabPanel>
 
@@ -457,11 +536,12 @@ export default function WardrobePage() {
       )}
 
       {/* Kid add/edit dialog */}
-      <Dialog open={kidDialog !== null} onClose={() => setKidDialog(null)} aria-labelledby="kid-dialog-title">
+      <Dialog open={kidDialog !== null} onClose={() => openKidDialog(null)} aria-labelledby="kid-dialog-title">
         {kidDialog && (
           <>
-            <DialogHeader id="kid-dialog-title" title={kidDialog.id ? t('editKid') : t('addKid')} onClose={() => setKidDialog(null)} />
+            <DialogHeader id="kid-dialog-title" title={kidDialog.id ? t('editKid') : t('addKid')} onClose={() => openKidDialog(null)} />
             <DialogBody className="space-y-4">
+              <FormError message={kidError} />
               <label className="block">
                 <span className="block text-sm text-gray-300 mb-1">{t('kidForm.name')}</span>
                 <input
@@ -494,7 +574,7 @@ export default function WardrobePage() {
               </div>
             </DialogBody>
             <DialogFooter>
-              <button onClick={() => setKidDialog(null)} className="px-4 py-2 text-sm text-gray-300 hover:text-white cursor-pointer">
+              <button onClick={() => openKidDialog(null)} className="px-4 py-2 text-sm text-gray-300 hover:text-white cursor-pointer">
                 {t('common:actions.cancel')}
               </button>
               <button
@@ -510,11 +590,12 @@ export default function WardrobePage() {
       </Dialog>
 
       {/* Item add/edit dialog */}
-      <Dialog open={itemDialog !== null} onClose={() => setItemDialog(null)} aria-labelledby="item-dialog-title" maxWidth="max-w-lg">
+      <Dialog open={itemDialog !== null} onClose={() => openItemDialog(null)} aria-labelledby="item-dialog-title" maxWidth="max-w-lg">
         {itemDialog && (
           <>
-            <DialogHeader id="item-dialog-title" title={itemDialog.id ? t('editItem') : t('addItem')} onClose={() => setItemDialog(null)} />
+            <DialogHeader id="item-dialog-title" title={itemDialog.id ? t('editItem') : t('addItem')} onClose={() => openItemDialog(null)} />
             <DialogBody className="space-y-4">
+              <FormError message={itemError} />
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <label className="block">
                   <span className="block text-sm text-gray-300 mb-1">{t('itemForm.name')}</span>
@@ -583,7 +664,7 @@ export default function WardrobePage() {
               </label>
             </DialogBody>
             <DialogFooter>
-              <button onClick={() => setItemDialog(null)} className="px-4 py-2 text-sm text-gray-300 hover:text-white cursor-pointer">
+              <button onClick={() => openItemDialog(null)} className="px-4 py-2 text-sm text-gray-300 hover:text-white cursor-pointer">
                 {t('common:actions.cancel')}
               </button>
               <button
@@ -826,22 +907,23 @@ function ItemRow({ item, onEdit, onStatus, onDelete }: {
   )
 }
 
-function MeasurementsTab({ kid, measurements, dateFmt, onChanged, onError }: {
+function MeasurementsTab({ kid, measurements, dateFmt, onChanged }: {
   kid: Kid
   measurements: Measurement[]
   dateFmt: Intl.DateTimeFormat
   onChanged: () => Promise<void>
-  onError: () => void
 }) {
   const { t } = useTranslation(['wardrobe', 'common'])
   const [form, setForm] = useState({ date: today(), height: '', foot: '', weight: '', note: '' })
   const [saving, setSaving] = useState(false)
+  const [formError, setFormError] = useState('')
 
   const canSave = form.date !== '' && (form.height !== '' || form.foot !== '' || form.weight !== '')
 
   const save = async () => {
     if (!canSave || saving) return
     setSaving(true)
+    setFormError('')
     try {
       await api(`/kids/${kid.id}/measurements`, {
         method: 'POST',
@@ -855,19 +937,21 @@ function MeasurementsTab({ kid, measurements, dateFmt, onChanged, onError }: {
       })
       setForm({ date: today(), height: '', foot: '', weight: '', note: '' })
       await onChanged()
-    } catch {
-      onError()
+    } catch (e) {
+      // Keep the typed values so the offending field can be corrected.
+      setFormError(messageFor(e, t, 'errors.failedToSave'))
     } finally {
       setSaving(false)
     }
   }
 
   const remove = async (id: number) => {
+    setFormError('')
     try {
       await api(`/measurements/${id}`, { method: 'DELETE' })
       await onChanged()
-    } catch {
-      onError()
+    } catch (e) {
+      setFormError(messageFor(e, t, 'errors.failedToDelete'))
     }
   }
 
@@ -900,6 +984,7 @@ function MeasurementsTab({ kid, measurements, dateFmt, onChanged, onError }: {
           </label>
         </div>
         <p className="text-xs text-gray-500 mt-2">{t('measurements.footHint')}</p>
+        <FormError message={formError} className="mt-2" />
         <div className="flex justify-end mt-3">
           <button onClick={save} disabled={!canSave || saving}
             className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg px-4 py-2 text-sm cursor-pointer transition-colors">
@@ -1014,23 +1099,19 @@ function CategoriesDialog({ open, onClose, categories, onChanged }: {
         }),
       })
       await onChanged()
-    } catch {
-      setRowError(t('errors.failedToSave'))
+    } catch (e) {
+      setRowError(messageFor(e, t, 'errors.failedToSave'))
     }
   }
 
   const removeCategory = async (cat: Category) => {
     setRowError('')
     try {
-      const res = await fetch(`/api/wardrobe/categories/${cat.id}`, { method: 'DELETE', credentials: 'include' })
-      if (res.status === 409) {
-        setRowError(t('categories.inUse'))
-        return
-      }
-      if (!res.ok) throw new Error('delete failed')
+      // A 409 "category has items" maps to categories.inUse via the shared mapper.
+      await api(`/categories/${cat.id}`, { method: 'DELETE' })
       await onChanged()
-    } catch {
-      setRowError(t('errors.failedToDelete'))
+    } catch (e) {
+      setRowError(messageFor(e, t, 'errors.failedToDelete'))
     }
   }
 
@@ -1050,8 +1131,8 @@ function CategoriesDialog({ open, onClose, categories, onChanged }: {
       })
       setNewCat({ name: '', icon: '', size_system: 'clothing', target: '0' })
       await onChanged()
-    } catch {
-      setRowError(t('errors.failedToSave'))
+    } catch (e) {
+      setRowError(messageFor(e, t, 'errors.failedToSave'))
     } finally {
       setBusy(false)
     }

--- a/web/src/pages/WardrobePage.tsx
+++ b/web/src/pages/WardrobePage.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { TFunction } from 'i18next'
 import { Plus, Pencil, Trash2, Ruler, Settings2, X, Baby, ShoppingBag } from 'lucide-react'
 import { useAuth } from '../auth'
+import { api, messageFor } from './wardrobeApi'
 import { Dialog, DialogHeader, DialogBody, DialogFooter } from '../components/ui/dialog'
 import { Tabs, TabList, TabTrigger, TabPanel } from '../components/ui/tabs'
 import { Select, type SelectOption } from '../components/ui/select'
@@ -96,74 +96,6 @@ const emptyItemForm = (kidId: number): ItemForm => ({
 
 function today(): string {
   return new Date().toISOString().slice(0, 10)
-}
-
-// ApiError carries the HTTP status and the backend's `{"error": "..."}` message
-// so callers can show something more useful than a generic failure notice.
-export class ApiError extends Error {
-  readonly status: number
-  readonly serverMessage: string | null
-
-  constructor(status: number, serverMessage: string | null, message: string) {
-    super(message)
-    this.name = 'ApiError'
-    this.status = status
-    this.serverMessage = serverMessage
-  }
-}
-
-export async function api(path: string, init?: RequestInit): Promise<Response> {
-  const res = await fetch(`/api/wardrobe${path}`, {
-    credentials: 'include',
-    headers: init?.body ? { 'Content-Type': 'application/json' } : undefined,
-    ...init,
-  })
-  if (!res.ok) {
-    let serverMessage: string | null = null
-    try {
-      const body = await res.json()
-      if (body && typeof body.error === 'string') serverMessage = body.error
-    } catch {
-      // Non-JSON body (an HTML error page, an empty 502) — fall back to the generic text.
-    }
-    throw new ApiError(res.status, serverMessage, `${init?.method ?? 'GET'} ${path} failed`)
-  }
-  return res
-}
-
-// Backend messages (internal/wardrobe/handlers.go) mapped to translation keys.
-// Anything not listed here — 5xx internals, "invalid JSON" — falls back to the
-// caller's generic key so no raw English reaches the UI.
-const SERVER_MESSAGE_KEYS = {
-  'name is required': 'errors.server.nameRequired',
-  'birthdate must be YYYY-MM-DD': 'errors.server.birthdateFormat',
-  'measured_at must be YYYY-MM-DD': 'errors.server.measuredAtFormat',
-  'measurement out of range': 'errors.server.measurementOutOfRange',
-  'at least one measurement is required': 'errors.server.measurementRequired',
-  'quantity must be at most 99': 'errors.server.quantityMax',
-  'invalid condition': 'errors.server.invalidCondition',
-  'invalid status': 'errors.server.invalidStatus',
-  'invalid location': 'errors.server.invalidLocation',
-  'invalid season': 'errors.server.invalidSeason',
-  'kid_id is required': 'errors.server.kidRequired',
-  'kid not found': 'errors.server.kidNotFound',
-  'category not found': 'errors.server.categoryNotFound',
-  'target_qty must be between 0 and 99': 'errors.server.targetQtyRange',
-  'invalid size_system': 'errors.server.invalidSizeSystem',
-  'category has items': 'categories.inUse',
-} as const
-
-type ServerMessageKey = (typeof SERVER_MESSAGE_KEYS)[keyof typeof SERVER_MESSAGE_KEYS]
-type FallbackKey = 'errors.failedToSave' | 'errors.failedToDelete' | 'errors.failedToLoad'
-type WardrobeT = TFunction<['wardrobe', 'common']>
-
-// messageFor translates a known backend message, or the generic fallback.
-export function messageFor(err: unknown, t: WardrobeT, fallbackKey: FallbackKey): string {
-  if (err instanceof ApiError && err.serverMessage) {
-    const key: ServerMessageKey | undefined = SERVER_MESSAGE_KEYS[err.serverMessage as keyof typeof SERVER_MESSAGE_KEYS]
-    if (key) return t(key)
-  }
-  return t(fallbackKey)
 }
 
 // FormError renders a validation message inside the form that produced it.

--- a/web/src/pages/wardrobeApi.ts
+++ b/web/src/pages/wardrobeApi.ts
@@ -1,0 +1,69 @@
+import type { TFunction } from 'i18next'
+
+// ApiError carries the HTTP status and the backend's `{"error": "..."}` message
+// so callers can show something more useful than a generic failure notice.
+export class ApiError extends Error {
+  readonly status: number
+  readonly serverMessage: string | null
+
+  constructor(status: number, serverMessage: string | null, message: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.serverMessage = serverMessage
+  }
+}
+
+export async function api(path: string, init?: RequestInit): Promise<Response> {
+  const res = await fetch(`/api/wardrobe${path}`, {
+    credentials: 'include',
+    headers: init?.body ? { 'Content-Type': 'application/json' } : undefined,
+    ...init,
+  })
+  if (!res.ok) {
+    let serverMessage: string | null = null
+    try {
+      const body = await res.json()
+      if (body && typeof body.error === 'string') serverMessage = body.error
+    } catch {
+      // Non-JSON body (an HTML error page, an empty 502) — fall back to the generic text.
+    }
+    throw new ApiError(res.status, serverMessage, `${init?.method ?? 'GET'} ${path} failed`)
+  }
+  return res
+}
+
+// Backend messages (internal/wardrobe/handlers.go) mapped to translation keys.
+// Anything not listed here — 5xx internals, "invalid JSON" — falls back to the
+// caller's generic key so no raw English reaches the UI.
+const SERVER_MESSAGE_KEYS = {
+  'name is required': 'errors.server.nameRequired',
+  'birthdate must be YYYY-MM-DD': 'errors.server.birthdateFormat',
+  'measured_at must be YYYY-MM-DD': 'errors.server.measuredAtFormat',
+  'measurement out of range': 'errors.server.measurementOutOfRange',
+  'at least one measurement is required': 'errors.server.measurementRequired',
+  'quantity must be at most 99': 'errors.server.quantityMax',
+  'invalid condition': 'errors.server.invalidCondition',
+  'invalid status': 'errors.server.invalidStatus',
+  'invalid location': 'errors.server.invalidLocation',
+  'invalid season': 'errors.server.invalidSeason',
+  'kid_id is required': 'errors.server.kidRequired',
+  'kid not found': 'errors.server.kidNotFound',
+  'category not found': 'errors.server.categoryNotFound',
+  'target_qty must be between 0 and 99': 'errors.server.targetQtyRange',
+  'invalid size_system': 'errors.server.invalidSizeSystem',
+  'category has items': 'categories.inUse',
+} as const
+
+type ServerMessageKey = (typeof SERVER_MESSAGE_KEYS)[keyof typeof SERVER_MESSAGE_KEYS]
+type FallbackKey = 'errors.failedToSave' | 'errors.failedToDelete' | 'errors.failedToLoad'
+type WardrobeT = TFunction<['wardrobe', 'common']>
+
+// messageFor translates a known backend message, or the generic fallback.
+export function messageFor(err: unknown, t: WardrobeT, fallbackKey: FallbackKey): string {
+  if (err instanceof ApiError && err.serverMessage) {
+    const key: ServerMessageKey | undefined = SERVER_MESSAGE_KEYS[err.serverMessage as keyof typeof SERVER_MESSAGE_KEYS]
+    if (key) return t(key)
+  }
+  return t(fallbackKey)
+}


### PR DESCRIPTION
## Changes

- **Wardrobe forms show the real reason a save failed** - Validation errors from the API (measurement out of range, name is required, birthdate format, quantity limits, category in use) are now translated and shown inside the form that caused them instead of a generic "failed to save" banner, and the dialog stays open with the entered values. (Hytte-aut7n)

## Original Issue (feature): Surface the API's real error message instead of a generic banner

### Scope
Make `WardrobePage` surface the backend's `{"error": "..."}` message instead of collapsing every failure into `errors.failedToSave`. The `api()` helper (`web/src/pages/WardrobePage.tsx:99`) parses the JSON error body and throws a typed error carrying `status` + server message; a small mapper translates the known backend strings via `wardrobe.json`, falling back to the existing generic text. Errors from a form are rendered inside that form (kid dialog, item dialog, measurements tab, categories dialog) rather than in the page-level banner. Backend messages stay exactly as they are — no Go changes.

### Files to touch
- `web/src/pages/WardrobePage.tsx` — `ApiError` class + body parsing in `api()`; a `messageFor(err, t, fallbackKey)` helper; per-form error state for the kid dialog (`saveKid`), item dialog (`saveItem`), and `MeasurementsTab` (widen its `onError` prop to take a message); reuse in `CategoriesDialog`'s existing `rowError`.
- `web/src/pages/WardrobePage.test.tsx` (new, or extend an existing wardrobe test) — vitest coverage for the mapper and `api()` parsing.
- `web/public/locales/en/wardrobe.json`, `.../nb/wardrobe.json`, `.../th/wardrobe.json` — new `errors.server.*` keys.
- `changelog.d/<name>.md` (new) — `category: Changed` fragment.

### Acceptance criteria
- Saving a measurement of 400 cm shows the translated "measurement out of range" text inside the measurements form; the page-level banner stays empty.
- Saving a kid with a blank name or a malformed birthdate shows the translated "name is required" / "birthdate must be YYYY-MM-DD" text inside the kid dialog, and the dialog stays open with the entered values intact.
- Item dialog surfaces its validation messages the same way (`quantity must be at most 99`, `invalid condition|status|location|season`, `kid_id is required`, `kid not found`, `category not found`).
- `CategoriesDialog` still shows `categories.inUse` for the 409 `category has items`, now via the shared mapper, plus `target_qty must be between 0 and 99` and `invalid size_system`.
- Any unmapped message (e.g. 5xx `failed to add item`, `invalid JSON`, or a non-JSON/HTML response) falls back to `errors.failedToSave` / `errors.failedToDelete` — no raw English leaks into the UI and no crash from parsing a non-JSON body.
- All new keys exist in en, nb and th with real translations; no hardcoded strings in JSX.
- `npm run lint`, `npm run build`, `npm test` and `go test ./...` pass.

### Non-goals
- No changes to `internal/wardrobe/*.go` — message wording, status codes, and validation rules stay as-is.
- No structured error codes/field names in the API response; mapping is by exact message string.
- No inline per-field validation or client-side pre-validation before submit.
- No rework of the generic `errors.failedToLoad` path (list/refresh failures keep the page banner).
- Not extended to other pages' `api()` helpers.

## Source

Created from Suggestions page (suggestion id 260, page slug "wardrobe", source=claude).

## Original suggestion

The `api()` helper in WardrobePage.tsx throws `new Error('${method} ${path} failed')` and discards the `{"error": "..."}` body, so every failure collapses into `errors.failedToSave` in a page-level banner — a parent who types 400 cm in the height field gets "failed to save" instead of the backend's "measurement out of range", and the same happens for "name is required" and "birthdate must be YYYY-MM-DD". Parse the JSON error body in `api()`, attach it to the thrown error, and render it inside the dialog that caused it (the CategoriesDialog already proves the pattern with its 409 `categories.inUse` handling). Map the handful of known backend messages to translated strings in `wardrobe.json` for en/nb/th, falling back to the generic text for anything unmapped. Users get actionable, correctable feedback without leaving the form.


---
Bead: Hytte-aut7n | Branch: forge/Hytte-aut7n
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->