### PR TITLE
Stride chat drops stride_custom_prompt (generation reads it, chat doesn't) (Hytte-dxs7s)

### DIFF
--- a/changelog.d/Hytte-dxs7s.md
+++ b/changelog.d/Hytte-dxs7s.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Stride coach chat now respects your custom prompt** - The `stride_custom_prompt` training preference already shaped generated plans, but was invisible to the coach chat, so it could re-derive or contradict that context in conversation. Chat now loads and decrypts the same preference and renders it as a clearly-labelled section that overrides generic coaching defaults. (Hytte-dxs7s)

--- a/internal/stride/chat_handlers.go
+++ b/internal/stride/chat_handlers.go
@@ -463,7 +463,12 @@ func buildChatContext(ctx context.Context, db *sql.DB, userID int64, plan Plan) 
 
 	calibration := loadTreadmillCalibration(db, userID)
 
-	return BuildChatSystemPrompt(profile, plan, evaluations, races, acr, acute, chronic, notes, calibration)
+	// The athlete's custom prompt shapes plan generation, so the chat coach needs
+	// it too. Failures are logged inside the helper and degrade to no custom
+	// instructions rather than failing the chat turn.
+	customPrompt := loadCustomPrompt(db, userID)
+
+	return BuildChatSystemPrompt(profile, plan, evaluations, races, acr, acute, chronic, notes, calibration, customPrompt)
 }
 
 // streamChatClaude runs the Claude CLI with stream-json output and sends text

--- a/internal/stride/chat_prompt.go
+++ b/internal/stride/chat_prompt.go
@@ -11,8 +11,13 @@ import (
 // BuildChatSystemPrompt assembles the system prompt that gives Claude coaching
 // context for a real-time Stride chat conversation. It includes the current
 // plan, athlete profile, evaluations, races, training load, active notes, and
-// the athlete's persisted treadmill calibration — but NOT the full Marius Bakken
-// generation instructions.
+// the athlete's persisted treadmill calibration and standing custom coaching
+// instructions — but NOT the full Marius Bakken generation instructions.
+//
+// customPrompt is the decrypted stride_custom_prompt preference. It is the same
+// durable athlete-specific context that shapes plan generation, so the chat
+// coach must see it too; otherwise it re-derives (and can contradict) it every
+// conversation. Pass an empty string when the athlete has not configured one.
 func BuildChatSystemPrompt(
 	profile training.UserTrainingProfile,
 	plan Plan,
@@ -22,6 +27,7 @@ func BuildChatSystemPrompt(
 	acute, chronic float64,
 	notes []Note,
 	treadmillCalibration string,
+	customPrompt string,
 ) string {
 	var b strings.Builder
 
@@ -50,7 +56,21 @@ Only output plan JSON when you are actually making a change — not when just di
 ` + workoutFormatGuidance + `
 `)
 
-	// 2. Current plan
+	// 2. Athlete's standing custom coaching instructions.
+	// Rendered before the plan so it frames everything that follows, and stated
+	// as overriding generic defaults — this is the same text that shaped the
+	// generated plan, so the coach must not contradict it mid-conversation.
+	if customPrompt != "" {
+		b.WriteString("\n## Athlete's Standing Coaching Instructions\n\n")
+		b.WriteString("These are durable, athlete-configured preferences that also shaped the generated plan. ")
+		b.WriteString("They OVERRIDE your generic coaching defaults wherever the two disagree, and apply to every ")
+		b.WriteString("answer and plan edit in this conversation. They do NOT override your coaching role, the ")
+		b.WriteString("output format rules above, or athlete safety.\n\n")
+		b.WriteString(customPrompt)
+		b.WriteString("\n")
+	}
+
+	// 3. Current plan
 	b.WriteString("\n## Current Weekly Plan\n\n")
 	b.WriteString(fmt.Sprintf("Week: %s to %s | Phase: %s\n\n", plan.WeekStart, plan.WeekEnd, plan.Phase))
 
@@ -69,14 +89,14 @@ Only output plan JSON when you are actually making a change — not when just di
 		b.WriteString("\n```\n")
 	}
 
-	// 3. Training profile
+	// 4. Training profile
 	if profile.Block != "" {
 		b.WriteString("\n## Athlete Profile\n\n")
 		b.WriteString(profile.Block)
 		b.WriteString("\n")
 	}
 
-	// 3b. Persisted treadmill calibration. Chat edits represcribe belt speeds, so
+	// 4b. Persisted treadmill calibration. Chat edits represcribe belt speeds, so
 	// the athlete's own measurements must be here too — otherwise the coach
 	// re-derives them mid-conversation and contradicts the generated plan.
 	if section := renderTreadmillCalibration(treadmillCalibration); section != "" {
@@ -84,7 +104,7 @@ Only output plan JSON when you are actually making a change — not when just di
 		b.WriteString(section)
 	}
 
-	// 4. This week's evaluations
+	// 5. This week's evaluations
 	if len(evaluations) > 0 {
 		b.WriteString("\n## Completed Sessions This Week\n\n")
 		for _, er := range evaluations {
@@ -104,7 +124,7 @@ Only output plan JSON when you are actually making a change — not when just di
 		}
 	}
 
-	// 5. Race calendar
+	// 6. Race calendar
 	if len(races) > 0 {
 		b.WriteString("\n## Upcoming Races\n\n")
 		for _, r := range races {
@@ -118,7 +138,7 @@ Only output plan JSON when you are actually making a change — not when just di
 		}
 	}
 
-	// 6. Training load context
+	// 7. Training load context
 	b.WriteString("\n## Training Load\n\n")
 	if acr != nil {
 		b.WriteString(fmt.Sprintf("- ACR (acute:chronic ratio): %.2f\n", *acr))
@@ -126,7 +146,7 @@ Only output plan JSON when you are actually making a change — not when just di
 	b.WriteString(fmt.Sprintf("- Acute load: %.0f\n", acute))
 	b.WriteString(fmt.Sprintf("- Chronic load: %.0f\n", chronic))
 
-	// 7. Active notes
+	// 8. Active notes
 	if len(notes) > 0 {
 		b.WriteString("\n## Athlete Notes\n\n")
 		for _, n := range notes {

--- a/internal/stride/chat_prompt_test.go
+++ b/internal/stride/chat_prompt_test.go
@@ -2,9 +2,7 @@ package stride
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -405,7 +403,6 @@ func TestBuildChatSystemPrompt_OmitsCustomPromptSectionWhenEmpty(t *testing.T) {
 
 func TestLoadCustomPrompt_DecryptsStoredPreference(t *testing.T) {
 	db := setupTestDB(t)
-	insertPromptTestUser(t, db, 1)
 
 	want := "Long run always on Sunday. Knee flares up on back-to-back hard days."
 	enc, err := encryption.EncryptField(want)
@@ -425,7 +422,6 @@ func TestLoadCustomPrompt_DecryptsStoredPreference(t *testing.T) {
 
 func TestLoadCustomPrompt_AbsentPreference(t *testing.T) {
 	db := setupTestDB(t)
-	insertPromptTestUser(t, db, 1)
 
 	if got := loadCustomPrompt(db, 1); got != "" {
 		t.Errorf("loadCustomPrompt = %q, want empty string when no preference is set", got)
@@ -436,7 +432,6 @@ func TestLoadCustomPrompt_AbsentPreference(t *testing.T) {
 // rather than propagating an error and failing the chat turn.
 func TestLoadCustomPrompt_DecryptFailureDegradesToEmpty(t *testing.T) {
 	db := setupTestDB(t)
-	insertPromptTestUser(t, db, 1)
 
 	enc, err := encryption.EncryptField("Secret coaching preferences")
 	if err != nil {
@@ -463,7 +458,6 @@ func TestLoadCustomPrompt_DecryptFailureDegradesToEmpty(t *testing.T) {
 // custom prompt in the system prompt it hands to Claude.
 func TestBuildChatContext_IncludesCustomPrompt(t *testing.T) {
 	db := setupTestDB(t)
-	insertPromptTestUser(t, db, 1)
 
 	custom := "Prefers morning sessions; avoid hills on Tuesdays."
 	enc, err := encryption.EncryptField(custom)
@@ -492,17 +486,5 @@ func TestBuildChatContext_IncludesCustomPrompt(t *testing.T) {
 	}
 	if !strings.Contains(result, "Athlete's Standing Coaching Instructions") {
 		t.Error("chat context should contain the custom prompt section header")
-	}
-}
-
-// insertPromptTestUser inserts a minimal user row so user_preferences rows
-// satisfy the foreign key.
-func insertPromptTestUser(t *testing.T, db *sql.DB, id int64) {
-	t.Helper()
-	if _, err := db.Exec(
-		`INSERT INTO users (id, email, name, google_id) VALUES (?, ?, ?, ?)`,
-		id, fmt.Sprintf("athlete%d@example.com", id), "Athlete", fmt.Sprintf("g%d", id),
-	); err != nil {
-		t.Fatalf("insert user: %v", err)
 	}
 }

--- a/internal/stride/chat_prompt_test.go
+++ b/internal/stride/chat_prompt_test.go
@@ -1,10 +1,14 @@
 package stride
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/Robin831/Hytte/internal/encryption"
 	"github.com/Robin831/Hytte/internal/training"
 )
 
@@ -132,7 +136,7 @@ Current phase: Threshold development`,
 
 func TestBuildChatSystemPrompt_ContainsCurrentPlan(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	// Should contain plan dates and session details
 	for _, want := range []string{
@@ -151,7 +155,7 @@ func TestBuildChatSystemPrompt_ContainsCurrentPlan(t *testing.T) {
 
 func TestBuildChatSystemPrompt_ContainsWorkoutFormatGuidance(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	// Chat edits must follow the same treadmill-friendly dual-unit format as
 	// initial generation.
@@ -168,7 +172,7 @@ func TestBuildChatSystemPrompt_ContainsWorkoutFormatGuidance(t *testing.T) {
 
 func TestBuildChatSystemPrompt_ContainsTreadmillSpeedCaveat(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	// Editing a session over chat must not reintroduce the bug where an
 	// outdoor km/h figure is handed over as a treadmill belt setting.
@@ -190,7 +194,7 @@ func TestBuildChatSystemPrompt_ContainsTreadmillCalibration(t *testing.T) {
 	const calibration = "Belt sits ~3% below outdoor km/h at matched HR."
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
 
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, calibration)
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, calibration, "")
 	if !strings.Contains(result, treadmillCalibrationHeading) {
 		t.Errorf("chat prompt should contain %q when a calibration is set", treadmillCalibrationHeading)
 	}
@@ -198,7 +202,7 @@ func TestBuildChatSystemPrompt_ContainsTreadmillCalibration(t *testing.T) {
 		t.Error("chat prompt should carry the calibration text verbatim")
 	}
 
-	without := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	without := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 	if strings.Contains(without, treadmillCalibrationHeading) {
 		t.Error("chat prompt should omit the calibration section when none is set")
 	}
@@ -206,7 +210,7 @@ func TestBuildChatSystemPrompt_ContainsTreadmillCalibration(t *testing.T) {
 
 func TestBuildChatSystemPrompt_ContainsProfile(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	for _, want := range []string{
 		"Threshold HR: 166",
@@ -223,7 +227,7 @@ func TestBuildChatSystemPrompt_ContainsProfile(t *testing.T) {
 
 func TestBuildChatSystemPrompt_ContainsEvaluations(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	for _, want := range []string{
 		"Completed Sessions This Week",
@@ -240,7 +244,7 @@ func TestBuildChatSystemPrompt_ContainsEvaluations(t *testing.T) {
 
 func TestBuildChatSystemPrompt_ContainsRaces(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	for _, want := range []string{
 		"Upcoming Races",
@@ -259,7 +263,7 @@ func TestBuildChatSystemPrompt_ContainsRaces(t *testing.T) {
 
 func TestBuildChatSystemPrompt_ContainsModificationInstructions(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	for _, want := range []string{
 		"When modifying the plan, output the FULL updated 7-day plan",
@@ -276,7 +280,7 @@ func TestBuildChatSystemPrompt_ContainsModificationInstructions(t *testing.T) {
 
 func TestBuildChatSystemPrompt_OmitsMariusBakkenFullInstructions(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	// These are distinctive phrases from the full mariusBakkenInstructions constant
 	// that should NOT appear in the chat prompt.
@@ -295,7 +299,7 @@ func TestBuildChatSystemPrompt_OmitsMariusBakkenFullInstructions(t *testing.T) {
 
 func TestBuildChatSystemPrompt_ContainsTrainingLoad(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	for _, want := range []string{
 		"Training Load",
@@ -311,7 +315,7 @@ func TestBuildChatSystemPrompt_ContainsTrainingLoad(t *testing.T) {
 
 func TestBuildChatSystemPrompt_ContainsNotes(t *testing.T) {
 	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
 
 	for _, want := range []string{
 		"Athlete Notes",
@@ -326,7 +330,7 @@ func TestBuildChatSystemPrompt_ContainsNotes(t *testing.T) {
 
 func TestBuildChatSystemPrompt_NilACR(t *testing.T) {
 	profile, plan, evals, races, _, acute, chronic, notes := buildTestPromptInputs()
-	result := BuildChatSystemPrompt(profile, plan, evals, races, nil, acute, chronic, notes, "")
+	result := BuildChatSystemPrompt(profile, plan, evals, races, nil, acute, chronic, notes, "", "")
 
 	if strings.Contains(result, "ACR") {
 		t.Error("prompt should not contain ACR when acr is nil")
@@ -345,7 +349,7 @@ func TestBuildChatSystemPrompt_EmptyOptionalSections(t *testing.T) {
 		Plan:      json.RawMessage(`[]`),
 	}
 
-	result := BuildChatSystemPrompt(profile, plan, nil, nil, nil, 0, 0, nil, "")
+	result := BuildChatSystemPrompt(profile, plan, nil, nil, nil, 0, 0, nil, "", "")
 
 	// Should NOT contain optional section headers when data is empty
 	if strings.Contains(result, "Completed Sessions This Week") {
@@ -363,5 +367,142 @@ func TestBuildChatSystemPrompt_EmptyOptionalSections(t *testing.T) {
 	}
 	if !strings.Contains(result, "Training Load") {
 		t.Error("prompt should always contain the training load section")
+	}
+}
+
+// The athlete's custom prompt shapes plan generation, so the chat coach must see
+// the same durable context in a clearly-labelled, precedence-setting section.
+func TestBuildChatSystemPrompt_ContainsCustomPrompt(t *testing.T) {
+	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
+	custom := "Treadmill belt reads 3% slow. Never prescribe doubles."
+
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", custom)
+
+	if !strings.Contains(result, custom) {
+		t.Errorf("prompt should contain the custom prompt text %q, but it does not", custom)
+	}
+	if !strings.Contains(result, "Athlete's Standing Coaching Instructions") {
+		t.Error("prompt should label the custom prompt with its own section header")
+	}
+	if !strings.Contains(result, "OVERRIDE your generic coaching defaults") {
+		t.Error("custom prompt section should state that it overrides generic defaults")
+	}
+}
+
+func TestBuildChatSystemPrompt_OmitsCustomPromptSectionWhenEmpty(t *testing.T) {
+	profile, plan, evals, races, acr, acute, chronic, notes := buildTestPromptInputs()
+
+	result := BuildChatSystemPrompt(profile, plan, evals, races, acr, acute, chronic, notes, "", "")
+
+	if strings.Contains(result, "Athlete's Standing Coaching Instructions") {
+		t.Error("prompt should not contain the custom prompt header when no custom prompt is set")
+	}
+	// The rest of the prompt must be unaffected.
+	if !strings.Contains(result, "Current Weekly Plan") {
+		t.Error("prompt should still contain the current plan section")
+	}
+}
+
+func TestLoadCustomPrompt_DecryptsStoredPreference(t *testing.T) {
+	db := setupTestDB(t)
+	insertPromptTestUser(t, db, 1)
+
+	want := "Long run always on Sunday. Knee flares up on back-to-back hard days."
+	enc, err := encryption.EncryptField(want)
+	if err != nil {
+		t.Fatalf("encrypt custom prompt: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'stride_custom_prompt', ?)`, enc,
+	); err != nil {
+		t.Fatalf("insert preference: %v", err)
+	}
+
+	if got := loadCustomPrompt(db, 1); got != want {
+		t.Errorf("loadCustomPrompt = %q, want %q", got, want)
+	}
+}
+
+func TestLoadCustomPrompt_AbsentPreference(t *testing.T) {
+	db := setupTestDB(t)
+	insertPromptTestUser(t, db, 1)
+
+	if got := loadCustomPrompt(db, 1); got != "" {
+		t.Errorf("loadCustomPrompt = %q, want empty string when no preference is set", got)
+	}
+}
+
+// A corrupt or key-rotated ciphertext must degrade to no custom instructions
+// rather than propagating an error and failing the chat turn.
+func TestLoadCustomPrompt_DecryptFailureDegradesToEmpty(t *testing.T) {
+	db := setupTestDB(t)
+	insertPromptTestUser(t, db, 1)
+
+	enc, err := encryption.EncryptField("Secret coaching preferences")
+	if err != nil {
+		t.Fatalf("encrypt custom prompt: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'stride_custom_prompt', ?)`, enc,
+	); err != nil {
+		t.Fatalf("insert preference: %v", err)
+	}
+
+	// Switch to a different encryption key so decryption fails.
+	encryption.ResetEncryptionKey()
+	t.Setenv("ENCRYPTION_KEY", "different-key-causes-decrypt-fail")
+	encryption.ResetEncryptionKey()
+	t.Cleanup(func() { encryption.ResetEncryptionKey() })
+
+	if got := loadCustomPrompt(db, 1); got != "" {
+		t.Errorf("loadCustomPrompt = %q, want empty string when decryption fails", got)
+	}
+}
+
+// End-to-end: the chat handler's context builder must surface the decrypted
+// custom prompt in the system prompt it hands to Claude.
+func TestBuildChatContext_IncludesCustomPrompt(t *testing.T) {
+	db := setupTestDB(t)
+	insertPromptTestUser(t, db, 1)
+
+	custom := "Prefers morning sessions; avoid hills on Tuesdays."
+	enc, err := encryption.EncryptField(custom)
+	if err != nil {
+		t.Fatalf("encrypt custom prompt: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO user_preferences (user_id, key, value) VALUES (1, 'stride_custom_prompt', ?)`, enc,
+	); err != nil {
+		t.Fatalf("insert preference: %v", err)
+	}
+
+	plan := Plan{
+		ID:        1,
+		UserID:    1,
+		WeekStart: "2026-04-13",
+		WeekEnd:   "2026-04-19",
+		Phase:     "base",
+		Plan:      json.RawMessage(`[]`),
+	}
+
+	result := buildChatContext(context.Background(), db, 1, plan)
+
+	if !strings.Contains(result, custom) {
+		t.Errorf("chat context should contain the custom prompt %q, but it does not", custom)
+	}
+	if !strings.Contains(result, "Athlete's Standing Coaching Instructions") {
+		t.Error("chat context should contain the custom prompt section header")
+	}
+}
+
+// insertPromptTestUser inserts a minimal user row so user_preferences rows
+// satisfy the foreign key.
+func insertPromptTestUser(t *testing.T, db *sql.DB, id int64) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO users (id, email, name, google_id) VALUES (?, ?, ?, ?)`,
+		id, fmt.Sprintf("athlete%d@example.com", id), "Athlete", fmt.Sprintf("g%d", id),
+	); err != nil {
+		t.Fatalf("insert user: %v", err)
 	}
 }

--- a/internal/stride/generate.go
+++ b/internal/stride/generate.go
@@ -174,6 +174,35 @@ func currentWeek() (weekStart, weekEnd string) {
 	return monday.Format(dateFmt), sunday.Format(dateFmt)
 }
 
+// decryptCustomPrompt decrypts a raw stride_custom_prompt preference value.
+// The preference is stored encrypted at rest, so callers must never use the raw
+// value. A decrypt failure is logged and degrades to an empty string so plan
+// generation and chat both keep working without the custom instructions rather
+// than failing outright.
+func decryptCustomPrompt(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	dec, err := encryption.DecryptField(raw)
+	if err != nil {
+		log.Printf("stride: failed to decrypt stride_custom_prompt, skipping: %v", err)
+		return ""
+	}
+	return dec
+}
+
+// loadCustomPrompt reads the athlete's stride_custom_prompt preference and
+// returns it decrypted. Any failure (preference lookup or decrypt) is logged and
+// yields an empty string.
+func loadCustomPrompt(db *sql.DB, userID int64) string {
+	prefs, err := auth.GetPreferences(db, userID)
+	if err != nil {
+		log.Printf("stride: load preferences for user %d: %v", userID, err)
+		return ""
+	}
+	return decryptCustomPrompt(prefs["stride_custom_prompt"])
+}
+
 // GeneratePlan generates a weekly training plan for the given user using Claude AI.
 // It queries training context from the DB, builds a prompt with Marius Bakken
 // threshold-dominant model instructions, calls Claude, and stores the result in
@@ -241,15 +270,7 @@ func GeneratePlan(ctx context.Context, db *sql.DB, userID int64, weekMode string
 
 	// Read optional custom prompt appended to the plan generation request.
 	// Decrypt it because the preference is stored encrypted at rest.
-	customPrompt := prefs["stride_custom_prompt"]
-	if customPrompt != "" {
-		if dec, err := encryption.DecryptField(customPrompt); err != nil {
-			log.Printf("stride: failed to decrypt stride_custom_prompt, skipping: %v", err)
-			customPrompt = ""
-		} else {
-			customPrompt = dec
-		}
-	}
+	customPrompt := decryptCustomPrompt(prefs["stride_custom_prompt"])
 
 	// Athlete-measured treadmill calibration, persisted across weeks so the coach
 	// never has to re-derive belt-speed and indoor-HR offsets — and so it cannot


### PR DESCRIPTION
## Changes

- **Stride coach chat now respects your custom prompt** - The `stride_custom_prompt` training preference already shaped generated plans, but was invisible to the coach chat, so it could re-derive or contradict that context in conversation. Chat now loads and decrypts the same preference and renders it as a clearly-labelled section that overrides generic coaching defaults. (Hytte-dxs7s)

## Original Issue (bug): Stride chat drops stride_custom_prompt (generation reads it, chat doesn't)

GeneratePlan reads the per-user encrypted stride_custom_prompt preference (generate.go:246) and appends it to the generation prompt as '## Additional Instructions' (generate.go:848). BuildChatSystemPrompt (chat_prompt.go) never loads it. Result: durable athlete-specific context shapes the generated plan but is invisible when the athlete discusses or edits that same plan in chat, so the coach re-derives (and can contradict) it every conversation.

---
Bead: Hytte-dxs7s | Branch: forge/Hytte-dxs7s
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->